### PR TITLE
Render the LLM protocol in status

### DIFF
--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -420,7 +420,7 @@ def status() -> None:
         ping = _format_ping(ping_results.get(stage))
         table.add_row(
             f"Model ({stage})",
-            f"{profile.provider}/{profile.model} [{profile.protocol}]   {ping}",
+            f"{profile.provider}/{profile.model} ({profile.protocol})   {ping}",
         )
 
     console.print(table)

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -25,6 +25,7 @@ def test_status_renders_mocked_pings(ac_root: Path, monkeypatch: pytest.MonkeyPa
     assert "Model (reducer)" in out
     assert "Model (classifier)" in out
     assert "Model (compact)" in out
+    assert "(anthropic)" in out
     # All four stages share the default model, so they all show the mocked tick.
     assert out.count("mocked") >= 4
 


### PR DESCRIPTION
## Summary
- render stage protocols with parentheses so Rich does not consume them as markup tags
- add a CLI regression assertion for the visible protocol

## Verification
- `PERSOME_LLM_MOCK=1 uv run pytest tests/test_cli_status.py -q` (17 passed)
- ruff check and format check pass