### PR TITLE
Enable OCR during install onboarding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,8 +126,9 @@ Update matching docs in the same change as behavior.
   layer; treat local endpoint access as access to personal data.
 - Prompt edits follow `docs/prompt-engineering.md`: define an eval criterion,
   then change and verify the smallest prompt surface.
-- Live capture uses compiled Swift helpers bundled into the wheel. OCR is off
-  by default and runs in an isolated worker when enabled.
+- Live capture uses compiled Swift helpers bundled into the wheel. On supported
+  Apple Silicon installs, onboarding enables bundled OCR and requests Screen
+  Recording; inference runs in an isolated worker.
 - `--capture-only` disables timeline and model-processing tasks, but keeps
   capture, session tracking, reducer recovery/safety net, and configured MCP.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -33,8 +33,9 @@ tests can run on Linux with macOS-marked tests deselected.
 
 ## State formation
 
-1. `capture/` receives Accessibility events. AX-poor apps can opt into bundled,
-   subprocess-isolated PP-OCRv6; the default is AX-only.
+1. `capture/` receives Accessibility events. Supported installs enable bundled,
+   subprocess-isolated PP-OCRv6 as a fallback when an app exposes no usable AX
+   text; AX remains the primary signal.
 2. `parsers/` normalizes app-specific structures into capture records.
 3. `timeline/` groups records into one-minute blocks and preserves authored
    evidence.

--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ This sample path is deliberately separate from the real-data path below.
 Requirements: macOS 13 or newer, Xcode Command Line Tools, and a Python build
 with SQLite 3.42+ (the installer verifies the secure FTS capability). The installer
 finds or installs `uv`, provisions Python 3.11-3.13, compiles the Swift AX
-helpers, generates the local screenshot-encryption key, and offers to register
-detected MCP clients. Its fallback `uv` download is version-pinned and checked
+helpers, generates the local screenshot-encryption key, enables and verifies
+local OCR, requests Screen Recording, and offers to register detected MCP
+clients. Its fallback `uv` download is version-pinned and checked
 against repository-pinned SHA-256 digests; the Runtime environment is installed
 from the committed `uv.lock`, and the complete build-backend closure is
 hash-constrained rather than resolved afresh.
@@ -85,15 +86,25 @@ cd persome-core
 bash install.sh
 
 persome doctor
+persome ocr status --check
 persome start
 persome model open
 ```
 
 Grant **Accessibility** to the terminal or app that launches Persome in
 **System Settings -> Privacy & Security -> Accessibility**. This permission is
-required to read focused AX text and structure. Grant **Screen Recording** only
-when enabling OCR fallback or screenshot retention; it supplies pixels to the
-local OCR worker. Persome does not require Full Disk Access.
+required to read focused AX text and structure. The installer enables bundled
+local OCR, requests **Screen Recording**, verifies the isolated OCR worker, and
+opens the correct settings pane when permission remains denied. OCR supplies
+text for AX-poor apps such as WeChat and Feishu; pixels never enter an LLM
+prompt. Persome does not require Full Disk Access.
+
+```bash
+# Recheck or repair OCR onboarding; disable is always explicit and reversible.
+persome ocr setup
+persome ocr status --check
+persome ocr disable
+```
 
 An LLM is optional for collection and BM25 recall, but required for semantic
 modeling. During installation, the provider wizard asks you to choose a service

--- a/SECURITY_PRIVACY.md
+++ b/SECURITY_PRIVACY.md
@@ -25,9 +25,10 @@ artifacts are private from creation.
 
 Default capture retention is seven days. Screenshot payloads are stripped
 earlier by the configured screenshot retention window, except explicitly
-actionable captures covered by extended retention. OCR is disabled by default;
-when enabled, inference is local, subprocess-isolated, and uses bundled
-PP-OCRv6 weights.
+actionable captures covered by extended retention. On supported Apple Silicon
+installs, `install.sh` enables OCR after requesting Screen Recording and proving
+the isolated worker can load bundled PP-OCRv6 weights. Inference remains local;
+`persome ocr disable` is the explicit opt-out.
 
 Lock-screen detection is privacy-conservative: when both macOS probes are
 unavailable or error, capture pauses until a probe can establish that the

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -78,6 +78,7 @@ After installing the Swift helpers and granting Accessibility permission:
 ```bash
 bash install.sh
 persome llm status --check
+persome ocr status --check
 persome doctor
 persome start
 
@@ -124,8 +125,10 @@ PERSOME_ROOT=/tmp/persome-wheel-root \
   /tmp/persome-wheel-venv/bin/persome llm providers
 ```
 
-`persome ocr-selftest <image>` performs a full bundled OCR inference check on
-Apple Silicon.
+`install.sh` runs `persome ocr setup`, which requests Screen Recording and
+performs a full bundled worker initialization on Apple Silicon.
+`persome ocr-selftest <image>` remains available for a known-image inference
+check.
 
 For a GitHub Release produced by the current workflow (older releases are not
 retroactively attested), also download `SHA256SUMS`, verify it from the

--- a/docs/api.md
+++ b/docs/api.md
@@ -18,10 +18,10 @@ runtime schema.
 
 | Method | Path | Purpose |
 |---|---|---|
-| GET | `/health` | Liveness probe. |
+| GET | `/health` | Liveness plus compact OCR readiness (`ok` or `degraded`). |
 | POST | `/auth/browser-bootstrap` | Exchange the bearer for a 60-second, one-use viewer URL. |
-| GET | `/permissions` | macOS Accessibility state. |
-| GET | `/status` | Daemon, capture, session, memory, and provider status. |
+| GET | `/permissions` | macOS Accessibility and Screen Recording state. |
+| GET | `/status` | Daemon, capture, OCR, session, memory, and provider status. |
 | POST | `/captures/ingest` | Ingest one bearer-authenticated capture from a trusted local producer. |
 | GET | `/model` | Open the offline Point/Line/Face/Volume/Root explorer. |
 | GET | `/model/graph` | Read the canonical versioned model snapshot. |
@@ -36,6 +36,9 @@ intentionally omitted from OpenAPI.
 endpoint, key variable name, credential presence, and legacy-migration state.
 It never returns the credential value. Provider network probes run only for
 the explicit `GET /status?check_models=true` request and are cached briefly.
+`/status.data.ocr` reports the configured tier, Runtime and model availability,
+kill switch, Screen Recording, and effective readiness. `/health` exposes only
+the compact OCR state because it is the unauthenticated liveness route.
 
 ## Chat routes
 

--- a/docs/capture.md
+++ b/docs/capture.md
@@ -4,7 +4,8 @@ Capture is the only layer that touches the outside world. It produces one JSON f
 
 Live capture requires macOS Accessibility permission for the process that runs
 Persome. Screen Recording is additionally required when screenshots or OCR are
-enabled. OCR is bundled but **disabled by default**.
+enabled. `install.sh` enables and verifies bundled OCR on supported Apple
+Silicon Macs, then requests Screen Recording from the same Runtime identity.
 
 ## Two signal sources
 
@@ -26,11 +27,13 @@ The filename is ISO-8601 with `:` → `-` and `+` → `p` / `-` → `m` for the 
 
 The same capture scheduler also invokes `SessionManager.on_event` (wired as a `pre_capture_hook` in `daemon.py`), so the session cutter sees every written, non-duplicate observation without a separate subscription path.
 
-## Optional local OCR
+## Local OCR fallback
 
-Set `enable_ocr_fallback = true` only when AX-poor applications matter. The
+The installer runs `persome ocr setup`, which checks the native Runtime and
+bundled weights, requests Screen Recording, starts the isolated worker, and
+writes `enable_ocr_fallback = true` only after the worker initializes. The
 focused screenshot is used locally and is never placed in an LLM prompt. The
-default OCR path is:
+OCR path is:
 
 ```text
 focused screenshot bytes
@@ -45,6 +48,13 @@ The subprocess is the native-crash boundary: a Paddle fault fails the OCR call
 without killing the daemon. `PERSOME_DISABLE_OCR=1` prevents Paddle from being
 loaded at all. `PERSOME_OCR_IN_PROCESS=1` exists only for debugging and removes
 that isolation.
+
+```bash
+persome ocr setup          # enable, request permission, verify worker
+persome ocr status         # quick config/runtime/model/TCC state
+persome ocr status --check # also start and verify the worker engine
+persome ocr disable        # explicit opt-out; restart to apply
+```
 
 ## Debounce / dedup / gap
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -112,7 +112,7 @@ screenshot_jpeg_quality = 80
 ax_depth = 100
 ax_timeout_seconds = 3
 
-enable_ocr_fallback = false
+enable_ocr_fallback = true
 ocr_tier = "tiny"                 # tiny | small | medium
 ocr_min_gap_seconds = 15.0
 ocr_structured = true
@@ -123,12 +123,13 @@ cmux_source_enabled = true
   from the trusted bearer-authenticated `/captures/ingest` producer and starts
   no OS watcher. The producer must obtain `PERSOME_LOCAL_API_TOKEN` through an
   owner-approved local secret channel and must never put it in a URL.
-- Accessibility permission is required for daemon AX capture. Screen Recording
-  is required for screenshot/OCR use.
-- OCR is off by default. When enabled, Paddle inference runs in a local worker
-  subprocess so a native crash does not kill the daemon. OCR text is backfilled
-  into capture search and consumed by timeline/modeling; pixels are not sent to
-  an LLM stage.
+- Accessibility permission is required for daemon AX capture. `install.sh`
+  requests Screen Recording and enables OCR after its worker initializes.
+- Paddle inference runs in a local worker subprocess so a native crash does not
+  kill the daemon. OCR text is backfilled into capture search and consumed by
+  timeline/modeling; pixels are not sent to an LLM stage. The source-level
+  config default remains off for unsupported/direct-library environments;
+  supported macOS installation writes the enabled state shown above.
 - `PERSOME_DISABLE_OCR=1` is the deployment kill switch.
 - `PERSOME_OCR_IN_PROCESS=1` is a debugging escape hatch that gives up crash
   isolation and should not be used for normal operation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ uv run python scripts/sample_demo.py
 ```bash
 bash install.sh
 persome llm status --check
+persome ocr status --check
 persome doctor
 persome start
 persome model open

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -20,13 +20,17 @@ compile the Swift AX helpers.
 | Permission | Required | Purpose | Effect when disabled |
 |---|---|---|---|
 | Accessibility | yes for live collection | reads the focused AX tree, application, window, selected control, and visible text | daemon remains healthy but produces no useful live captures |
-| Screen Recording | only for OCR or retained screenshots | supplies focused-window pixels to the local OCR worker or encrypted screenshot retention | AX collection continues; OCR-poor surfaces remain sparse and no screenshot can be retained |
+| Screen Recording | yes in the standard install | supplies focused-window pixels to the enabled local OCR worker and encrypted screenshot retention | AX collection continues, but health reports OCR degraded and AX-poor surfaces remain sparse |
 | Full Disk Access | no | not used | no effect |
 | Automation / Apple Events | no | not used by the Runtime | no effect |
 
 Grant permissions to the executable that launches Persome. If a terminal starts
 the daemon, grant that terminal. If launchd later owns the daemon, rerun
 `persome doctor` after the handoff and confirm live capture.
+
+`install.sh` requests Screen Recording during OCR onboarding. Verify the whole
+local path with `persome ocr status --check`; use `persome ocr disable` for an
+explicit opt-out.
 
 ## Local paths
 
@@ -55,6 +59,7 @@ upgrade, and gives its LaunchAgent umask `0077`.
 
 ```bash
 persome llm status --check
+persome ocr status --check
 persome doctor
 persome start
 persome status

--- a/docs/runtime-internals.md
+++ b/docs/runtime-internals.md
@@ -70,10 +70,12 @@ belong in core.
 | `backup/` | optional SQLite snapshots |
 | `logs/` | component logs |
 
-OCR is off by default. When enabled it uses a child worker process managed by
-`capture/ocr_subprocess.py`; a native Paddle crash does not take down the daemon.
-The parent OCR submission thread only coordinates local inference and SQLite
-backfill.
+Supported installs enable OCR through `persome ocr setup`. It uses a child
+worker process managed by `capture/ocr_subprocess.py`; a native Paddle crash
+does not take down the daemon. The parent OCR submission thread only coordinates
+local inference and SQLite backfill. Quick health checks inspect configuration,
+Runtime, weights, kill switch, and Screen Recording without loading Paddle;
+`persome ocr status --check` verifies the worker engine.
 
 New code must use `paths.py`; tests use a temporary `PERSOME_ROOT` and must
 never inspect the real store.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -56,16 +56,25 @@ fallback for old installs or a changed TCC principal.
 
 Second most common cause: **`ax_depth` too shallow for Electron apps.** See [capture.md](capture.md#ax-depth-the-1-footgun).
 
-For an AX-poor app, enable local OCR explicitly and grant Screen Recording:
+The installer normally enables local OCR and requests Screen Recording. Check
+the complete state first:
 
-```toml
-[capture]
-enable_ocr_fallback = true
+```bash
+persome ocr status --check
 ```
 
-Then restart and run `persome ocr-selftest <image>`. OCR worker failures should
-leave the daemon alive. `PERSOME_DISABLE_OCR=1` disables inference entirely;
-remove it if self-test reports OCR disabled.
+If it reports disabled, missing permission, or an incomplete worker setup, run:
+
+```bash
+persome ocr setup
+persome stop
+persome start
+persome doctor
+```
+
+The setup command opens Screen Recording settings when needed. OCR worker
+failures leave the daemon alive. `PERSOME_DISABLE_OCR=1` disables inference
+entirely; remove it if health reports `disabled_by_environment`.
 
 ## No event-daily entries appearing
 

--- a/install.sh
+++ b/install.sh
@@ -515,10 +515,23 @@ PY
   echo "OPENAI_* embedding credentials in ${INSTALL_HOME}/env. Without them the"
   echo "daemon runs keyword (BM25) search only — no degraded behaviour."
   echo ""
-  echo "OCR for AX-poor apps (WeChat/Feishu) runs fully on-device (bundled"
-  echo "PP-OCRv6) — no key, no upload, no network."
   echo "A machine-local screenshot encryption key is generated automatically;"
   echo "you never need to enter or manage it manually."
+}
+
+configure_ocr() {
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  Local OCR Setup"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+  echo "Persome enables bundled PP-OCRv6 for AX-poor apps such as WeChat and"
+  echo "Feishu. Recognition runs in an isolated local process with no API key,"
+  echo "upload, or network model download. macOS will request Screen Recording."
+  echo ""
+  if ! PERSOME_ROOT="${INSTALL_HOME}" "${INSTALL_BIN_DIR}/persome" ocr setup --tier tiny; then
+    warn "OCR is not ready; grant Screen Recording and rerun 'persome ocr setup'"
+  fi
 }
 
 ensure_screenshot_key() {
@@ -583,11 +596,12 @@ Virtualenv   : ${VENV_DIR}
 CLI shim     : ${INSTALL_BIN_DIR}/persome
 
 Next steps:
-  1. Grant Accessibility permission to your terminal so Persome can read the
-     focused app's AX text and structure:
+  1. Grant Accessibility so Persome can read focused AX text and structure:
      System Settings -> Privacy & Security -> Accessibility
-     Screen Recording is optional. Grant it only for local OCR fallback or
-     encrypted screenshot retention; AX collection continues without it.
+     The installer requested Screen Recording for on-device OCR and encrypted
+     screenshot capture. If it is still denied, enable the terminal or Persome
+     runtime entry shown by macOS under:
+     System Settings -> Privacy & Security -> Screen Recording
      Persome does not require Full Disk Access or Automation permission.
   2. Start the daemon:
      persome start
@@ -610,6 +624,7 @@ Connect an agent (MCP):
 
 Run a health check any time:
   persome doctor
+  persome ocr status --check
 
 Change or verify the LLM provider:
   persome llm setup
@@ -643,6 +658,7 @@ main() {
   install_shim
   inject_detected_clients
   maybe_configure_llm
+  configure_ocr
   print_summary
 }
 

--- a/openapi.json
+++ b/openapi.json
@@ -12,7 +12,7 @@
           "system"
         ],
         "summary": "Health",
-        "description": "Return the service liveness status.",
+        "description": "Return liveness plus the configured local-OCR readiness state.",
         "operationId": "health_health_get",
         "responses": {
           "200": {
@@ -57,7 +57,7 @@
           "system"
         ],
         "summary": "Permissions",
-        "description": "Return the daemon's current macOS permission state.\n\nAccessibility belongs to the daemon process because it launches the AX\nhelpers that read the tree. A GUI onboarding flow should poll this endpoint\ninstead of creating a second TCC identity. ``accessibility`` is ``granted``\nor ``denied`` and is always ``denied`` on non-macOS hosts.",
+        "description": "Return the daemon's current macOS permission state.\n\nAccessibility and Screen Recording belong to the daemon process. A GUI\nonboarding flow should poll this endpoint instead of creating another TCC\nidentity. Each field is ``granted`` or ``denied``.",
         "operationId": "permissions_permissions_get",
         "responses": {
           "200": {

--- a/src/persome/api/routes.py
+++ b/src/persome/api/routes.py
@@ -20,7 +20,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse, Response
 
 from .. import __version__, paths
-from ..capture import ax_capture, scheduler
+from ..capture import ax_capture, ocr_health, scheduler, screen_recording
 from ..capture.timestamps import newest_capture_path
 from ..config import Config
 from ..config import load as load_config
@@ -206,8 +206,10 @@ router = APIRouter()
 
 @router.get("/health", response_model=ApiResponse, tags=["system"])
 def health() -> ApiResponse:
-    """Return the service liveness status."""
-    return ApiResponse(data={"status": "ok"})
+    """Return liveness plus the configured local-OCR readiness state."""
+    current = ocr_health.inspect(_get_cfg().capture)
+    status = "degraded" if current.enabled and not current.ready else "ok"
+    return ApiResponse(data={"status": status, "ocr": current.state})
 
 
 @router.post(BROWSER_BOOTSTRAP_PATH, response_model=ApiResponse, tags=["system"])
@@ -257,12 +259,18 @@ def consume_browser_bootstrap(
 def permissions() -> ApiResponse:
     """Return the daemon's current macOS permission state.
 
-    Accessibility belongs to the daemon process because it launches the AX
-    helpers that read the tree. A GUI onboarding flow should poll this endpoint
-    instead of creating a second TCC identity. ``accessibility`` is ``granted``
-    or ``denied`` and is always ``denied`` on non-macOS hosts.
+    Accessibility and Screen Recording belong to the daemon process. A GUI
+    onboarding flow should poll this endpoint instead of creating another TCC
+    identity. Each field is ``granted`` or ``denied``.
     """
-    return ApiResponse(data={"accessibility": "granted" if ax_capture.ax_trusted() else "denied"})
+    return ApiResponse(
+        data={
+            "accessibility": "granted" if ax_capture.ax_trusted() else "denied",
+            "screen_recording": (
+                "granted" if screen_recording.has_screen_recording() else "denied"
+            ),
+        }
+    )
 
 
 @router.get("/status", response_model=ApiResponse, tags=["system"])
@@ -282,6 +290,7 @@ def status(check_models: bool = False) -> ApiResponse:
         "uptime": uptime,
         "health": health_label,
         "capture": "paused" if paused else "active",
+        "ocr": ocr_health.inspect(cfg.capture).as_dict(),
     }
 
     if last_ts:

--- a/src/persome/capture/ocr_health.py
+++ b/src/persome/capture/ocr_health.py
@@ -1,0 +1,82 @@
+"""Side-effect-free health model for the local OCR capture path."""
+
+from __future__ import annotations
+
+import platform
+import sys
+from dataclasses import asdict, dataclass
+from typing import Literal
+
+from ..config import CaptureConfig
+from . import ocr_local, screen_recording
+
+OCRState = Literal[
+    "ready",
+    "disabled",
+    "disabled_by_environment",
+    "runtime_unavailable",
+    "models_missing",
+    "permission_required",
+]
+
+
+@dataclass(frozen=True)
+class OCRHealth:
+    state: OCRState
+    ready: bool
+    enabled: bool
+    tier: str
+    runtime_available: bool
+    models_available: bool
+    screen_recording: Literal["granted", "denied", "not_applicable"]
+    disabled_by_environment: bool
+    detail: str
+
+    def as_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def inspect(cfg: CaptureConfig) -> OCRHealth:
+    """Return the effective OCR state without importing Paddle or requesting TCC access."""
+    enabled = bool(cfg.enable_ocr_fallback)
+    tier = cfg.ocr_tier
+    runtime_ready = ocr_local.runtime_available()
+    models_ready = ocr_local.models_available(tier)
+    env_disabled = ocr_local.disabled_by_environment()
+
+    if sys.platform == "darwin":
+        permission = "granted" if screen_recording.has_screen_recording() else "denied"
+    else:
+        permission = "not_applicable"
+
+    if not enabled:
+        state: OCRState = "disabled"
+        detail = "disabled in capture settings; run `persome ocr setup`"
+    elif env_disabled:
+        state = "disabled_by_environment"
+        detail = "disabled by PERSOME_DISABLE_OCR"
+    elif not runtime_ready:
+        state = "runtime_unavailable"
+        machine = platform.machine() or "unknown architecture"
+        detail = f"Paddle OCR runtime unavailable on {machine}"
+    elif not models_ready:
+        state = "models_missing"
+        detail = f"bundled PP-OCRv6 {tier} weights are missing"
+    elif permission != "granted":
+        state = "permission_required"
+        detail = "Screen Recording permission is required"
+    else:
+        state = "ready"
+        detail = f"local PP-OCRv6 {tier}, isolated worker"
+
+    return OCRHealth(
+        state=state,
+        ready=state == "ready",
+        enabled=enabled,
+        tier=tier,
+        runtime_available=runtime_ready,
+        models_available=models_ready,
+        screen_recording=permission,
+        disabled_by_environment=env_disabled,
+        detail=detail,
+    )

--- a/src/persome/capture/ocr_local.py
+++ b/src/persome/capture/ocr_local.py
@@ -94,6 +94,11 @@ def _ocr_disabled() -> bool:
     return val.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def disabled_by_environment() -> bool:
+    """Public, side-effect-free view of the emergency OCR kill switch."""
+    return _ocr_disabled()
+
+
 def _use_isolation() -> bool:
     """Whether OCR inference runs in the isolated crash-domain subprocess (default: yes).
 
@@ -143,6 +148,13 @@ def _model_dir(tier: str, kind: str) -> str | None:
         return None
     d = root / f"PP-OCRv6_{tier}_{kind}"
     return str(d) if (d / "inference.json").exists() else None
+
+
+def models_available(tier: str = DEFAULT_TIER) -> bool:
+    """Whether both bundled model graphs required by ``tier`` are present."""
+    if tier not in _VALID_TIERS:
+        return False
+    return _model_dir(tier, "det") is not None and _model_dir(tier, "rec") is not None
 
 
 def _build_engine(tier: str) -> Any | None:
@@ -209,7 +221,7 @@ def _get_engine(tier: str) -> Any | None:
     return engine
 
 
-def warm(tier: str = DEFAULT_TIER) -> None:
+def warm(tier: str = DEFAULT_TIER) -> bool:
     """Pre-build the engine so the first real capture doesn't pay graph-load latency.
 
     No-op when OCR is disabled (``PERSOME_DISABLE_OCR``): paddle is never imported.
@@ -218,20 +230,19 @@ def warm(tier: str = DEFAULT_TIER) -> None:
     """
     if _ocr_disabled():
         logger.info("local OCR disabled via PERSOME_DISABLE_OCR; skipping warm")
-        return
+        return False
     if not runtime_available():
         logger.info(
             "local OCR runtime unavailable in this build (no paddlepaddle wheel for this arch, "
             "e.g. x86_64 macOS); AX-poor apps run without OCR text — see #226. Skipping warm"
         )
-        return
+        return False
     if _use_isolation():
         from . import ocr_subprocess
 
-        ocr_subprocess.get_client().warm(tier)
-        return
+        return ocr_subprocess.get_client().warm(tier)
     with _lock:
-        _get_engine(tier)
+        return _get_engine(tier) is not None
 
 
 def recognize(image_bytes: bytes, tier: str = DEFAULT_TIER) -> str | None:

--- a/src/persome/capture/ocr_subprocess.py
+++ b/src/persome/capture/ocr_subprocess.py
@@ -78,9 +78,9 @@ class OCRWorkerClient:
             return None
         return self._request(tier, image_bytes)
 
-    def warm(self, tier: str) -> None:
-        """Pre-spawn the worker and pre-build its engine (empty image = warm request)."""
-        self._request(tier, b"")
+    def warm(self, tier: str) -> bool:
+        """Pre-build the worker engine and report whether it became ready."""
+        return self._request(tier, b"") is not None
 
     def shutdown(self) -> None:
         """Terminate the worker (best-effort). The worker also exits on stdin EOF."""

--- a/src/persome/capture/ocr_worker.py
+++ b/src/persome/capture/ocr_worker.py
@@ -48,8 +48,7 @@ def serve() -> int:
         result: ocr_protocol.Detailed | None
         if not image:
             # Warm request: build the engine now so the first real capture is fast.
-            ocr_local.warm(tier)
-            result = ([], [], [])
+            result = ([], [], []) if ocr_local.warm(tier) else None
         else:
             # A native fault inside here takes down ONLY this process (by design).
             try:

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -333,9 +333,11 @@ def status() -> None:
     cfg = _init()
     # Source the env file before resolving/probing the selected provider.
     env_file_mod.load_env_file(paths.env_file())
+    from .capture.ocr_health import inspect as inspect_ocr
     from .providers import resolve_profile
 
     default_profile = resolve_profile(cfg.model_for("default"))
+    ocr_health = inspect_ocr(cfg.capture)
     pid = _read_pid()
     paused = paths.paused_flag().exists()
 
@@ -350,6 +352,22 @@ def status() -> None:
     table.add_row("Uptime", uptime)
     table.add_row("Health", f"[{health_style}]{health_label}[/{health_style}]")
     table.add_row("Capture", "[yellow]paused[/yellow]" if paused else "active")
+    ocr_style = "green" if ocr_health.ready else "yellow" if not ocr_health.enabled else "red"
+    table.add_row(
+        "OCR",
+        f"[{ocr_style}]{ocr_health.state}[/{ocr_style}] ({ocr_health.tier})",
+    )
+    permission_style = (
+        "green"
+        if ocr_health.screen_recording == "granted"
+        else "yellow"
+        if ocr_health.screen_recording == "not_applicable"
+        else "red"
+    )
+    table.add_row(
+        "Screen Recording",
+        f"[{permission_style}]{ocr_health.screen_recording}[/{permission_style}]",
+    )
 
     if last_ts:
         try:
@@ -448,8 +466,9 @@ def doctor() -> None:
     Prints one ✓/✗/⚠ line per prerequisite — env file present + private (0600),
     local API bearer token present, selected provider credential configured,
     endpoint reachable (HEAD, warn-only), Swift capture helpers compiled, macOS
-    Accessibility trust, data root writable, daemon port available. Exits 1 if
-    any check FAILS; warnings never fail.
+    Accessibility and Screen Recording trust, local OCR readiness, data root
+    writable, daemon port available. Exits 1 if any check FAILS; warnings never
+    fail.
     """
     from . import doctor as doctor_mod
 
@@ -541,6 +560,128 @@ def mcp() -> None:
     from .mcp import server as mcp_server
 
     mcp_server.run_stdio()
+
+
+ocr_app = typer.Typer(help="Configure and inspect on-device OCR for AX-poor apps.")
+app.add_typer(ocr_app, name="ocr")
+
+
+def _open_screen_recording_settings() -> None:
+    if sys.platform != "darwin":
+        return
+    subprocess.run(
+        [
+            "open",
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture",
+        ],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+@ocr_app.command("setup")
+def ocr_setup(
+    tier: str = typer.Option("tiny", "--tier", help="OCR tier: tiny | small | medium."),
+    open_settings: bool = typer.Option(
+        True,
+        "--open-settings/--no-open-settings",
+        help="Open Screen Recording settings when permission is not granted.",
+    ),
+) -> None:
+    """Enable local OCR, request Screen Recording, and verify the worker."""
+    from .capture import ocr_local, screen_recording
+    from .ocr_setup import VALID_TIERS, save_ocr_config
+
+    _init()
+    env_file_mod.load_env_file(paths.env_file())
+    if tier not in VALID_TIERS:
+        console.print(f"[red]Unsupported OCR tier {tier!r}: choose {', '.join(VALID_TIERS)}.[/red]")
+        raise typer.Exit(2)
+    if ocr_local.disabled_by_environment():
+        console.print(
+            "[red]OCR is disabled by PERSOME_DISABLE_OCR. Remove that variable and retry.[/red]"
+        )
+        raise typer.Exit(1)
+    if not ocr_local.runtime_available():
+        console.print(
+            "[red]The local Paddle OCR runtime is unavailable on this architecture.[/red] "
+            "AX capture remains available."
+        )
+        raise typer.Exit(1)
+    if not ocr_local.models_available(tier):
+        console.print(f"[red]Bundled PP-OCRv6 {tier} model weights are missing.[/red]")
+        raise typer.Exit(1)
+
+    console.print("Requesting macOS Screen Recording permission for local OCR...")
+    screen_recording.request_screen_recording()
+    with console.status("Starting the isolated local OCR worker..."):
+        engine_ready = ocr_local.warm(tier)
+    if not engine_ready:
+        console.print("[red]The local OCR worker could not initialize. Nothing was enabled.[/red]")
+        raise typer.Exit(1)
+
+    save_ocr_config(enabled=True, tier=tier, config_path=paths.config_file())
+    permission_ready = screen_recording.has_screen_recording()
+    if not permission_ready:
+        if open_settings:
+            _open_screen_recording_settings()
+        console.print(
+            "[yellow]OCR is enabled, but Screen Recording is not granted yet.[/yellow]\n"
+            "Enable the terminal or Persome runtime entry shown in System Settings -> "
+            "Privacy & Security -> Screen Recording, then restart the daemon."
+        )
+        raise typer.Exit(1)
+
+    console.print(f"[green]✓ Local OCR enabled and ready[/green] ({tier}, isolated worker)")
+    if _read_pid() is not None:
+        console.print("Restart the daemon to load the updated OCR configuration.")
+
+
+@ocr_app.command("status")
+def ocr_status(
+    check: bool = typer.Option(False, "--check", help="Start the worker and verify its engine."),
+) -> None:
+    """Show OCR configuration, runtime, models, and permission state."""
+    from .capture import ocr_health, ocr_local
+
+    cfg = _init()
+    env_file_mod.load_env_file(paths.env_file())
+    health = ocr_health.inspect(cfg.capture)
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_row("State", health.state)
+    table.add_row("Enabled", "yes" if health.enabled else "no")
+    table.add_row("Tier", health.tier)
+    table.add_row("Runtime", "available" if health.runtime_available else "unavailable")
+    table.add_row("Models", "available" if health.models_available else "missing")
+    table.add_row("Screen Recording", health.screen_recording)
+    table.add_row("Detail", health.detail)
+    console.print(table)
+    if check:
+        if not health.enabled or health.disabled_by_environment:
+            raise typer.Exit(1)
+        with console.status("Checking the isolated local OCR worker..."):
+            ready = ocr_local.warm(health.tier)
+        if not ready:
+            console.print("[red]✗ OCR worker check failed[/red]")
+            raise typer.Exit(1)
+        console.print("[green]✓ OCR worker is ready[/green]")
+    if health.enabled and not health.ready:
+        raise typer.Exit(1)
+
+
+@ocr_app.command("disable")
+def ocr_disable() -> None:
+    """Disable OCR fallback without changing screenshot retention."""
+    from .ocr_setup import save_ocr_config
+
+    cfg = _init()
+    save_ocr_config(
+        enabled=False,
+        tier=cfg.capture.ocr_tier,
+        config_path=paths.config_file(),
+    )
+    console.print("[yellow]Local OCR disabled. Restart the daemon to apply.[/yellow]")
 
 
 @app.command("ocr-selftest")

--- a/src/persome/config.py
+++ b/src/persome/config.py
@@ -692,7 +692,7 @@ ax_depth = 100                # Electron apps (Claude Desktop, VS Code, Slack) h
 ax_timeout_seconds = 3
 # OCR fallback for apps that block Accessibility API (WeChat, Feishu, NetEase Music, etc.)
 # On-device PP-OCRv6 — the focused-window screenshot is OCR'd locally; nothing leaves the machine.
-enable_ocr_fallback = false   # local inference; no network, no API token
+enable_ocr_fallback = false   # install.sh verifies the worker, then writes true on supported Macs
 # Inference runs in an isolated local worker, so a native Paddle crash does not
 # kill the daemon. PERSOME_DISABLE_OCR=1 is the deployment kill switch.
 ocr_tier = "tiny"             # tiny (default) | small | medium — local PP-OCRv6 weights

--- a/src/persome/daemon.py
+++ b/src/persome/daemon.py
@@ -304,7 +304,8 @@ async def _run(cfg: Config, *, capture_only: bool = False, hard_exit: bool = Fal
 
         def _warm_ocr() -> None:
             try:
-                ocr_local.warm(cfg.capture.ocr_tier)
+                if not ocr_local.warm(cfg.capture.ocr_tier):
+                    logger.warning("boot: OCR warmup did not produce a ready engine")
             except Exception as exc:  # noqa: BLE001
                 logger.warning("boot: OCR warmup failed: %s", exc)
             finally:

--- a/src/persome/doctor.py
+++ b/src/persome/doctor.py
@@ -274,6 +274,48 @@ def check_ax_trust() -> Check:
     )
 
 
+def check_screen_recording(capture: config_mod.CaptureConfig) -> Check:
+    """Check the TCC permission required by OCR and screenshot capture."""
+    if platform.system() != "Darwin":
+        return Check("Screen Recording", "warn", "unknown (not macOS)")
+    required = capture.enable_ocr_fallback or capture.include_screenshot
+    if not required:
+        return Check("Screen Recording", "ok", "not required by current capture settings")
+    try:
+        from .capture.screen_recording import has_screen_recording
+
+        granted = has_screen_recording()
+    except Exception as exc:  # noqa: BLE001 - TCC probes must not crash doctor
+        return Check(
+            "Screen Recording",
+            "warn",
+            f"unknown (probe failed: {exc.__class__.__name__})",
+        )
+    if granted:
+        return Check("Screen Recording", "ok", "granted to the Persome runtime")
+    status: Status = "fail" if capture.enable_ocr_fallback else "warn"
+    return Check(
+        "Screen Recording",
+        status,
+        "not granted — System Settings → Privacy & Security → Screen Recording; "
+        "required for local OCR and screenshots",
+    )
+
+
+def check_ocr(capture: config_mod.CaptureConfig) -> Check:
+    """Check OCR configuration, kill switch, runtime, models, and permission."""
+    from .capture.ocr_health import inspect
+
+    health = inspect(capture)
+    if health.ready:
+        return Check("local OCR", "ok", health.detail)
+    if health.state == "disabled":
+        return Check("local OCR", "warn", health.detail)
+    if health.state == "runtime_unavailable" and platform.machine() != "arm64":
+        return Check("local OCR", "warn", f"{health.detail}; AX capture remains available")
+    return Check("local OCR", "fail", f"{health.state}: {health.detail}")
+
+
 def check_root_writable() -> Check:
     """The data root exists (created on demand) and accepts writes."""
     root = paths.root()
@@ -323,7 +365,8 @@ def run_checks(host: str, port: int) -> list[Check]:
     """Run every check in display order. Merges the env file into ``os.environ``
     first (same semantics as ``persome start``: pre-set shell vars win)."""
     env_file_mod.load_env_file(paths.env_file())
-    profile = _llm_profile()
+    cfg = config_mod.load()
+    profile = resolve_profile(cfg.model_for("default"))
     checks: list[Check] = [
         check_env_file(profile),
         check_local_api_token(),
@@ -333,6 +376,8 @@ def run_checks(host: str, port: int) -> list[Check]:
         check_base_url(profile),
         *check_helpers(),
         check_ax_trust(),
+        check_screen_recording(cfg.capture),
+        check_ocr(cfg.capture),
         check_root_writable(),
         check_port(host, port),
     ]

--- a/src/persome/ocr_setup.py
+++ b/src/persome/ocr_setup.py
@@ -1,0 +1,35 @@
+"""Persistence helpers for local OCR onboarding."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from . import paths
+
+VALID_TIERS = ("tiny", "small", "medium")
+
+
+def save_ocr_config(*, enabled: bool, tier: str, config_path: Path) -> None:
+    """Update only the OCR fields while preserving the rest of config.toml."""
+    import tomlkit
+    from tomlkit.items import Table
+
+    if tier not in VALID_TIERS:
+        raise ValueError(f"unsupported OCR tier: {tier}")
+    if config_path.is_symlink():
+        raise RuntimeError(f"config file must not be a symlink: {config_path}")
+
+    if config_path.exists():
+        document = tomlkit.parse(config_path.read_text(encoding="utf-8"))
+    else:
+        document = tomlkit.document()
+
+    capture = document.get("capture")
+    if not isinstance(capture, Table):
+        capture = tomlkit.table()
+        document["capture"] = capture
+    capture["enable_ocr_fallback"] = enabled
+    capture["ocr_tier"] = tier
+    capture["ocr_structured"] = True
+
+    paths.atomic_write_private_text(config_path, tomlkit.dumps(document))

--- a/tests/test_api_origin_guard.py
+++ b/tests/test_api_origin_guard.py
@@ -82,7 +82,8 @@ def test_health_allowed_despite_malicious_origin() -> None:
         headers={"origin": "https://evil.com", "host": "attacker.com"},
     )
     assert response.status_code == 200
-    assert response.json() == {"success": True, "data": {"status": "ok"}}
+    assert response.json()["data"]["status"] == "ok"
+    assert "ocr" in response.json()["data"]
 
 
 def test_disabled_guard_does_not_block() -> None:

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -2,20 +2,48 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from fastapi.testclient import TestClient
 
 from persome import __version__
-from persome.api import build_api_app
+from persome.api import build_api_app, routes
 
 
-def test_health_returns_ok() -> None:
+def test_health_returns_ok(monkeypatch) -> None:
     """GET /health must return the documented envelope immediately."""
+    monkeypatch.setattr(
+        routes.ocr_health,
+        "inspect",
+        lambda capture: SimpleNamespace(enabled=True, ready=True, state="ready"),
+    )
     client = TestClient(build_api_app(auth_enabled=False))
     response = client.get("/health")
 
     assert response.status_code == 200
     body = response.json()
-    assert body == {"success": True, "data": {"status": "ok"}}
+    assert body == {"success": True, "data": {"status": "ok", "ocr": "ready"}}
+
+
+def test_health_reports_enabled_ocr_degradation(monkeypatch) -> None:
+    monkeypatch.setattr(
+        routes.ocr_health,
+        "inspect",
+        lambda capture: SimpleNamespace(
+            enabled=True,
+            ready=False,
+            state="permission_required",
+        ),
+    )
+    client = TestClient(build_api_app(auth_enabled=False))
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json()["data"] == {
+        "status": "degraded",
+        "ocr": "permission_required",
+    }
 
 
 def test_openapi_reports_runtime_version() -> None:

--- a/tests/test_api_status_cache.py
+++ b/tests/test_api_status_cache.py
@@ -90,6 +90,7 @@ def test_polled_status_does_not_ping_without_explicit_check(ac_root, monkeypatch
     assert ordinary.status_code == 200
     assert ordinary.json()["data"]["models_checked"] is False
     assert ordinary.json()["data"]["models"] == {}
+    assert ordinary.json()["data"]["ocr"]["state"] == "disabled"
     assert calls_after_ordinary == []
     assert calls == ["timeline"]
     assert explicit.status_code == 200

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -238,7 +238,7 @@ def test_last_capture_handles_corrupted_json(ac_root: Path) -> None:
 
 
 def test_status_renders_new_fields(ac_root: Path) -> None:
-    """Status output includes Version, Uptime, Health, and Last Capture."""
+    """Status output includes runtime, capture, permission, and OCR health."""
     runner = CliRunner()
     result = runner.invoke(cli.app, ["status"])
     assert result.exit_code == 0, result.output
@@ -246,6 +246,8 @@ def test_status_renders_new_fields(ac_root: Path) -> None:
     assert "Uptime" in result.output
     assert "Health" in result.output
     assert "Last Capture" in result.output
+    assert "OCR" in result.output
+    assert "Screen Recording" in result.output
 
 
 def test_status_shows_version(ac_root: Path) -> None:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -19,6 +19,8 @@ from pathlib import Path
 import pytest
 
 from persome import doctor, paths
+from persome.capture import ocr_health, ocr_local, screen_recording
+from persome.config import CaptureConfig
 from persome.providers import PROVIDERS
 
 
@@ -282,6 +284,69 @@ def test_ax_trust_non_macos_warns_unknown(monkeypatch: pytest.MonkeyPatch) -> No
     assert "unknown" in c.detail
 
 
+# ── Screen Recording + local OCR ─────────────────────────────────────────────
+
+
+def test_screen_recording_granted_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(doctor.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(screen_recording, "has_screen_recording", lambda: True)
+
+    check = doctor.check_screen_recording(CaptureConfig(enable_ocr_fallback=True))
+
+    assert check.status == "ok"
+
+
+def test_screen_recording_denied_fails_when_ocr_is_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(doctor.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(screen_recording, "has_screen_recording", lambda: False)
+
+    check = doctor.check_screen_recording(CaptureConfig(enable_ocr_fallback=True))
+
+    assert check.status == "fail"
+    assert "Screen Recording" in check.detail
+
+
+def test_ocr_ready_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ocr_health.sys, "platform", "darwin")
+    monkeypatch.setattr(ocr_local, "runtime_available", lambda: True)
+    monkeypatch.setattr(ocr_local, "models_available", lambda tier: True)
+    monkeypatch.setattr(ocr_local, "disabled_by_environment", lambda: False)
+    monkeypatch.setattr(screen_recording, "has_screen_recording", lambda: True)
+
+    check = doctor.check_ocr(CaptureConfig(enable_ocr_fallback=True))
+
+    assert check.status == "ok"
+    assert "isolated worker" in check.detail
+
+
+def test_ocr_permission_block_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ocr_health.sys, "platform", "darwin")
+    monkeypatch.setattr(ocr_local, "runtime_available", lambda: True)
+    monkeypatch.setattr(ocr_local, "models_available", lambda tier: True)
+    monkeypatch.setattr(ocr_local, "disabled_by_environment", lambda: False)
+    monkeypatch.setattr(screen_recording, "has_screen_recording", lambda: False)
+
+    check = doctor.check_ocr(CaptureConfig(enable_ocr_fallback=True))
+
+    assert check.status == "fail"
+    assert "permission_required" in check.detail
+
+
+def test_ocr_disabled_is_visible_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ocr_health.sys, "platform", "darwin")
+    monkeypatch.setattr(ocr_local, "runtime_available", lambda: True)
+    monkeypatch.setattr(ocr_local, "models_available", lambda tier: True)
+    monkeypatch.setattr(ocr_local, "disabled_by_environment", lambda: False)
+    monkeypatch.setattr(screen_recording, "has_screen_recording", lambda: True)
+
+    check = doctor.check_ocr(CaptureConfig(enable_ocr_fallback=False))
+
+    assert check.status == "warn"
+    assert "persome ocr setup" in check.detail
+
+
 # ── data root ─────────────────────────────────────────────────────────────────
 
 
@@ -373,6 +438,8 @@ def test_run_checks_merges_env_file_first(
     assert by_name["PERSOME_LOCAL_API_TOKEN"].status == "ok"
     assert by_name["SQLite secure FTS"].status == "ok"
     assert by_name["PERSOME_SCREENSHOT_KEY"].status == "warn"
+    assert "Screen Recording" in by_name
+    assert by_name["local OCR"].status == "warn"
 
 
 def test_openai_profile_uses_selected_credential_and_endpoint(

--- a/tests/test_local_api_auth.py
+++ b/tests/test_local_api_auth.py
@@ -92,7 +92,8 @@ def test_health_is_public_but_missing_token_closes_protected_rest(
     protected = client.get("/openapi.json")
 
     assert health.status_code == 200
-    assert health.json() == {"success": True, "data": {"status": "ok"}}
+    assert health.json()["data"]["status"] == "ok"
+    assert "ocr" in health.json()["data"]
     assert protected.status_code == 503
     assert protected.headers["connection"] == "close"
     assert protected.json() == {

--- a/tests/test_ocr_local.py
+++ b/tests/test_ocr_local.py
@@ -66,6 +66,8 @@ class TestModelResolution:
         rec = ocr_local._model_dir("tiny", "rec")
         assert det is not None and det.endswith("PP-OCRv6_tiny_det")
         assert rec is not None and rec.endswith("PP-OCRv6_tiny_rec")
+        assert ocr_local.models_available("tiny") is True
+        assert ocr_local.models_available("invalid") is False
 
     def test_env_override(self, monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
         monkeypatch.setenv("PERSOME_OCR_MODELS_DIR", str(tmp_path))
@@ -175,7 +177,7 @@ class TestDisableKillSwitch:
             raise AssertionError("warm must not build the engine when OCR is disabled")
 
         monkeypatch.setattr(ocr_local, "_build_engine", _boom)
-        ocr_local.warm("tiny")  # must not raise
+        assert ocr_local.warm("tiny") is False
 
     def test_enabled_recognize_still_runs(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # Guard against the kill-switch accidentally disabling OCR when unset/off.

--- a/tests/test_ocr_onboarding.py
+++ b/tests/test_ocr_onboarding.py
@@ -1,0 +1,141 @@
+"""OCR onboarding, persistence, and side-effect-free health state."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from persome import config, paths
+from persome.capture import ocr_health, ocr_local, screen_recording
+from persome.cli import app
+from persome.config import CaptureConfig
+from persome.ocr_setup import save_ocr_config
+
+
+def _ready_probes(monkeypatch: pytest.MonkeyPatch, *, permission: bool = True) -> None:
+    monkeypatch.setattr(ocr_health.sys, "platform", "darwin")
+    monkeypatch.setattr(ocr_local, "runtime_available", lambda: True)
+    monkeypatch.setattr(ocr_local, "models_available", lambda tier: True)
+    monkeypatch.setattr(ocr_local, "disabled_by_environment", lambda: False)
+    monkeypatch.setattr(screen_recording, "has_screen_recording", lambda: permission)
+
+
+def test_health_ready_requires_config_runtime_models_and_permission(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _ready_probes(monkeypatch)
+
+    health = ocr_health.inspect(CaptureConfig(enable_ocr_fallback=True))
+
+    assert health.ready is True
+    assert health.state == "ready"
+    assert health.as_dict()["screen_recording"] == "granted"
+
+
+def test_health_reports_permission_block(monkeypatch: pytest.MonkeyPatch) -> None:
+    _ready_probes(monkeypatch, permission=False)
+
+    health = ocr_health.inspect(CaptureConfig(enable_ocr_fallback=True))
+
+    assert health.ready is False
+    assert health.state == "permission_required"
+
+
+def test_health_reports_disabled_without_hiding_runtime_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _ready_probes(monkeypatch)
+
+    health = ocr_health.inspect(CaptureConfig(enable_ocr_fallback=False))
+
+    assert health.state == "disabled"
+    assert health.runtime_available is True
+    assert health.models_available is True
+
+
+def test_save_ocr_config_preserves_other_capture_fields(tmp_path: Path) -> None:
+    path = tmp_path / "config.toml"
+    path.write_text("[capture]\ninterval_minutes = 7\n", encoding="utf-8")
+
+    save_ocr_config(enabled=True, tier="small", config_path=path)
+
+    text = path.read_text(encoding="utf-8")
+    assert "interval_minutes = 7" in text
+    loaded = config.load(path).capture
+    assert loaded.enable_ocr_fallback is True
+    assert loaded.ocr_tier == "small"
+    assert loaded.ocr_structured is True
+
+
+def test_setup_requests_permission_warms_worker_and_enables_ocr(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _ready_probes(monkeypatch)
+    calls: list[str] = []
+    monkeypatch.setattr(
+        screen_recording,
+        "request_screen_recording",
+        lambda: calls.append("permission") or True,
+    )
+    monkeypatch.setattr(ocr_local, "warm", lambda tier: calls.append(f"warm:{tier}") or True)
+
+    result = CliRunner().invoke(app, ["ocr", "setup", "--tier", "tiny"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == ["permission", "warm:tiny"]
+    assert config.load().capture.enable_ocr_fallback is True
+    assert "enabled and ready" in result.output
+
+
+def test_setup_enables_ocr_but_fails_until_permission_is_granted(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _ready_probes(monkeypatch, permission=False)
+    opened: list[bool] = []
+    monkeypatch.setattr(screen_recording, "request_screen_recording", lambda: False)
+    monkeypatch.setattr(ocr_local, "warm", lambda tier: True)
+    monkeypatch.setattr(
+        "persome.cli._open_screen_recording_settings",
+        lambda: opened.append(True),
+    )
+
+    result = CliRunner().invoke(app, ["ocr", "setup"])
+
+    assert result.exit_code == 1
+    assert config.load().capture.enable_ocr_fallback is True
+    assert opened == [True]
+    assert "not granted yet" in result.output
+
+
+def test_setup_does_not_enable_missing_runtime(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(ocr_local, "disabled_by_environment", lambda: False)
+    monkeypatch.setattr(ocr_local, "runtime_available", lambda: False)
+
+    result = CliRunner().invoke(app, ["ocr", "setup"])
+
+    assert result.exit_code == 1
+    assert config.load().capture.enable_ocr_fallback is False
+    assert "runtime is unavailable" in result.output
+
+
+def test_disable_preserves_tier(ac_root: Path) -> None:
+    save_ocr_config(enabled=True, tier="small", config_path=paths.config_file())
+
+    result = CliRunner().invoke(app, ["ocr", "disable"])
+
+    assert result.exit_code == 0
+    capture = config.load().capture
+    assert capture.enable_ocr_fallback is False
+    assert capture.ocr_tier == "small"
+
+
+def test_install_runs_ocr_onboarding_without_an_opt_in_prompt() -> None:
+    script = (Path(__file__).resolve().parents[1] / "install.sh").read_text(encoding="utf-8")
+
+    assert "configure_ocr()" in script
+    assert 'persome" ocr setup --tier tiny' in script
+    assert "configure_ocr\n  print_summary" in script

--- a/tests/test_ocr_runtime_availability.py
+++ b/tests/test_ocr_runtime_availability.py
@@ -61,4 +61,4 @@ def test_ocr_entrypoints_degrade_cleanly_without_runtime(monkeypatch: pytest.Mon
 
     assert ocr_local.recognize(b"\xff\xd8\xff-not-a-real-jpeg") is None
     assert ocr_local.recognize_detailed(b"\xff\xd8\xff-not-a-real-jpeg") is None
-    ocr_local.warm()  # clean no-op, no exception
+    assert ocr_local.warm() is False

--- a/tests/test_ocr_subprocess.py
+++ b/tests/test_ocr_subprocess.py
@@ -144,14 +144,14 @@ class TestCrashContainment:
 
         client = ocr_subprocess.OCRWorkerClient(spawn=_boom, timeout=1)
         assert client.recognize_detailed(_JPEG, "tiny") is None
-        assert client.warm("tiny") is None  # warm also fails open, never raises
+        assert client.warm("tiny") is False  # warm also fails open, never raises
 
 
 class TestWarm:
     def test_warm_spawns_worker(self) -> None:
         client = ocr_subprocess.OCRWorkerClient(spawn=_spawner(_ECHO), timeout=10)
         try:
-            client.warm("tiny")
+            assert client.warm("tiny") is True
             assert client._proc is not None and client._proc.poll() is None
         finally:
             client.shutdown()

--- a/tests/test_permissions_api.py
+++ b/tests/test_permissions_api.py
@@ -1,9 +1,9 @@
-"""Tests for the GET /permissions endpoint and the ax_trusted() probe.
+"""Tests for the GET /permissions endpoint and macOS TCC probes.
 
 The daemon is the process that reads the AX tree (via mac-ax-helper /
-mac-ax-watcher), so /permissions reports the daemon's own Accessibility trust —
-the authoritative signal the app's onboarding reflects instead of self-checking
-in the GUI process (which would create a redundant second TCC principal).
+mac-ax-watcher and captures focused-window pixels, so /permissions reports the
+daemon's own Accessibility and Screen Recording trust. This is the authoritative
+signal for onboarding instead of probing from a second GUI TCC principal.
 """
 
 from __future__ import annotations
@@ -13,7 +13,7 @@ import platform
 from fastapi.testclient import TestClient
 
 from persome.api import build_api_app
-from persome.capture import ax_capture
+from persome.capture import ax_capture, screen_recording
 
 
 def _make_client() -> TestClient:
@@ -22,18 +22,22 @@ def _make_client() -> TestClient:
 
 def test_permissions_reports_granted(monkeypatch) -> None:
     monkeypatch.setattr(ax_capture, "ax_trusted", lambda: True)
+    monkeypatch.setattr(screen_recording, "has_screen_recording", lambda: True)
     resp = _make_client().get("/permissions")
     assert resp.status_code == 200
     body = resp.json()
     assert body["success"] is True
     assert body["data"]["accessibility"] == "granted"
+    assert body["data"]["screen_recording"] == "granted"
 
 
 def test_permissions_reports_denied(monkeypatch) -> None:
     monkeypatch.setattr(ax_capture, "ax_trusted", lambda: False)
+    monkeypatch.setattr(screen_recording, "has_screen_recording", lambda: False)
     resp = _make_client().get("/permissions")
     assert resp.status_code == 200
     assert resp.json()["data"]["accessibility"] == "denied"
+    assert resp.json()["data"]["screen_recording"] == "denied"
 
 
 def test_ax_trusted_false_off_darwin() -> None:


### PR DESCRIPTION
## Summary

- run local OCR setup automatically during `install.sh`
- request macOS Screen Recording, verify bundled model weights, and perform a real isolated-worker warmup before enabling OCR
- add `persome ocr setup`, `persome ocr status [--check]`, and `persome ocr disable`
- expose one shared OCR state through `persome doctor`, `persome status`, `/health`, `/permissions`, and `/status`
- report unsupported architectures and emergency kill-switch state without fabricating readiness
- update README, security, architecture, operations, capture, config, API, troubleshooting, validation, and OpenAPI contracts

## Why

OCR was packaged but disabled by default, Screen Recording was requested only indirectly at daemon startup, and health surfaces could report a healthy Runtime without showing that AX-poor apps had no OCR path. Installation now proves the worker and asks for permission while health reports the effective state end to end.

## Validation

- `PERSOME_LLM_MOCK=1 uv run pytest -m "not macos and not integration" -q` (`1636 passed, 15 deselected`)
- real Chinese OCR integration passed
- real isolated-worker end-to-end OCR integration passed
- fresh temporary-root `persome ocr setup` and `persome ocr status --check` passed with bundled weights and Screen Recording
- `uv run ruff check .` and `uv run ruff format --check .`
- secret, PII, language, documentation-link, OpenAPI drift, and shell syntax checks passed