### PR TITLE
fix: make release checksums portable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,8 +69,9 @@ jobs:
       - name: Build sdist + wheel
         run: |
           uv build
-          sha256sum dist/*.whl dist/*.tar.gz > dist/SHA256SUMS
-          sha256sum --check dist/SHA256SUMS
+          cd dist
+          sha256sum *.whl *.tar.gz > SHA256SUMS
+          sha256sum --check SHA256SUMS
 
       - name: Smoke-test built wheel
         run: |
@@ -122,7 +123,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          sha256sum --check dist/SHA256SUMS
+          cd dist
+          sha256sum --check SHA256SUMS
+          cd ..
           gh release create "$GITHUB_REF_NAME" dist/* \
             --title "$GITHUB_REF_NAME" \
             --notes-file ".github/releases/${GITHUB_REF_NAME}.md" \


### PR DESCRIPTION
## Finding

The first `v0.2.2` workflow generated valid hashes but recorded asset paths as `dist/<filename>`. After users downloaded the three release assets into one directory, the documented `sha256sum --check SHA256SUMS` command failed because no `dist/` subdirectory existed.

## Fix

Generate and verify `SHA256SUMS` from inside `dist/`, then verify from that same directory in the release job. The published checksum now contains portable basenames.

## Verification

- release workflow YAML parsed successfully;
- sdist and wheel rebuilt;
- checksums passed in the build `dist/` directory;
- the three files were copied into a fresh flat download directory;
- `sha256sum --check SHA256SUMS` passed from that directory.

After merge, the defective launch release/tag will be replaced from the corrected `main` commit and its downloaded assets will be verified again.
