### PR TITLE
docs: add the native macOS checksum command

### DIFF
--- a/.github/releases/v0.2.2.md
+++ b/.github/releases/v0.2.2.md
@@ -35,9 +35,13 @@ creates the private environment file, and configures local clients.
 The release workflow runs the offline test suite on mocked LLMs, ruff, shell
 syntax, secret/PII/language/documentation scans, synthetic MCP transport smoke,
 wheel installation outside the checkout, and bundled-resource checks. Verify
-downloaded artifacts with:
+downloaded artifacts with either platform's built-in checksum tool:
 
 ```bash
+# macOS
+shasum -a 256 --check SHA256SUMS
+
+# Linux with GNU coreutils
 sha256sum --check SHA256SUMS
 ```
 


### PR DESCRIPTION
## Finding

The portable checksum now verifies correctly, but release notes showed only GNU `sha256sum`. Some supported macOS versions provide the native `shasum` command instead.

## Fix

Document macOS first with `shasum -a 256 --check SHA256SUMS`, then retain the GNU/Linux command.

## Verification

Both commands verified the flat downloaded `v0.2.2` wheel and sdist against the published checksum file. Documentation links, language scan, and diff checks pass.
