### PR TITLE
Simplify LLM provider onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,12 @@ when enabling OCR fallback or screenshot retention; it supplies pixels to the
 local OCR worker. Persome does not require Full Disk Access.
 
 An LLM is optional for collection and BM25 recall, but required for semantic
-modeling. During installation, the provider wizard discovers existing keys,
-lets you edit the endpoint and model, tests completion and tool calling, and
-only then saves the route. API keys go to the owner-only `~/.persome/env` file;
-the non-secret route goes to `~/.persome/config.toml`. Nothing ships with a key.
+modeling. During installation, the provider wizard asks you to choose a service
+and enter its API key. Persome supplies that provider's endpoint and default
+model, tests completion and tool calling, and only then saves the route. Existing
+keys are detected automatically. API keys go to the owner-only
+`~/.persome/env` file; the non-secret route goes to `~/.persome/config.toml`.
+Nothing ships with a key.
 
 ```bash
 # If provider setup was skipped during installation:
@@ -113,8 +115,9 @@ OpenAI-compatible Chat Completions. Presets cover Anthropic, OpenAI, DeepSeek,
 OpenRouter, Gemini, Groq, Mistral, xAI, Qwen, Moonshot/Kimi, Zhipu GLM,
 SiliconFlow, Together, Fireworks, Cerebras, Azure OpenAI, Ollama, LM Studio, and
 vLLM. `custom-openai` and `custom-anthropic` accept another compatible endpoint.
-A preset means the route is configured, not that every model has the necessary
-capabilities; Persome warns when the selected model cannot call tools.
+Azure and custom endpoints use a clearly marked advanced setup path. A preset
+means the route is configured, not that every model has the necessary
+capabilities; Persome warns when the default model cannot call tools.
 
 Active work is reduced every five minutes by default. A first useful recall is
 therefore expected within ten minutes of valid capture plus a working semantic
@@ -130,8 +133,8 @@ or degraded states instead of inventing geometry.
 - AX is the default signal. Optional PP-OCRv6 runs locally in an isolated
   subprocess with bundled weights.
 - The HTTP/MCP server binds to `127.0.0.1` by default, and there is no telemetry.
-- Only configured semantic stages send derived text to the LLM or embedding
-  endpoint you choose.
+- Only configured semantic stages send derived text to the selected provider's
+  LLM or embedding endpoint.
 
 ### Cross-app
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -19,16 +19,24 @@ Messages and OpenAI-compatible Chat Completions. Use the guided path instead of
 editing secrets by hand:
 
 ```bash
-persome llm providers       # presets and locally detected key names
-persome llm setup           # select, edit, probe, then save
+persome llm providers       # provider names and locally detected keys
+persome llm setup           # choose provider, enter key, probe, then save
 persome llm status --check  # inspect the effective route and retest it
 ```
 
 `setup` checks the current profile first, auto-selects when exactly one known
 credential is found, prompts when several are available, and accepts keyless
-local endpoints. It makes a small completion call and a forced tool call before
-saving. A failed connectivity/authentication probe writes nothing. A model that
-completes but cannot call tools requires an explicit degraded-mode confirmation.
+local providers. For a normal hosted provider, the only inputs are the provider
+and its API key; Persome owns the endpoint and default model. It then makes a
+small completion call and a forced tool call before saving. A failed
+connectivity/authentication probe writes nothing. A model that completes but
+cannot call tools requires an explicit degraded-mode confirmation.
+
+Azure deployments and `custom-openai` / `custom-anthropic` are explicitly
+advanced because their endpoint and model or deployment name are user-specific.
+Automation can also override a preset with `--base-url`, `--model`, and
+`--api-key-env`. Run `persome llm providers --details` to inspect those routing
+defaults; they are not part of regular onboarding.
 
 The resulting non-secret configuration has this shape:
 

--- a/install.sh
+++ b/install.sh
@@ -347,9 +347,9 @@ write_default_if_missing()
   echo "  LLM Provider Setup (bring your own key or local model)"
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
   echo ""
-  echo "Persome can discover existing provider credentials or configure an"
-  echo "Anthropic Messages / OpenAI-compatible endpoint. It verifies both"
-  echo "completion and tool calling before saving anything."
+  echo "Choose your LLM provider and enter its API key. Persome selects the"
+  echo "endpoint and default model, then verifies completion and tool calling"
+  echo "before saving anything. Existing keys are detected automatically."
   echo ""
   if ! prompt_yes_no "Configure and test the Runtime LLM now?"; then
     echo "Skipped. Run 'persome llm setup' at any time."

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -1051,19 +1051,28 @@ launchagent_app = typer.Typer(
 )
 app.add_typer(launchagent_app, name="launchagent")
 
-llm_app = typer.Typer(help="Discover, verify, and configure the Runtime's LLM provider.")
+llm_app = typer.Typer(help="Choose and verify the Runtime's LLM provider.")
 app.add_typer(llm_app, name="llm")
+
+
+def _interactive_terminal() -> bool:
+    return sys.stdin.isatty() and sys.stdout.isatty()
+
+
+def _llm_credential_summary(spec: ProviderSpec) -> str:
+    if not spec.key_required:
+        return "[dim]local, no key[/dim]"
+    if os.environ.get(spec.api_key_env):
+        return "[green]key found[/green]"
+    return "[dim]API key required[/dim]"
 
 
 def _choose_llm_provider(specs: Sequence[ProviderSpec]) -> ProviderSpec:
     for index, spec in enumerate(specs, start=1):
-        credential = "none (local)" if not spec.key_required else spec.api_key_env
-        endpoint = spec.base_url or "enter during setup"
-        console.print(f"  [bold cyan]{index:>2}[/bold cyan]. {spec.label} [dim]({spec.id})[/dim]")
-        console.print(
-            f"      {spec.protocol} | {credential} | {endpoint}\n"
-            f"      [dim]{spec.description}[/dim]"
-        )
+        flags = [_llm_credential_summary(spec)]
+        if spec.advanced:
+            flags.append("[yellow]advanced[/yellow]")
+        console.print(f"  [bold cyan]{index:>2}[/bold cyan]. {spec.label}  {' | '.join(flags)}")
     while True:
         choice = typer.prompt("Choose a provider", type=int)
         if 1 <= choice <= len(specs):
@@ -1072,31 +1081,38 @@ def _choose_llm_provider(specs: Sequence[ProviderSpec]) -> ProviderSpec:
 
 
 @llm_app.command("providers")
-def llm_providers() -> None:
+def llm_providers(
+    details: bool = typer.Option(
+        False,
+        "--details",
+        help="Show protocol, default model, endpoint, and credential variable.",
+    ),
+) -> None:
     """List supported presets and mark credentials already found locally."""
     from .providers import PROVIDERS
 
     env_file_mod.load_env_file(paths.env_file())
     for spec in PROVIDERS:
-        credential = "none (local)" if not spec.key_required else spec.api_key_env
-        detected = (
-            "[green]keyless[/green]"
-            if not spec.key_required
-            else "[green]yes[/green]"
-            if os.environ.get(spec.api_key_env)
-            else ""
-        )
-        suffix = f"  {detected}" if detected else ""
-        console.print(f"[bold]{spec.label}[/bold] [dim]({spec.id})[/dim]{suffix}")
+        flags = [_llm_credential_summary(spec)]
+        if spec.advanced:
+            flags.append("[yellow]advanced[/yellow]")
+        console.print(f"[bold]{spec.label}[/bold] [dim]({spec.id})[/dim]  {' | '.join(flags)}")
+        if details:
+            credential = "none" if not spec.key_required else spec.api_key_env
+            console.print(
+                f"  Protocol: {spec.protocol}\n"
+                f"  Default model: {spec.default_model}\n"
+                f"  Endpoint: {spec.base_url or 'configured during advanced setup'}\n"
+                f"  Credential variable: {credential}\n"
+                f"  [dim]{spec.description}[/dim]\n"
+            )
+    if not details:
         console.print(
-            f"  Protocol: {spec.protocol}\n"
-            f"  Credential: {credential}\n"
-            f"  Endpoint: {spec.base_url or 'enter during setup'}\n"
-            f"  [dim]{spec.description}[/dim]\n"
+            "\n[dim]Run `persome llm providers --details` for technical routing details.[/dim]"
         )
     console.print(
-        "[dim]Presets use Anthropic Messages or OpenAI-compatible Chat Completions. "
-        "Use custom-openai/custom-anthropic for another compatible endpoint.[/dim]"
+        "[dim]Provider presets choose the endpoint and model automatically. "
+        "Azure and custom providers use an advanced setup path.[/dim]"
     )
 
 
@@ -1156,10 +1172,10 @@ def llm_setup(
     provider: str = typer.Option(
         "", "--provider", help="Provider id from `persome llm providers`."
     ),
-    model: str = typer.Option("", "--model", help="Model id sent to the provider."),
-    base_url: str = typer.Option("", "--base-url", help="Override the provider endpoint."),
+    model: str = typer.Option("", "--model", help="Advanced: override the preset model."),
+    base_url: str = typer.Option("", "--base-url", help="Advanced: override the endpoint."),
     api_key_env: str = typer.Option(
-        "", "--api-key-env", help="Environment variable holding the key."
+        "", "--api-key-env", help="Advanced: environment variable holding the key."
     ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Accept detected/default values."),
     allow_no_tools: bool = typer.Option(
@@ -1173,7 +1189,7 @@ def llm_setup(
         help="Save without a live probe (not recommended).",
     ),
 ) -> None:
-    """Detect credentials, verify a provider, then save one Runtime-wide profile."""
+    """Choose a provider, enter its key, verify it, and save the Runtime profile."""
     from .llm_setup import probe_profile, save_profile
     from .providers import (
         PROVIDERS,
@@ -1188,7 +1204,7 @@ def llm_setup(
     env_file_mod.load_env_file(paths.env_file())
     cfg = config_mod.load()
     current = resolve_profile(cfg.model_for("default"))
-    interactive = sys.stdin.isatty() and sys.stdout.isatty() and not yes
+    interactive = _interactive_terminal() and not yes
 
     selected = None
     keep_current = False
@@ -1199,11 +1215,8 @@ def llm_setup(
             raise typer.Exit(2)
     elif current.credential_ready:
         if interactive:
-            console.print(
-                f"Detected current route: [bold]{current.provider_label}[/bold] / "
-                f"{current.model} at {current.base_url or 'provider default'}"
-            )
-            keep_current = typer.confirm("Keep and verify this route?", default=True)
+            console.print(f"Current provider: [bold]{current.provider_label}[/bold]")
+            keep_current = typer.confirm("Use and verify this provider?", default=True)
         else:
             keep_current = True
 
@@ -1211,9 +1224,7 @@ def llm_setup(
         detected = detected_providers()
         if len(detected) == 1:
             selected = detected[0]
-            console.print(
-                f"[green]Detected {selected.api_key_env}; selected {selected.label}.[/green]"
-            )
+            console.print(f"[green]Found an existing {selected.label} API key.[/green]")
         elif len(detected) > 1:
             if not interactive:
                 names = ", ".join(spec.id for spec in detected)
@@ -1249,12 +1260,21 @@ def llm_setup(
         chosen_key_env = api_key_env or selected.api_key_env
         api_key = os.environ.get(chosen_key_env)
 
-    if interactive:
-        if selected is not None and selected.id.startswith("custom-"):
-            chosen_key_env = typer.prompt("API key environment variable", default=chosen_key_env)
-            api_key = os.environ.get(chosen_key_env) or api_key
-        chosen_base_url = typer.prompt("API endpoint", default=chosen_base_url or "")
-        chosen_model = typer.prompt("Model id", default=chosen_model)
+    selected_spec = selected or provider_spec(provider_id)
+    provider_label = selected_spec.label if selected_spec is not None else current.provider_label
+    advanced_setup = bool(
+        (selected_spec and selected_spec.advanced) or base_url or model or api_key_env
+    )
+    if interactive and not keep_current and selected_spec and selected_spec.advanced:
+        console.print(
+            "[yellow]Advanced setup:[/yellow] this provider needs deployment-specific "
+            "routing details."
+        )
+        api_key = os.environ.get(chosen_key_env) or api_key
+        if not base_url:
+            chosen_base_url = typer.prompt("API endpoint", default=chosen_base_url or "")
+        if not model:
+            chosen_model = typer.prompt("Model id", default=chosen_model)
     if not chosen_base_url:
         console.print("[red]An API endpoint is required.[/red]")
         raise typer.Exit(2)
@@ -1277,9 +1297,8 @@ def llm_setup(
             )
             raise typer.Exit(2)
         api_key = typer.prompt(
-            f"API key ({chosen_key_env})",
+            f"{provider_label} API key",
             hide_input=True,
-            confirmation_prompt=True,
         )
 
     profile = make_profile(
@@ -1296,17 +1315,27 @@ def llm_setup(
             result = probe_profile(profile)
         if not result.completion_ok:
             console.print(f"[red]✗ Provider check failed. Nothing was saved.[/red] {result.error}")
-            if not interactive or not typer.confirm("Edit settings and retry?", default=True):
+            if not interactive:
                 raise typer.Exit(1)
-            chosen_base_url = typer.prompt("API endpoint", default=profile.base_url)
-            chosen_model = typer.prompt("Model id", default=profile.model)
-            replacement = typer.prompt(
-                "New API key (Enter to keep the current key)",
-                default="",
-                show_default=False,
-                hide_input=True,
-            )
-            api_key = replacement or profile.api_key
+            if advanced_setup:
+                if not typer.confirm("Edit advanced settings and retry?", default=True):
+                    raise typer.Exit(1)
+                chosen_base_url = typer.prompt("API endpoint", default=profile.base_url)
+                chosen_model = typer.prompt("Model id", default=profile.model)
+                replacement = typer.prompt(
+                    "New API key (Enter to keep the current key)",
+                    default="",
+                    show_default=False,
+                    hide_input=True,
+                )
+                api_key = replacement or profile.api_key
+            else:
+                if not typer.confirm("Try a different API key?", default=True):
+                    raise typer.Exit(1)
+                api_key = typer.prompt(
+                    f"{provider_label} API key",
+                    hide_input=True,
+                )
             profile = make_profile(
                 provider_id,
                 model=chosen_model,
@@ -1330,6 +1359,12 @@ def llm_setup(
             interactive and typer.confirm("Save this limited model anyway?", default=False)
         ):
             break
+        if not advanced_setup:
+            console.print(
+                "[red]The provider preset did not pass the tool-call check. Nothing was saved."
+                "[/red]"
+            )
+            raise typer.Exit(1)
         if not interactive or not typer.confirm("Choose another model and retry?", default=True):
             console.print("[red]Nothing was saved.[/red]")
             raise typer.Exit(1)
@@ -1347,7 +1382,7 @@ def llm_setup(
     console.print(f"[green]✓ Saved {profile.provider_label} as the Runtime LLM profile.[/green]")
     console.print(f"  Config: {paths.config_file()}")
     if profile.api_key:
-        console.print(f"  Secret: {paths.env_file()} ({profile.api_key_env}, mode 0600)")
+        console.print(f"  Secret: {paths.env_file()} (mode 0600)")
     console.print("  Next: persome llm status --check")
 
 

--- a/src/persome/config.py
+++ b/src/persome/config.py
@@ -619,15 +619,16 @@ def load(path: Path | None = None) -> Config:
 DEFAULT_CONFIG_TEMPLATE = """# Persome configuration
 # One verified profile powers timeline reduction, personal modeling, and Chat.
 # Persome supports Anthropic Messages and OpenAI-compatible Chat Completions.
-# Run `persome llm setup` to detect an existing key, choose/edit the endpoint and
-# model, test completion + tool calling, and write the fields below. Every stage
-# inherits [models.default] unless its own section overrides a field.
+# Run `persome llm setup` to choose a provider and enter its key. Provider presets
+# supply the endpoint and default model, then Persome tests completion + tool
+# calling before writing the fields below. Every stage inherits [models.default]
+# unless its own section overrides a field.
 #
 # API keys never belong in this file. `api_key_env` stores only the variable
 # name; the secret itself lives in ~/.persome/env (mode 0600). Endpoints are not
 # secrets and are stored here so Chat and daemon subprocesses use the same route.
-# `persome llm providers` lists hosted/local presets. Custom compatible gateways
-# use provider="custom-openai" or provider="custom-anthropic".
+# `persome llm providers` lists hosted/local presets. Azure and custom compatible
+# gateways use the clearly separated advanced setup path.
 
 # Cross-cutting runtime/model switches.
 api_require_local_origin = true

--- a/src/persome/providers.py
+++ b/src/persome/providers.py
@@ -27,6 +27,7 @@ class ProviderSpec:
     base_url_env: str = ""
     key_required: bool = True
     local: bool = False
+    advanced: bool = False
 
     @property
     def resolved_base_url_env(self) -> str:
@@ -238,6 +239,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         "deployment-name",
         "Azure OpenAI v1 endpoint; model is the deployment name",
         base_url_env="AZURE_OPENAI_BASE_URL",
+        advanced=True,
     ),
     ProviderSpec(
         "custom-openai",
@@ -248,6 +250,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         "model-id",
         "Any OpenAI-compatible Chat Completions endpoint",
         base_url_env="PERSOME_LLM_BASE_URL",
+        advanced=True,
     ),
     ProviderSpec(
         "custom-anthropic",
@@ -258,6 +261,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         "model-id",
         "Any Anthropic-compatible Messages endpoint",
         base_url_env="PERSOME_LLM_BASE_URL",
+        advanced=True,
     ),
 )
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -76,7 +76,7 @@ def test_env_file_owner_only_stricter_than_0600_ok(ac_root: Path) -> None:
 # ── API key ───────────────────────────────────────────────────────────────────
 
 
-def test_api_key_set_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_api_key_set_ok(ac_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-synthetic")
     c = doctor.check_api_key()
     assert c.status == "ok"
@@ -104,7 +104,9 @@ def test_screenshot_key_missing_warns(clean_llm_env: None) -> None:
 # ── base URL (warn-only) ──────────────────────────────────────────────────────
 
 
-def test_base_url_reachable_ok(monkeypatch: pytest.MonkeyPatch, clean_llm_env: None) -> None:
+def test_base_url_reachable_ok(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch, clean_llm_env: None
+) -> None:
     import httpx
 
     def fake_head(url: str, **kw: object) -> object:
@@ -118,7 +120,7 @@ def test_base_url_reachable_ok(monkeypatch: pytest.MonkeyPatch, clean_llm_env: N
 
 
 def test_base_url_unreachable_warns_never_fails(
-    monkeypatch: pytest.MonkeyPatch, clean_llm_env: None
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch, clean_llm_env: None
 ) -> None:
     import httpx
 

--- a/tests/test_llm_setup.py
+++ b/tests/test_llm_setup.py
@@ -103,7 +103,7 @@ def test_probe_retries_auto_when_forced_tool_choice_is_rejected(monkeypatch) -> 
     assert calls == 3
 
 
-def test_setup_cli_detects_exported_key_and_persists_profile(ac_root: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_setup_cli_uses_provider_defaults_and_persists_profile(ac_root: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
     monkeypatch.setenv("OPENAI_API_KEY", "synthetic-secret")
     runner = CliRunner()
 
@@ -114,10 +114,6 @@ def test_setup_cli_detects_exported_key_and_persists_profile(ac_root: Path, monk
             "setup",
             "--provider",
             "openai",
-            "--model",
-            "gpt-test",
-            "--base-url",
-            "https://gateway.example/v1",
             "--yes",
             "--skip-check",
         ],
@@ -127,8 +123,99 @@ def test_setup_cli_detects_exported_key_and_persists_profile(ac_root: Path, monk
     assert "synthetic-secret" not in result.output
     selected = config.load().model_for("default")
     assert selected.provider == "openai"
-    assert selected.model == "gpt-test"
+    assert selected.model == "gpt-4.1-mini"
+    assert selected.base_url == "https://api.openai.com/v1"
     assert paths.env_file().read_text().count("OPENAI_API_KEY=") == 1
+
+
+def test_interactive_preset_setup_only_asks_for_provider_key(ac_root: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr("persome.cli._interactive_terminal", lambda: True)
+
+    result = CliRunner().invoke(
+        app,
+        ["llm", "setup", "--provider", "openai", "--skip-check"],
+        input="synthetic-secret\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "OpenAI API key" in result.output
+    assert "OPENAI_API_KEY" not in result.output
+    assert "API endpoint" not in result.output
+    assert "Model id" not in result.output
+    selected = config.load().model_for("default")
+    assert selected.model == "gpt-4.1-mini"
+    assert selected.base_url == "https://api.openai.com/v1"
+    assert paths.env_file().read_text() == "OPENAI_API_KEY=synthetic-secret\n"
+
+
+def test_interactive_custom_setup_is_explicitly_advanced(ac_root: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.delenv("PERSOME_LLM_API_KEY", raising=False)
+    monkeypatch.setattr("persome.cli._interactive_terminal", lambda: True)
+
+    result = CliRunner().invoke(
+        app,
+        ["llm", "setup", "--provider", "custom-openai", "--skip-check"],
+        input="https://gateway.example/v1\nmodel-x\nsynthetic-secret\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Advanced setup" in result.output
+    assert "API endpoint" in result.output
+    assert "Model id" in result.output
+    selected = config.load().model_for("default")
+    assert selected.base_url == "https://gateway.example/v1"
+    assert selected.model == "model-x"
+
+
+def test_rerun_keeps_advanced_route_without_reasking_for_routing(
+    ac_root: Path, monkeypatch
+) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("PERSOME_LLM_API_KEY", "synthetic-secret")
+    first = CliRunner().invoke(
+        app,
+        [
+            "llm",
+            "setup",
+            "--provider",
+            "custom-openai",
+            "--base-url",
+            "https://gateway.example/v1",
+            "--model",
+            "model-x",
+            "--yes",
+            "--skip-check",
+        ],
+    )
+    assert first.exit_code == 0, first.output
+    monkeypatch.setattr("persome.cli._interactive_terminal", lambda: True)
+
+    rerun = CliRunner().invoke(
+        app,
+        ["llm", "setup", "--skip-check"],
+        input="\n",
+    )
+
+    assert rerun.exit_code == 0, rerun.output
+    assert "Use and verify this provider?" in rerun.output
+    assert "Advanced setup" not in rerun.output
+    assert "API endpoint" not in rerun.output
+    assert "Model id" not in rerun.output
+
+
+def test_provider_list_hides_routing_details_by_default(ac_root: Path) -> None:
+    runner = CliRunner()
+
+    simple = runner.invoke(app, ["llm", "providers"])
+    detailed = runner.invoke(app, ["llm", "providers", "--details"])
+
+    assert simple.exit_code == 0
+    assert "Endpoint:" not in simple.output
+    assert "Default model:" not in simple.output
+    assert "providers --details" in simple.output
+    assert detailed.exit_code == 0
+    assert "Endpoint:" in detailed.output
+    assert "Default model:" in detailed.output
 
 
 def test_setup_cli_does_not_save_failed_probe(ac_root: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
@@ -146,10 +233,6 @@ def test_setup_cli_does_not_save_failed_probe(ac_root: Path, monkeypatch) -> Non
             "setup",
             "--provider",
             "openai",
-            "--model",
-            "gpt-test",
-            "--base-url",
-            "https://bad.example/v1",
             "--yes",
         ],
     )


### PR DESCRIPTION
## Summary

- reduce standard provider setup to provider selection plus one API key prompt
- apply provider-owned endpoint and default model automatically
- keep Azure and custom endpoints in a clearly marked advanced path
- hide routing internals from the default provider list while retaining `--details` and automation overrides
- isolate Doctor tests from the real user data root

## Why

Regular users should not need to understand protocol endpoints or model identifiers to configure a supported LLM service. Those are preset-owned implementation details.

## Validation

- `PERSOME_LLM_MOCK=1 uv run pytest -m "not macos and not integration" -q` (`1449 passed, 15 deselected`)
- `uv run ruff check .`
- `uv run ruff format --check .`
- secret, PII, language, and documentation-link scans
- fresh-root pseudo-terminal smoke: OpenAI setup prompted only for `OpenAI API key`, then saved the preset endpoint/model with an owner-only secret file