### PR TITLE
Add provider-aware LLM onboarding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,8 @@ uv run python scripts/pii_scan.py
 uv run python scripts/language_scan.py
 
 persome doctor
+persome llm setup
+persome llm status --check
 persome start
 persome status
 persome stop
@@ -105,8 +107,10 @@ Update matching docs in the same change as behavior.
 - Use `src/persome/paths.py` for every runtime path. Tests use `ac_root` and
   must never touch the real data root.
 - Use `with fts.cursor() as conn:` for SQLite. The store runs in WAL mode.
-- All stage LLM calls go through `writer/llm.py`. Model names are bare gateway
-  names; secrets belong in `<PERSOME_ROOT>/env`, never `config.toml`.
+- All stage LLM calls go through `writer/llm.py`. The selected profile uses
+  Anthropic Messages or OpenAI-compatible Chat Completions. Provider, protocol,
+  model, endpoint, and key variable name live in `config.toml`; key values
+  belong in `<PERSOME_ROOT>/env`, never TOML.
 - `install.sh` generates and preserves `PERSOME_SCREENSHOT_KEY`. If encrypted
   screenshot persistence lacks a valid key, omit pixels; never write plaintext.
 - Default Point/Line production is the windowed `memory_delta` followed by

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -110,4 +110,6 @@ legacy completed activity can be read through a neutral adapter.
 - A model export is redacted by default and written with mode `0600`.
 - SQLite access uses `with fts.cursor() as conn:` so readers and the writer
   coexist under WAL mode.
-- LLM calls flow through `writer/llm.py`; secrets stay out of `config.toml`.
+- LLM calls flow through `writer/llm.py` over Anthropic Messages or
+  OpenAI-compatible Chat Completions. Route metadata lives in `config.toml`;
+  key values stay in the owner-only `env` file.

--- a/README.md
+++ b/README.md
@@ -91,18 +91,30 @@ required to read focused AX text and structure. Grant **Screen Recording** only
 when enabling OCR fallback or screenshot retention; it supplies pixels to the
 local OCR worker. Persome does not require Full Disk Access.
 
-An LLM key is optional for collection and BM25 recall, but required for real
-semantic modeling. `install.sh` can save an Anthropic key or an
-Anthropic-compatible gateway key to the owner-only `~/.persome/env` file.
-Nothing ships with a key.
+An LLM is optional for collection and BM25 recall, but required for semantic
+modeling. During installation, the provider wizard discovers existing keys,
+lets you edit the endpoint and model, tests completion and tool calling, and
+only then saves the route. API keys go to the owner-only `~/.persome/env` file;
+the non-secret route goes to `~/.persome/config.toml`. Nothing ships with a key.
 
 ```bash
-# If the installer was run without a key:
-printf 'ANTHROPIC_API_KEY=%s\n' 'your-provider-key' >> ~/.persome/env
-chmod 600 ~/.persome/env
+# If provider setup was skipped during installation:
+persome llm providers
+persome llm setup
+persome llm status --check
+
+# Restart after changing the active provider:
 persome stop || true
 persome start
 ```
+
+Persome speaks two wire protocols: native Anthropic Messages and
+OpenAI-compatible Chat Completions. Presets cover Anthropic, OpenAI, DeepSeek,
+OpenRouter, Gemini, Groq, Mistral, xAI, Qwen, Moonshot/Kimi, Zhipu GLM,
+SiliconFlow, Together, Fireworks, Cerebras, Azure OpenAI, Ollama, LM Studio, and
+vLLM. `custom-openai` and `custom-anthropic` accept another compatible endpoint.
+A preset means the route is configured, not that every model has the necessary
+capabilities; Persome warns when the selected model cannot call tools.
 
 Active work is reduced every five minutes by default. A first useful recall is
 therefore expected within ten minutes of valid capture plus a working semantic

--- a/SECURITY_PRIVACY.md
+++ b/SECURITY_PRIVACY.md
@@ -34,7 +34,9 @@ screenshot when persistent screenshot storage is off.
 There is no telemetry or update phone-home. Runtime egress occurs only through
 configured capabilities:
 
-1. `ANTHROPIC_BASE_URL` receives prompts for enabled LLM stages and Chat. Stage
+1. The endpoint selected under `[models.default]` receives prompts for enabled
+   LLM stages and Chat over Anthropic Messages or OpenAI-compatible Chat
+   Completions. Stage
    prompts can contain derived personal context. When Chat invokes a memory or
    capture tool, the next model request also contains that tool result, which
    can include raw memory text, screen text, window titles, URLs, focused-field
@@ -61,7 +63,7 @@ model stages report degradation rather than silently claiming success.
   endpoint.
 - MCP tool execution itself has no provider egress, but a connected agent may
   send returned personal data to its own model provider. Persome Chat sends
-  tool results to the configured `ANTHROPIC_BASE_URL` as described above.
+  tool results to the configured Runtime LLM endpoint as described above.
 - `/model/graph` is a raw owner-local inspection surface. Default CLI/MCP model
   export is redacted; the browser viewer is not a safe publication artifact.
 - Exposing the server through a tunnel changes the privacy boundary and is not

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -73,6 +73,7 @@ After installing the Swift helpers and granting Accessibility permission:
 
 ```bash
 bash install.sh
+persome llm status --check
 persome doctor
 persome start
 
@@ -91,8 +92,9 @@ The installer generates `PERSOME_SCREENSHOT_KEY` automatically. Exports
 default to `<PERSOME_ROOT>/exports/`, are redacted, and use mode `0600`.
 `--raw` is an explicit sensitive-data opt-out from redaction.
 
-Without an LLM key, capture and BM25 retrieval continue while semantic modeling
-reports degradation. A sparse model may correctly remain degraded until it has
+Without a configured hosted credential or keyless local endpoint, capture and
+BM25 retrieval continue while semantic modeling reports degradation. A sparse
+model may correctly remain degraded until it has
 enough repeated evidence for higher geometry.
 
 ## 6. Verify the release artifact
@@ -109,6 +111,8 @@ uv pip install --python /tmp/persome-wheel-venv/bin/python dist/persome_core-*.w
 cd /tmp
 PERSOME_ROOT=/tmp/persome-wheel-root \
   /tmp/persome-wheel-venv/bin/persome doctor
+PERSOME_ROOT=/tmp/persome-wheel-root \
+  /tmp/persome-wheel-venv/bin/persome llm providers
 ```
 
 `persome ocr-selftest <image>` performs a full bundled OCR inference check on
@@ -135,7 +139,8 @@ PERSOME_ROOT=/tmp/persome-soak uv run python scripts/soak_healthcheck.py
 ```
 
 The soak check rebuilds the retrieval projection in the copied root. It should
-not be pointed at a live store. Provider maintainers can verify prompt-cache
-support separately with `scripts/probe_prompt_cache.py`; it uses
-`ANTHROPIC_API_KEY` and `ANTHROPIC_BASE_URL` by default and performs two real
+not be pointed at a live store. Verify the active Runtime profile with
+`persome llm status --check`; it tests completion and tool calling. Anthropic
+endpoint maintainers can additionally inspect prompt-cache behavior with
+`scripts/probe_prompt_cache.py`; that protocol-specific probe performs two real
 LLM calls.

--- a/docs/api.md
+++ b/docs/api.md
@@ -31,6 +31,10 @@ Face, Volume, and Root hierarchy from their declared `members`. It loads its
 pinned Three.js modules from `/model/assets/*`; those package resources are
 intentionally omitted from OpenAPI.
 
+`/status.data.llm_profile` reports the effective provider, protocol, model,
+endpoint, key variable name, credential presence, and legacy-migration state.
+It never returns the credential value.
+
 ## Chat routes
 
 | Method | Path | Purpose |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -152,7 +152,8 @@ audio, or evaluation runner.
 
 ## Failure semantics
 
-- No provider key: capture and BM25 remain available; semantic stages report
+- No selected provider credential (unless using a keyless local endpoint):
+  capture and BM25 remain available; semantic stages report
   skips/failures and model status stays degraded.
 - OCR worker crash: the worker is restarted/fails open; the daemon survives.
 - Reducer failure: persisted exponential retry; final exhaustion writes an

--- a/docs/config.md
+++ b/docs/config.md
@@ -76,9 +76,10 @@ Ollama, LM Studio, and vLLM. Presets describe endpoint defaults, not a blanket
 capability guarantee for every model. Use `custom-openai` or
 `custom-anthropic` for another compatible gateway.
 
-For migration, a config without `provider`, `protocol`, and `api_key_env`
-retains the former `ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL` route exactly.
-Running `persome llm setup` tests and converts that route to explicit fields.
+For migration, a config without `provider` and `protocol` retains the former
+`ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL` route exactly, even if an older file
+contains an ignored `api_key_env`. Running `persome llm setup` tests and
+converts that route to explicit fields.
 
 ## Capture
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -7,19 +7,38 @@ file is created on first initialization.
 ```bash
 persome config   # print the path and current file
 persome doctor   # offline prerequisites; no LLM call
+persome llm status --check  # live completion and tool-call check
 ```
 
 The daemon loads configuration once. Restart it after editing.
 
 ## Providers and stage models
 
-All semantic stages use the Anthropic Messages API through the official SDK in
-`writer/llm.py`. `model` is the bare name accepted by the configured endpoint.
+One profile powers semantic stages and Chat. Persome supports native Anthropic
+Messages and OpenAI-compatible Chat Completions. Use the guided path instead of
+editing secrets by hand:
+
+```bash
+persome llm providers       # presets and locally detected key names
+persome llm setup           # select, edit, probe, then save
+persome llm status --check  # inspect the effective route and retest it
+```
+
+`setup` checks the current profile first, auto-selects when exactly one known
+credential is found, prompts when several are available, and accepts keyless
+local endpoints. It makes a small completion call and a forced tool call before
+saving. A failed connectivity/authentication probe writes nothing. A model that
+completes but cannot call tools requires an explicit degraded-mode confirmation.
+
+The resulting non-secret configuration has this shape:
 
 ```toml
 [models.default]
-model = "deepseek-v4-flash"
-# base_url = ""       # rare per-stage override; prefer env
+provider = "openrouter"
+protocol = "openai"
+model = "anthropic/claude-sonnet-4"
+base_url = "https://openrouter.ai/api/v1"
+api_key_env = "OPENROUTER_API_KEY"
 # max_tokens = 4096
 
 [models.timeline]
@@ -32,11 +51,10 @@ model = "deepseek-v4-flash"
 [models.schema_miner]
 ```
 
-Credentials in `<PERSOME_ROOT>/env`:
+Only the value named by `api_key_env` is stored in `<PERSOME_ROOT>/env`:
 
 ```dotenv
-ANTHROPIC_API_KEY=...
-# ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic
+OPENROUTER_API_KEY=...
 
 # Optional dense retrieval:
 OPENAI_API_KEY=...
@@ -46,9 +64,21 @@ OPENAI_API_KEY=...
 Common model stages are `timeline`, `reducer`, `classifier`, `memory_delta`,
 `pattern_detector`, `case_extractor`, `compact`, `schema_miner`,
 `cross_domain_sweeper`, `root_synthesis`, `contradiction_check`, and
-`memory_decay`. The classifier and pattern detector require correct Anthropic
-tool-use support. JSON stages require reliable structured output. No-key mode
-still captures and serves BM25, but semantic model stages remain degraded.
+`memory_decay`. Tool-loop stages require function/tool calling; JSON stages
+require reliable structured output. Without a hosted credential or keyless
+local endpoint, Persome still captures and serves BM25, but semantic model
+stages remain degraded.
+
+Hosted presets currently include Anthropic, OpenAI, DeepSeek, OpenRouter,
+Gemini, Groq, Mistral, xAI, Qwen, Moonshot/Kimi, Zhipu GLM, SiliconFlow,
+Together, Fireworks, Cerebras, and Azure OpenAI. Keyless local presets cover
+Ollama, LM Studio, and vLLM. Presets describe endpoint defaults, not a blanket
+capability guarantee for every model. Use `custom-openai` or
+`custom-anthropic` for another compatible gateway.
+
+For migration, a config without `provider`, `protocol`, and `api_key_env`
+retains the former `ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL` route exactly.
+Running `persome llm setup` tests and converts that route to explicit fields.
 
 ## Capture
 
@@ -297,7 +327,7 @@ read_receipt_enabled = true
 entity_graph_enabled = true
 
 [chat]
-model = "deepseek-v4-flash"
+# The complete models.default profile is inherited unless overridden here.
 thinking_budget = 0
 unsafe_local_tools_enabled = false
 mcp_connect_daemon = true
@@ -316,6 +346,10 @@ Chat always loads skill Markdown as model guidance. Executable
 `unsafe_local_tools_enabled=true`. Configured external MCP servers are another
 explicit trust expansion and can have their own network behavior. The Runtime
 ships a terminal client (`persome chat`), not a browser Chat page.
+
+Anthropic profiles retain prompt caching and optional extended thinking.
+OpenAI-compatible profiles use streamed Chat Completions and the same built-in
+and MCP tools; `thinking_budget` is ignored on that protocol.
 
 ## Privacy and API flags
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,7 @@ uv run python scripts/sample_demo.py
 
 ```bash
 bash install.sh
+persome llm status --check
 persome doctor
 persome start
 open http://127.0.0.1:8742/model
@@ -43,6 +44,7 @@ optional on-device OCR, and serves streamable HTTP MCP at
 
 - [Product experience and Quick Start](https://github.com/Persome-ai/persome-core#readme)
 - [Architecture](architecture.md)
+- [LLM provider configuration](config.md#providers-and-stage-models)
 - [MCP clients](mcp-clients.md)
 - [Operations and data control](operations.md)
 - [Benchmark scope](benchmarks.md)

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -74,7 +74,7 @@ port = 8742
   only connect trusted clients.
 - The MCP server does not forward results to a model provider by itself. A
   connected agent may do so, and Persome Chat sends invoked tool results to its
-  configured `ANTHROPIC_BASE_URL`.
+  configured Runtime LLM endpoint.
 - Screenshots are excluded unless a tool call explicitly requests one.
 - `get_model_snapshot` redacts detectable secrets and local paths by default.
 - Write tools are explicit and auditable; the removed computer-use tools are

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -52,6 +52,7 @@ data, not harmless metadata.
 ## Lifecycle and first recall
 
 ```bash
+persome llm status --check
 persome doctor
 persome start
 persome status
@@ -63,8 +64,9 @@ persome stop
 The default active-session flush is five minutes. Timeline closure and model
 processing add bounded local work, so the operational target for first useful
 recall is at most ten minutes after valid AX capture and provider availability.
-No-key mode still supports capture and BM25 recall; semantic modeling reports a
-degraded state until a provider is configured.
+Without a hosted credential or keyless local endpoint, capture and BM25 recall
+still work; semantic modeling reports a degraded state. Run
+`persome llm setup` to change the active route, then restart the daemon.
 
 Use these checks when memory does not appear:
 

--- a/docs/runtime-internals.md
+++ b/docs/runtime-internals.md
@@ -7,14 +7,14 @@ mode `0600`. `persome start` loads this file before daemonization. Business
 code reads the resulting environment variables:
 
 ```text
-ANTHROPIC_API_KEY
-ANTHROPIC_BASE_URL
-OPENAI_API_KEY
-OPENAI_BASE_URL
+<api_key_env selected by models.default>
+OPENAI_API_KEY / OPENAI_BASE_URL (optional dense retrieval)
 PERSOME_SCREENSHOT_KEY
 ```
 
-`config.toml` contains behavior and model names, never API keys. `PERSOME_ROOT`
+`config.toml` contains behavior plus the provider id, protocol, model, endpoint,
+and key variable name, never the key value. `persome llm setup` writes that
+profile only after a live check. `PERSOME_ROOT`
 redirects the entire runtime for tests or isolated profiles.
 `install.sh` generates the machine-local screenshot key automatically and
 preserves it across reinstalls; it is not a provider credential.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,7 +2,9 @@
 
 Work from symptoms to cause. Each section links to the relevant log file under `~/.persome/logs/`.
 
-Start with the install self-check — it covers the most common bring-your-own-key setup mistakes (env file missing / wrong perms, no `ANTHROPIC_API_KEY`, uncompiled Swift helpers, missing Accessibility grant, occupied port) in one offline pass:
+Start with the install self-check. It covers an absent/private env file, a
+missing selected-provider credential, endpoint reachability, uncompiled Swift
+helpers, Accessibility, and the daemon port in one offline pass:
 
 ```bash
 persome doctor   # ✓/✗/⚠ per prerequisite; exits 1 if anything FAILS; zero LLM calls
@@ -30,8 +32,10 @@ persome start --foreground
 Read the console output. Common culprits:
 
 - `OSError: [Errno 48] Address already in use` → another process holds port 8742. `lsof -i :8742` to find it.
-- Missing `ANTHROPIC_API_KEY` does not prevent capture startup; it degrades LLM
-  stages. Put provider secrets in `~/.persome/env`, never `config.toml`.
+- A missing selected-provider credential does not prevent capture startup; it
+  degrades LLM stages. Run `persome llm setup`, then verify with
+  `persome llm status --check`. Key values belong in `~/.persome/env`, never
+  `config.toml`.
 - `mac-ax-helper` / `mac-ax-watcher` binary missing → run `bash install.sh`.
 
 ## Captures are empty / tree has no content

--- a/docs/writer.md
+++ b/docs/writer.md
@@ -155,7 +155,10 @@ selected projections and preserve receipts/history.
 
 ## LLM and failure rules
 
-- Stage calls use `writer/llm.py`; keys come from `<PERSOME_ROOT>/env`.
+- Stage calls use `writer/llm.py` with the profile selected by
+  `persome llm setup`. Anthropic Messages and OpenAI-compatible Chat
+  Completions share one response/tool-loop contract; keys come from
+  `<PERSOME_ROOT>/env`.
 - Terminal finalization sets `sessions.modeled_at` only after every enabled
   stage completes or reports a deliberate benign skip.
 - Semantic-stage errors degrade the model and remain retryable; they do not

--- a/install.sh
+++ b/install.sh
@@ -324,11 +324,9 @@ inject_detected_clients() {
   fi
 }
 
-maybe_configure_api_key() {
+maybe_configure_llm() {
   local config_path="${INSTALL_HOME}/config.toml"
-  local env_path="${INSTALL_HOME}/env"
 
-  # Create default config if missing
   if [[ ! -f "${config_path}" ]]; then
     log "creating default config at ${config_path}"
     "${VENV_DIR}/bin/python" -c "
@@ -339,56 +337,31 @@ write_default_if_missing()
 " || warn "failed to create default config; you can create it manually later"
   fi
 
-  # Secrets live in the 0600 env file next to config.toml (never in config.toml).
-  # Skip if a key is already provided (env file or the current shell).
-  if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
-    log "ANTHROPIC_API_KEY detected in environment"
-    return 0
-  fi
-  if [[ -f "${env_path}" ]] && grep -qE '^ANTHROPIC_API_KEY=.' "${env_path}" 2>/dev/null; then
-    log "ANTHROPIC_API_KEY already set in ${env_path}"
-    return 0
-  fi
-
-  # Skip in non-interactive mode
   if [[ ! -t 0 ]]; then
+    log "non-interactive install: run 'persome llm setup' to configure a provider"
     return 0
   fi
 
   echo ""
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "  LLM API Key Setup (bring your own key)"
+  echo "  LLM Provider Setup (bring your own key or local model)"
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
   echo ""
-  echo "The daemon calls an LLM (Anthropic Messages API) for timeline"
-  echo "normalisation, session reduction, and durable-memory writing."
-  echo "It uses YOUR key — nothing is sent anywhere else."
+  echo "Persome can discover existing provider credentials or configure an"
+  echo "Anthropic Messages / OpenAI-compatible endpoint. It verifies both"
+  echo "completion and tool calling before saving anything."
   echo ""
-  echo "The key is written to ${env_path} (chmod 600). To use a compatible"
-  echo "gateway instead of api.anthropic.com (e.g. DeepSeek's /anthropic"
-  echo "endpoint), you can also set a base URL below."
-  echo ""
-
-  local api_key base_url
-  read -r -s -p "Enter ANTHROPIC_API_KEY (or press Enter to skip): " api_key
-  printf '\n'
-  if [[ -z "${api_key}" ]]; then
-    echo "Skipped. Set it later:  echo 'ANTHROPIC_API_KEY=sk-...' >> ${env_path}"
+  if ! prompt_yes_no "Configure and test the Runtime LLM now?"; then
+    echo "Skipped. Run 'persome llm setup' at any time."
     return 0
   fi
-  read -r -p "Base URL for a gateway (or Enter for api.anthropic.com): " base_url
-
-  umask 177  # 0600 for the secrets file
-  {
-    printf 'ANTHROPIC_API_KEY=%s\n' "${api_key}"
-    [[ -n "${base_url}" ]] && printf 'ANTHROPIC_BASE_URL=%s\n' "${base_url}"
-  } >>"${env_path}" || warn "failed to write ${env_path}"
-  chmod 600 "${env_path}" 2>/dev/null || true
-  log "API key saved to ${env_path} (chmod 600)"
+  if ! "${INSTALL_BIN_DIR}/persome" llm setup; then
+    warn "LLM setup was not completed; rerun it later with 'persome llm setup'"
+  fi
 
   echo ""
   echo "Optional: for semantic (paraphrase-robust) memory search, also set"
-  echo "OPENAI_* embedding credentials in ${env_path}. Without them the"
+  echo "OPENAI_* embedding credentials in ${INSTALL_HOME}/env. Without them the"
   echo "daemon runs keyword (BM25) search only — no degraded behaviour."
   echo ""
   echo "OCR for AX-poor apps (WeChat/Feishu) runs fully on-device (bundled"
@@ -458,6 +431,10 @@ Connect an agent (MCP):
 
 Run a health check any time:
   persome doctor
+
+Change or verify the LLM provider:
+  persome llm setup
+  persome llm status --check
 EOF
 
   case ":${PATH}:" in
@@ -483,7 +460,7 @@ main() {
   install_shim
   verify_install
   inject_detected_clients
-  maybe_configure_api_key
+  maybe_configure_llm
   ensure_screenshot_key
   print_summary
 }

--- a/persome.spec
+++ b/persome.spec
@@ -2,7 +2,7 @@
 #
 # Use a spec because several dependencies dynamically import modules that a
 # static scan cannot see. collect_all and collect_submodules include them
-# explicitly. LLM traffic uses the Anthropic SDK over httpx.
+# explicitly. LLM traffic uses the Anthropic or OpenAI SDK over httpx.
 #
 # Invocation used by build_python_bundle.sh:
 #   pyinstaller --noconfirm \
@@ -43,6 +43,9 @@ datas, binaries, hiddenimports = _merge(
     collect_all("mcp"),
     collect_all("typer"),
     collect_all("rich"),
+    collect_all("anthropic"),
+    collect_all("openai"),
+    collect_all("tomlkit"),
     # PaddleOCR for on-device OCR (PP-OCRv6 tiny tier) — arm64 macOS only;
     # paddle has no x86_64 macOS wheel, so these are no-ops on x86_64 builds.
     _safe_collect("paddleocr"),
@@ -87,7 +90,7 @@ for _mod in ("imagesize", "pyclipper", "bidi", "einops", "ftfy",
     except Exception:
         pass
 
-# HTTP stack: the Anthropic SDK uses httpx; OCR and optional web paths use
+# HTTP stack: both LLM SDKs use httpx; OCR and optional web paths use
 # requests. requests/urllib3 contrib modules are dynamic and must be collected
 # so gzip, zstandard, and brotli responses can be decompressed.
 hiddenimports += collect_submodules("httpx")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,8 @@ dependencies = [
     "certifi>=2024.2",
     "cryptography>=42.0",
     "anthropic>=0.50",
-    "openai>=1.75",
-    "tomlkit>=0.13",
+    "openai>=1.75,<3",
+    "tomlkit>=0.13,<1",
     # On-device OCR for AX-poor apps (WeChat/Feishu). PP-OCRv6 via paddleocr on the
     # paddlepaddle CPU runtime; weights are vendored in ocr_models/ and loaded from a
     # local dir (no network). Paddle's macOS wheel is arm64-only; Intel installs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ dependencies = [
     "certifi>=2024.2",
     "cryptography>=42.0",
     "anthropic>=0.50",
+    "openai>=1.75",
+    "tomlkit>=0.13",
     # On-device OCR for AX-poor apps (WeChat/Feishu). PP-OCRv6 via paddleocr on the
     # paddlepaddle CPU runtime; weights are vendored in ocr_models/ and loaded from a
     # local dir (no network). Paddle's macOS wheel is arm64-only; Intel installs

--- a/src/persome/api/chat_models.py
+++ b/src/persome/api/chat_models.py
@@ -10,8 +10,9 @@ from pydantic import BaseModel, Field
 
 
 class ChatMessageBlock(BaseModel):
-    """One block in an assistant/user turn — preserves the Anthropic content-list
-    structure so clients can render text + tool calls in their original order.
+    """One block in a provider-folded turn.
+
+    Preserves text and tool calls in their original order.
 
     Each block carries the subset of fields relevant to its ``type``; other
     fields are ``None`` (omitted from the wire form because of

--- a/src/persome/api/chat_routes.py
+++ b/src/persome/api/chat_routes.py
@@ -149,8 +149,8 @@ def _first_user_preview(messages: list[dict[str, Any]]) -> str | None:
     """Build a sidebar preview string from the first user turn.
 
     Walks ``messages`` in order, picks the first ``role=="user"`` entry,
-    normalizes its content to a plain string (collapsing Anthropic SDK
-    block lists via :func:`_content_to_text`), strips whitespace, and
+    normalizes its content to a plain string (collapsing provider block lists
+    via :func:`_content_to_text`), strips whitespace, and
     truncates with an ellipsis if it exceeds ``_PREVIEW_MAX_CHARS``.
     Returns ``None`` when there is no user message or the content is
     effectively empty — callers should treat ``None`` as "fall back to
@@ -175,12 +175,9 @@ def _first_user_preview(messages: list[dict[str, Any]]) -> str | None:
 def _content_to_text(content: Any) -> str | None:
     """Normalize a stored message ``content`` field to a plain string.
 
-    Sessions persist assistant turns in the Anthropic SDK shape — content is
-    a list of blocks like ``[{"type": "text", "text": "..."}, {"type":
-    "tool_use", ...}]``. The HTTP contract advertises ``content: str | None``,
-    so we collapse text blocks into one string here and drop non-text blocks
-    (tool_use / thinking are surfaced via the SSE stream, not the history
-    endpoint).
+    Anthropic turns use a list of content blocks; OpenAI-compatible turns use a
+    string plus optional ``tool_calls``. This helper collapses the former while
+    plain strings pass through unchanged.
     """
     if content is None or isinstance(content, str):
         return content
@@ -208,7 +205,7 @@ def _is_real_user(content: Any) -> bool:
 
 
 def _projected_block(b: dict[str, Any]) -> dict[str, Any] | None:
-    """Project a stored Anthropic content block to the wire-shape block.
+    """Project a stored provider content block to the wire-shape block.
 
     Stored blocks may carry extra fields (cache markers, signatures, other
     internal SDK keys); the wire shape only keeps what clients render.
@@ -278,8 +275,35 @@ def _projected_blocks(content: Any) -> list[dict[str, Any]]:
     return []
 
 
+def _openai_tool_use_blocks(message: dict[str, Any]) -> list[dict[str, Any]]:
+    """Project OpenAI ``tool_calls`` into the public tool-use block shape."""
+    out: list[dict[str, Any]] = []
+    for call in message.get("tool_calls") or []:
+        if not isinstance(call, dict):
+            continue
+        function = call.get("function")
+        if not isinstance(function, dict):
+            continue
+        arguments = function.get("arguments") or "{}"
+        if isinstance(arguments, str):
+            try:
+                parsed = json.loads(arguments)
+            except json.JSONDecodeError:
+                parsed = {}
+        else:
+            parsed = arguments
+        out.append(
+            {
+                "type": "tool_use",
+                "name": function.get("name") or "",
+                "input": parsed if isinstance(parsed, dict) else {},
+            }
+        )
+    return out
+
+
 def _fold_agent_loop(raw: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Collapse Anthropic agent-loop iterations into one assistant turn.
+    """Collapse provider agent-loop iterations into one assistant turn.
 
     Storage keeps each loop iteration faithful (assistant text+tool_use →
     user tool_result → assistant text+tool_use → ... → final assistant
@@ -333,6 +357,16 @@ def _fold_agent_loop(raw: list[dict[str, Any]]) -> list[dict[str, Any]]:
             pending_blocks.extend(_projected_blocks(content))
         elif role == "assistant":
             pending_blocks.extend(_projected_blocks(content))
+            pending_blocks.extend(_openai_tool_use_blocks(m))
+        elif role == "tool":
+            pending_blocks.append(
+                {
+                    "type": "tool_result",
+                    "name": m.get("name"),
+                    "content": str(content or ""),
+                    "tool_use_id": m.get("tool_call_id"),
+                }
+            )
     _flush_assistant()
     return out
 

--- a/src/persome/api/routes.py
+++ b/src/persome/api/routes.py
@@ -195,16 +195,17 @@ def status() -> ApiResponse:
     try:
         from concurrent.futures import ThreadPoolExecutor
 
-        from ..config import infer_provider, provider_api_key, provider_base_url
+        from ..llm_setup import profile_dict
+        from ..providers import resolve_profile
         from ..writer.llm import ping_stage
 
-        dedup: dict[tuple[str, str, str], list[str]] = {}
+        data["llm_profile"] = profile_dict(resolve_profile(cfg.model_for("default")))
+
+        dedup: dict[tuple[str, str, str, str], list[str]] = {}
         for stage in stages:
             m = cfg.model_for(stage)
-            provider = infer_provider(m.model)
-            base_url = m.base_url or (provider_base_url(provider) or "")
-            api_key = provider_api_key(provider) or ""
-            key = (m.model, base_url, api_key)
+            profile = resolve_profile(m)
+            key = (profile.protocol, profile.model, profile.base_url, profile.api_key or "")
             dedup.setdefault(key, []).append(stage)
 
         if dedup:

--- a/src/persome/chat/agent.py
+++ b/src/persome/chat/agent.py
@@ -51,7 +51,7 @@ def complete_sync(
         extra["X-Trace-Id"] = tid
     if profile.protocol == "anthropic":
         client = anthropic.Anthropic(
-            api_key=profile.api_key,
+            api_key=profile.client_api_key(),
             base_url=profile.base_url or None,
         )
         msg = client.messages.create(
@@ -68,7 +68,7 @@ def complete_sync(
     from openai import OpenAI
 
     client = OpenAI(
-        api_key=profile.api_key or "local-no-key",
+        api_key=profile.client_api_key(),
         base_url=profile.base_url,
     )
     response = client.chat.completions.create(
@@ -345,14 +345,14 @@ class ChatAgent:
         self._profile: ResolvedLLMProfile = resolve_profile(cfg)
         if self._profile.protocol == "anthropic":
             self.client = AsyncAnthropic(
-                api_key=self._profile.api_key,
+                api_key=self._profile.client_api_key(),
                 base_url=self._profile.base_url or None,
             )
         else:
             from openai import AsyncOpenAI
 
             self.client = AsyncOpenAI(
-                api_key=self._profile.api_key or "local-no-key",
+                api_key=self._profile.client_api_key(),
                 base_url=self._profile.base_url,
             )
         self.model = self._profile.wire_model

--- a/src/persome/chat/agent.py
+++ b/src/persome/chat/agent.py
@@ -1,4 +1,4 @@
-"""Anthropic SDK-based agent loop for interactive chat."""
+"""Provider-aware agent loops for interactive chat."""
 
 from __future__ import annotations
 
@@ -19,6 +19,7 @@ from mcp.client.streamable_http import streamable_http_client
 
 from .. import config as config_mod
 from ..logger import get as _get_logger
+from ..providers import ResolvedLLMProfile, resolve_profile
 from ..trace import get_trace_id
 from .tools import to_anthropic_tools
 
@@ -38,29 +39,45 @@ def complete_sync(
     *,
     max_tokens: int = 2048,
 ) -> str:
-    """One-shot synchronous Anthropic call. Returns the first text block.
+    """One-shot synchronous provider call. Returns the first text response.
 
     Shared by all auxiliary LLM callers (compression, away summary,
     memory extraction) so provider config is resolved in one place.
     """
-    client = anthropic.Anthropic(
-        api_key=config_mod.provider_api_key("anthropic"),
-        base_url=config_mod.provider_base_url("anthropic"),
-    )
+    profile = resolve_profile(chat_cfg)
     extra: dict[str, str] = {}
     tid = get_trace_id()
     if tid:
         extra["X-Trace-Id"] = tid
-    msg = client.messages.create(
-        model=chat_cfg.model,
-        messages=messages,  # type: ignore[arg-type]
+    if profile.protocol == "anthropic":
+        client = anthropic.Anthropic(
+            api_key=profile.api_key,
+            base_url=profile.base_url or None,
+        )
+        msg = client.messages.create(
+            model=profile.wire_model,
+            messages=messages,  # type: ignore[arg-type]
+            max_tokens=max_tokens,
+            extra_headers=extra or None,
+        )
+        for block in msg.content:
+            if hasattr(block, "text"):
+                return block.text
+        return ""
+
+    from openai import OpenAI
+
+    client = OpenAI(
+        api_key=profile.api_key or "local-no-key",
+        base_url=profile.base_url,
+    )
+    response = client.chat.completions.create(
+        model=profile.wire_model,
+        messages=_to_openai_messages(messages),  # type: ignore[arg-type]
         max_tokens=max_tokens,
         extra_headers=extra or None,
     )
-    for block in msg.content:
-        if hasattr(block, "text"):
-            return block.text
-    return ""
+    return response.choices[0].message.content or ""
 
 
 @dataclass
@@ -102,6 +119,77 @@ def _to_anthropic_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any
             out.append({"role": role, "content": content})
     if out:
         out[-1] = _with_terminal_cache_breakpoint(out[-1])
+    return out
+
+
+def _to_openai_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Normalize persisted Anthropic/OpenAI history for Chat Completions."""
+    out: list[dict[str, Any]] = []
+    for message in messages:
+        role = message.get("role")
+        content = message.get("content")
+        if role == "system":
+            if isinstance(content, str) and content:
+                out.append({"role": "system", "content": content})
+            continue
+        if role == "tool":
+            out.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": message.get("tool_call_id"),
+                    "content": str(content or ""),
+                }
+            )
+            continue
+        if role not in {"user", "assistant"}:
+            continue
+
+        if isinstance(content, str):
+            normalized: dict[str, Any] = {"role": role, "content": content}
+            if role == "assistant" and message.get("tool_calls"):
+                normalized["tool_calls"] = message["tool_calls"]
+            out.append(normalized)
+            continue
+        if not isinstance(content, list):
+            continue
+
+        text_parts: list[str] = []
+        tool_calls: list[dict[str, Any]] = []
+        tool_results: list[dict[str, Any]] = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            block_type = block.get("type")
+            if block_type == "text" and block.get("text"):
+                text_parts.append(str(block["text"]))
+            elif block_type == "tool_use" and role == "assistant":
+                tool_calls.append(
+                    {
+                        "id": block.get("id"),
+                        "type": "function",
+                        "function": {
+                            "name": block.get("name", ""),
+                            "arguments": json.dumps(block.get("input") or {}, ensure_ascii=False),
+                        },
+                    }
+                )
+            elif block_type == "tool_result" and role == "user":
+                tool_results.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": block.get("tool_use_id"),
+                        "content": str(block.get("content") or ""),
+                    }
+                )
+        if role == "assistant":
+            normalized = {"role": "assistant", "content": "\n".join(text_parts) or None}
+            if tool_calls:
+                normalized["tool_calls"] = tool_calls
+            if normalized["content"] or tool_calls:
+                out.append(normalized)
+        elif text_parts:
+            out.append({"role": "user", "content": "\n".join(text_parts)})
+        out.extend(tool_results)
     return out
 
 
@@ -235,12 +323,10 @@ def _accumulate_usage(msg_usage: Any, usage: dict[str, int]) -> None:
 
 
 class ChatAgent:
-    """Agentic chat loop backed by the Anthropic Python SDK tool_runner.
+    """Agentic chat loop backed by the configured provider protocol.
 
-    Each call to ``run_turn`` uses ``client.beta.messages.tool_runner(stream=True)``
-    which handles the multi-round tool-call loop internally. Per-token streaming
-    is preserved — each round yields a ``BetaAsyncMessageStream`` that we iterate
-    for token events.
+    Anthropic uses its SDK tool runner and prompt caching. OpenAI-compatible
+    providers use a small explicit streaming tool loop over Chat Completions.
 
     Tools included per turn:
       - Built-in handlers (sync, wrapped via ``_make_async_sdk_tool``)
@@ -256,12 +342,22 @@ class ChatAgent:
         *,
         daemon_mcp_url: str = "",
     ) -> None:
-        self.client = AsyncAnthropic(
-            api_key=config_mod.provider_api_key("anthropic"),
-            base_url=config_mod.provider_base_url("anthropic"),
-        )
-        self.model = cfg.model
+        self._profile: ResolvedLLMProfile = resolve_profile(cfg)
+        if self._profile.protocol == "anthropic":
+            self.client = AsyncAnthropic(
+                api_key=self._profile.api_key,
+                base_url=self._profile.base_url or None,
+            )
+        else:
+            from openai import AsyncOpenAI
+
+            self.client = AsyncOpenAI(
+                api_key=self._profile.api_key or "local-no-key",
+                base_url=self._profile.base_url,
+            )
+        self.model = self._profile.wire_model
         self._cfg = cfg
+        self._openai_schemas = [dict(schema) for schema in all_schemas]
         self._sdk_schemas = to_anthropic_tools(all_schemas)
         self._handlers = all_handlers
         self._daemon_mcp_url = daemon_mcp_url
@@ -342,6 +438,35 @@ class ChatAgent:
         await self.client.close()
 
     async def run_turn(
+        self,
+        messages: list[dict[str, Any]],
+        system: str,
+        *,
+        on_token: _OnTokenT | None = None,
+        on_thinking: _OnTokenT | None = None,
+        on_tool_call: _OnToolCallT | None = None,
+        max_tokens: int = 8192,
+        thinking_budget: int = 0,
+    ) -> AgentTurnResult:
+        if self._profile.protocol == "openai":
+            return await self._run_openai_turn(
+                messages,
+                system,
+                on_token=on_token,
+                on_tool_call=on_tool_call,
+                max_tokens=max_tokens,
+            )
+        return await self._run_anthropic_turn(
+            messages,
+            system,
+            on_token=on_token,
+            on_thinking=on_thinking,
+            on_tool_call=on_tool_call,
+            max_tokens=max_tokens,
+            thinking_budget=thinking_budget,
+        )
+
+    async def _run_anthropic_turn(
         self,
         messages: list[dict[str, Any]],
         system: str,
@@ -536,6 +661,220 @@ class ChatAgent:
             )
 
         except Exception as exc:
+            _logger.exception("turn error: %s", exc)
+            return AgentTurnResult(
+                messages=messages,
+                assistant_message=final_text,
+                tool_calls_executed=tool_calls_executed,
+                usage=usage,
+                error=str(exc),
+                ttft_ms=ttft_ms,
+            )
+
+        return AgentTurnResult(
+            messages=messages,
+            assistant_message=final_text,
+            tool_calls_executed=tool_calls_executed,
+            usage=usage,
+            ttft_ms=ttft_ms,
+        )
+
+    async def _run_openai_turn(
+        self,
+        messages: list[dict[str, Any]],
+        system: str,
+        *,
+        on_token: _OnTokenT | None,
+        on_tool_call: _OnToolCallT | None,
+        max_tokens: int,
+    ) -> AgentTurnResult:
+        """Run a streaming OpenAI-compatible tool loop."""
+        tool_calls_executed: list[dict[str, Any]] = []
+        usage: dict[str, int] = {}
+        final_text = ""
+        turn_start = time.perf_counter()
+        ttft_ms: float | None = None
+
+        tools: list[dict[str, Any]] = []
+        executors: dict[str, tuple[str, Any]] = {}
+        for schema in sorted(self._openai_schemas, key=lambda item: item["function"]["name"]):
+            function = schema.get("function") or {}
+            name = str(function.get("name") or "")
+            if name and name in self._handlers and name not in executors:
+                tools.append({"type": "function", "function": dict(function)})
+                executors[name] = ("static", self._handlers[name])
+
+        for spec, session in sorted(self._mcp_tool_specs, key=lambda item: item[0].name):
+            name = spec.name
+            if name in executors:
+                _logger.warning("dropping duplicate MCP tool name %r", name)
+                continue
+            tools.append(
+                {
+                    "type": "function",
+                    "function": {
+                        "name": name,
+                        "description": spec.description or "",
+                        "parameters": (
+                            dict(spec.inputSchema)
+                            if spec.inputSchema
+                            else {"type": "object", "properties": {}}
+                        ),
+                    },
+                }
+            )
+            executors[name] = ("mcp", session)
+
+        async def execute_tool(name: str, arguments: dict[str, Any]) -> str:
+            started = time.monotonic()
+            target = executors.get(name)
+            try:
+                if target is None:
+                    result: Any = {"error": f"Unknown tool: {name}"}
+                elif target[0] == "static":
+                    result = await asyncio.to_thread(target[1], arguments)
+                else:
+                    call_result = await target[1].call_tool(name=name, arguments=arguments)
+                    if call_result.isError:
+                        result = {"error": str(call_result.content)}
+                    else:
+                        parts = [item.text for item in call_result.content if hasattr(item, "text")]
+                        result = "\n".join(parts)
+            except Exception as exc:  # noqa: BLE001
+                result = {"error": f"{type(exc).__name__}: {exc}"}
+            result_str = (
+                result
+                if isinstance(result, str)
+                else json.dumps(result, ensure_ascii=False, default=str)
+            )
+            if len(result_str) > _MAX_TOOL_RESULT_BYTES:
+                truncated = len(result_str) - _MAX_TOOL_RESULT_BYTES
+                result_str = (
+                    result_str[:_MAX_TOOL_RESULT_BYTES] + f"\n...(truncated {truncated} bytes)"
+                )
+            elapsed = (time.monotonic() - started) * 1000
+            tool_calls_executed.append({"name": name, "arguments": arguments})
+            _logger.info("tool %s elapsed=%.0fms size=%d", name, elapsed, len(result_str))
+            if on_tool_call:
+                await on_tool_call(name, arguments, result_str, elapsed)
+            return result_str
+
+        wire_messages = [
+            {"role": "system", "content": system},
+            *(m for m in _to_openai_messages(messages) if m.get("role") != "system"),
+        ]
+        tid = get_trace_id()
+
+        try:
+            _logger.info("turn start messages=%d protocol=openai", len(messages))
+            for round_index in range(8):
+                request: dict[str, Any] = {
+                    "model": self.model,
+                    "messages": wire_messages,
+                    "max_tokens": max_tokens,
+                    "stream": True,
+                    "extra_headers": {"X-Trace-Id": tid} if tid else None,
+                }
+                if tools:
+                    request["tools"] = tools
+                stream = await self.client.chat.completions.create(**request)
+
+                round_text = ""
+                fragments: dict[int, dict[str, str]] = {}
+                async for chunk in stream:
+                    chunk_usage = getattr(chunk, "usage", None)
+                    if chunk_usage:
+                        for source, target in (
+                            ("prompt_tokens", "input_tokens"),
+                            ("completion_tokens", "output_tokens"),
+                        ):
+                            value = getattr(chunk_usage, source, None)
+                            if value is not None:
+                                usage[target] = usage.get(target, 0) + int(value)
+                    choices = getattr(chunk, "choices", None) or []
+                    if not choices:
+                        continue
+                    delta = choices[0].delta
+                    content = getattr(delta, "content", None)
+                    if content:
+                        if ttft_ms is None:
+                            ttft_ms = (time.perf_counter() - turn_start) * 1000
+                        round_text += content
+                        final_text += content
+                        if on_token:
+                            await on_token(content)
+                    for position, tool_delta in enumerate(getattr(delta, "tool_calls", None) or []):
+                        index = getattr(tool_delta, "index", None)
+                        index = position if index is None else int(index)
+                        fragment = fragments.setdefault(
+                            index, {"id": "", "name": "", "arguments": ""}
+                        )
+                        if getattr(tool_delta, "id", None):
+                            fragment["id"] += tool_delta.id
+                        function = getattr(tool_delta, "function", None)
+                        if function is not None:
+                            if getattr(function, "name", None):
+                                fragment["name"] += function.name
+                            if getattr(function, "arguments", None):
+                                fragment["arguments"] += function.arguments
+
+                round_tool_calls: list[dict[str, Any]] = []
+                for index in sorted(fragments):
+                    fragment = fragments[index]
+                    call_id = fragment["id"] or f"call_{round_index}_{index}"
+                    round_tool_calls.append(
+                        {
+                            "id": call_id,
+                            "type": "function",
+                            "function": {
+                                "name": fragment["name"],
+                                "arguments": fragment["arguments"] or "{}",
+                            },
+                        }
+                    )
+
+                assistant_message: dict[str, Any] = {
+                    "role": "assistant",
+                    "content": round_text or None,
+                }
+                if round_tool_calls:
+                    assistant_message["tool_calls"] = round_tool_calls
+                wire_messages.append(assistant_message)
+                messages.append(dict(assistant_message))
+
+                if not round_tool_calls:
+                    break
+
+                for tool_call in round_tool_calls:
+                    raw_arguments = tool_call["function"]["arguments"]
+                    try:
+                        arguments = json.loads(raw_arguments)
+                        if not isinstance(arguments, dict):
+                            raise TypeError("tool arguments must be an object")
+                    except (json.JSONDecodeError, TypeError) as exc:
+                        result_str = json.dumps(
+                            {"error": f"Invalid tool arguments: {exc}"}, ensure_ascii=False
+                        )
+                    else:
+                        result_str = await execute_tool(tool_call["function"]["name"], arguments)
+                    tool_message = {
+                        "role": "tool",
+                        "tool_call_id": tool_call["id"],
+                        "content": result_str,
+                    }
+                    wire_messages.append(tool_message)
+                    messages.append(dict(tool_message))
+            else:
+                raise RuntimeError("OpenAI-compatible tool loop exceeded 8 rounds")
+
+            _logger.info(
+                "turn end tools=%d usage=%s ttft_ms=%s protocol=openai",
+                len(tool_calls_executed),
+                usage,
+                f"{ttft_ms:.0f}" if ttft_ms is not None else "n/a",
+                extra={"ttft_ms": round(ttft_ms, 1)} if ttft_ms is not None else {},
+            )
+        except Exception as exc:  # noqa: BLE001
             _logger.exception("turn error: %s", exc)
             return AgentTurnResult(
                 messages=messages,

--- a/src/persome/chat/handler.py
+++ b/src/persome/chat/handler.py
@@ -76,9 +76,8 @@ def _load_compress_prompt() -> str:
 def _get_context_window(model: str) -> int:
     """Return the context window size for the given model string.
 
-    Takes a bare model identifier so the same heuristic works whether the
-    string came from ``cfg.chat.model`` or a ``[models.*]`` stage — both
-    now go through the Anthropic SDK.
+    Takes the endpoint model identifier from ``cfg.chat`` or ``[models.*]``;
+    the estimate is provider-independent.
     """
     if "[1m]" in model or "1m" in model.lower():
         return 1_000_000
@@ -592,7 +591,7 @@ async def _run_turn(
 
 
 async def run_chat(cfg: config_mod.Config) -> None:
-    """Interactive chat loop driven by the Anthropic SDK ChatAgent."""
+    """Interactive chat loop driven by the configured provider ChatAgent."""
     console.print(f"[bold]Chat with {cfg.chat.model}[/bold] (type 'exit' or Ctrl+C to quit)")
     console.print("[dim]Commands: 'new' = new conversation, 'exit' = quit[/dim]\n")
 

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -1146,6 +1146,9 @@ def llm_status(
             console.print("[green]✓ Tool calling works[/green]")
         else:
             console.print("[yellow]⚠ Tool calling was not confirmed for this model.[/yellow]")
+            if result.error:
+                console.print(f"[dim]{result.error}[/dim]")
+            raise typer.Exit(1)
 
 
 @llm_app.command("setup")

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -19,8 +19,10 @@ import signal
 import subprocess
 import sys
 import threading
+from collections.abc import Sequence
 from datetime import datetime, timedelta
 from pathlib import Path
+from urllib.parse import urlparse
 
 import typer
 from rich.console import Console
@@ -30,6 +32,7 @@ from . import __version__, integrity, paths
 from . import config as config_mod
 from . import env_file as env_file_mod
 from . import logger as logger_mod
+from .providers import ProviderSpec
 from .store import entries as entries_mod
 from .store import fts, index_md
 
@@ -319,13 +322,11 @@ def resume() -> None:
 def status() -> None:
     """Show daemon status + memory stats."""
     cfg = _init()
-    # Source the env file (LLM secrets SoT) before the per-stage model-health
-    # probe below. ping_stage builds the Anthropic client with
-    # provider_api_key("anthropic") == os.environ["ANTHROPIC_API_KEY"]; without
-    # this load the `status` process has no creds, so every stage falsely reports
-    # an auth error ("Could not resolve authentication method") even when the
-    # daemon — which loads env before forking in start() — is perfectly healthy.
+    # Source the env file before resolving/probing the selected provider.
     env_file_mod.load_env_file(paths.env_file())
+    from .providers import resolve_profile
+
+    default_profile = resolve_profile(cfg.model_for("default"))
     pid = _read_pid()
     paused = paths.paused_flag().exists()
 
@@ -373,6 +374,12 @@ def status() -> None:
         table.add_row("Captures (1h)", f"{cap_count}  {gap_str}")
 
     table.add_row("Install", _install_source())
+    credential = "ready" if default_profile.credential_ready else "credential missing"
+    table.add_row(
+        "LLM",
+        f"{default_profile.provider_label} / {default_profile.protocol} / "
+        f"{default_profile.model} ({credential})",
+    )
 
     buf = paths.capture_buffer_dir()
     if buf.exists():
@@ -409,18 +416,22 @@ def status() -> None:
     ping_results = _ping_stages(cfg, stages)
     for stage in stages:
         m = cfg.model_for(stage)
+        profile = resolve_profile(m)
         ping = _format_ping(ping_results.get(stage))
-        table.add_row(f"Model ({stage})", f"{m.model}   {ping}")
+        table.add_row(
+            f"Model ({stage})",
+            f"{profile.provider}/{profile.model} [{profile.protocol}]   {ping}",
+        )
 
     console.print(table)
 
 
 @app.command()
 def doctor() -> None:
-    """Self-check a bring-your-own-key install (offline; zero LLM calls).
+    """Self-check a bring-your-own-provider install (offline; zero LLM calls).
 
     Prints one ✓/✗/⚠ line per prerequisite — env file present + private (0600),
-    ANTHROPIC_API_KEY configured, base URL reachable (HEAD, warn-only), Swift
+    selected provider credential configured, endpoint reachable (HEAD, warn-only), Swift
     capture helpers compiled, macOS Accessibility trust, data root writable,
     daemon port available. Exits 1 if any check FAILS; warnings never fail.
     """
@@ -448,17 +459,16 @@ def _ping_stages(cfg: config_mod.Config, stages: tuple[str, ...]) -> dict:
     from concurrent.futures import ThreadPoolExecutor
     from dataclasses import replace
 
+    from .providers import resolve_profile
     from .writer.llm import PingResult, ping_stage
 
-    # Dedup by (model, resolved base_url, resolved api key) — common case is
+    # Dedup by effective profile — common case is
     # one model for all four stages, which should hit the network once.
-    dedup: dict[tuple[str, str, str], list[str]] = {}
+    dedup: dict[tuple[str, str, str, str], list[str]] = {}
     for stage in stages:
         m = cfg.model_for(stage)
-        provider = config_mod.infer_provider(m.model)
-        base_url = m.base_url or (config_mod.provider_base_url(provider) or "")
-        api_key = config_mod.provider_api_key(provider) or ""
-        key = (m.model, base_url, api_key)
+        profile = resolve_profile(m)
+        key = (profile.protocol, profile.model, profile.base_url, profile.api_key or "")
         dedup.setdefault(key, []).append(stage)
 
     results: dict = {}
@@ -1040,6 +1050,302 @@ launchagent_app = typer.Typer(
     help="Manage the macOS LaunchAgent so launchd owns the daemon lifecycle."
 )
 app.add_typer(launchagent_app, name="launchagent")
+
+llm_app = typer.Typer(help="Discover, verify, and configure the Runtime's LLM provider.")
+app.add_typer(llm_app, name="llm")
+
+
+def _choose_llm_provider(specs: Sequence[ProviderSpec]) -> ProviderSpec:
+    for index, spec in enumerate(specs, start=1):
+        credential = "none (local)" if not spec.key_required else spec.api_key_env
+        endpoint = spec.base_url or "enter during setup"
+        console.print(f"  [bold cyan]{index:>2}[/bold cyan]. {spec.label} [dim]({spec.id})[/dim]")
+        console.print(
+            f"      {spec.protocol} | {credential} | {endpoint}\n"
+            f"      [dim]{spec.description}[/dim]"
+        )
+    while True:
+        choice = typer.prompt("Choose a provider", type=int)
+        if 1 <= choice <= len(specs):
+            return specs[choice - 1]
+        console.print(f"[red]Enter a number from 1 to {len(specs)}.[/red]")
+
+
+@llm_app.command("providers")
+def llm_providers() -> None:
+    """List supported presets and mark credentials already found locally."""
+    from .providers import PROVIDERS
+
+    env_file_mod.load_env_file(paths.env_file())
+    for spec in PROVIDERS:
+        credential = "none (local)" if not spec.key_required else spec.api_key_env
+        detected = (
+            "[green]keyless[/green]"
+            if not spec.key_required
+            else "[green]yes[/green]"
+            if os.environ.get(spec.api_key_env)
+            else ""
+        )
+        suffix = f"  {detected}" if detected else ""
+        console.print(f"[bold]{spec.label}[/bold] [dim]({spec.id})[/dim]{suffix}")
+        console.print(
+            f"  Protocol: {spec.protocol}\n"
+            f"  Credential: {credential}\n"
+            f"  Endpoint: {spec.base_url or 'enter during setup'}\n"
+            f"  [dim]{spec.description}[/dim]\n"
+        )
+    console.print(
+        "[dim]Presets use Anthropic Messages or OpenAI-compatible Chat Completions. "
+        "Use custom-openai/custom-anthropic for another compatible endpoint.[/dim]"
+    )
+
+
+@llm_app.command("status")
+def llm_status(
+    check: bool = typer.Option(False, "--check", help="Run a live completion and tool-call probe."),
+) -> None:
+    """Show the effective provider profile without revealing its key."""
+    from .llm_setup import probe_profile
+    from .providers import resolve_profile
+
+    env_file_mod.load_env_file(paths.env_file())
+    cfg = config_mod.load()
+    profile = resolve_profile(cfg.model_for("default"))
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_row("Provider", f"{profile.provider_label} ({profile.provider})")
+    table.add_row("Protocol", profile.protocol)
+    table.add_row("Model", profile.model)
+    table.add_row("Endpoint", profile.base_url or "provider default")
+    if not profile.key_required:
+        credential = "[green]not required[/green] (local endpoint)"
+    elif profile.credential_ready:
+        credential = f"[green]set[/green] via {profile.api_key_env}"
+    else:
+        credential = f"[red]missing[/red] ({profile.api_key_env})"
+    table.add_row("Credential", credential)
+    table.add_row("Configuration", "legacy compatibility" if profile.legacy else "explicit profile")
+    console.print(table)
+    if profile.legacy:
+        console.print(
+            "[yellow]This installation still uses the pre-provider Anthropic-compatible route. "
+            "Run `persome llm setup` to verify and migrate it explicitly.[/yellow]"
+        )
+    if check:
+        if not profile.credential_ready:
+            console.print(
+                f"[red]✗ {profile.api_key_env} is missing. Run `persome llm setup`.[/red]"
+            )
+            raise typer.Exit(1)
+        with console.status("Testing completion and tool calling..."):
+            result = probe_profile(profile)
+        if not result.completion_ok:
+            console.print(f"[red]✗ Probe failed:[/red] {result.error}")
+            raise typer.Exit(1)
+        console.print(f"[green]✓ Completion works[/green] ({result.latency_ms} ms)")
+        if result.tool_call_ok:
+            console.print("[green]✓ Tool calling works[/green]")
+        else:
+            console.print("[yellow]⚠ Tool calling was not confirmed for this model.[/yellow]")
+
+
+@llm_app.command("setup")
+def llm_setup(
+    provider: str = typer.Option(
+        "", "--provider", help="Provider id from `persome llm providers`."
+    ),
+    model: str = typer.Option("", "--model", help="Model id sent to the provider."),
+    base_url: str = typer.Option("", "--base-url", help="Override the provider endpoint."),
+    api_key_env: str = typer.Option(
+        "", "--api-key-env", help="Environment variable holding the key."
+    ),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Accept detected/default values."),
+    allow_no_tools: bool = typer.Option(
+        False,
+        "--allow-no-tools",
+        help="Save even when tool calling cannot be confirmed (modeling/Chat may degrade).",
+    ),
+    skip_check: bool = typer.Option(
+        False,
+        "--skip-check",
+        help="Save without a live probe (not recommended).",
+    ),
+) -> None:
+    """Detect credentials, verify a provider, then save one Runtime-wide profile."""
+    from .llm_setup import probe_profile, save_profile
+    from .providers import (
+        PROVIDERS,
+        detected_providers,
+        make_profile,
+        provider_spec,
+        resolve_profile,
+    )
+
+    paths.ensure_dirs()
+    config_mod.write_default_if_missing()
+    env_file_mod.load_env_file(paths.env_file())
+    cfg = config_mod.load()
+    current = resolve_profile(cfg.model_for("default"))
+    interactive = sys.stdin.isatty() and sys.stdout.isatty() and not yes
+
+    selected = None
+    keep_current = False
+    if provider:
+        selected = provider_spec(provider)
+        if selected is None:
+            console.print(f"[red]Unknown provider {provider!r}. Run `persome llm providers`.[/red]")
+            raise typer.Exit(2)
+    elif current.credential_ready:
+        if interactive:
+            console.print(
+                f"Detected current route: [bold]{current.provider_label}[/bold] / "
+                f"{current.model} at {current.base_url or 'provider default'}"
+            )
+            keep_current = typer.confirm("Keep and verify this route?", default=True)
+        else:
+            keep_current = True
+
+    if selected is None and not keep_current:
+        detected = detected_providers()
+        if len(detected) == 1:
+            selected = detected[0]
+            console.print(
+                f"[green]Detected {selected.api_key_env}; selected {selected.label}.[/green]"
+            )
+        elif len(detected) > 1:
+            if not interactive:
+                names = ", ".join(spec.id for spec in detected)
+                console.print(
+                    f"[red]Multiple credentials detected ({names}); pass --provider.[/red]"
+                )
+                raise typer.Exit(2)
+            console.print("Multiple provider credentials were found:")
+            selected = _choose_llm_provider(tuple(detected))
+        elif not interactive:
+            console.print(
+                "[red]No configured LLM credential found; pass --provider and export its key.[/red]"
+            )
+            raise typer.Exit(2)
+        else:
+            console.print("Choose the LLM provider Persome should use:")
+            selected = _choose_llm_provider(PROVIDERS)
+
+    if keep_current:
+        provider_id = current.provider
+        protocol = current.protocol
+        chosen_model = model or current.model
+        chosen_base_url = base_url or current.base_url
+        chosen_key_env = api_key_env or current.api_key_env
+        api_key = os.environ.get(chosen_key_env) or current.api_key
+    else:
+        assert selected is not None
+        provider_id = selected.id
+        protocol = selected.protocol
+        chosen_model = model or selected.default_model
+        chosen_base_url = base_url or os.environ.get(selected.resolved_base_url_env, "")
+        chosen_base_url = chosen_base_url or selected.base_url
+        chosen_key_env = api_key_env or selected.api_key_env
+        api_key = os.environ.get(chosen_key_env)
+
+    if interactive:
+        if selected is not None and selected.id.startswith("custom-"):
+            chosen_key_env = typer.prompt("API key environment variable", default=chosen_key_env)
+            api_key = os.environ.get(chosen_key_env) or api_key
+        chosen_base_url = typer.prompt("API endpoint", default=chosen_base_url or "")
+        chosen_model = typer.prompt("Model id", default=chosen_model)
+    if not chosen_base_url:
+        console.print("[red]An API endpoint is required.[/red]")
+        raise typer.Exit(2)
+    if not chosen_model:
+        console.print("[red]A model id is required.[/red]")
+        raise typer.Exit(2)
+    parsed_endpoint = urlparse(chosen_base_url)
+    if parsed_endpoint.scheme not in {"http", "https"} or not parsed_endpoint.netloc:
+        console.print("[red]The API endpoint must be an absolute http(s) URL.[/red]")
+        raise typer.Exit(2)
+    if not chosen_key_env.isascii() or not chosen_key_env.isidentifier():
+        console.print("[red]The API key environment variable name is invalid.[/red]")
+        raise typer.Exit(2)
+
+    key_required = selected.key_required if selected is not None else current.key_required
+    if key_required and not api_key:
+        if not interactive:
+            console.print(
+                f"[red]{chosen_key_env} is not set. Export it or run setup interactively.[/red]"
+            )
+            raise typer.Exit(2)
+        api_key = typer.prompt(
+            f"API key ({chosen_key_env})",
+            hide_input=True,
+            confirmation_prompt=True,
+        )
+
+    profile = make_profile(
+        provider_id,
+        model=chosen_model,
+        base_url=chosen_base_url,
+        api_key_env=chosen_key_env,
+        api_key=api_key,
+        protocol=protocol,
+    )
+
+    while not skip_check:
+        with console.status("Testing completion and tool calling before saving..."):
+            result = probe_profile(profile)
+        if not result.completion_ok:
+            console.print(f"[red]✗ Provider check failed. Nothing was saved.[/red] {result.error}")
+            if not interactive or not typer.confirm("Edit settings and retry?", default=True):
+                raise typer.Exit(1)
+            chosen_base_url = typer.prompt("API endpoint", default=profile.base_url)
+            chosen_model = typer.prompt("Model id", default=profile.model)
+            replacement = typer.prompt(
+                "New API key (Enter to keep the current key)",
+                default="",
+                show_default=False,
+                hide_input=True,
+            )
+            api_key = replacement or profile.api_key
+            profile = make_profile(
+                provider_id,
+                model=chosen_model,
+                base_url=chosen_base_url,
+                api_key_env=chosen_key_env,
+                api_key=api_key,
+                protocol=protocol,
+            )
+            continue
+        console.print(f"[green]✓ Completion works[/green] ({result.latency_ms} ms)")
+        if result.tool_call_ok:
+            console.print("[green]✓ Tool calling works[/green]")
+            break
+        console.print(
+            "[yellow]The endpoint completed a prompt, but this model did not call the test "
+            "tool. Persome modeling and Chat rely on tool calling.[/yellow]"
+        )
+        if result.error:
+            console.print(f"[dim]{result.error}[/dim]")
+        if allow_no_tools or (
+            interactive and typer.confirm("Save this limited model anyway?", default=False)
+        ):
+            break
+        if not interactive or not typer.confirm("Choose another model and retry?", default=True):
+            console.print("[red]Nothing was saved.[/red]")
+            raise typer.Exit(1)
+        chosen_model = typer.prompt("Model id", default=profile.model)
+        profile = make_profile(
+            provider_id,
+            model=chosen_model,
+            base_url=chosen_base_url,
+            api_key_env=chosen_key_env,
+            api_key=api_key,
+            protocol=protocol,
+        )
+
+    save_profile(profile, config_path=paths.config_file(), env_path=paths.env_file())
+    console.print(f"[green]✓ Saved {profile.provider_label} as the Runtime LLM profile.[/green]")
+    console.print(f"  Config: {paths.config_file()}")
+    if profile.api_key:
+        console.print(f"  Secret: {paths.env_file()} ({profile.api_key_env}, mode 0600)")
+    console.print("  Next: persome llm status --check")
 
 
 def _default_daemon_binary() -> str:

--- a/src/persome/config.py
+++ b/src/persome/config.py
@@ -528,16 +528,26 @@ def _build_dataclass(cls, raw: dict):  # type: ignore[no-untyped-def]
 def _build_chat(raw: dict, default_model: ModelConfig) -> ChatConfig:
     # The LLM route inherits from [models.default]. Chat-only controls remain
     # independent. Explicit [chat] values override only their matching fields.
-    inherited = {
-        "model": default_model.model,
-        "provider": default_model.provider,
-        "protocol": default_model.protocol,
-        "api_key_env": default_model.api_key_env,
-        "base_url": default_model.base_url,
-    }
+    default_is_explicit = bool(default_model.provider or default_model.protocol)
+    inherited = (
+        {
+            "model": default_model.model,
+            "provider": default_model.provider,
+            "protocol": default_model.protocol,
+            "api_key_env": default_model.api_key_env,
+            "base_url": default_model.base_url,
+        }
+        if default_is_explicit
+        else {}
+    )
     scalar_fields = {
         k: v for k, v in raw.items() if k in ChatConfig.__dataclass_fields__ and k != "mcp_servers"
     }
+    if not raw.get("provider") and not raw.get("protocol"):
+        # Old ChatConfig ignored these keys. Do not let stale TOML silently
+        # override a newly selected default route during migration.
+        scalar_fields.pop("api_key_env", None)
+        scalar_fields.pop("base_url", None)
     cfg = ChatConfig(**{**inherited, **scalar_fields})
     # Parse [[chat.mcp_servers]] array-of-tables
     raw_servers = raw.get("mcp_servers", [])

--- a/src/persome/config.py
+++ b/src/persome/config.py
@@ -2,20 +2,25 @@
 
 from __future__ import annotations
 
-import os
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal, cast
 
 from . import paths
+from . import providers as provider_mod
 
 
 @dataclass
 class ModelConfig:
     model: str = "deepseek-v4-flash"
-    # Optional override; when empty, ``provider_base_url(model)`` falls back to
-    # the canonical ``{PROVIDER}_BASE_URL`` environment variable.
+    # Provider routing is explicit after ``persome llm setup``. Empty values
+    # preserve old configs and are inferred from the model/environment.
+    provider: str = ""
+    protocol: str = ""
+    api_key_env: str = ""
+    # Endpoints are not secrets and may be stored in TOML. The matching
+    # provider BASE_URL environment variable remains a supported fallback.
     base_url: str = ""
     max_tokens: int | None = None
 
@@ -422,23 +427,13 @@ class MCPServerSpec:
 
 @dataclass
 class ChatConfig:
-    # Chat uses the Anthropic SDK directly for prompt caching, extended thinking,
-    # and tool use. Configured under [chat] in config.toml.
-    #
-    # API key and base URL are NOT in TOML — they come from the env vars
-    # ``ANTHROPIC_API_KEY`` / ``ANTHROPIC_BASE_URL``, loaded from the runtime
-    # env file or the user's shell.
-    #
-    # NO routing prefix here. The chat agent calls the Anthropic SDK
-    # directly (``anthropic.AsyncAnthropic`` in ``chat/agent.py``); whatever
-    # string sits in ``model`` is sent verbatim in the request body and
-    # validated by the gateway. DeepSeek's ``/anthropic`` endpoint only
-    # accepts bare names (``deepseek-v4-flash`` / ``deepseek-v4-pro``); a
-    # routing-style ``anthropic/...`` prefix would be rejected as an unknown
-    # model. Prompt caching for the chat agent is enabled via the
-    # ``cache_control`` field on message content (see ``chat/agent.py``),
-    # independent of the model name.
+    # Chat inherits the default model profile unless one of these values is
+    # explicitly overridden under [chat].
     model: str = "deepseek-v4-flash"
+    provider: str = ""
+    protocol: str = ""
+    api_key_env: str = ""
+    base_url: str = ""
     # Extended thinking (Anthropic "thinking" block). 0 disables (default —
     # safe for non-reasoning models like deepseek-v4-flash). Set to >=1024
     # to enable; requires a reasoning-capable model (Claude Opus/Sonnet 4.5+,
@@ -491,44 +486,17 @@ class Config:
         return self.models.get(stage) or self.models.get("default") or ModelConfig()
 
 
-# Provider name -> canonical environment-variable prefix.
-_PROVIDER_ENV_PREFIX: dict[str, str] = {
-    "anthropic": "ANTHROPIC",
-    "openai": "OPENAI",
-    "deepseek": "DEEPSEEK",
-}
-
-
 def infer_provider(model: str) -> str:
-    """Best-effort provider name from an optional ``provider/model`` string.
-
-    Recognises explicit ``provider/model`` prefixes first; falls back to a few
-    well-known bare-name heuristics. Returns ``"openai"`` when unknown — the
-    compatibility default so legacy ``gpt-*`` configs keep working.
-    """
-    head = model.split("/", 1)[0].lower() if "/" in model else ""
-    if head in _PROVIDER_ENV_PREFIX:
-        return head
-    lower = model.lower()
-    if lower.startswith("claude"):
-        return "anthropic"
-    if lower.startswith("deepseek"):
-        return "deepseek"
-    return "openai"
+    """Compatibility wrapper for callers that import provider helpers here."""
+    return provider_mod.infer_provider(model)
 
 
 def provider_api_key(provider: str) -> str | None:
-    prefix = _PROVIDER_ENV_PREFIX.get(provider)
-    if not prefix:
-        return None
-    return os.environ.get(f"{prefix}_API_KEY")
+    return provider_mod.provider_api_key(provider)
 
 
 def provider_base_url(provider: str) -> str | None:
-    prefix = _PROVIDER_ENV_PREFIX.get(provider)
-    if not prefix:
-        return None
-    return os.environ.get(f"{prefix}_BASE_URL")
+    return provider_mod.provider_base_url(provider)
 
 
 def _as_dict(section: Any) -> dict:
@@ -557,13 +525,20 @@ def _build_dataclass(cls, raw: dict):  # type: ignore[no-untyped-def]
     return cls(**allowed)
 
 
-def _build_chat(raw: dict) -> ChatConfig:
-    # Secrets/base URLs are env-only. TOML scalars cover model,
-    # thinking_budget, and mcp_connect_daemon.
+def _build_chat(raw: dict, default_model: ModelConfig) -> ChatConfig:
+    # The LLM route inherits from [models.default]. Chat-only controls remain
+    # independent. Explicit [chat] values override only their matching fields.
+    inherited = {
+        "model": default_model.model,
+        "provider": default_model.provider,
+        "protocol": default_model.protocol,
+        "api_key_env": default_model.api_key_env,
+        "base_url": default_model.base_url,
+    }
     scalar_fields = {
         k: v for k, v in raw.items() if k in ChatConfig.__dataclass_fields__ and k != "mcp_servers"
     }
-    cfg = ChatConfig(**scalar_fields)
+    cfg = ChatConfig(**{**inherited, **scalar_fields})
     # Parse [[chat.mcp_servers]] array-of-tables
     raw_servers = raw.get("mcp_servers", [])
     if isinstance(raw_servers, list):
@@ -599,8 +574,9 @@ def load(path: Path | None = None) -> Config:
         with open(path, "rb") as f:
             raw = tomllib.load(f)
 
+    models = _build_models(_as_dict(raw.get("models")))
     return Config(
-        models=_build_models(_as_dict(raw.get("models"))),
+        models=models,
         capture=_build_capture(raw),
         timeline=_build_dataclass(TimelineConfig, _as_dict(raw.get("timeline"))),
         session=_build_dataclass(SessionConfig, _as_dict(raw.get("session"))),
@@ -619,7 +595,7 @@ def load(path: Path | None = None) -> Config:
         skill_check=_build_dataclass(SkillCheckConfig, _as_dict(raw.get("skill_check"))),
         schema=_build_dataclass(SchemaConfig, _as_dict(raw.get("schema"))),
         user=_build_dataclass(UserConfig, _as_dict(raw.get("user"))),
-        chat=_build_chat(_as_dict(raw.get("chat"))),
+        chat=_build_chat(_as_dict(raw.get("chat")), models["default"]),
         # Competitive-enhancement flat toggles (spec 2026-06-23): top-level TOML
         # scalars so config.toml can override the safe defaults.
         api_require_local_origin=bool(raw.get("api_require_local_origin", True)),
@@ -631,26 +607,17 @@ def load(path: Path | None = None) -> Config:
 
 
 DEFAULT_CONFIG_TEMPLATE = """# Persome configuration
-# All LLM stages call the Anthropic Messages API via the official SDK (same path
-# as chat). The backend speaks only the Anthropic protocol — the official
-# endpoint or a compatible gateway (e.g. DeepSeek's /anthropic). ``model`` is a
-# BARE name (no routing prefix) sent verbatim to ANTHROPIC_BASE_URL; legacy
-# ``anthropic/...`` prefixes are tolerated (stripped). Each stage inherits from
-# [models.default]. Prompt caching is automatic (cache_control passes through);
-# no model-name prefix is needed.
+# One verified profile powers timeline reduction, personal modeling, and Chat.
+# Persome supports Anthropic Messages and OpenAI-compatible Chat Completions.
+# Run `persome llm setup` to detect an existing key, choose/edit the endpoint and
+# model, test completion + tool calling, and write the fields below. Every stage
+# inherits [models.default] unless its own section overrides a field.
 #
-# Secrets (API keys, base URLs) are NOT in this file. They live in
-# ``~/.persome/env`` (dotenv format). Canonical env var names: {PROVIDER}_API_KEY and
-# {PROVIDER}_BASE_URL where {PROVIDER} ∈ {ANTHROPIC, OPENAI, DEEPSEEK}.
-# For CLI debugging you may export the same vars in your shell.
-#
-# Bring-your-own-key model naming:
-# - Official Anthropic endpoint: leave ANTHROPIC_BASE_URL unset and use a bare
-#   claude model name, e.g. model = "claude-haiku-4-5".
-# - Anthropic-compatible gateways (e.g. DeepSeek): set
-#   ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic and use the bare name
-#   the gateway serves, e.g. model = "deepseek-v4-flash" (the shipped default).
-# Verify your setup any time with `persome doctor` (offline, zero LLM calls).
+# API keys never belong in this file. `api_key_env` stores only the variable
+# name; the secret itself lives in ~/.persome/env (mode 0600). Endpoints are not
+# secrets and are stored here so Chat and daemon subprocesses use the same route.
+# `persome llm providers` lists hosted/local presets. Custom compatible gateways
+# use provider="custom-openai" or provider="custom-anthropic".
 
 # Cross-cutting runtime/model switches.
 api_require_local_origin = true
@@ -666,7 +633,9 @@ edge_promote_fanout = 20
 # name = "Alice"
 
 [models.default]
-model = "deepseek-v4-flash"   # bare name, sent verbatim to ANTHROPIC_BASE_URL gateway
+# `persome llm setup` writes provider, protocol, model, base_url, and api_key_env.
+# Until then, these legacy defaults retain compatibility with pre-provider installs.
+model = "deepseek-v4-flash"
 
 [models.compact]
 # Accuracy-sensitive — match or exceed the default.
@@ -680,7 +649,7 @@ model = "deepseek-v4-flash"   # bare name, sent verbatim to ANTHROPIC_BASE_URL g
 # runs on every 1-min window — slow LLM calls here cause the pipeline to
 # lag behind real time and delay all downstream memory updates.
 # Example override (uncomment): a faster model just for this hot path.
-# model = "deepseek-v4-flash"   # bare name; routed to ANTHROPIC_BASE_URL
+# model = "a-faster-model-id"
 
 [models.reducer]
 # Session-level S2 reduce-from-blocks. Prompt is short (blocks are already
@@ -800,10 +769,9 @@ host = "127.0.0.1"                # bind address; keep localhost-only by default
 port = 8742
 
 [chat]
-# Anthropic SDK-based chat assistant. Set ANTHROPIC_API_KEY (and optionally
-# ANTHROPIC_BASE_URL to point at e.g. DeepSeek's /anthropic gateway) via
-# the env file next to config.toml, or export them in your shell for CLI debugging.
-# model = "deepseek-v4-flash"      # bare name sent through the Anthropic SDK
+# Chat inherits the complete [models.default] provider profile. Override model,
+# provider, protocol, base_url, or api_key_env here only when Chat intentionally
+# uses another endpoint. thinking_budget applies only to Anthropic models.
 # thinking_budget = 0
 unsafe_local_tools_enabled = false # opt in to shell, arbitrary filesystem, and web tools
 mcp_connect_daemon = true         # auto-connect to the daemon's own MCP server

--- a/src/persome/doctor.py
+++ b/src/persome/doctor.py
@@ -1,4 +1,4 @@
-"""``persome doctor`` — offline self-check for a bring-your-own-key install.
+"""``persome doctor`` — offline self-check for a bring-your-own-provider install.
 
 Each check returns a :class:`Check` with a three-state status:
 
@@ -10,7 +10,7 @@ Each check returns a :class:`Check` with a three-state status:
 Design constraints (BYO-key onboarding):
 
 * **Zero LLM calls.** The only network I/O is a single HTTP ``HEAD`` against the
-  configured ``ANTHROPIC_BASE_URL`` (3s timeout), and even that failing is a
+  configured provider endpoint (3s timeout), and even that failing is a
   warning only — a firewalled machine must still be able to get a green doctor.
 * **No side effects** beyond creating the data root when probing writability.
   Doctor never compiles helpers, never touches the DB, never writes config.
@@ -28,16 +28,15 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
+from . import config as config_mod
 from . import env_file as env_file_mod
 from . import paths
+from .providers import ResolvedLLMProfile, resolve_profile
 
 Status = Literal["ok", "fail", "warn"]
 
 # HEAD probe budget for the base-URL reachability check (seconds).
 _HEAD_TIMEOUT = 3.0
-
-# Default official endpoint when ANTHROPIC_BASE_URL is unset.
-_DEFAULT_BASE_URL = "https://api.anthropic.com"
 
 # Swift helper binaries the capture pipeline shells out to, with their
 # path-override env vars (mirrors capture/ax_capture.py + capture/watcher.py).
@@ -74,21 +73,34 @@ def _helper_candidates(name: str) -> list[Path]:
     return candidates
 
 
-def check_env_file() -> Check:
+def _llm_profile() -> ResolvedLLMProfile:
+    return resolve_profile(config_mod.load().model_for("default"))
+
+
+def check_env_file(profile: ResolvedLLMProfile | None = None) -> Check:
     """The dotenv secret store exists and is private (0600 — no group/other bits)."""
+    profile = profile or _llm_profile()
     p = paths.env_file()
     if not p.exists():
-        if os.environ.get("ANTHROPIC_API_KEY"):
+        if profile.credential_ready:
+            if not profile.key_required:
+                return Check(
+                    "env file",
+                    "warn",
+                    f"{p} missing (the local LLM needs no key; rerun install.sh "
+                    "to provision screenshot encryption)",
+                )
             return Check(
                 "env file",
                 "warn",
-                f"{p} missing (ANTHROPIC_API_KEY is exported in this shell; "
+                f"{p} missing ({profile.api_key_env} is available in this shell; "
                 "writing it to the env file survives restarts)",
             )
         return Check(
             "env file",
             "fail",
-            f"{p} missing — create it with ANTHROPIC_API_KEY=sk-... then chmod 600",
+            f"{p} missing — run `persome llm setup`, then rerun install.sh "
+            "to provision the screenshot key",
         )
     try:
         mode = stat.S_IMODE(p.stat().st_mode)
@@ -103,15 +115,18 @@ def check_env_file() -> Check:
     return Check("env file", "ok", str(p))
 
 
-def check_api_key() -> Check:
-    """``ANTHROPIC_API_KEY`` resolvable (env file already merged by run_checks)."""
-    if os.environ.get("ANTHROPIC_API_KEY"):
-        return Check("ANTHROPIC_API_KEY", "ok", "set")
+def check_api_key(profile: ResolvedLLMProfile | None = None) -> Check:
+    """The selected provider credential is resolvable without exposing it."""
+    profile = profile or _llm_profile()
+    if profile.credential_ready:
+        detail = (
+            "not required (local endpoint)" if not profile.key_required else profile.api_key_env
+        )
+        return Check("LLM credential", "ok", detail)
     return Check(
-        "ANTHROPIC_API_KEY",
+        "LLM credential",
         "fail",
-        f"not set — add ANTHROPIC_API_KEY=... to {paths.env_file()} "
-        "(official Anthropic key, or a compatible gateway's key with ANTHROPIC_BASE_URL)",
+        f"{profile.api_key_env} is not set for {profile.provider_label} — run `persome llm setup`",
     )
 
 
@@ -128,20 +143,22 @@ def check_screenshot_key() -> Check:
     )
 
 
-def check_base_url() -> Check:
-    """HEAD the configured (or default) Anthropic base URL. Reachability is a
+def check_base_url(profile: ResolvedLLMProfile | None = None) -> Check:
+    """HEAD the configured provider endpoint. Reachability is a
     warning-only signal: any HTTP response counts as reachable; a network error
     warns but never fails (offline machines still get a usable doctor)."""
-    base = os.environ.get("ANTHROPIC_BASE_URL") or ""
-    url = base or _DEFAULT_BASE_URL
-    label = url if base else f"{url} (default)"
+    profile = profile or _llm_profile()
+    url = profile.base_url
+    if not url:
+        return Check("LLM endpoint", "fail", "missing — run `persome llm setup`")
+    label = f"{profile.provider_label}: {url}"
     try:
         import httpx
 
         httpx.head(url, timeout=_HEAD_TIMEOUT, follow_redirects=True)
     except Exception as exc:  # noqa: BLE001 — reachability is advisory only
-        return Check("base URL", "warn", f"{label}: unreachable ({exc.__class__.__name__})")
-    return Check("base URL", "ok", label)
+        return Check("LLM endpoint", "warn", f"{label}: unreachable ({exc.__class__.__name__})")
+    return Check("LLM endpoint", "ok", label)
 
 
 def check_helpers() -> list[Check]:
@@ -262,11 +279,12 @@ def run_checks(host: str, port: int) -> list[Check]:
     """Run every check in display order. Merges the env file into ``os.environ``
     first (same semantics as ``persome start``: pre-set shell vars win)."""
     env_file_mod.load_env_file(paths.env_file())
+    profile = _llm_profile()
     checks: list[Check] = [
-        check_env_file(),
-        check_api_key(),
+        check_env_file(profile),
+        check_api_key(profile),
         check_screenshot_key(),
-        check_base_url(),
+        check_base_url(profile),
         *check_helpers(),
         check_ax_trust(),
         check_root_writable(),

--- a/src/persome/env_file.py
+++ b/src/persome/env_file.py
@@ -50,7 +50,7 @@ def load_env_file(path: Path) -> int:
 
     Pre-existing env vars are NOT overwritten. Unreadable / missing files are
     silently ignored (returns 0) — the daemon will surface a clearer error
-    later when a specific ``ANTHROPIC_API_KEY`` etc. lookup comes back empty.
+    later when the selected provider credential lookup comes back empty.
     """
     if not path.exists():
         return 0
@@ -69,6 +69,49 @@ def load_env_file(path: Path) -> int:
         os.environ[key] = value
         added += 1
     return added
+
+
+def write_env_values(path: Path, updates: dict[str, str]) -> None:
+    """Atomically upsert dotenv values while preserving unrelated entries.
+
+    Used by guided onboarding so credentials are durable across daemon restarts.
+    Updated keys are emitted once at the end of the owner-only file.
+    """
+    invalid = [key for key in updates if not key or not key.replace("_", "").isalnum()]
+    if invalid:
+        raise ValueError(f"invalid environment variable name: {invalid[0]}")
+    if any("\n" in value or "\r" in value for value in updates.values()):
+        raise ValueError("environment variable values must be single-line")
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        lines = []
+
+    kept: list[str] = []
+    for line in lines:
+        parsed = _parse_line(line)
+        if parsed is not None and parsed[0] in updates:
+            continue
+        kept.append(line)
+    kept.extend(f"{key}={value}" for key, value in updates.items())
+    payload = "\n".join(kept).rstrip("\n") + "\n"
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        temporary.replace(path)
+        path.chmod(0o600)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+    for key, value in updates.items():
+        os.environ[key] = value
 
 
 def is_valid_screenshot_key(value: str | None) -> bool:

--- a/src/persome/evomem/relation_extractor.py
+++ b/src/persome/evomem/relation_extractor.py
@@ -628,7 +628,7 @@ def run_relation_extraction(
     """Run both passes over the consolidated PAST layer, writing shadow edges. No-op disabled.
 
     ``memory`` / ``llm_call`` / ``conn_factory`` are injectable seams for tests; live defaults
-    use a fresh ``EvoMemory``, ``llm.call_llm`` (Anthropic, mock-aware), and ``fts.cursor``.
+    use a fresh ``EvoMemory``, provider-aware ``llm.call_llm``, and ``fts.cursor``.
     """
     if not getattr(cfg, "relation_extraction_enabled", False):
         return ExtractionResult()

--- a/src/persome/llm_setup.py
+++ b/src/persome/llm_setup.py
@@ -44,7 +44,7 @@ def probe_profile(profile: ResolvedLLMProfile, *, timeout: float = 20.0) -> Prob
             import anthropic
 
             client = anthropic.Anthropic(
-                api_key=profile.api_key,
+                api_key=profile.client_api_key(),
                 base_url=profile.base_url or None,
                 timeout=timeout,
             )
@@ -57,7 +57,7 @@ def probe_profile(profile: ResolvedLLMProfile, *, timeout: float = 20.0) -> Prob
             from openai import OpenAI
 
             client = OpenAI(
-                api_key=profile.api_key or "local-no-key",
+                api_key=profile.client_api_key(),
                 base_url=profile.base_url,
                 timeout=timeout,
             )

--- a/src/persome/llm_setup.py
+++ b/src/persome/llm_setup.py
@@ -1,0 +1,195 @@
+"""Guided, test-before-save LLM provider onboarding."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from . import env_file
+from .providers import ResolvedLLMProfile
+
+_PROBE_TOOL_NAME = "persome_setup_check"
+_PROBE_TOOL_DESCRIPTION = "Confirm that this model can call Persome memory tools."
+_PROBE_SCHEMA = {"type": "object", "properties": {}, "additionalProperties": False}
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    completion_ok: bool
+    tool_call_ok: bool
+    latency_ms: int | None
+    error: str | None = None
+
+
+def _safe_error(exc: Exception, api_key: str | None) -> str:
+    message = str(exc).strip().splitlines()[0] if str(exc).strip() else ""
+    if api_key:
+        message = message.replace(api_key, "***")
+    label = type(exc).__name__
+    return f"{label}: {message[:180]}" if message else label
+
+
+def probe_profile(profile: ResolvedLLMProfile, *, timeout: float = 20.0) -> ProbeResult:
+    """Verify authentication/completion, then test required tool calling.
+
+    A successful completion is the hard connectivity gate. Tool calling is
+    reported separately because some compatible models authenticate correctly
+    but cannot run Persome's modeling and Chat tool loops.
+    """
+    started = time.monotonic()
+    try:
+        if profile.protocol == "anthropic":
+            import anthropic
+
+            client = anthropic.Anthropic(
+                api_key=profile.api_key,
+                base_url=profile.base_url or None,
+                timeout=timeout,
+            )
+            client.messages.create(
+                model=profile.wire_model,
+                messages=[{"role": "user", "content": "Reply with exactly: ok"}],
+                max_tokens=8,
+            )
+        else:
+            from openai import OpenAI
+
+            client = OpenAI(
+                api_key=profile.api_key or "local-no-key",
+                base_url=profile.base_url,
+                timeout=timeout,
+            )
+            client.chat.completions.create(
+                model=profile.wire_model,
+                messages=[{"role": "user", "content": "Reply with exactly: ok"}],
+                max_tokens=8,
+            )
+    except Exception as exc:  # noqa: BLE001
+        return ProbeResult(
+            completion_ok=False,
+            tool_call_ok=False,
+            latency_ms=None,
+            error=_safe_error(exc, profile.api_key),
+        )
+
+    tool_ok = False
+    tool_error: str | None = None
+    prompt = f"You must call {_PROBE_TOOL_NAME} now. Do not answer with text."
+    if profile.protocol == "anthropic":
+        tool = {
+            "name": _PROBE_TOOL_NAME,
+            "description": _PROBE_TOOL_DESCRIPTION,
+            "input_schema": _PROBE_SCHEMA,
+        }
+        choices: list[Any] = [
+            {"type": "tool", "name": _PROBE_TOOL_NAME},
+            {"type": "auto"},
+        ]
+        for tool_choice in choices:
+            try:
+                tool_response = client.messages.create(
+                    model=profile.wire_model,
+                    messages=[{"role": "user", "content": prompt}],
+                    max_tokens=128,
+                    tools=[tool],
+                    tool_choice=tool_choice,
+                )
+            except Exception as exc:  # noqa: BLE001
+                tool_error = _safe_error(exc, profile.api_key)
+                continue
+            tool_ok = any(
+                getattr(block, "type", None) == "tool_use"
+                and getattr(block, "name", None) == _PROBE_TOOL_NAME
+                for block in tool_response.content
+            )
+            if tool_ok:
+                break
+    else:
+        tool = {
+            "type": "function",
+            "function": {
+                "name": _PROBE_TOOL_NAME,
+                "description": _PROBE_TOOL_DESCRIPTION,
+                "parameters": _PROBE_SCHEMA,
+            },
+        }
+        choices = [
+            {"type": "function", "function": {"name": _PROBE_TOOL_NAME}},
+            "auto",
+        ]
+        for tool_choice in choices:
+            try:
+                tool_response = client.chat.completions.create(
+                    model=profile.wire_model,
+                    messages=[{"role": "user", "content": prompt}],
+                    max_tokens=128,
+                    tools=[tool],
+                    tool_choice=tool_choice,
+                )
+            except Exception as exc:  # noqa: BLE001
+                tool_error = _safe_error(exc, profile.api_key)
+                continue
+            tool_ok = any(
+                call.function.name == _PROBE_TOOL_NAME
+                for call in (tool_response.choices[0].message.tool_calls or [])
+            )
+            if tool_ok:
+                break
+    return ProbeResult(
+        completion_ok=True,
+        tool_call_ok=tool_ok,
+        latency_ms=int((time.monotonic() - started) * 1000),
+        error=None if tool_ok else tool_error,
+    )
+
+
+def save_profile(
+    profile: ResolvedLLMProfile,
+    *,
+    config_path: Path,
+    env_path: Path,
+) -> None:
+    """Persist one verified profile without placing its secret in TOML."""
+    import tomlkit
+    from tomlkit.items import Table
+
+    if config_path.exists():
+        document = tomlkit.parse(config_path.read_text(encoding="utf-8"))
+    else:
+        document = tomlkit.document()
+
+    models = document.get("models")
+    if not isinstance(models, Table):
+        models = tomlkit.table()
+        document["models"] = models
+    default = models.get("default")
+    if not isinstance(default, Table):
+        default = tomlkit.table()
+        models["default"] = default
+
+    default["provider"] = profile.provider
+    default["protocol"] = profile.protocol
+    default["model"] = profile.model
+    default["base_url"] = profile.base_url
+    default["api_key_env"] = profile.api_key_env
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(tomlkit.dumps(document), encoding="utf-8")
+    if profile.api_key:
+        env_file.write_env_values(env_path, {profile.api_key_env: profile.api_key})
+
+
+def profile_dict(profile: ResolvedLLMProfile) -> dict[str, Any]:
+    """Public, secret-free profile fields for CLI/API status surfaces."""
+    return {
+        "provider": profile.provider,
+        "provider_label": profile.provider_label,
+        "protocol": profile.protocol,
+        "model": profile.model,
+        "base_url": profile.base_url,
+        "api_key_env": profile.api_key_env,
+        "credential_ready": profile.credential_ready,
+        "legacy": profile.legacy,
+    }

--- a/src/persome/providers.py
+++ b/src/persome/providers.py
@@ -292,6 +292,14 @@ class ResolvedLLMProfile:
     def credential_ready(self) -> bool:
         return bool(self.api_key) or not self.key_required
 
+    def client_api_key(self) -> str:
+        """Return an SDK-safe key or raise before any hosted network call."""
+        if self.api_key:
+            return self.api_key
+        if not self.key_required:
+            return "persome-local"
+        raise RuntimeError(f"{self.api_key_env} is not set for {self.provider_label}")
+
 
 def provider_spec(provider: str) -> ProviderSpec | None:
     return _BY_ID.get(provider.lower())
@@ -339,9 +347,9 @@ def _legacy_anthropic_profile(model_cfg: Any) -> ResolvedLLMProfile | None:
     regardless of the model name. When no new routing fields are explicit,
     retain those exact semantics, including a missing credential.
     """
-    explicit = any(
-        str(getattr(model_cfg, name, "") or "") for name in ("provider", "protocol", "api_key_env")
-    )
+    # ``api_key_env`` appeared in older TOMLs while the runtime still ignored
+    # it. Only an explicit provider/protocol opts into the new routing contract.
+    explicit = any(str(getattr(model_cfg, name, "") or "") for name in ("provider", "protocol"))
     if explicit:
         return None
     key = os.environ.get("ANTHROPIC_API_KEY")

--- a/src/persome/providers.py
+++ b/src/persome/providers.py
@@ -1,0 +1,427 @@
+"""LLM provider registry and runtime profile resolution.
+
+Persome intentionally supports two wire protocols: Anthropic Messages and
+OpenAI-compatible Chat Completions. Provider presets supply sensible endpoint,
+credential, and model defaults; custom endpoints cover compatible gateways that
+are not listed here.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+LLMProtocol = Literal["anthropic", "openai"]
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    id: str
+    label: str
+    protocol: LLMProtocol
+    api_key_env: str
+    base_url: str
+    default_model: str
+    description: str
+    base_url_env: str = ""
+    key_required: bool = True
+    local: bool = False
+
+    @property
+    def resolved_base_url_env(self) -> str:
+        if self.base_url_env:
+            return self.base_url_env
+        if self.api_key_env.endswith("_API_KEY"):
+            return f"{self.api_key_env[:-8]}_BASE_URL"
+        return ""
+
+
+# These presets are deliberately protocol-level rather than SDK-specific.
+# Hosted providers below expose an OpenAI-compatible Chat Completions endpoint;
+# Anthropic uses its native Messages endpoint. Local servers must expose /v1.
+PROVIDERS: tuple[ProviderSpec, ...] = (
+    ProviderSpec(
+        "anthropic",
+        "Anthropic",
+        "anthropic",
+        "ANTHROPIC_API_KEY",
+        "https://api.anthropic.com",
+        "claude-sonnet-4-5",
+        "Native Anthropic Messages API",
+    ),
+    ProviderSpec(
+        "openai",
+        "OpenAI",
+        "openai",
+        "OPENAI_API_KEY",
+        "https://api.openai.com/v1",
+        "gpt-4.1-mini",
+        "OpenAI Chat Completions API",
+    ),
+    ProviderSpec(
+        "deepseek",
+        "DeepSeek",
+        "openai",
+        "DEEPSEEK_API_KEY",
+        "https://api.deepseek.com/v1",
+        "deepseek-chat",
+        "DeepSeek OpenAI-compatible API",
+    ),
+    ProviderSpec(
+        "openrouter",
+        "OpenRouter",
+        "openai",
+        "OPENROUTER_API_KEY",
+        "https://openrouter.ai/api/v1",
+        "openai/gpt-4.1-mini",
+        "OpenRouter model gateway",
+    ),
+    ProviderSpec(
+        "gemini",
+        "Google Gemini",
+        "openai",
+        "GEMINI_API_KEY",
+        "https://generativelanguage.googleapis.com/v1beta/openai/",
+        "gemini-3.5-flash",
+        "Gemini OpenAI compatibility endpoint",
+    ),
+    ProviderSpec(
+        "groq",
+        "Groq",
+        "openai",
+        "GROQ_API_KEY",
+        "https://api.groq.com/openai/v1",
+        "llama-3.3-70b-versatile",
+        "Groq OpenAI-compatible API",
+    ),
+    ProviderSpec(
+        "mistral",
+        "Mistral AI",
+        "openai",
+        "MISTRAL_API_KEY",
+        "https://api.mistral.ai/v1",
+        "mistral-small-latest",
+        "Mistral OpenAI-compatible API",
+    ),
+    ProviderSpec(
+        "xai",
+        "xAI",
+        "openai",
+        "XAI_API_KEY",
+        "https://api.x.ai/v1",
+        "grok-4.3",
+        "xAI OpenAI-compatible API",
+    ),
+    ProviderSpec(
+        "qwen-cn",
+        "Qwen (China)",
+        "openai",
+        "DASHSCOPE_API_KEY",
+        "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        "qwen-plus",
+        "Alibaba Cloud Model Studio China endpoint",
+        base_url_env="DASHSCOPE_BASE_URL",
+    ),
+    ProviderSpec(
+        "qwen-us",
+        "Qwen (US)",
+        "openai",
+        "DASHSCOPE_API_KEY",
+        "https://dashscope-us.aliyuncs.com/compatible-mode/v1",
+        "qwen-plus",
+        "Alibaba Cloud Model Studio US endpoint",
+        base_url_env="DASHSCOPE_BASE_URL",
+    ),
+    ProviderSpec(
+        "moonshot-cn",
+        "Moonshot / Kimi (China)",
+        "openai",
+        "MOONSHOT_API_KEY",
+        "https://api.moonshot.cn/v1",
+        "kimi-k2.5",
+        "Moonshot China OpenAI-compatible API",
+    ),
+    ProviderSpec(
+        "moonshot-intl",
+        "Moonshot / Kimi (International)",
+        "openai",
+        "MOONSHOT_API_KEY",
+        "https://api.moonshot.ai/v1",
+        "kimi-k2.5",
+        "Moonshot international OpenAI-compatible API",
+    ),
+    ProviderSpec(
+        "zhipu",
+        "Zhipu GLM",
+        "openai",
+        "ZHIPU_API_KEY",
+        "https://open.bigmodel.cn/api/paas/v4",
+        "glm-4-flash",
+        "Zhipu OpenAI-compatible API",
+    ),
+    ProviderSpec(
+        "siliconflow",
+        "SiliconFlow",
+        "openai",
+        "SILICONFLOW_API_KEY",
+        "https://api.siliconflow.cn/v1",
+        "deepseek-ai/DeepSeek-V3",
+        "SiliconFlow OpenAI-compatible API",
+    ),
+    ProviderSpec(
+        "together",
+        "Together AI",
+        "openai",
+        "TOGETHER_API_KEY",
+        "https://api.together.xyz/v1",
+        "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+        "Together OpenAI-compatible API",
+    ),
+    ProviderSpec(
+        "fireworks",
+        "Fireworks AI",
+        "openai",
+        "FIREWORKS_API_KEY",
+        "https://api.fireworks.ai/inference/v1",
+        "accounts/fireworks/models/llama-v3p3-70b-instruct",
+        "Fireworks OpenAI-compatible API",
+    ),
+    ProviderSpec(
+        "cerebras",
+        "Cerebras",
+        "openai",
+        "CEREBRAS_API_KEY",
+        "https://api.cerebras.ai/v1",
+        "llama-3.3-70b",
+        "Cerebras OpenAI-compatible API",
+    ),
+    ProviderSpec(
+        "ollama",
+        "Ollama (local)",
+        "openai",
+        "OLLAMA_API_KEY",
+        "http://127.0.0.1:11434/v1",
+        "qwen3:8b",
+        "Local Ollama OpenAI compatibility endpoint",
+        key_required=False,
+        local=True,
+    ),
+    ProviderSpec(
+        "lm-studio",
+        "LM Studio (local)",
+        "openai",
+        "LM_STUDIO_API_KEY",
+        "http://127.0.0.1:1234/v1",
+        "local-model",
+        "Local LM Studio OpenAI compatibility endpoint",
+        key_required=False,
+        local=True,
+    ),
+    ProviderSpec(
+        "vllm",
+        "vLLM (local)",
+        "openai",
+        "VLLM_API_KEY",
+        "http://127.0.0.1:8000/v1",
+        "local-model",
+        "Local vLLM OpenAI compatibility endpoint",
+        key_required=False,
+        local=True,
+    ),
+    ProviderSpec(
+        "azure-openai",
+        "Azure OpenAI",
+        "openai",
+        "AZURE_OPENAI_API_KEY",
+        "",
+        "deployment-name",
+        "Azure OpenAI v1 endpoint; model is the deployment name",
+        base_url_env="AZURE_OPENAI_BASE_URL",
+    ),
+    ProviderSpec(
+        "custom-openai",
+        "Custom OpenAI-compatible",
+        "openai",
+        "PERSOME_LLM_API_KEY",
+        "",
+        "model-id",
+        "Any OpenAI-compatible Chat Completions endpoint",
+        base_url_env="PERSOME_LLM_BASE_URL",
+    ),
+    ProviderSpec(
+        "custom-anthropic",
+        "Custom Anthropic-compatible",
+        "anthropic",
+        "PERSOME_LLM_API_KEY",
+        "",
+        "model-id",
+        "Any Anthropic-compatible Messages endpoint",
+        base_url_env="PERSOME_LLM_BASE_URL",
+    ),
+)
+
+_BY_ID = {provider.id: provider for provider in PROVIDERS}
+
+
+@dataclass(frozen=True)
+class ResolvedLLMProfile:
+    provider: str
+    provider_label: str
+    protocol: LLMProtocol
+    model: str
+    base_url: str
+    api_key_env: str
+    api_key: str | None = field(default=None, repr=False)
+    key_required: bool = True
+    legacy: bool = False
+
+    @property
+    def wire_model(self) -> str:
+        """Return the model identifier sent to the selected endpoint.
+
+        Only the selected provider's optional routing prefix is removed. This
+        preserves nested model IDs such as ``anthropic/claude-*`` on OpenRouter.
+        """
+        prefix = f"{self.provider}/"
+        if self.model.startswith(prefix):
+            return self.model[len(prefix) :]
+        return self.model
+
+    @property
+    def credential_ready(self) -> bool:
+        return bool(self.api_key) or not self.key_required
+
+
+def provider_spec(provider: str) -> ProviderSpec | None:
+    return _BY_ID.get(provider.lower())
+
+
+def infer_provider(model: str) -> str:
+    """Best-effort provider from an optional ``provider/model`` identifier."""
+    head = model.split("/", 1)[0].lower() if "/" in model else ""
+    if head in _BY_ID:
+        return head
+    lower = model.lower()
+    if lower.startswith("claude"):
+        return "anthropic"
+    if lower.startswith("deepseek"):
+        return "deepseek"
+    if lower.startswith("gemini"):
+        return "gemini"
+    if lower.startswith("grok"):
+        return "xai"
+    if lower.startswith("mistral") or lower.startswith("ministral"):
+        return "mistral"
+    if lower.startswith("qwen"):
+        return "qwen-cn"
+    if lower.startswith("glm"):
+        return "zhipu"
+    return "openai"
+
+
+def provider_api_key(provider: str) -> str | None:
+    spec = provider_spec(provider)
+    return os.environ.get(spec.api_key_env) if spec else None
+
+
+def provider_base_url(provider: str) -> str | None:
+    spec = provider_spec(provider)
+    if not spec or not spec.resolved_base_url_env:
+        return None
+    return os.environ.get(spec.resolved_base_url_env)
+
+
+def _legacy_anthropic_profile(model_cfg: Any) -> ResolvedLLMProfile | None:
+    """Preserve pre-provider Persome installations without rewriting them.
+
+    Before provider profiles existed, every runtime call used ``ANTHROPIC_*``
+    regardless of the model name. When no new routing fields are explicit,
+    retain those exact semantics, including a missing credential.
+    """
+    explicit = any(
+        str(getattr(model_cfg, name, "") or "") for name in ("provider", "protocol", "api_key_env")
+    )
+    if explicit:
+        return None
+    key = os.environ.get("ANTHROPIC_API_KEY")
+    model = str(getattr(model_cfg, "model", "") or "")
+    provider = infer_provider(model)
+    spec = provider_spec(provider)
+    base_url = str(getattr(model_cfg, "base_url", "") or "")
+    base_url = base_url or os.environ.get("ANTHROPIC_BASE_URL", "")
+    if not base_url:
+        base_url = _BY_ID["anthropic"].base_url
+    return ResolvedLLMProfile(
+        provider=provider,
+        provider_label=f"{spec.label if spec else provider} (legacy Anthropic route)",
+        protocol="anthropic",
+        model=model,
+        base_url=base_url,
+        api_key_env="ANTHROPIC_API_KEY",
+        api_key=key,
+        key_required=True,
+        legacy=True,
+    )
+
+
+def resolve_profile(model_cfg: Any) -> ResolvedLLMProfile:
+    """Resolve a model/chat config into one complete runtime profile."""
+    legacy = _legacy_anthropic_profile(model_cfg)
+    if legacy is not None:
+        return legacy
+
+    model = str(getattr(model_cfg, "model", "") or "")
+    provider = str(getattr(model_cfg, "provider", "") or "") or infer_provider(model)
+    spec = provider_spec(provider)
+    if spec is None:
+        spec = _BY_ID["custom-openai"]
+    protocol_raw = str(getattr(model_cfg, "protocol", "") or "") or spec.protocol
+    protocol: LLMProtocol = "anthropic" if protocol_raw == "anthropic" else "openai"
+    api_key_env = str(getattr(model_cfg, "api_key_env", "") or "") or spec.api_key_env
+    base_url = str(getattr(model_cfg, "base_url", "") or "")
+    if not base_url and spec.resolved_base_url_env:
+        base_url = os.environ.get(spec.resolved_base_url_env, "")
+    base_url = base_url or spec.base_url
+    return ResolvedLLMProfile(
+        provider=provider,
+        provider_label=spec.label,
+        protocol=protocol,
+        model=model or spec.default_model,
+        base_url=base_url,
+        api_key_env=api_key_env,
+        api_key=os.environ.get(api_key_env),
+        key_required=spec.key_required,
+    )
+
+
+def make_profile(
+    provider: str,
+    *,
+    model: str,
+    base_url: str,
+    api_key_env: str,
+    api_key: str | None,
+    protocol: LLMProtocol | None = None,
+) -> ResolvedLLMProfile:
+    """Build a profile from onboarding inputs before they are persisted."""
+    spec = provider_spec(provider) or _BY_ID["custom-openai"]
+    return ResolvedLLMProfile(
+        provider=provider,
+        provider_label=spec.label,
+        protocol=protocol or spec.protocol,
+        model=model,
+        base_url=base_url,
+        api_key_env=api_key_env,
+        api_key=api_key,
+        key_required=spec.key_required,
+    )
+
+
+def detected_providers() -> list[ProviderSpec]:
+    """Return hosted provider candidates whose credential is present.
+
+    Region/protocol variants intentionally remain separate even when they use
+    the same key variable; guessing the wrong endpoint is worse than prompting.
+    """
+    return [spec for spec in PROVIDERS if not spec.local and os.environ.get(spec.api_key_env)]

--- a/src/persome/writer/case_extractor.py
+++ b/src/persome/writer/case_extractor.py
@@ -225,7 +225,7 @@ def run_case_extraction(
     ``cfg.case_extraction_enabled`` is truthy.
 
     ``llm_call`` / ``memory`` are injectable seams for testing; the live defaults
-    use ``llm_mod.call_llm`` (Anthropic) and a fresh ``EvoMemory`` (its
+    use provider-aware ``llm_mod.call_llm`` and a fresh ``EvoMemory`` (its
     deterministic ``add_direct`` write entrance — no reconciler/LLM needed).
     """
 

--- a/src/persome/writer/chat_title.py
+++ b/src/persome/writer/chat_title.py
@@ -1,8 +1,8 @@
 """Generate a short sidebar title for a chat session.
 
 Called once per session, after the first user/assistant exchange. Uses the
-same Anthropic SDK path the chat agent uses (``chat.agent.complete_sync``
-+ ``[chat] model`` + ``ANTHROPIC_*`` env), so any user who can chat at all
+same resolved provider path as the chat agent (``chat.agent.complete_sync``),
+so any user who can chat at all
 has a working title generator without configuring a separate ``[models.*]``
 stage — title generation rides the same already-validated provider as their
 chat replies.
@@ -107,15 +107,8 @@ def generate_title(cfg: Config, messages: list[dict[str, Any]]) -> str | None:
     body += "\n\nTitle:"
 
     try:
-        # max_tokens budget must cover a reasoning-model "thinking" block AND
-        # the actual title text. DeepSeek's /anthropic gateway routes
-        # `deepseek-v4-flash` (and v4-pro) as reasoning models that emit a
-        # thinking block before the text block — a tight budget (e.g. 64)
-        # gets consumed entirely by thinking, the response stops with
-        # `stop_reason: max_tokens` and no text block at all, and
-        # ``complete_sync`` returns "". 1024 is comfortably above observed
-        # thinking-block sizes for this prompt; the actual title is ≤24
-        # chars so the cost is bounded by the thinking length, not by us.
+        # Leave enough output room for providers that emit reasoning before the
+        # title. A tight budget can end before any text block is returned.
         raw = complete_sync(
             cfg.chat,
             [{"role": "user", "content": _PROMPT_PREFIX + body}],

--- a/src/persome/writer/embeddings_client.py
+++ b/src/persome/writer/embeddings_client.py
@@ -61,7 +61,7 @@ def _resolve_endpoint() -> tuple[str, str] | None:
     - **Azure OpenAI / full URL**: a base that already names the route
       (``…/openai/deployments/<dep>/embeddings?api-version=…``, or any URL ending in
       ``/embeddings`` / carrying ``api-version=``) is used VERBATIM, with the key in ``api-key``
-      (Azure's header). Lets a bring-your-own-key user point straight at Azure te3-large.
+      (Azure's header). Lets a user point dense retrieval straight at Azure te3-large.
     """
     base = provider_base_url("openai")
     if not base:

--- a/src/persome/writer/llm.py
+++ b/src/persome/writer/llm.py
@@ -169,8 +169,6 @@ def _to_openai_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
             normalized["tool_calls"] = message["tool_calls"]
         if role == "tool":
             normalized["tool_call_id"] = message.get("tool_call_id")
-            if message.get("name"):
-                normalized["name"] = message["name"]
         out.append(normalized)
     return out
 
@@ -262,11 +260,11 @@ def _make_openai_client(api_key: str, base_url: str) -> Any:
 
 
 def _anthropic_client(profile: ResolvedLLMProfile) -> Any:
-    return _make_anthropic_client(profile.api_key, profile.base_url or None)
+    return _make_anthropic_client(profile.client_api_key(), profile.base_url or None)
 
 
 def _openai_client(profile: ResolvedLLMProfile) -> Any:
-    return _make_openai_client(profile.api_key or "local-no-key", profile.base_url)
+    return _make_openai_client(profile.client_api_key(), profile.base_url)
 
 
 def call_llm(
@@ -409,7 +407,7 @@ def ping_stage(cfg: Config, stage: str, *, timeout: float = 5.0) -> PingResult:
             import anthropic
 
             client = anthropic.Anthropic(
-                api_key=profile.api_key,
+                api_key=profile.client_api_key(),
                 base_url=profile.base_url or None,
                 timeout=timeout,
             )
@@ -422,7 +420,7 @@ def ping_stage(cfg: Config, stage: str, *, timeout: float = 5.0) -> PingResult:
             from openai import OpenAI
 
             client = OpenAI(
-                api_key=profile.api_key or "local-no-key",
+                api_key=profile.client_api_key(),
                 base_url=profile.base_url,
                 timeout=timeout,
             )

--- a/src/persome/writer/llm.py
+++ b/src/persome/writer/llm.py
@@ -1,17 +1,8 @@
-"""Anthropic SDK wrapper with per-stage model resolution.
+"""Provider-aware LLM wrapper with per-stage model resolution.
 
-All background stages (timeline / reducer / classifier / compact /
-pattern_detector / case_extractor / memory_delta) call the Anthropic
-Messages API directly through the official SDK — the same client path chat uses.
-litellm was removed: it serialized custom tools with a ``type:"custom"`` variant
-the DeepSeek ``/anthropic`` gateway rejects (``unknown variant 'custom'``), which
-broke every tool-calling stage. The backend talks only the Anthropic protocol
-(official endpoint or a compatible gateway like DeepSeek's ``/anthropic``).
-
-To keep the blast radius minimal, ``call_llm`` still returns the OpenAI-shaped
-``_Resp([_Choice(_Msg(content, tool_calls))])`` object the rest of this module
-(``run_tool_loop`` / ``extract_text`` / ``extract_tool_calls`` / ``extract_usage``)
-and every caller already consume — the Anthropic response is adapted back into it.
+Background stages use either Anthropic Messages or OpenAI-compatible Chat
+Completions. Both paths return the same small OpenAI-shaped response contract so
+the reducer/classifier/modeling tool loops remain provider-independent.
 """
 
 from __future__ import annotations
@@ -25,8 +16,9 @@ from functools import lru_cache
 from types import SimpleNamespace
 from typing import Any, cast
 
-from ..config import Config, ModelConfig, provider_api_key, provider_base_url
+from ..config import Config, ModelConfig
 from ..logger import get
+from ..providers import ResolvedLLMProfile, resolve_profile
 
 logger = get("persome.writer")
 
@@ -60,21 +52,8 @@ class _RetryCtx:
     overloaded_count: int = 0
 
 
-# litellm routing prefixes — stripped to a bare model name for the Anthropic SDK,
-# which (like the chat agent) sends the bare name verbatim to the gateway.
-_ROUTING_PREFIXES = ("anthropic/", "deepseek/", "openai/", "openrouter/", "gemini/")
-
 # Default output cap when a stage's ModelConfig sets none (Anthropic requires max_tokens).
 _DEFAULT_MAX_TOKENS = 8192
-
-
-def _bare_model(model: str) -> str:
-    """Strip a routing prefix → bare model name (e.g. ``anthropic/deepseek-v4-flash``
-    → ``deepseek-v4-flash``). Back-compat for existing ``anthropic/...`` configs."""
-    for p in _ROUTING_PREFIXES:
-        if model.startswith(p):
-            return model[len(p) :]
-    return model
 
 
 def _unfence_json(text: str) -> str:
@@ -160,6 +139,63 @@ def _to_anthropic_messages(
     return system, out
 
 
+def _text_content(content: Any) -> str | None:
+    """Flatten text-only provider content while dropping protocol extensions."""
+    if content is None or isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return str(content)
+    parts: list[str] = []
+    for block in content:
+        if isinstance(block, str):
+            parts.append(block)
+        elif isinstance(block, dict) and block.get("type") == "text":
+            parts.append(str(block.get("text") or ""))
+    return "\n".join(part for part in parts if part) or None
+
+
+def _to_openai_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Normalize shared messages for OpenAI-compatible Chat Completions."""
+    out: list[dict[str, Any]] = []
+    for message in messages:
+        role = message.get("role")
+        if role not in {"system", "user", "assistant", "tool"}:
+            continue
+        normalized: dict[str, Any] = {
+            "role": role,
+            "content": _text_content(message.get("content")),
+        }
+        if role == "assistant" and message.get("tool_calls"):
+            normalized["tool_calls"] = message["tool_calls"]
+        if role == "tool":
+            normalized["tool_call_id"] = message.get("tool_call_id")
+            if message.get("name"):
+                normalized["name"] = message["name"]
+        out.append(normalized)
+    return out
+
+
+def _to_openai_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Remove Anthropic-only cache metadata from OpenAI function tools."""
+    out: list[dict[str, Any]] = []
+    for tool in tools:
+        if tool.get("type") == "function" and isinstance(tool.get("function"), dict):
+            out.append({"type": "function", "function": dict(tool["function"])})
+        elif "name" in tool and "input_schema" in tool:
+            out.append(
+                {
+                    "type": "function",
+                    "function": {
+                        "name": tool["name"],
+                        "description": tool.get("description", ""),
+                        "parameters": tool.get("input_schema")
+                        or {"type": "object", "properties": {}},
+                    },
+                }
+            )
+    return out
+
+
 def _adapt(msg: Any) -> Any:
     """Adapt an Anthropic ``Message`` into the OpenAI-shaped ``_Resp`` the rest of
     the module consumes (text + tool_calls + finish_reason + usage)."""
@@ -204,7 +240,7 @@ def _adapt(msg: Any) -> Any:
     return _Resp([_Choice(_Msg("".join(text_parts) or None, tool_calls or None), finish)], usage)
 
 
-@lru_cache(maxsize=4)
+@lru_cache(maxsize=16)
 def _make_anthropic_client(api_key: str | None, base_url: str | None) -> Any:
     """Build (and memoize) an Anthropic client per (key, base_url). Cached so the underlying httpx
     connection pool — and its keep-alive TLS connections to the relay — are REUSED across calls
@@ -217,9 +253,20 @@ def _make_anthropic_client(api_key: str | None, base_url: str | None) -> Any:
     return anthropic.Anthropic(api_key=api_key, base_url=base_url)
 
 
-def _anthropic_client() -> Any:
-    """Cached Anthropic client from the canonical ANTHROPIC_* env (same as chat)."""
-    return _make_anthropic_client(provider_api_key("anthropic"), provider_base_url("anthropic"))
+@lru_cache(maxsize=16)
+def _make_openai_client(api_key: str, base_url: str) -> Any:
+    """Build and memoize an OpenAI-compatible client per credential/endpoint."""
+    from openai import OpenAI
+
+    return OpenAI(api_key=api_key, base_url=base_url)
+
+
+def _anthropic_client(profile: ResolvedLLMProfile) -> Any:
+    return _make_anthropic_client(profile.api_key, profile.base_url or None)
+
+
+def _openai_client(profile: ResolvedLLMProfile) -> Any:
+    return _make_openai_client(profile.api_key or "local-no-key", profile.base_url)
 
 
 def call_llm(
@@ -231,16 +278,13 @@ def call_llm(
     json_mode: bool = False,
     extra: dict[str, Any] | None = None,
 ) -> Any:
-    """Invoke the Anthropic Messages API for the given stage.
+    """Invoke the configured provider for one background stage.
 
-    Returns the OpenAI-shaped ``_Resp`` adapter (see module docstring), so
-    ``run_tool_loop`` / ``extract_*`` and every caller stay unchanged.
+    Anthropic responses are adapted to the shared response shape. OpenAI SDK
+    responses already expose that shape and pass through directly.
     Respects ``PERSOME_LLM_MOCK=1`` (test stub) and ``PERSOME_FALLBACK_MODEL``
-    (529 fallback). ``cache_control`` on messages/tools/system passes through —
-    the Anthropic protocol honors it natively (no stripping, no prefix tricks).
-    ``extra`` merges raw request params into the call body (e.g.
-    ``{"thinking": {"type": "disabled"}}`` for a fast stage) — forwarded
-    verbatim, so the relay passes them to the upstream gateway.
+    (529 fallback). Anthropic cache-control metadata passes through only on the
+    Anthropic path; it is removed for OpenAI-compatible endpoints.
     """
     if os.environ.get("PERSOME_LLM_MOCK") == "1":
         return _mock_response(stage, messages, tools, json_mode)
@@ -249,23 +293,40 @@ def call_llm(
     override = os.environ.get("PERSOME_FALLBACK_MODEL")
     if override:
         model_cfg = ModelConfig(**{**model_cfg.__dict__, "model": override})
+    profile = resolve_profile(model_cfg)
 
-    system, amsgs = _to_anthropic_messages(messages)
-    kwargs: dict[str, Any] = {
-        "model": _bare_model(model_cfg.model),
-        "messages": amsgs,
-        "max_tokens": model_cfg.max_tokens or _DEFAULT_MAX_TOKENS,
-    }
-    if system is not None:
-        kwargs["system"] = system
-    if tools:
-        kwargs["tools"] = _to_anthropic_tools(tools)
-    if extra:
-        kwargs.update(extra)
-
-    logger.debug("llm call stage=%s model=%s", stage, model_cfg.model)
-    msg = _anthropic_client().messages.create(**kwargs)
-    resp = _adapt(msg)
+    logger.debug(
+        "llm call stage=%s provider=%s protocol=%s model=%s",
+        stage,
+        profile.provider,
+        profile.protocol,
+        profile.model,
+    )
+    if profile.protocol == "anthropic":
+        system, provider_messages = _to_anthropic_messages(messages)
+        kwargs: dict[str, Any] = {
+            "model": profile.wire_model,
+            "messages": provider_messages,
+            "max_tokens": model_cfg.max_tokens or _DEFAULT_MAX_TOKENS,
+        }
+        if system is not None:
+            kwargs["system"] = system
+        if tools:
+            kwargs["tools"] = _to_anthropic_tools(tools)
+        if extra:
+            kwargs.update(extra)
+        resp = _adapt(_anthropic_client(profile).messages.create(**kwargs))
+    else:
+        openai_kwargs: dict[str, Any] = {
+            "model": profile.wire_model,
+            "messages": _to_openai_messages(messages),
+            "max_tokens": model_cfg.max_tokens or _DEFAULT_MAX_TOKENS,
+        }
+        if tools:
+            openai_kwargs["tools"] = _to_openai_tools(tools)
+        # ``extra`` contains Anthropic-specific controls in existing callers.
+        # Do not leak those unsupported fields into compatible gateways.
+        resp = _openai_client(profile).chat.completions.create(**openai_kwargs)
     if json_mode and resp.choices and resp.choices[0].message.content:
         resp.choices[0].message.content = _unfence_json(resp.choices[0].message.content)
     return resp
@@ -331,6 +392,7 @@ def ping_stage(cfg: Config, stage: str, *, timeout: float = 5.0) -> PingResult:
     informational callers must remain non-fatal.
     """
     model_cfg = cfg.model_for(stage)
+    profile = resolve_profile(model_cfg)
     if os.environ.get("PERSOME_LLM_MOCK") == "1":
         return PingResult(
             stage=stage,
@@ -341,29 +403,34 @@ def ping_stage(cfg: Config, stage: str, *, timeout: float = 5.0) -> PingResult:
             mocked=True,
         )
 
-    try:
-        import anthropic  # lazy import — keeps CLI startup fast
-    except ImportError as exc:
-        return PingResult(
-            stage=stage,
-            model=model_cfg.model,
-            ok=False,
-            latency_ms=None,
-            error=f"ImportError: {exc}",
-        )
-
     start = time.monotonic()
     try:
-        client = anthropic.Anthropic(
-            api_key=provider_api_key("anthropic"),
-            base_url=provider_base_url("anthropic"),
-            timeout=timeout,
-        )
-        client.messages.create(
-            model=_bare_model(model_cfg.model),
-            messages=[{"role": "user", "content": "Reply with 'ok'."}],
-            max_tokens=4,
-        )
+        if profile.protocol == "anthropic":
+            import anthropic
+
+            client = anthropic.Anthropic(
+                api_key=profile.api_key,
+                base_url=profile.base_url or None,
+                timeout=timeout,
+            )
+            client.messages.create(
+                model=profile.wire_model,
+                messages=[{"role": "user", "content": "Reply with 'ok'."}],
+                max_tokens=4,
+            )
+        else:
+            from openai import OpenAI
+
+            client = OpenAI(
+                api_key=profile.api_key or "local-no-key",
+                base_url=profile.base_url,
+                timeout=timeout,
+            )
+            client.chat.completions.create(
+                model=profile.wire_model,
+                messages=[{"role": "user", "content": "Reply with 'ok'."}],
+                max_tokens=4,
+            )
     except Exception as exc:  # noqa: BLE001
         label = type(exc).__name__
         msg = str(exc).strip().splitlines()[0] if str(exc).strip() else ""
@@ -494,14 +561,17 @@ def count_tokens_api(cfg: Config, stage: str, messages: list[dict[str, Any]]) ->
     if not cfg.writer.use_token_count_api:
         return None
     model_cfg = cfg.model_for(stage)
+    profile = resolve_profile(model_cfg)
+    if profile.protocol != "anthropic":
+        return None
     try:
         import anthropic  # noqa: F401
 
         system, amsgs = _to_anthropic_messages(messages)
-        kwargs: dict[str, Any] = {"model": _bare_model(model_cfg.model), "messages": amsgs}
+        kwargs: dict[str, Any] = {"model": profile.wire_model, "messages": amsgs}
         if system is not None:
             kwargs["system"] = system
-        result = _anthropic_client().messages.count_tokens(**kwargs)
+        result = _anthropic_client(profile).messages.count_tokens(**kwargs)
         return int(getattr(result, "input_tokens", 0)) or None
     except Exception:  # noqa: BLE001
         return None

--- a/tests/test_chat_history_fold.py
+++ b/tests/test_chat_history_fold.py
@@ -1,8 +1,7 @@
 """Tests for the agent-loop folding in GET /chat/sessions/{id}/messages.
 
-The chat agent persists Anthropic agent-loop iterations faithfully —
-``assistant text+tool_use`` rows interleaved with ``user tool_result`` rows
-— but the HTTP messages endpoint is a presentation projection that folds
+The chat agent persists provider-native agent-loop iterations faithfully, but
+the HTTP messages endpoint is a presentation projection that folds
 each agent-loop span into ONE assistant turn carrying:
 
   - ``content``: plain-text join of every text block (fallback for older
@@ -170,6 +169,44 @@ def test_fold_string_content_assistant_kept() -> None:
     out = _fold_agent_loop(raw)
     assert out[1]["content"] == "plain string answer"
     assert out[1]["blocks"] == [{"type": "text", "text": "plain string answer"}]
+
+
+def test_fold_openai_tool_calls_and_results() -> None:
+    raw = [
+        {"role": "user", "content": "search my memory"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "search_memory",
+                        "arguments": '{"query":"project"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": "memory result",
+        },
+        {"role": "assistant", "content": "I found the project."},
+    ]
+
+    out = _fold_agent_loop(raw)
+
+    assert len(out) == 2
+    assert out[1]["content"] == "I found the project."
+    assert _types(out[1]) == ["tool_use", "tool_result", "text"]
+    assert out[1]["blocks"][0] == {
+        "type": "tool_use",
+        "name": "search_memory",
+        "input": {"query": "project"},
+    }
+    assert out[1]["blocks"][1]["tool_use_id"] == "call_1"
 
 
 def test_fold_multiple_turns() -> None:

--- a/tests/test_chat_openai.py
+++ b/tests/test_chat_openai.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from persome.chat.agent import ChatAgent, complete_sync
+from persome.config import ChatConfig
+
+
+def _openai_chat_config() -> ChatConfig:
+    return ChatConfig(
+        provider="openai",
+        protocol="openai",
+        model="gpt-4.1-mini",
+        base_url="https://gateway.example/v1",
+        api_key_env="OPENAI_API_KEY",
+    )
+
+
+class _Stream:
+    def __init__(self, chunks: list[Any]) -> None:
+        self._chunks = iter(chunks)
+
+    def __aiter__(self):  # type: ignore[no-untyped-def]
+        return self
+
+    async def __anext__(self):  # type: ignore[no-untyped-def]
+        try:
+            return next(self._chunks)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+def _chunk(*, content: str | None = None, tool_calls: list[Any] | None = None) -> Any:
+    delta = SimpleNamespace(content=content, tool_calls=tool_calls)
+    return SimpleNamespace(choices=[SimpleNamespace(delta=delta)], usage=None)
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_stream_executes_tools_and_persists_rounds(monkeypatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "synthetic")
+    schema = {
+        "type": "function",
+        "function": {
+            "name": "lookup",
+            "description": "Look up memory",
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        },
+    }
+    seen: list[dict[str, Any]] = []
+    agent = ChatAgent(
+        _openai_chat_config(),
+        [schema],
+        {"lookup": lambda args: seen.append(args) or {"answer": "remembered"}},
+    )
+    await agent.client.close()
+
+    first = _Stream(
+        [
+            _chunk(
+                tool_calls=[
+                    SimpleNamespace(
+                        index=0,
+                        id="call_1",
+                        function=SimpleNamespace(name="lookup", arguments='{"query":"project"}'),
+                    )
+                ]
+            )
+        ]
+    )
+    second = _Stream([_chunk(content="I found it.")])
+
+    class _FakeCompletions:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def create(self, **kwargs: Any) -> _Stream:
+            self.calls += 1
+            assert kwargs["stream"] is True
+            assert kwargs["tools"][0]["function"]["name"] == "lookup"
+            return first if self.calls == 1 else second
+
+    fake_completions = _FakeCompletions()
+
+    class _FakeClient:
+        chat = SimpleNamespace(completions=fake_completions)
+
+        async def close(self) -> None:
+            return None
+
+    agent.client = _FakeClient()  # type: ignore[assignment]
+    messages = [{"role": "user", "content": "What do you remember?"}]
+    streamed: list[str] = []
+
+    async def on_token(token: str) -> None:
+        streamed.append(token)
+
+    result = await agent.run_turn(messages, "Use memory tools.", on_token=on_token)
+    await agent.aclose()
+
+    assert result.error is None
+    assert result.assistant_message == "I found it."
+    assert streamed == ["I found it."]
+    assert seen == [{"query": "project"}]
+    assert [message["role"] for message in messages] == [
+        "user",
+        "assistant",
+        "tool",
+        "assistant",
+    ]
+    assert result.tool_calls_executed == [{"name": "lookup", "arguments": {"query": "project"}}]
+
+
+def test_complete_sync_uses_openai_profile(monkeypatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "synthetic")
+    captured: dict[str, Any] = {}
+
+    class _FakeCompletions:
+        def create(self, **kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content="summary"))]
+            )
+
+    class _FakeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            captured["client"] = kwargs
+            self.chat = SimpleNamespace(completions=_FakeCompletions())
+
+    monkeypatch.setattr("openai.OpenAI", _FakeClient)
+
+    result = complete_sync(_openai_chat_config(), [{"role": "user", "content": "Summarize"}])
+
+    assert result == "summary"
+    assert captured["model"] == "gpt-4.1-mini"
+    assert captured["client"]["base_url"] == "https://gateway.example/v1"

--- a/tests/test_chat_ttft.py
+++ b/tests/test_chat_ttft.py
@@ -61,6 +61,7 @@ class _FakeRunner:
 
 
 def _make_agent(monkeypatch, runner: _FakeRunner) -> ChatAgent:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "synthetic")
     agent = ChatAgent(ChatConfig(), all_schemas=[], all_handlers={})
 
     def fake_tool_runner(**_kw: Any) -> _FakeRunner:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -69,8 +69,8 @@ capture_actionable_retention_days = 2
     assert capture.actionable_retention_days == 2
 
 
-def test_inline_api_key_is_ignored_but_route_fields_load(tmp_path: Path) -> None:
-    """Secrets in TOML are ignored; non-secret route fields are supported."""
+def test_legacy_route_fields_do_not_silently_change_protocol(tmp_path: Path) -> None:
+    """Old inline secrets/routes stay ignored until provider/protocol is explicit."""
     path = tmp_path / "config.toml"
     path.write_text(
         """
@@ -90,8 +90,15 @@ base_url = "https://api.example/anthropic"
     assert not hasattr(default, "api_key")
     assert default.api_key_env == "OPENAI_API_KEY"
     assert not hasattr(cfg.chat, "api_key")
-    assert cfg.chat.api_key_env == "ANTHROPIC_API_KEY"
-    assert cfg.chat.base_url == "https://api.example/anthropic"
+    assert cfg.chat.model == "deepseek-v4-flash"
+    assert cfg.chat.api_key_env == ""
+    assert cfg.chat.base_url == ""
+
+    from persome.providers import resolve_profile
+
+    assert resolve_profile(default).legacy is True
+    assert resolve_profile(default).protocol == "anthropic"
+    assert resolve_profile(cfg.chat).legacy is True
 
 
 def test_write_default_creates_file(tmp_path: Path) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -69,9 +69,8 @@ capture_actionable_retention_days = 2
     assert capture.actionable_retention_days == 2
 
 
-def test_legacy_api_key_fields_ignored(tmp_path: Path) -> None:
-    """Old TOMLs may still set ``api_key`` / ``api_key_env`` — silently drop
-    them so users can upgrade without a migration step."""
+def test_inline_api_key_is_ignored_but_route_fields_load(tmp_path: Path) -> None:
+    """Secrets in TOML are ignored; non-secret route fields are supported."""
     path = tmp_path / "config.toml"
     path.write_text(
         """
@@ -88,12 +87,11 @@ base_url = "https://api.example/anthropic"
     )
     cfg = config.load(path)
     default = cfg.model_for("default")
-    # No AttributeError, no leakage into the dataclass.
     assert not hasattr(default, "api_key")
-    assert not hasattr(default, "api_key_env")
+    assert default.api_key_env == "OPENAI_API_KEY"
     assert not hasattr(cfg.chat, "api_key")
-    assert not hasattr(cfg.chat, "api_key_env")
-    assert not hasattr(cfg.chat, "base_url")
+    assert cfg.chat.api_key_env == "ANTHROPIC_API_KEY"
+    assert cfg.chat.base_url == "https://api.example/anthropic"
 
 
 def test_write_default_creates_file(tmp_path: Path) -> None:
@@ -102,8 +100,8 @@ def test_write_default_creates_file(tmp_path: Path) -> None:
     assert p.exists()
     text = p.read_text()
     assert "[models.default]" in text
-    # Template no longer mentions key/env fields.
-    assert "api_key_env" not in text
+    assert "persome llm setup" in text
+    assert "api_key_env" in text
     # idempotent
     assert not config.write_default_if_missing(p)
 
@@ -130,3 +128,25 @@ def test_infer_provider() -> None:
     # Unknown bare names default to openai (litellm's own default).
     assert config.infer_provider("gpt-5.4-nano") == "openai"
     assert config.infer_provider("mystery-model") == "openai"
+
+
+def test_chat_inherits_default_provider_profile(tmp_path: Path) -> None:
+    path = tmp_path / "config.toml"
+    path.write_text(
+        """
+[models.default]
+provider = "openrouter"
+protocol = "openai"
+model = "anthropic/claude-sonnet-4"
+base_url = "https://openrouter.ai/api/v1"
+api_key_env = "OPENROUTER_API_KEY"
+
+[chat]
+thinking_budget = 0
+"""
+    )
+    cfg = config.load(path)
+    assert cfg.chat.provider == "openrouter"
+    assert cfg.chat.protocol == "openai"
+    assert cfg.chat.model == "anthropic/claude-sonnet-4"
+    assert cfg.chat.api_key_env == "OPENROUTER_API_KEY"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,4 +1,4 @@
-"""`persome doctor` — the BYO-key install self-check (src/persome/doctor.py).
+"""`persome doctor` — the BYO-provider install self-check.
 
 Every branch is exercised offline via monkeypatch: no network, no LLM, no real
 TCC probe. Contract pinned here:
@@ -19,15 +19,17 @@ from pathlib import Path
 import pytest
 
 from persome import doctor, paths
+from persome.providers import PROVIDERS
 
 
 @pytest.fixture
 def clean_llm_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    for var in (
-        "ANTHROPIC_API_KEY",
-        "ANTHROPIC_BASE_URL",
-        "PERSOME_SCREENSHOT_KEY",
-    ):
+    variables = {"ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "PERSOME_SCREENSHOT_KEY"}
+    for spec in PROVIDERS:
+        variables.add(spec.api_key_env)
+        if spec.resolved_base_url_env:
+            variables.add(spec.resolved_base_url_env)
+    for var in variables:
         monkeypatch.delenv(var, raising=False)
 
 
@@ -112,7 +114,7 @@ def test_base_url_reachable_ok(monkeypatch: pytest.MonkeyPatch, clean_llm_env: N
     monkeypatch.setattr(httpx, "head", fake_head)
     c = doctor.check_base_url()
     assert c.status == "ok"
-    assert "(default)" in c.detail
+    assert "legacy Anthropic route" in c.detail
 
 
 def test_base_url_unreachable_warns_never_fails(
@@ -319,8 +321,32 @@ def test_run_checks_merges_env_file_first(
     checks = doctor.run_checks("127.0.0.1", 0)
     by_name = {c.name: c for c in checks}
     assert by_name["env file"].status == "ok"
-    assert by_name["ANTHROPIC_API_KEY"].status == "ok"
+    assert by_name["LLM credential"].status == "ok"
     assert by_name["PERSOME_SCREENSHOT_KEY"].status == "warn"
+
+
+def test_openai_profile_uses_selected_credential_and_endpoint(
+    ac_root: Path, clean_llm_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import httpx
+
+    paths.config_file().write_text(
+        """
+[models.default]
+provider = "openai"
+protocol = "openai"
+model = "gpt-4.1-mini"
+base_url = "https://gateway.example/v1"
+api_key_env = "OPENAI_API_KEY"
+"""
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "synthetic")
+    seen: list[str] = []
+    monkeypatch.setattr(httpx, "head", lambda url, **kw: seen.append(url) or object())
+
+    assert doctor.check_api_key().status == "ok"
+    assert doctor.check_base_url().status == "ok"
+    assert seen == ["https://gateway.example/v1"]
 
 
 def test_has_failure_ignores_warnings() -> None:

--- a/tests/test_env_file.py
+++ b/tests/test_env_file.py
@@ -71,6 +71,20 @@ def test_invalid_key_skipped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     assert n >= 1
 
 
+def test_write_env_values_upserts_atomically(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "env"
+    path.write_text("KEEP=yes\nOPENAI_API_KEY=old\nOPENAI_API_KEY=duplicate\n")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    env_file.write_env_values(path, {"OPENAI_API_KEY": "new"})
+
+    assert path.read_text() == "KEEP=yes\nOPENAI_API_KEY=new\n"
+    assert path.stat().st_mode & 0o777 == 0o600
+    assert os.environ["OPENAI_API_KEY"] == "new"
+
+
 def test_ensure_screenshot_key_generates_owner_only_file(tmp_path: Path) -> None:
     path = tmp_path / "env"
     path.write_text("ANTHROPIC_API_KEY=synthetic\n")

--- a/tests/test_integration_deepseek.py
+++ b/tests/test_integration_deepseek.py
@@ -1,4 +1,4 @@
-"""Integration tests using real DeepSeek API (deepseek/deepseek-v4-flash).
+"""Integration tests using DeepSeek's OpenAI-compatible API.
 
 Run with:
     DEEPSEEK_API_KEY=sk-... uv run pytest tests/test_integration_deepseek.py -v -s
@@ -45,14 +45,21 @@ pytestmark = [
     ),
 ]
 
-MODEL = "deepseek/deepseek-v4-flash"
+MODEL = "deepseek-chat"
 
 
 def _make_cfg(max_tokens: int = 64):
     from persome.config import Config, ModelConfig, WriterConfig
 
     cfg = Config(writer=WriterConfig(llm_retry_attempts=2))
-    cfg.models["default"] = ModelConfig(model=MODEL, max_tokens=max_tokens)
+    cfg.models["default"] = ModelConfig(
+        provider="deepseek",
+        protocol="openai",
+        model=MODEL,
+        base_url="https://api.deepseek.com/v1",
+        api_key_env="DEEPSEEK_API_KEY",
+        max_tokens=max_tokens,
+    )
     return cfg
 
 

--- a/tests/test_llm_setup.py
+++ b/tests/test_llm_setup.py
@@ -9,7 +9,7 @@ from typer.testing import CliRunner
 
 from persome import config, paths
 from persome.cli import app
-from persome.llm_setup import probe_profile, save_profile
+from persome.llm_setup import ProbeResult, probe_profile, save_profile
 from persome.providers import make_profile
 
 
@@ -180,3 +180,20 @@ def test_status_describes_keyless_local_provider(ac_root: Path) -> None:
     assert status.exit_code == 0
     assert "not required" in status.output
     assert "set via OLLAMA_API_KEY" not in status.output
+
+
+def test_status_check_fails_when_tool_calling_is_unconfirmed(ac_root: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    setup = CliRunner().invoke(
+        app,
+        ["llm", "setup", "--provider", "ollama", "--yes", "--skip-check"],
+    )
+    assert setup.exit_code == 0, setup.output
+    monkeypatch.setattr(
+        "persome.llm_setup.probe_profile",
+        lambda profile: ProbeResult(True, False, 12, "tool choice unsupported"),
+    )
+
+    status = CliRunner().invoke(app, ["llm", "status", "--check"])
+
+    assert status.exit_code == 1
+    assert "not confirmed" in status.output

--- a/tests/test_llm_setup.py
+++ b/tests/test_llm_setup.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from typer.testing import CliRunner
+
+from persome import config, paths
+from persome.cli import app
+from persome.llm_setup import probe_profile, save_profile
+from persome.providers import make_profile
+
+
+def _profile(api_key: str = "synthetic-secret"):  # type: ignore[no-untyped-def]
+    return make_profile(
+        "openai",
+        model="gpt-4.1-mini",
+        base_url="https://gateway.example/v1",
+        api_key_env="OPENAI_API_KEY",
+        api_key=api_key,
+        protocol="openai",
+    )
+
+
+def test_save_profile_keeps_secret_out_of_toml(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.toml"
+    env_path = tmp_path / "env"
+    config_path.write_text("[capture]\ninterval_minutes = 3\n")
+
+    save_profile(_profile(), config_path=config_path, env_path=env_path)
+
+    text = config_path.read_text()
+    assert "synthetic-secret" not in text
+    assert 'provider = "openai"' in text
+    assert "interval_minutes = 3" in text
+    assert env_path.read_text() == "OPENAI_API_KEY=synthetic-secret\n"
+    assert stat.S_IMODE(env_path.stat().st_mode) == 0o600
+    loaded = config.load(config_path).model_for("default")
+    assert loaded.protocol == "openai"
+    assert loaded.base_url == "https://gateway.example/v1"
+
+
+def test_probe_profile_checks_completion_and_tools(monkeypatch) -> None:
+    calls = 0
+
+    class _FakeCompletions:
+        def create(self, **kwargs: Any) -> Any:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return SimpleNamespace(
+                    choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+                )
+            tool_call = SimpleNamespace(function=SimpleNamespace(name="persome_setup_check"))
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(tool_calls=[tool_call]))]
+            )
+
+    class _FakeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            self.chat = SimpleNamespace(completions=_FakeCompletions())
+
+    monkeypatch.setattr("openai.OpenAI", _FakeClient)
+
+    result = probe_profile(_profile())
+
+    assert result.completion_ok is True
+    assert result.tool_call_ok is True
+    assert calls == 2
+
+
+def test_probe_retries_auto_when_forced_tool_choice_is_rejected(monkeypatch) -> None:
+    calls = 0
+
+    class _FakeCompletions:
+        def create(self, **kwargs: Any) -> Any:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return SimpleNamespace(
+                    choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+                )
+            if calls == 2:
+                raise RuntimeError("forced tool_choice is unsupported")
+            assert kwargs["tool_choice"] == "auto"
+            tool_call = SimpleNamespace(function=SimpleNamespace(name="persome_setup_check"))
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(tool_calls=[tool_call]))]
+            )
+
+    class _FakeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            self.chat = SimpleNamespace(completions=_FakeCompletions())
+
+    monkeypatch.setattr("openai.OpenAI", _FakeClient)
+
+    result = probe_profile(_profile())
+
+    assert result.tool_call_ok is True
+    assert result.error is None
+    assert calls == 3
+
+
+def test_setup_cli_detects_exported_key_and_persists_profile(ac_root: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("OPENAI_API_KEY", "synthetic-secret")
+    runner = CliRunner()
+
+    result = runner.invoke(
+        app,
+        [
+            "llm",
+            "setup",
+            "--provider",
+            "openai",
+            "--model",
+            "gpt-test",
+            "--base-url",
+            "https://gateway.example/v1",
+            "--yes",
+            "--skip-check",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "synthetic-secret" not in result.output
+    selected = config.load().model_for("default")
+    assert selected.provider == "openai"
+    assert selected.model == "gpt-test"
+    assert paths.env_file().read_text().count("OPENAI_API_KEY=") == 1
+
+
+def test_setup_cli_does_not_save_failed_probe(ac_root: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("OPENAI_API_KEY", "synthetic-secret")
+
+    class _BrokenClient:
+        def __init__(self, **kwargs: Any) -> None:
+            raise RuntimeError("bad endpoint")
+
+    monkeypatch.setattr("openai.OpenAI", _BrokenClient)
+    result = CliRunner().invoke(
+        app,
+        [
+            "llm",
+            "setup",
+            "--provider",
+            "openai",
+            "--model",
+            "gpt-test",
+            "--base-url",
+            "https://bad.example/v1",
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Nothing was saved" in result.output
+    assert "synthetic-secret" not in paths.config_file().read_text()
+
+
+def test_status_describes_keyless_local_provider(ac_root: Path) -> None:
+    setup = CliRunner().invoke(
+        app,
+        [
+            "llm",
+            "setup",
+            "--provider",
+            "ollama",
+            "--model",
+            "qwen3:8b",
+            "--yes",
+            "--skip-check",
+        ],
+    )
+    assert setup.exit_code == 0, setup.output
+
+    status = CliRunner().invoke(app, ["llm", "status"])
+
+    assert status.exit_code == 0
+    assert "not required" in status.output
+    assert "set via OLLAMA_API_KEY" not in status.output

--- a/tests/test_openai_protocol_http.py
+++ b/tests/test_openai_protocol_http.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import json
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+import pytest
+
+from persome.chat.agent import ChatAgent
+from persome.config import ChatConfig, Config, ModelConfig
+from persome.llm_setup import probe_profile
+from persome.providers import make_profile
+from persome.writer.llm import call_llm, extract_text
+
+
+class _Handler(BaseHTTPRequestHandler):
+    requests: list[dict[str, Any]] = []
+
+    def log_message(self, format: str, *args: Any) -> None:
+        return None
+
+    def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler contract
+        length = int(self.headers.get("Content-Length", "0"))
+        body = json.loads(self.rfile.read(length))
+        self.requests.append(
+            {
+                "path": self.path,
+                "authorization": self.headers.get("Authorization"),
+                "body": body,
+            }
+        )
+        if body.get("stream"):
+            self._stream(body)
+        else:
+            self._json_completion(body)
+
+    def _json_completion(self, body: dict[str, Any]) -> None:
+        message: dict[str, Any] = {"role": "assistant", "content": "ok"}
+        finish_reason = "stop"
+        if body.get("tools"):
+            message = {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_probe",
+                        "type": "function",
+                        "function": {"name": "persome_setup_check", "arguments": "{}"},
+                    }
+                ],
+            }
+            finish_reason = "tool_calls"
+        payload = {
+            "id": "chatcmpl-test",
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": "test-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": message,
+                    "finish_reason": finish_reason,
+                }
+            ],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4},
+        }
+        raw = json.dumps(payload).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def _stream(self, body: dict[str, Any]) -> None:
+        has_tool_result = any(message.get("role") == "tool" for message in body["messages"])
+        if has_tool_result:
+            delta: dict[str, Any] = {"role": "assistant", "content": "tool result received"}
+            finish_reason = "stop"
+        else:
+            delta = {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": '{"query":"project"}'},
+                    }
+                ],
+            }
+            finish_reason = "tool_calls"
+        chunk = {
+            "id": "chatcmpl-stream",
+            "object": "chat.completion.chunk",
+            "created": int(time.time()),
+            "model": "test-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": delta,
+                    "finish_reason": finish_reason,
+                }
+            ],
+        }
+        raw = f"data: {json.dumps(chunk)}\n\ndata: [DONE]\n\n".encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+
+@contextmanager
+def _server() -> Iterator[tuple[str, list[dict[str, Any]]]]:
+    _Handler.requests = []
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address
+    try:
+        yield f"http://{host}:{port}/v1", _Handler.requests
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def test_writer_uses_real_openai_sdk_over_configured_endpoint(monkeypatch) -> None:
+    monkeypatch.delenv("PERSOME_LLM_MOCK", raising=False)
+    monkeypatch.setenv("PERSOME_LLM_API_KEY", "wire-secret")
+    with _server() as (base_url, requests):
+        cfg = Config(
+            models={
+                "default": ModelConfig(
+                    provider="custom-openai",
+                    protocol="openai",
+                    model="test-model",
+                    base_url=base_url,
+                    api_key_env="PERSOME_LLM_API_KEY",
+                )
+            }
+        )
+
+        response = call_llm(
+            cfg,
+            "timeline",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+
+    assert extract_text(response) == "ok"
+    assert requests[0]["path"] == "/v1/chat/completions"
+    assert requests[0]["authorization"] == "Bearer wire-secret"
+
+
+def test_onboarding_probe_uses_real_openai_sdk(monkeypatch) -> None:
+    monkeypatch.setenv("PERSOME_LLM_API_KEY", "wire-secret")
+    with _server() as (base_url, requests):
+        profile = make_profile(
+            "custom-openai",
+            model="test-model",
+            base_url=base_url,
+            api_key_env="PERSOME_LLM_API_KEY",
+            api_key="wire-secret",
+            protocol="openai",
+        )
+
+        result = probe_profile(profile)
+
+    assert result.completion_ok is True
+    assert result.tool_call_ok is True
+    assert len(requests) == 2
+    assert requests[1]["body"]["tool_choice"]["function"]["name"] == "persome_setup_check"
+
+
+@pytest.mark.asyncio
+async def test_chat_uses_real_openai_sdk_streaming_tool_loop(monkeypatch) -> None:
+    monkeypatch.setenv("PERSOME_LLM_API_KEY", "wire-secret")
+    with _server() as (base_url, requests):
+        cfg = ChatConfig(
+            provider="custom-openai",
+            protocol="openai",
+            model="test-model",
+            base_url=base_url,
+            api_key_env="PERSOME_LLM_API_KEY",
+        )
+        schema = {
+            "type": "function",
+            "function": {
+                "name": "lookup",
+                "description": "Look up memory",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        seen: list[dict[str, Any]] = []
+        agent = ChatAgent(
+            cfg,
+            [schema],
+            {"lookup": lambda arguments: seen.append(arguments) or {"ok": True}},
+        )
+        messages = [{"role": "user", "content": "Use the tool"}]
+
+        result = await agent.run_turn(messages, "Use tools when needed.")
+        await agent.aclose()
+
+    assert result.error is None
+    assert result.assistant_message == "tool result received"
+    assert seen == [{"query": "project"}]
+    assert len(requests) == 2
+    assert requests[1]["body"]["messages"][-1]["role"] == "tool"

--- a/tests/test_pipeline_prompt_cache.py
+++ b/tests/test_pipeline_prompt_cache.py
@@ -20,6 +20,7 @@ import pytest
 from persome.writer.llm import (
     _to_anthropic_messages,
     _to_anthropic_tools,
+    _to_openai_messages,
 )
 
 _EPHEMERAL = {"type": "ephemeral"}
@@ -88,6 +89,20 @@ def test_to_anthropic_messages_folds_tool_calls_and_results() -> None:
     assert (
         tr["type"] == "tool_result" and tr["tool_use_id"] == "c1" and tr["content"] == "result-text"
     )
+
+
+def test_to_openai_messages_omits_nonstandard_tool_name() -> None:
+    messages = [
+        {
+            "role": "tool",
+            "tool_call_id": "c1",
+            "name": "search_memory",
+            "content": "result",
+        }
+    ]
+    assert _to_openai_messages(messages) == [
+        {"role": "tool", "tool_call_id": "c1", "content": "result"}
+    ]
 
 
 # ─── call_llm end-to-end (stubbed Anthropic client) ──────────────────────────

--- a/tests/test_pipeline_prompt_cache.py
+++ b/tests/test_pipeline_prompt_cache.py
@@ -3,7 +3,6 @@
 Since the migration off litellm, the background stages call the Anthropic
 Messages API directly. ``call_llm`` converts the OpenAI-shaped messages/tools
 into Anthropic shape and adapts the response back. Covers:
-- ``_bare_model`` — routing-prefix stripping
 - ``_to_anthropic_tools`` — OpenAI function → Anthropic ``input_schema`` (+ cache_control)
 - ``_to_anthropic_messages`` — system extraction, tool_result folding, tool_use, cache_control pass-through
 - ``call_llm`` forwards a bare model + converted tools/system to the SDK, preserving cache_control
@@ -19,23 +18,11 @@ from typing import Any
 import pytest
 
 from persome.writer.llm import (
-    _bare_model,
     _to_anthropic_messages,
     _to_anthropic_tools,
 )
 
 _EPHEMERAL = {"type": "ephemeral"}
-
-
-# ─── _bare_model ─────────────────────────────────────────────────────────────
-
-
-def test_bare_model_strips_routing_prefixes() -> None:
-    assert _bare_model("anthropic/deepseek-v4-flash") == "deepseek-v4-flash"
-    assert _bare_model("deepseek/deepseek-v4-flash") == "deepseek-v4-flash"
-    assert _bare_model("openai/gpt-4o") == "gpt-4o"
-    assert _bare_model("deepseek-v4-flash") == "deepseek-v4-flash"  # already bare
-    assert _bare_model("claude-haiku-4-5") == "claude-haiku-4-5"
 
 
 # ─── tool conversion ─────────────────────────────────────────────────────────
@@ -123,7 +110,7 @@ def test_call_llm_forwards_bare_model_and_converted_tools(monkeypatch) -> None:
             )
 
     monkeypatch.setattr(
-        llm_mod, "_anthropic_client", lambda: SimpleNamespace(messages=_FakeMessages())
+        llm_mod, "_anthropic_client", lambda _profile: SimpleNamespace(messages=_FakeMessages())
     )
 
     cfg = config_mod.Config()
@@ -152,6 +139,67 @@ def test_call_llm_forwards_bare_model_and_converted_tools(monkeypatch) -> None:
     # response adapted back into OpenAI shape
     assert llm_mod.extract_text(resp) == "ok"
     assert llm_mod.extract_usage(resp)["prompt_tokens"] == 3
+
+
+def test_call_llm_openai_compatible_strips_anthropic_extensions(monkeypatch) -> None:
+    monkeypatch.delenv("PERSOME_LLM_MOCK", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "synthetic")
+    from persome import config as config_mod
+    from persome.writer import llm as llm_mod
+
+    captured: dict[str, Any] = {}
+
+    class _FakeCompletions:
+        def create(self, **kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(content="ok", tool_calls=None),
+                        finish_reason="stop",
+                    )
+                ],
+                usage=SimpleNamespace(prompt_tokens=4, completion_tokens=1, total_tokens=5),
+            )
+
+    fake_client = SimpleNamespace(chat=SimpleNamespace(completions=_FakeCompletions()))
+    monkeypatch.setattr(llm_mod, "_openai_client", lambda _profile: fake_client)
+
+    cfg = config_mod.Config(
+        models={
+            "default": config_mod.ModelConfig(
+                provider="openrouter",
+                protocol="openai",
+                model="anthropic/claude-sonnet-4",
+                base_url="https://openrouter.ai/api/v1",
+                api_key_env="OPENROUTER_API_KEY",
+            )
+        }
+    )
+    response = llm_mod.call_llm(
+        cfg,
+        "default",
+        messages=[
+            {
+                "role": "system",
+                "content": [{"type": "text", "text": "sys", "cache_control": _EPHEMERAL}],
+            },
+            {"role": "user", "content": "hi"},
+        ],
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "lookup", "parameters": {"type": "object"}},
+                "cache_control": _EPHEMERAL,
+            }
+        ],
+    )
+
+    assert captured["model"] == "anthropic/claude-sonnet-4"
+    assert captured["messages"][0] == {"role": "system", "content": "sys"}
+    assert "cache_control" not in captured["tools"][0]
+    assert llm_mod.extract_text(response) == "ok"
+    assert llm_mod.extract_usage(response)["total_tokens"] == 5
 
 
 # ─── system prompt templates carry no format placeholders ───────────────────

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -198,7 +198,7 @@ def test_system_prompt_template_has_no_current_time_placeholder() -> None:
 # ─── run_turn tool-list assembly: sorted by name, last has cache_control ────
 
 
-def test_run_turn_tools_are_sorted_and_last_has_cache_control() -> None:
+def test_run_turn_tools_are_sorted_and_last_has_cache_control(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     """End-to-end shape check on ChatAgent.run_turn's combined_tools.
 
     Mocks the SDK at the boundary so we can inspect the kwargs passed to
@@ -260,6 +260,7 @@ def test_run_turn_tools_are_sorted_and_last_has_cache_control() -> None:
         async def close(self) -> None:
             pass
 
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "synthetic")
     cfg = ChatConfig(model="deepseek-chat")
     agent = ChatAgent(cfg, schemas, handlers)
     agent.client = _FakeClient()  # type: ignore[assignment]

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from persome.config import ModelConfig
 from persome.providers import PROVIDERS, detected_providers, resolve_profile
 
@@ -78,6 +80,21 @@ def test_local_provider_does_not_require_a_key(monkeypatch) -> None:
     )
     assert profile.api_key is None
     assert profile.credential_ready is True
+    assert profile.client_api_key() == "persome-local"
+
+
+def test_hosted_profile_fails_before_network_when_key_is_missing(monkeypatch) -> None:
+    _clear_provider_env(monkeypatch)
+    profile = resolve_profile(
+        ModelConfig(
+            provider="openai",
+            protocol="openai",
+            model="gpt-4.1-mini",
+            api_key_env="OPENAI_API_KEY",
+        )
+    )
+    with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
+        profile.client_api_key()
 
 
 def test_detected_providers_keeps_region_choices_for_shared_credential(monkeypatch) -> None:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from persome.config import ModelConfig
+from persome.providers import PROVIDERS, detected_providers, resolve_profile
+
+
+def _clear_provider_env(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    for spec in PROVIDERS:
+        monkeypatch.delenv(spec.api_key_env, raising=False)
+        if spec.resolved_base_url_env:
+            monkeypatch.delenv(spec.resolved_base_url_env, raising=False)
+
+
+def test_explicit_deepseek_profile_uses_openai_compatibility(monkeypatch) -> None:
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "synthetic")
+    profile = resolve_profile(
+        ModelConfig(
+            provider="deepseek",
+            protocol="openai",
+            model="deepseek-chat",
+            api_key_env="DEEPSEEK_API_KEY",
+        )
+    )
+    assert profile.protocol == "openai"
+    assert profile.base_url == "https://api.deepseek.com/v1"
+    assert profile.api_key == "synthetic"
+    assert profile.credential_ready is True
+
+
+def test_legacy_config_keeps_anthropic_wire_semantics(monkeypatch) -> None:
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "legacy")
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://gateway.example/anthropic")
+    profile = resolve_profile(ModelConfig(model="deepseek-v4-flash"))
+    assert profile.legacy is True
+    assert profile.provider == "deepseek"
+    assert profile.protocol == "anthropic"
+    assert profile.api_key_env == "ANTHROPIC_API_KEY"
+    assert profile.base_url == "https://gateway.example/anthropic"
+
+
+def test_openrouter_preserves_nested_model_provider_prefix(monkeypatch) -> None:
+    _clear_provider_env(monkeypatch)
+    profile = resolve_profile(
+        ModelConfig(
+            provider="openrouter",
+            protocol="openai",
+            model="anthropic/claude-sonnet-4",
+            api_key_env="OPENROUTER_API_KEY",
+        )
+    )
+    assert profile.wire_model == "anthropic/claude-sonnet-4"
+
+
+def test_selected_provider_routing_prefix_is_removed(monkeypatch) -> None:
+    _clear_provider_env(monkeypatch)
+    profile = resolve_profile(
+        ModelConfig(
+            provider="openai",
+            protocol="openai",
+            model="openai/gpt-4.1-mini",
+            api_key_env="OPENAI_API_KEY",
+        )
+    )
+    assert profile.wire_model == "gpt-4.1-mini"
+
+
+def test_local_provider_does_not_require_a_key(monkeypatch) -> None:
+    _clear_provider_env(monkeypatch)
+    profile = resolve_profile(
+        ModelConfig(
+            provider="ollama",
+            protocol="openai",
+            model="qwen3:8b",
+            api_key_env="OLLAMA_API_KEY",
+        )
+    )
+    assert profile.api_key is None
+    assert profile.credential_ready is True
+
+
+def test_detected_providers_keeps_region_choices_for_shared_credential(monkeypatch) -> None:
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "synthetic")
+    monkeypatch.setenv("OPENAI_API_KEY", "synthetic")
+    detected = detected_providers()
+    assert [spec.id for spec in detected] == ["openai", "qwen-cn", "qwen-us"]

--- a/tests/test_token_count.py
+++ b/tests/test_token_count.py
@@ -35,7 +35,7 @@ def _patch_client(monkeypatch, count_tokens) -> list[dict]:
             return count_tokens(**kwargs)
 
     monkeypatch.setattr(
-        llm_mod, "_anthropic_client", lambda: SimpleNamespace(messages=_FakeMessages())
+        llm_mod, "_anthropic_client", lambda _profile: SimpleNamespace(messages=_FakeMessages())
     )
     return calls
 

--- a/tests/test_writer_llm_ping.py
+++ b/tests/test_writer_llm_ping.py
@@ -27,6 +27,7 @@ def _patch_anthropic(monkeypatch: pytest.MonkeyPatch, create: Callable[..., Any]
     Returns a list capturing each ``messages.create`` kwargs dict."""
     import anthropic
 
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "synthetic")
     calls: list[dict] = []
 
     class _FakeMessages:
@@ -175,3 +176,24 @@ def test_ping_stage_openai_compatible_uses_selected_endpoint(
     assert result.ok is True
     assert captured_client["base_url"] == "https://gateway.example/v1"
     assert captured_call["model"] == "gpt-4.1-mini"
+
+
+def test_ping_stage_reports_missing_selected_credential(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PERSOME_LLM_MOCK", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    cfg = Config(
+        models={
+            "default": ModelConfig(
+                provider="openai",
+                protocol="openai",
+                model="gpt-4.1-mini",
+                api_key_env="OPENAI_API_KEY",
+            )
+        }
+    )
+
+    result = llm_mod.ping_stage(cfg, "timeline")
+
+    assert result.ok is False
+    assert result.error is not None
+    assert "OPENAI_API_KEY" in result.error

--- a/tests/test_writer_llm_ping.py
+++ b/tests/test_writer_llm_ping.py
@@ -135,3 +135,43 @@ def test_ping_stage_truncates_long_error_message(monkeypatch: pytest.MonkeyPatch
     assert res.ok is False
     assert res.error is not None
     assert len(res.error) <= 80
+
+
+def test_ping_stage_openai_compatible_uses_selected_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PERSOME_LLM_MOCK", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "synthetic")
+    import openai
+
+    captured_client: dict[str, Any] = {}
+    captured_call: dict[str, Any] = {}
+
+    class _FakeCompletions:
+        def create(self, **kwargs: Any) -> Any:
+            captured_call.update(kwargs)
+            return SimpleNamespace(choices=[])
+
+    class _FakeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            captured_client.update(kwargs)
+            self.chat = SimpleNamespace(completions=_FakeCompletions())
+
+    monkeypatch.setattr(openai, "OpenAI", _FakeClient)
+    cfg = Config(
+        models={
+            "default": ModelConfig(
+                provider="openai",
+                protocol="openai",
+                model="gpt-4.1-mini",
+                base_url="https://gateway.example/v1",
+                api_key_env="OPENAI_API_KEY",
+            )
+        }
+    )
+
+    result = llm_mod.ping_stage(cfg, "timeline")
+
+    assert result.ok is True
+    assert captured_client["base_url"] == "https://gateway.example/v1"
+    assert captured_call["model"] == "gpt-4.1-mini"

--- a/uv.lock
+++ b/uv.lock
@@ -1260,7 +1260,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.0" },
     { name = "mss", specifier = ">=9.0" },
     { name = "numpy", specifier = ">=1.26" },
-    { name = "openai", specifier = ">=1.75" },
+    { name = "openai", specifier = ">=1.75,<3" },
     { name = "paddleocr", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'", specifier = "==3.7.0" },
     { name = "paddlepaddle", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'", specifier = "==3.3.1" },
     { name = "pillow", specifier = ">=10.0" },
@@ -1269,7 +1269,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.7" },
     { name = "sse-starlette", specifier = ">=2.1" },
     { name = "starlette", specifier = ">=0.40" },
-    { name = "tomlkit", specifier = ">=0.13" },
+    { name = "tomlkit", specifier = ">=0.13,<1" },
     { name = "typer", specifier = ">=0.12" },
     { name = "uvicorn", specifier = ">=0.30" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -33,14 +33,14 @@ name = "aiohttp"
 version = "3.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohappyeyeballs" },
-    { name = "aiosignal" },
-    { name = "attrs" },
-    { name = "frozenlist" },
-    { name = "multidict" },
-    { name = "propcache" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-    { name = "yarl" },
+    { name = "aiohappyeyeballs", marker = "sys_platform == 'darwin'" },
+    { name = "aiosignal", marker = "sys_platform == 'darwin'" },
+    { name = "attrs", marker = "sys_platform == 'darwin'" },
+    { name = "frozenlist", marker = "sys_platform == 'darwin'" },
+    { name = "multidict", marker = "sys_platform == 'darwin'" },
+    { name = "propcache", marker = "sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' and sys_platform == 'darwin'" },
+    { name = "yarl", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/82/78/8ea7308cac6934de8c74a14f3d5f65d1c89287426688be79538d0e5c013d/aiohttp-3.14.1.tar.gz", hash = "sha256:307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035", size = 7955794, upload-time = "2026-06-07T21:09:35.529Z" }
 wheels = [
@@ -59,8 +59,8 @@ name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "frozenlist" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "frozenlist", marker = "sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' and sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
@@ -72,12 +72,12 @@ name = "aistudio-sdk"
 version = "0.3.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "bce-python-sdk" },
-    { name = "click" },
-    { name = "prettytable" },
-    { name = "psutil" },
-    { name = "requests" },
-    { name = "tqdm" },
+    { name = "bce-python-sdk", marker = "sys_platform == 'darwin'" },
+    { name = "click", marker = "sys_platform == 'darwin'" },
+    { name = "prettytable", marker = "sys_platform == 'darwin'" },
+    { name = "psutil", marker = "sys_platform == 'darwin'" },
+    { name = "requests", marker = "sys_platform == 'darwin'" },
+    { name = "tqdm", marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/77/cd71a481bb7a76b0e9d0b6bf47711c627b1dd079001ea246893f19a9d04c/aistudio_sdk-0.3.8-py3-none-any.whl", hash = "sha256:bfc96af7243ac2ee3303014849aa4028717cce5afa622af8cfe3a1d44d1941d6", size = 62972, upload-time = "2025-09-19T11:42:39.384Z" },
@@ -147,10 +147,10 @@ name = "bce-python-sdk"
 version = "0.9.72"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "crc32c" },
-    { name = "future" },
-    { name = "pycryptodome" },
-    { name = "six" },
+    { name = "crc32c", marker = "sys_platform == 'darwin'" },
+    { name = "future", marker = "sys_platform == 'darwin'" },
+    { name = "pycryptodome", marker = "sys_platform == 'darwin'" },
+    { name = "six", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/32/bb/1ccb8b28bfa0802356f8588e479adb61cfd2268b37fabc6c8a805d645cd5/bce_python_sdk-0.9.72.tar.gz", hash = "sha256:d9db568698792d74db4245252d98776eae8c9c5225fc0ba86548dfc52d478fcc", size = 302207, upload-time = "2026-06-08T12:10:32.326Z" }
 wheels = [
@@ -336,9 +336,6 @@ wheels = [
 name = "colorlog"
 version = "6.10.1"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
 sdist = { url = "https://files.pythonhosted.org/packages/a2/61/f083b5ac52e505dfc1c624eafbf8c7589a0d7f32daa398d2e7590efa5fda/colorlog-6.10.1.tar.gz", hash = "sha256:eb4ae5cb65fe7fec7773c2306061a8e63e02efc2c72eba9d27b0fa23c94f1321", size = 17162, upload-time = "2025-10-16T16:14:11.978Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl", hash = "sha256:2d7e8348291948af66122cff006c9f8da6255d224e7cf8e37d8de2df3bad8c9c", size = 11743, upload-time = "2025-10-16T16:14:10.512Z" },
@@ -690,15 +687,15 @@ name = "huggingface-hub"
 version = "1.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "httpx" },
-    { name = "packaging" },
-    { name = "pyyaml" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
+    { name = "click", marker = "sys_platform == 'darwin'" },
+    { name = "filelock", marker = "sys_platform == 'darwin'" },
+    { name = "fsspec", marker = "sys_platform == 'darwin'" },
+    { name = "hf-xet", marker = "(platform_machine == 'AMD64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'darwin') or (platform_machine == 'amd64' and sys_platform == 'darwin') or (platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin')" },
+    { name = "httpx", marker = "sys_platform == 'darwin'" },
+    { name = "packaging", marker = "sys_platform == 'darwin'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin'" },
+    { name = "tqdm", marker = "sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/77/ea/dc54b4dda5841cb3a7812a178695be776e7c15c597887c2ed892f17d015a/huggingface_hub-1.22.0.tar.gz", hash = "sha256:e2dfe5fe1ec3b87ba2709aa34555b23e3f3f6ad4d7255238e13ddb8348e6bbfa", size = 914232, upload-time = "2026-07-03T09:46:44.685Z" }
 wheels = [
@@ -943,13 +940,13 @@ name = "modelscope"
 version = "1.38.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock" },
-    { name = "modelscope-hub" },
-    { name = "packaging" },
-    { name = "requests" },
-    { name = "setuptools" },
-    { name = "tqdm" },
-    { name = "urllib3" },
+    { name = "filelock", marker = "sys_platform == 'darwin'" },
+    { name = "modelscope-hub", marker = "sys_platform == 'darwin'" },
+    { name = "packaging", marker = "sys_platform == 'darwin'" },
+    { name = "requests", marker = "sys_platform == 'darwin'" },
+    { name = "setuptools", marker = "sys_platform == 'darwin'" },
+    { name = "tqdm", marker = "sys_platform == 'darwin'" },
+    { name = "urllib3", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/72/b37f46f8e1900c64485420b210eecda1f758cbd0fe8ade60c5bbf883b25e/modelscope-1.38.1.tar.gz", hash = "sha256:a81f3685b1545f52b415d88a763456416aa65170e622f9dcc02eadb3f8e1cfa0", size = 4542886, upload-time = "2026-07-06T15:13:56.427Z" }
 wheels = [
@@ -961,10 +958,10 @@ name = "modelscope-hub"
 version = "0.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock" },
-    { name = "requests" },
-    { name = "tqdm" },
-    { name = "urllib3" },
+    { name = "filelock", marker = "sys_platform == 'darwin'" },
+    { name = "requests", marker = "sys_platform == 'darwin'" },
+    { name = "tqdm", marker = "sys_platform == 'darwin'" },
+    { name = "urllib3", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b6/cb/6b9d3fcbcd09db6cdd7f1e0fd60be2998c99db07be28f37982c0dbd14496/modelscope_hub-0.1.7.tar.gz", hash = "sha256:b78730f3923cf13d5fbc56c6224a5ba617bf111a562fe3808c03e34c3c07840f", size = 126616, upload-time = "2026-07-07T07:35:36.465Z" }
 wheels = [
@@ -1066,11 +1063,30 @@ wheels = [
 ]
 
 [[package]]
+name = "openai"
+version = "2.45.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/60/d4219875289b11d2c2f7da93c36283da224a2e55865ed865ab64e0ce9217/openai-2.45.0.tar.gz", hash = "sha256:10d34ca9c5643bce775852fddbfc172505cb1d4de1ccd101696c3ecff358765d", size = 1109653, upload-time = "2026-07-09T18:02:44.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/b0/2291689e3ec4723fbf5bbf3b54afcd7b160f9ddc98ca7aedfd0132af5677/openai-2.45.0-py3-none-any.whl", hash = "sha256:5df105f5f8c9b711fcb9d06d2d3888cebc82506db216484c14a4e53cdf651777", size = 1629470, upload-time = "2026-07-09T18:02:42.21Z" },
+]
+
+[[package]]
 name = "opencv-contrib-python"
 version = "4.10.0.84"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/33/7b8ec6c4d45e678b26297e4a5e76464a93033a9adcc8c17eac01097065f6/opencv-contrib-python-4.10.0.84.tar.gz", hash = "sha256:4a3eae0ed9cadf1abe9293a6938a25a540e2fd6d7fc308595caa5896c8b36a0c", size = 150433857, upload-time = "2024-06-17T18:30:50.217Z" }
 wheels = [
@@ -1082,7 +1098,7 @@ name = "opt-einsum"
 version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7d/bf/9257e53a0e7715bc1127e15063e831f076723c6cd60985333a1c18878fb8/opt_einsum-3.3.0.tar.gz", hash = "sha256:59f6475f77bbc37dcf7cd748519c0ec60722e91e63ca114e68821c0c54a46549", size = 73951, upload-time = "2020-07-19T22:40:32.141Z" }
 wheels = [
@@ -1103,11 +1119,11 @@ name = "paddleocr"
 version = "3.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
-    { name = "paddlex", extra = ["ocr-core"] },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "typing-extensions" },
+    { name = "aiohttp", marker = "sys_platform == 'darwin'" },
+    { name = "paddlex", extra = ["ocr-core"], marker = "sys_platform == 'darwin'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin'" },
+    { name = "requests", marker = "sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/97/b1/9454e886afa925067ce51de2e513d146524645888de299d51ddc1caa3100/paddleocr-3.7.0.tar.gz", hash = "sha256:9b81eb62cf37e590d4873e60262ff56f968ff9de6ce1f565749760ceb1c422e2", size = 3082862, upload-time = "2026-06-11T12:09:52.545Z" }
 wheels = [
@@ -1119,15 +1135,15 @@ name = "paddlepaddle"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
-    { name = "networkx" },
-    { name = "numpy" },
-    { name = "opt-einsum" },
-    { name = "pillow" },
-    { name = "protobuf" },
-    { name = "safetensors" },
-    { name = "setuptools", marker = "python_full_version >= '3.12'" },
-    { name = "typing-extensions" },
+    { name = "httpx", marker = "sys_platform == 'darwin'" },
+    { name = "networkx", marker = "sys_platform == 'darwin'" },
+    { name = "numpy", marker = "sys_platform == 'darwin'" },
+    { name = "opt-einsum", marker = "sys_platform == 'darwin'" },
+    { name = "pillow", marker = "sys_platform == 'darwin'" },
+    { name = "protobuf", marker = "sys_platform == 'darwin'" },
+    { name = "safetensors", marker = "sys_platform == 'darwin'" },
+    { name = "setuptools", marker = "python_full_version >= '3.12' and sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/02/854d122760406d8024837112d91ff509e7820d763ac0a5002c4c2812f832/paddlepaddle-3.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:55df22b0bc6bfc0b97093a538eda3c774ef27050ad19e0ee5aa17e468b0de714", size = 104491591, upload-time = "2026-03-26T11:18:09.265Z" },
@@ -1140,24 +1156,24 @@ name = "paddlex"
 version = "3.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aistudio-sdk" },
-    { name = "chardet" },
-    { name = "colorlog" },
-    { name = "filelock" },
-    { name = "huggingface-hub" },
-    { name = "modelscope" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "pandas" },
-    { name = "pillow" },
-    { name = "prettytable" },
-    { name = "py-cpuinfo" },
-    { name = "pydantic" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "ruamel-yaml" },
-    { name = "typing-extensions" },
-    { name = "ujson" },
+    { name = "aistudio-sdk", marker = "sys_platform == 'darwin'" },
+    { name = "chardet", marker = "sys_platform == 'darwin'" },
+    { name = "colorlog", marker = "sys_platform == 'darwin'" },
+    { name = "filelock", marker = "sys_platform == 'darwin'" },
+    { name = "huggingface-hub", marker = "sys_platform == 'darwin'" },
+    { name = "modelscope", marker = "sys_platform == 'darwin'" },
+    { name = "numpy", marker = "sys_platform == 'darwin'" },
+    { name = "packaging", marker = "sys_platform == 'darwin'" },
+    { name = "pandas", marker = "sys_platform == 'darwin'" },
+    { name = "pillow", marker = "sys_platform == 'darwin'" },
+    { name = "prettytable", marker = "sys_platform == 'darwin'" },
+    { name = "py-cpuinfo", marker = "sys_platform == 'darwin'" },
+    { name = "pydantic", marker = "sys_platform == 'darwin'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin'" },
+    { name = "requests", marker = "sys_platform == 'darwin'" },
+    { name = "ruamel-yaml", marker = "sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
+    { name = "ujson", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dd/96/1e86d4056ffc1e494c53aebab7e2faf08dcf8b929180f9872ae46632e9bd/paddlex-3.7.2.tar.gz", hash = "sha256:6a60b4595e2d51460f7f51326672adca86b89ff9ecfd02ac348fb69739e0093c", size = 4415130, upload-time = "2026-06-25T05:50:53.34Z" }
 wheels = [
@@ -1166,12 +1182,12 @@ wheels = [
 
 [package.optional-dependencies]
 ocr-core = [
-    { name = "imagesize" },
-    { name = "opencv-contrib-python" },
-    { name = "pyclipper" },
-    { name = "pypdfium2" },
-    { name = "python-bidi" },
-    { name = "shapely" },
+    { name = "imagesize", marker = "sys_platform == 'darwin'" },
+    { name = "opencv-contrib-python", marker = "sys_platform == 'darwin'" },
+    { name = "pyclipper", marker = "sys_platform == 'darwin'" },
+    { name = "pypdfium2", marker = "sys_platform == 'darwin'" },
+    { name = "python-bidi", marker = "sys_platform == 'darwin'" },
+    { name = "shapely", marker = "sys_platform == 'darwin'" },
 ]
 
 [[package]]
@@ -1179,8 +1195,8 @@ name = "pandas"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "python-dateutil" },
+    { name = "numpy", marker = "sys_platform == 'darwin'" },
+    { name = "python-dateutil", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
 wheels = [
@@ -1203,6 +1219,7 @@ dependencies = [
     { name = "mcp" },
     { name = "mss" },
     { name = "numpy" },
+    { name = "openai" },
     { name = "paddleocr", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
     { name = "paddlepaddle", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
     { name = "pillow" },
@@ -1211,6 +1228,7 @@ dependencies = [
     { name = "rich" },
     { name = "sse-starlette" },
     { name = "starlette" },
+    { name = "tomlkit" },
     { name = "typer" },
     { name = "uvicorn" },
 ]
@@ -1242,6 +1260,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.0" },
     { name = "mss", specifier = ">=9.0" },
     { name = "numpy", specifier = ">=1.26" },
+    { name = "openai", specifier = ">=1.75" },
     { name = "paddleocr", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'", specifier = "==3.7.0" },
     { name = "paddlepaddle", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'", specifier = "==3.3.1" },
     { name = "pillow", specifier = ">=10.0" },
@@ -1250,6 +1269,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.7" },
     { name = "sse-starlette", specifier = ">=2.1" },
     { name = "starlette", specifier = ">=0.40" },
+    { name = "tomlkit", specifier = ">=0.13" },
     { name = "typer", specifier = ">=0.12" },
     { name = "uvicorn", specifier = ">=0.30" },
 ]
@@ -1321,7 +1341,7 @@ name = "prettytable"
 version = "3.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wcwidth" },
+    { name = "wcwidth", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/81/74/ba08d81e668ccfe8658d7520a307e63c19862c08eb4ccb26f356c5239a7a/prettytable-3.18.0.tar.gz", hash = "sha256:439217116152244369caf3d9f1caf2f9fe29b03bd79e88d2928c8e718c95d680", size = 76373, upload-time = "2026-06-22T16:07:50.174Z" }
 wheels = [
@@ -1620,7 +1640,7 @@ name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "six" },
+    { name = "six", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
@@ -1727,10 +1747,10 @@ name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "idna" },
-    { name = "urllib3" },
+    { name = "certifi", marker = "sys_platform == 'darwin'" },
+    { name = "charset-normalizer", marker = "sys_platform == 'darwin'" },
+    { name = "idna", marker = "sys_platform == 'darwin'" },
+    { name = "urllib3", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
@@ -1872,7 +1892,7 @@ name = "shapely"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4d/bc/0989043118a27cccb4e906a46b7565ce36ca7b57f5a18b78f4f1b0f72d9d/shapely-2.1.2.tar.gz", hash = "sha256:2ed4ecb28320a433db18a5bf029986aa8afcfd740745e78847e330d5d94922a9", size = 315489, upload-time = "2025-09-24T13:51:41.432Z" }
 wheels = [
@@ -1990,6 +2010,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tomlkit"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz", hash = "sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3", size = 161875, upload-time = "2026-05-10T07:38:22.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl", hash = "sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738", size = 41328, upload-time = "2026-05-10T07:38:23.517Z" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.68.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2095,9 +2124,9 @@ name = "yarl"
 version = "1.24.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "idna" },
-    { name = "multidict" },
-    { name = "propcache" },
+    { name = "idna", marker = "sys_platform == 'darwin'" },
+    { name = "multidict", marker = "sys_platform == 'darwin'" },
+    { name = "propcache", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/79/12/1e8f37460ea0f7eb59c221fdaf0ed75e7ac43e97f8093b9c6f411df50a78/yarl-1.24.2.tar.gz", hash = "sha256:9ac374123c6fd7abf64d1fec93962b0bd4ee2c19751755a762a72dd96c0378f8", size = 210798, upload-time = "2026-05-19T21:31:05.599Z" }
 wheels = [


### PR DESCRIPTION
## Summary
- add a provider registry for Anthropic Messages and OpenAI-compatible Chat Completions, including hosted, local, Azure, and custom endpoint presets
- add `persome llm providers`, `persome llm setup`, and `persome llm status --check` with credential discovery, masked input, editable endpoint/model, tool-capability probing, retry, and test-before-save persistence
- route modeling and Chat through the selected protocol, preserve legacy `ANTHROPIC_*` installs, and project both provider tool-history shapes through the Chat API
- integrate the provider wizard into `install.sh`, provider-aware doctor/status output, packaging, README, and Runtime docs

## Verification
- `PERSOME_LLM_MOCK=1 uv run pytest -m "not macos and not integration" -q` (1439 passed, 15 deselected)
- local HTTP/SSE protocol tests through the real OpenAI SDK
- real DeepSeek Anthropic-compatible completion + tool probe
- isolated real `persome chat` smoke returned `PERSOME_CHAT_OK`
- wheel build + isolated wheel install + keyless Ollama setup/status smoke
- ruff, secret scan, PII scan, language scan, and documentation link scan all pass

## Compatibility
Existing configs without explicit provider fields retain the previous `ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL` route. Running `persome llm setup` verifies and migrates that route without placing key values in TOML.