### PR TITLE
fix: make model labels the interaction target

### DIFF
--- a/docs/model-contract.md
+++ b/docs/model-contract.md
@@ -60,6 +60,11 @@ The layout is append-stable for normal chronological growth: existing nodes keep
 coordinates while later evidence expands the surrounding cloud. `window.__persomeLayoutState`
 exposes aggregate layout health for local visual smoke tests without exposing node content or IDs.
 
+Visible node labels and their Point, Face, Volume, Root, or context meshes open the same provenance
+detail panel. Labels are keyboard-focusable; Escape closes the selection. Lines remain visual
+evidence of evolution, relation, and hierarchy and are intentionally excluded from pointer picking.
+`window.__persomeInteractionState` exposes aggregate interaction counts for local smoke tests.
+
 ## Evidence sources
 
 Relation edges may carry the nullable triplet `source_kind`, `source_id`, and `source_receipt`.

--- a/resources/model_assets/viewer.css
+++ b/resources/model_assets/viewer.css
@@ -46,6 +46,8 @@ button {
 
 #canvas canvas {
   display: block;
+  cursor: grab;
+  touch-action: none;
 }
 
 .topbar {
@@ -312,18 +314,48 @@ button {
 }
 
 .model-label {
+  --label-accent: var(--text);
+  appearance: none;
+  min-height: 21px;
   max-width: 220px;
+  margin: 0;
   overflow: hidden;
-  padding: 2px 5px;
+  padding: 2px 6px;
   border: 1px solid rgba(71, 77, 88, 0.76);
   border-radius: 4px;
   background: rgba(8, 10, 13, 0.82);
   color: var(--text);
+  cursor: pointer;
   font-size: 10px;
   line-height: 15px;
+  pointer-events: auto;
+  text-align: left;
   text-overflow: ellipsis;
+  transition: border-color 120ms ease, background 120ms ease, box-shadow 120ms ease;
   white-space: nowrap;
-  pointer-events: none;
+}
+
+.model-label[data-kind="point"] { --label-accent: var(--point); }
+.model-label[data-kind="face"] { --label-accent: var(--face); }
+.model-label[data-kind="volume"] { --label-accent: var(--volume); }
+.model-label[data-kind="root"] { --label-accent: var(--root); }
+.model-label[data-kind="context"] { --label-accent: var(--muted); }
+
+.model-label:hover,
+.model-label:focus-visible {
+  border-color: var(--label-accent);
+  background: rgba(27, 31, 38, 0.96);
+}
+
+.model-label[aria-expanded="true"] {
+  border-color: var(--label-accent);
+  background: rgba(27, 31, 38, 0.96);
+  box-shadow: 0 0 0 1px var(--label-accent), 0 5px 16px rgba(0, 0, 0, 0.34);
+}
+
+.model-label:focus-visible {
+  outline: 2px solid var(--label-accent);
+  outline-offset: 2px;
 }
 
 .model-label.context {
@@ -331,7 +363,8 @@ button {
 }
 
 .model-label.hidden {
-  display: none;
+  visibility: hidden;
+  pointer-events: none;
 }
 
 @media (max-width: 760px) {
@@ -394,7 +427,9 @@ button {
   }
 
   .model-label {
+    min-height: 28px;
     max-width: 130px;
+    padding: 5px 7px;
     font-size: 9px;
   }
 }

--- a/resources/model_assets/viewer.js
+++ b/resources/model_assets/viewer.js
@@ -39,6 +39,7 @@ const renderer = new THREE.WebGLRenderer({
 renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
 renderer.setSize(window.innerWidth, window.innerHeight);
 renderer.outputColorSpace = THREE.SRGBColorSpace;
+renderer.domElement.setAttribute("aria-hidden", "true");
 canvasHost.appendChild(renderer.domElement);
 
 const labelRenderer = new CSS2DRenderer();
@@ -69,10 +70,13 @@ let minTime = new Date();
 let maxTime = new Date();
 let playTimer = null;
 let pointerDown = null;
+let hoverPointer = null;
+let hoverDirty = false;
 let selected = null;
 let portraitMode = null;
 let labels = [];
 let pickables = [];
+let selectionTargets = new Map();
 let positions = new Map();
 let items = new Map();
 let layerObjects = freshLayerObjects();
@@ -80,8 +84,8 @@ let currentLayout = null;
 let layoutRadius = 6;
 let framedRadius = 0;
 const layerVisible = { points: true, lines: true, faces: true, volumes: true, root: true };
+const kindLayers = { point: "points", context: "points", face: "faces", volume: "volumes", root: "root" };
 const raycaster = new THREE.Raycaster();
-raycaster.params.Line.threshold = 0.12;
 const pointer = new THREE.Vector2();
 
 function freshLayerObjects() {
@@ -128,40 +132,58 @@ function register(object, layer) {
   return object;
 }
 
+function selectionKey(kind, id) {
+  return `${kind}:${id}`;
+}
+
+function registerSelectionTarget(kind, id, target) {
+  const key = selectionKey(kind, id);
+  target.userData.ref = { kind, id };
+  const targets = selectionTargets.get(key) || [];
+  targets.push(target);
+  selectionTargets.set(key, targets);
+}
+
 function registerPickable(object, layer, kind, item) {
-  object.userData.ref = { kind, id: item.id };
+  registerSelectionTarget(kind, item.id, object);
   register(object, layer);
   pickables.push(object);
-  items.set(`${kind}:${item.id}`, item);
+  items.set(selectionKey(kind, item.id), item);
   return object;
 }
 
-function addLabel(text, position, layer, priority, context = false) {
-  const element = document.createElement("div");
+function addLabel(text, position, layer, priority, kind, item, context = false) {
+  const element = document.createElement("button");
+  element.type = "button";
   element.className = `model-label${context ? " context" : ""}`;
   element.textContent = shortLabel(text);
   element.title = String(text || "");
+  element.dataset.kind = kind;
+  element.setAttribute("aria-label", `Open ${kind} details: ${shortLabel(text, 80)}`);
+  element.setAttribute("aria-controls", "detail");
+  element.setAttribute("aria-expanded", "false");
   const label = new CSS2DObject(element);
   label.position.copy(position);
   label.userData.priority = priority;
+  registerSelectionTarget(kind, item.id, label);
+  element.addEventListener("pointerdown", (event) => event.stopPropagation());
+  element.addEventListener("click", (event) => {
+    event.stopPropagation();
+    showDetails(kind, item);
+  });
   register(label, layer);
   labels.push(label);
   return label;
 }
 
-function addLine(start, end, color, opacity, dashed, item, layer = "lines") {
+function addLine(start, end, color, opacity, dashed, layer = "lines") {
   const geometry = new THREE.BufferGeometry().setFromPoints([start, end]);
   const material = dashed
     ? new THREE.LineDashedMaterial({ color, transparent: true, opacity, dashSize: 0.12, gapSize: 0.09 })
     : new THREE.LineBasicMaterial({ color, transparent: true, opacity });
   const line = new THREE.Line(geometry, material);
   if (dashed) line.computeLineDistances();
-  if (item) {
-    line.userData.ref = { kind: "line", id: item.id };
-    items.set(`line:${item.id}`, item);
-  }
   register(line, layer);
-  if (item) pickables.push(line);
   return line;
 }
 
@@ -177,6 +199,7 @@ function disposeGraph() {
   scene.add(graph);
   labels = [];
   pickables = [];
+  selectionTargets = new Map();
   positions = new Map();
   items = new Map();
   layerObjects = freshLayerObjects();
@@ -198,7 +221,14 @@ function addPoint(point, position, baseRadius, showLabel, promoted) {
   const mesh = registerPickable(new THREE.Mesh(geometry, material), "points", "point", point);
   mesh.position.copy(position);
   if (showLabel) {
-    addLabel(point.content, position.clone().add(new THREE.Vector3(0, radius + 0.16, 0)), "points", active ? 55 : 25);
+    addLabel(
+      point.content,
+      position.clone().add(new THREE.Vector3(0, radius + 0.16, 0)),
+      "points",
+      active ? 55 : 25,
+      "point",
+      point
+    );
   }
 }
 
@@ -217,7 +247,15 @@ function addContextNode(id) {
   );
   mesh.position.copy(position);
   if (id === "self" || hash(id) < 0.16) {
-    addLabel(item.content, position.clone().add(new THREE.Vector3(0, 0.24, 0)), "points", 30, true);
+    addLabel(
+      item.content,
+      position.clone().add(new THREE.Vector3(0, 0.24, 0)),
+      "points",
+      30,
+      "context",
+      item,
+      true
+    );
   }
 }
 
@@ -263,8 +301,17 @@ function addFace(face, showLabel) {
     face
   );
   node.position.copy(position);
-  if (showLabel) addLabel(face.signature, position.clone().add(new THREE.Vector3(0, 0.4, 0)), "faces", 75);
-  memberPositions.forEach((member) => addLine(member, position, COLORS.hierarchy, 0.1, true, null));
+  if (showLabel) {
+    addLabel(
+      face.signature,
+      position.clone().add(new THREE.Vector3(0, 0.4, 0)),
+      "faces",
+      75,
+      "face",
+      face
+    );
+  }
+  memberPositions.forEach((member) => addLine(member, position, COLORS.hierarchy, 0.1, true));
 }
 
 function addVolume(volume, showLabel) {
@@ -287,10 +334,19 @@ function addVolume(volume, showLabel) {
     volume
   );
   mesh.position.copy(position);
-  if (showLabel) addLabel(volume.signature, position.clone().add(new THREE.Vector3(0, 0.55, 0)), "volumes", 90);
+  if (showLabel) {
+    addLabel(
+      volume.signature,
+      position.clone().add(new THREE.Vector3(0, 0.55, 0)),
+      "volumes",
+      90,
+      "volume",
+      volume
+    );
+  }
   const memberIds = currentLayout?.volumeFaceIds.get(volume.id) || [];
   memberIds.map((id) => positions.get(id)).filter(Boolean)
-    .forEach((member) => addLine(member, position, COLORS.volumes, 0.22, false, null));
+    .forEach((member) => addLine(member, position, COLORS.volumes, 0.22, false));
 }
 
 function addRoot(root) {
@@ -311,10 +367,17 @@ function addRoot(root) {
     root
   );
   mesh.position.copy(position);
-  addLabel(root.signature, position.clone().add(new THREE.Vector3(0, 0.66, 0)), "root", 120);
+  addLabel(
+    root.signature,
+    position.clone().add(new THREE.Vector3(0, 0.66, 0)),
+    "root",
+    120,
+    "root",
+    root
+  );
   const parentIds = currentLayout?.rootVolumeIds || [];
   parentIds.map((id) => positions.get(id)).filter(Boolean)
-    .forEach((member) => addLine(member, position, COLORS.root, 0.32, false, null));
+    .forEach((member) => addLine(member, position, COLORS.root, 0.32, false));
 }
 
 function addModelLine(line) {
@@ -327,7 +390,7 @@ function addModelLine(line) {
   const targetCluster = currentLayout?.pointClusterById.get(line.target);
   const sameCluster = sourceCluster && sourceCluster === targetCluster;
   const opacity = evolution ? (sameCluster ? 0.34 : 0.08) : 0.34;
-  addLine(start, end, evolution ? COLORS.lines : 0x6ebf8e, opacity, !evolution, line);
+  addLine(start, end, evolution ? COLORS.lines : 0x6ebf8e, opacity, !evolution);
 }
 
 function addGround() {
@@ -433,6 +496,38 @@ function renderStatus() {
   if (model.build?.status) statusEl.append(`  ·  Build ${model.build.status}`);
 }
 
+function pauseAutoRotate() {
+  if (!controls.autoRotate) return;
+  controls.autoRotate = false;
+  document.getElementById("rotate").setAttribute("aria-pressed", "false");
+}
+
+function syncSelectionState() {
+  const activeKey = selected ? selectionKey(selected.kind, selected.id) : null;
+  selectionTargets.forEach((targets, key) => {
+    const active = key === activeKey;
+    targets.forEach((target) => {
+      if (target.element) {
+        target.element.setAttribute("aria-expanded", String(active));
+      } else if (target.isMesh) {
+        target.scale.setScalar(active ? 1.32 : 1);
+      }
+    });
+  });
+  window.__persomeInteractionState = {
+    linePickables: pickables.filter((object) => object.isLine).length,
+    nodePickables: pickables.length,
+    interactiveLabels: labels.filter((label) => Boolean(label.userData.ref)).length,
+    selected: selected ? { ...selected } : null,
+  };
+}
+
+function clearSelection() {
+  selected = null;
+  detailEl.hidden = true;
+  syncSelectionState();
+}
+
 function applyLayerVisibility() {
   Object.entries(layerObjects).forEach(([layer, objects]) => {
     objects.forEach((object) => {
@@ -443,6 +538,15 @@ function applyLayerVisibility() {
   document.querySelectorAll("[data-layer]").forEach((button) => {
     button.setAttribute("aria-pressed", String(layerVisible[button.dataset.layer]));
   });
+  if (selected) {
+    const key = selectionKey(selected.kind, selected.id);
+    const layer = kindLayers[selected.kind];
+    if (!items.has(key) || (layer && !layerVisible[layer])) {
+      clearSelection();
+      return;
+    }
+  }
+  syncSelectionState();
 }
 
 function appendMeta(label, value) {
@@ -466,6 +570,8 @@ function receiptValues(item) {
 
 function showDetails(kind, item) {
   selected = { kind, id: item.id };
+  pauseAutoRotate();
+  syncSelectionState();
   detailKindEl.textContent = kind;
   detailTitleEl.textContent = item.content || item.signature || item.label || item.id;
   detailMetaEl.replaceChildren();
@@ -589,7 +695,14 @@ function resetCamera() {
 
 function cullLabels() {
   const occupied = [];
-  const maxLabels = window.innerWidth < 760 ? 8 : 20;
+  const mobile = window.innerWidth < 760;
+  const maxLabels = mobile ? 8 : 20;
+  const safeArea = {
+    left: mobile ? 8 : 6,
+    right: window.innerWidth - (mobile ? 8 : 6),
+    top: mobile ? 144 : 104,
+    bottom: window.innerHeight - (mobile ? 70 : 64),
+  };
   let shown = 0;
   const projected = new THREE.Vector3();
   const candidates = labels.filter((label) => label.visible).map((label) => {
@@ -597,16 +710,25 @@ function cullLabels() {
     projected.project(camera);
     const x = (projected.x * 0.5 + 0.5) * window.innerWidth;
     const y = (-projected.y * 0.5 + 0.5) * window.innerHeight;
-    const width = Math.min(window.innerWidth < 760 ? 130 : 220, (label.element.textContent.length * 6.2) + 12);
-    return { label, x, y, width, priority: label.userData.priority || 0, depth: projected.z };
+    const maxWidth = mobile ? 130 : 220;
+    const fallbackWidth = (label.element.textContent.length * 6.2) + 16;
+    const width = Math.min(maxWidth, Math.max(32, label.element.offsetWidth || fallbackWidth));
+    const height = Math.max(21, label.element.offsetHeight || 21);
+    return { label, x, y, width, height, priority: label.userData.priority || 0, depth: projected.z };
   }).sort((a, b) => b.priority - a.priority);
 
   candidates.forEach((candidate) => {
-    const { label, x, y, width, depth } = candidate;
-    const box = { x0: x - width / 2, x1: x + width / 2, y0: y - 9, y1: y + 9 };
+    const { label, x, y, width, height, depth } = candidate;
+    const box = { x0: x - width / 2, x1: x + width / 2, y0: y - height / 2, y1: y + height / 2 };
     const overlaps = occupied.some((other) => box.x0 < other.x1 && box.x1 > other.x0 && box.y0 < other.y1 && box.y1 > other.y0);
-    const hidden = depth < -1 || depth > 1 || overlaps || shown >= maxLabels;
-    label.element.classList.toggle("hidden", hidden);
+    const outsideSafeArea = box.x0 < safeArea.left || box.x1 > safeArea.right
+      || box.y0 < safeArea.top || box.y1 > safeArea.bottom;
+    const hidden = depth < -1 || depth > 1 || outsideSafeArea || overlaps || shown >= maxLabels;
+    if (label.element.classList.contains("hidden") !== hidden) {
+      label.element.classList.toggle("hidden", hidden);
+      label.element.setAttribute("aria-hidden", String(hidden));
+      label.element.tabIndex = hidden ? -1 : 0;
+    }
     if (!hidden) {
       occupied.push(box);
       shown += 1;
@@ -649,10 +771,7 @@ document.getElementById("rotate").addEventListener("click", (event) => {
   event.currentTarget.setAttribute("aria-pressed", String(controls.autoRotate));
 });
 document.getElementById("reset").addEventListener("click", resetCamera);
-document.getElementById("close-detail").addEventListener("click", () => {
-  selected = null;
-  detailEl.hidden = true;
-});
+document.getElementById("close-detail").addEventListener("click", clearSelection);
 
 slider.addEventListener("input", () => {
   updateCutoff();
@@ -680,27 +799,57 @@ document.getElementById("play").addEventListener("click", (event) => {
   }, 240);
 });
 
+function pickAt(event) {
+  const bounds = renderer.domElement.getBoundingClientRect();
+  if (!bounds.width || !bounds.height) return null;
+  pointer.x = ((event.clientX - bounds.left) / bounds.width) * 2 - 1;
+  pointer.y = -((event.clientY - bounds.top) / bounds.height) * 2 + 1;
+  raycaster.setFromCamera(pointer, camera);
+  return raycaster.intersectObjects(pickables.filter((object) => object.visible), false)[0] || null;
+}
+
 renderer.domElement.addEventListener("pointerdown", (event) => {
   pointerDown = { x: event.clientX, y: event.clientY };
+  hoverDirty = false;
+  renderer.domElement.style.cursor = "grabbing";
+});
+renderer.domElement.addEventListener("pointermove", (event) => {
+  if (pointerDown) return;
+  hoverPointer = { clientX: event.clientX, clientY: event.clientY };
+  hoverDirty = true;
+});
+renderer.domElement.addEventListener("pointerleave", () => {
+  hoverPointer = null;
+  hoverDirty = false;
+  if (!pointerDown) renderer.domElement.style.cursor = "grab";
+});
+renderer.domElement.addEventListener("pointercancel", () => {
+  pointerDown = null;
+  hoverPointer = null;
+  hoverDirty = false;
+  renderer.domElement.style.cursor = "grab";
 });
 renderer.domElement.addEventListener("pointerup", (event) => {
   if (!pointerDown) return;
   const movement = Math.abs(event.clientX - pointerDown.x) + Math.abs(event.clientY - pointerDown.y);
   pointerDown = null;
-  if (movement > 5) return;
-  const bounds = renderer.domElement.getBoundingClientRect();
-  pointer.x = ((event.clientX - bounds.left) / bounds.width) * 2 - 1;
-  pointer.y = -((event.clientY - bounds.top) / bounds.height) * 2 + 1;
-  raycaster.setFromCamera(pointer, camera);
-  const hit = raycaster.intersectObjects(pickables.filter((object) => object.visible), false)[0];
+  if (movement > 5) {
+    renderer.domElement.style.cursor = "grab";
+    return;
+  }
+  const hit = pickAt(event);
+  renderer.domElement.style.cursor = hit ? "pointer" : "grab";
   if (!hit?.object.userData.ref) {
-    selected = null;
-    detailEl.hidden = true;
+    clearSelection();
     return;
   }
   const ref = hit.object.userData.ref;
-  const item = items.get(`${ref.kind}:${ref.id}`);
+  const item = items.get(selectionKey(ref.kind, ref.id));
   if (item) showDetails(ref.kind, item);
+});
+
+window.addEventListener("keydown", (event) => {
+  if (event.key === "Escape" && selected) clearSelection();
 });
 
 window.addEventListener("resize", () => {
@@ -723,6 +872,10 @@ window.addEventListener("unhandledrejection", (event) => {
 
 function animate() {
   controls.update();
+  if (hoverDirty && hoverPointer && !pointerDown) {
+    renderer.domElement.style.cursor = pickAt(hoverPointer) ? "pointer" : "grab";
+    hoverDirty = false;
+  }
   cullLabels();
   renderer.render(scene, camera);
   labelRenderer.render(scene, camera);

--- a/src/persome/api/model_view.py
+++ b/src/persome/api/model_view.py
@@ -17,7 +17,7 @@ MEMORY_VIEW_HTML = """<!doctype html>
 </head>
 <body>
   <main id="viewer" aria-label="Persome personal model explorer">
-    <div id="canvas" aria-hidden="true"></div>
+    <div id="canvas"></div>
 
     <header class="topbar">
       <div class="brand">
@@ -48,7 +48,7 @@ MEMORY_VIEW_HTML = """<!doctype html>
       <div><span class="swatch root"></span><b>Root</b><span>current personal model</span></div>
     </aside>
 
-    <aside id="detail" class="detail" aria-live="polite" hidden>
+    <aside id="detail" class="detail" aria-labelledby="detail-title" aria-live="polite" hidden>
       <button id="close-detail" class="icon-button close" type="button" aria-label="Close details" title="Close details">×</button>
       <p id="detail-kind" class="detail-kind"></p>
       <h1 id="detail-title"></h1>

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -81,6 +81,21 @@ class TestViewPage:
         assert layout.media_type == "text/javascript"
         assert css.media_type == "text/css"
 
+    def test_viewer_interaction_contract_prefers_labels_over_lines(self, ac_root):
+        page = routes.model_view().body.decode()
+        viewer = routes.model_asset("viewer.js").body.decode()
+        css = routes.model_asset("viewer.css").body.decode()
+
+        assert 'id="canvas" aria-hidden="true"' not in page
+        assert 'document.createElement("button")' in viewer
+        assert 'element.setAttribute("aria-controls", "detail")' in viewer
+        assert 'element.setAttribute("aria-expanded", "false")' in viewer
+        assert 'event.key === "Escape"' in viewer
+        assert "raycaster.params.Line" not in viewer
+        assert "pickables.push(line)" not in viewer
+        assert "pointer-events: auto" in css
+        assert '.model-label[aria-expanded="true"]' in css
+
 
 class TestNodeReceipts:
     def test_snapshot_point_returns_its_exact_receipt(self, ac_root):


### PR DESCRIPTION
## Summary
- remove Lines from pointer picking while keeping Point, Face, Volume, Root, and context meshes selectable
- turn visible model labels into accessible mouse, touch, and keyboard controls
- add selection highlighting, hover cursor, rotation pause, Escape dismissal, layer-aware cleanup, and safe responsive label culling
- document and test the viewer interaction contract

## Verification
- 1417 passed, 15 deselected
- desktop 1440x900 and mobile 390x844 real-data interaction QA
- linePickables=0; label selection, rotation pause, Escape, and layer cleanup verified
- Node layout tests, Ruff, PII, secret, language, docs, and wheel asset checks