### PR TITLE
Use a provider-neutral Runtime LLM credential

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,9 @@ modeling. During installation, the provider wizard asks you to choose a service
 and enter its API key. Persome supplies that provider's endpoint and default
 model, tests completion and tool calling, and only then saves the route. Existing
 keys are detected automatically. API keys go to the owner-only
-`~/.persome/env` file; the non-secret route goes to `~/.persome/config.toml`.
-Nothing ships with a key.
+`~/.persome/env` file under the provider-neutral `PERSOME_LLM_API_KEY` name;
+provider-specific environment variables are import sources only. The non-secret
+route goes to `~/.persome/config.toml`. Nothing ships with a key.
 
 ```bash
 # If provider setup was skipped during installation:

--- a/docs/config.md
+++ b/docs/config.md
@@ -34,9 +34,11 @@ cannot call tools requires an explicit degraded-mode confirmation.
 
 Azure deployments and `custom-openai` / `custom-anthropic` are explicitly
 advanced because their endpoint and model or deployment name are user-specific.
-Automation can also override a preset with `--base-url`, `--model`, and
-`--api-key-env`. Run `persome llm providers --details` to inspect those routing
-defaults; they are not part of regular onboarding.
+Automation can also override a preset with `--base-url` and `--model`, or import
+a key from an existing variable with `--api-key-env`. Imported keys are still
+stored under Persome's provider-neutral `PERSOME_LLM_API_KEY` name. Run
+`persome llm providers --details` to inspect routing defaults; they are not part
+of regular onboarding.
 
 The resulting non-secret configuration has this shape:
 
@@ -46,7 +48,7 @@ provider = "openrouter"
 protocol = "openai"
 model = "anthropic/claude-sonnet-4"
 base_url = "https://openrouter.ai/api/v1"
-api_key_env = "OPENROUTER_API_KEY"
+api_key_env = "PERSOME_LLM_API_KEY"
 # max_tokens = 4096
 
 [models.timeline]
@@ -59,10 +61,11 @@ api_key_env = "OPENROUTER_API_KEY"
 [models.schema_miner]
 ```
 
-Only the value named by `api_key_env` is stored in `<PERSOME_ROOT>/env`:
+The active provider key is stored in `<PERSOME_ROOT>/env` under one stable,
+provider-neutral name:
 
 ```dotenv
-OPENROUTER_API_KEY=...
+PERSOME_LLM_API_KEY=...
 
 # Optional dense retrieval:
 OPENAI_API_KEY=...
@@ -84,10 +87,14 @@ Ollama, LM Studio, and vLLM. Presets describe endpoint defaults, not a blanket
 capability guarantee for every model. Use `custom-openai` or
 `custom-anthropic` for another compatible gateway.
 
-For migration, a config without `provider` and `protocol` retains the former
-`ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL` route exactly, even if an older file
-contains an ignored `api_key_env`. Running `persome llm setup` tests and
-converts that route to explicit fields.
+During onboarding, Persome can discover common provider-specific variables such
+as keys exported by provider CLIs or existing shell profiles. They are import
+sources only; the saved Runtime profile always references `PERSOME_LLM_API_KEY`.
+
+For migration, existing provider-specific `api_key_env` values and the former
+pre-provider route remain readable as compatibility fallbacks. Running
+`persome llm setup` tests the current route, copies the selected key to
+`PERSOME_LLM_API_KEY`, and writes an explicit provider profile.
 
 ## Capture
 

--- a/docs/runtime-internals.md
+++ b/docs/runtime-internals.md
@@ -7,7 +7,7 @@ mode `0600`. `persome start` loads this file before daemonization. Business
 code reads the resulting environment variables:
 
 ```text
-<api_key_env selected by models.default>
+PERSOME_LLM_API_KEY (active Runtime provider)
 OPENAI_API_KEY / OPENAI_BASE_URL (optional dense retrieval)
 PERSOME_SCREENSHOT_KEY
 PERSOME_LOCAL_API_TOKEN

--- a/scripts/probe_prompt_cache.py
+++ b/scripts/probe_prompt_cache.py
@@ -6,7 +6,7 @@ breakpoint, then reports usage.cache_creation_input_tokens and cache_read_input_
 Usage:
 
     uv run python scripts/probe_prompt_cache.py
-    uv run python scripts/probe_prompt_cache.py --base-url https://api.anthropic.com --model claude-haiku-4-5 --api-key-env ANTHROPIC_API_KEY
+    uv run python scripts/probe_prompt_cache.py --base-url https://api.anthropic.com --model claude-haiku-4-5
 
 Exit code is 0 iff the second call shows cache_read_input_tokens > 0. The output
 is a markdown table suitable for pasting into a PR description.
@@ -51,8 +51,8 @@ def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument(
         "--base-url",
-        default=os.environ.get("ANTHROPIC_BASE_URL", "https://api.anthropic.com"),
-        help="Anthropic-compatible base URL (default: ANTHROPIC_BASE_URL or official API).",
+        default=os.environ.get("PERSOME_LLM_BASE_URL", "https://api.anthropic.com"),
+        help="Anthropic-compatible base URL (default: PERSOME_LLM_BASE_URL or official API).",
     )
     p.add_argument(
         "--model",
@@ -61,8 +61,8 @@ def main() -> int:
     )
     p.add_argument(
         "--api-key-env",
-        default="ANTHROPIC_API_KEY",
-        help="Environment variable holding the API key (default: ANTHROPIC_API_KEY).",
+        default="PERSOME_LLM_API_KEY",
+        help="Environment variable holding the API key (default: PERSOME_LLM_API_KEY).",
     )
     args = p.parse_args()
 

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -1225,7 +1225,7 @@ def _interactive_terminal() -> bool:
 def _llm_credential_summary(spec: ProviderSpec) -> str:
     if not spec.key_required:
         return "[dim]local, no key[/dim]"
-    if os.environ.get(spec.api_key_env):
+    if os.environ.get(spec.discovery_api_key_env):
         return "[green]key found[/green]"
     return "[dim]API key required[/dim]"
 
@@ -1248,11 +1248,11 @@ def llm_providers(
     details: bool = typer.Option(
         False,
         "--details",
-        help="Show protocol, default model, endpoint, and credential variable.",
+        help="Show protocol, default model, endpoint, and credential storage.",
     ),
 ) -> None:
     """List supported presets and mark credentials already found locally."""
-    from .providers import PROVIDERS
+    from .providers import LLM_API_KEY_ENV, PROVIDERS
 
     env_file_mod.load_env_file(paths.env_file())
     for spec in PROVIDERS:
@@ -1261,12 +1261,12 @@ def llm_providers(
             flags.append("[yellow]advanced[/yellow]")
         console.print(f"[bold]{spec.label}[/bold] [dim]({spec.id})[/dim]  {' | '.join(flags)}")
         if details:
-            credential = "none" if not spec.key_required else spec.api_key_env
+            credential = "none" if not spec.key_required else LLM_API_KEY_ENV
             console.print(
                 f"  Protocol: {spec.protocol}\n"
                 f"  Default model: {spec.default_model}\n"
                 f"  Endpoint: {spec.base_url or 'configured during advanced setup'}\n"
-                f"  Credential variable: {credential}\n"
+                f"  Runtime credential: {credential}\n"
                 f"  [dim]{spec.description}[/dim]\n"
             )
     if not details:
@@ -1299,6 +1299,8 @@ def llm_status(
         credential = "[green]not required[/green] (local endpoint)"
     elif profile.credential_ready:
         credential = f"[green]set[/green] via {profile.api_key_env}"
+        if profile.credential_migration_required:
+            credential = f"[green]set[/green] (ready to migrate to {profile.api_key_env})"
     else:
         credential = f"[red]missing[/red] ({profile.api_key_env})"
     table.add_row("Credential", credential)
@@ -1306,8 +1308,13 @@ def llm_status(
     console.print(table)
     if profile.legacy:
         console.print(
-            "[yellow]This installation still uses the pre-provider Anthropic-compatible route. "
+            "[yellow]This installation still uses the pre-provider compatibility route. "
             "Run `persome llm setup` to verify and migrate it explicitly.[/yellow]"
+        )
+    elif profile.credential_migration_required:
+        console.print(
+            "[yellow]The key is being read through a provider-specific compatibility fallback. "
+            "Run `persome llm setup` to store it as PERSOME_LLM_API_KEY.[/yellow]"
         )
     if check:
         if not profile.credential_ready:
@@ -1338,7 +1345,7 @@ def llm_setup(
     model: str = typer.Option("", "--model", help="Advanced: override the preset model."),
     base_url: str = typer.Option("", "--base-url", help="Advanced: override the endpoint."),
     api_key_env: str = typer.Option(
-        "", "--api-key-env", help="Advanced: environment variable holding the key."
+        "", "--api-key-env", help="Advanced: import the key from this environment variable."
     ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Accept detected/default values."),
     allow_no_tools: bool = typer.Option(
@@ -1355,6 +1362,7 @@ def llm_setup(
     """Choose a provider, enter its key, verify it, and save the Runtime profile."""
     from .llm_setup import probe_profile, save_profile
     from .providers import (
+        LLM_API_KEY_ENV,
         PROVIDERS,
         detected_providers,
         make_profile,
@@ -1406,13 +1414,14 @@ def llm_setup(
             console.print("Choose the LLM provider Persome should use:")
             selected = _choose_llm_provider(PROVIDERS)
 
+    chosen_key_env = LLM_API_KEY_ENV
+    source_key_env = api_key_env
     if keep_current:
         provider_id = current.provider
         protocol = current.protocol
         chosen_model = model or current.model
         chosen_base_url = base_url or current.base_url
-        chosen_key_env = api_key_env or current.api_key_env
-        api_key = os.environ.get(chosen_key_env) or current.api_key
+        api_key = os.environ.get(source_key_env) if source_key_env else current.api_key
     else:
         assert selected is not None
         provider_id = selected.id
@@ -1420,8 +1429,11 @@ def llm_setup(
         chosen_model = model or selected.default_model
         chosen_base_url = base_url or os.environ.get(selected.resolved_base_url_env, "")
         chosen_base_url = chosen_base_url or selected.base_url
-        chosen_key_env = api_key_env or selected.api_key_env
-        api_key = os.environ.get(chosen_key_env)
+        if source_key_env:
+            api_key = os.environ.get(source_key_env)
+        else:
+            api_key = os.environ.get(selected.discovery_api_key_env)
+            api_key = api_key or os.environ.get(LLM_API_KEY_ENV)
 
     selected_spec = selected or provider_spec(provider_id)
     provider_label = selected_spec.label if selected_spec is not None else current.provider_label
@@ -1433,7 +1445,7 @@ def llm_setup(
             "[yellow]Advanced setup:[/yellow] this provider needs deployment-specific "
             "routing details."
         )
-        api_key = os.environ.get(chosen_key_env) or api_key
+        api_key = (os.environ.get(source_key_env) if source_key_env else None) or api_key
         if not base_url:
             chosen_base_url = typer.prompt("API endpoint", default=chosen_base_url or "")
         if not model:
@@ -1448,7 +1460,7 @@ def llm_setup(
     if parsed_endpoint.scheme not in {"http", "https"} or not parsed_endpoint.netloc:
         console.print("[red]The API endpoint must be an absolute http(s) URL.[/red]")
         raise typer.Exit(2)
-    if not chosen_key_env.isascii() or not chosen_key_env.isidentifier():
+    if source_key_env and (not source_key_env.isascii() or not source_key_env.isidentifier()):
         console.print("[red]The API key environment variable name is invalid.[/red]")
         raise typer.Exit(2)
 
@@ -1456,7 +1468,8 @@ def llm_setup(
     if key_required and not api_key:
         if not interactive:
             console.print(
-                f"[red]{chosen_key_env} is not set. Export it or run setup interactively.[/red]"
+                f"[red]No API key was found. Set {LLM_API_KEY_ENV} or run setup "
+                "interactively.[/red]"
             )
             raise typer.Exit(2)
         api_key = typer.prompt(

--- a/src/persome/config.py
+++ b/src/persome/config.py
@@ -14,8 +14,8 @@ from . import providers as provider_mod
 @dataclass
 class ModelConfig:
     model: str = "deepseek-v4-flash"
-    # Provider routing is explicit after ``persome llm setup``. Empty values
-    # preserve old configs and are inferred from the model/environment.
+    # Provider routing is explicit after ``persome llm setup``. ``api_key_env``
+    # is retained for old TOMLs; new profiles always use PERSOME_LLM_API_KEY.
     provider: str = ""
     protocol: str = ""
     api_key_env: str = ""
@@ -626,8 +626,8 @@ DEFAULT_CONFIG_TEMPLATE = """# Persome configuration
 # calling before writing the fields below. Every stage inherits [models.default]
 # unless its own section overrides a field.
 #
-# API keys never belong in this file. `api_key_env` stores only the variable
-# name; the secret itself lives in ~/.persome/env (mode 0600). Endpoints are not
+# API keys never belong in this file. The active secret is always named
+# PERSOME_LLM_API_KEY and lives in ~/.persome/env (mode 0600). Endpoints are not
 # secrets and are stored here so Chat and daemon subprocesses use the same route.
 # `persome llm providers` lists hosted/local presets. Azure and custom compatible
 # gateways use the clearly separated advanced setup path.
@@ -646,7 +646,8 @@ edge_promote_fanout = 20
 # name = "Alice"
 
 [models.default]
-# `persome llm setup` writes provider, protocol, model, base_url, and api_key_env.
+# `persome llm setup` writes provider, protocol, model, base_url, and the
+# PERSOME_LLM_API_KEY credential reference.
 # Until then, these legacy defaults retain compatibility with pre-provider installs.
 model = "deepseek-v4-flash"
 
@@ -783,8 +784,9 @@ port = 8742
 
 [chat]
 # Chat inherits the complete [models.default] provider profile. Override model,
-# provider, protocol, base_url, or api_key_env here only when Chat intentionally
-# uses another endpoint. thinking_budget applies only to Anthropic models.
+# provider, protocol, or base_url here only when Chat intentionally uses another
+# endpoint. The active credential remains PERSOME_LLM_API_KEY.
+# thinking_budget applies only to Anthropic models.
 # thinking_budget = 0
 unsafe_local_tools_enabled = false # opt in to shell, arbitrary filesystem, and web tools
 mcp_connect_daemon = true         # auto-connect to the daemon's own MCP server

--- a/src/persome/llm_setup.py
+++ b/src/persome/llm_setup.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from . import env_file, paths
-from .providers import ResolvedLLMProfile
+from .providers import LLM_API_KEY_ENV, ResolvedLLMProfile
 
 _PROBE_TOOL_NAME = "persome_setup_check"
 _PROBE_TOOL_DESCRIPTION = "Confirm that this model can call Persome memory tools."
@@ -173,13 +173,13 @@ def save_profile(
     default["protocol"] = profile.protocol
     default["model"] = profile.model
     default["base_url"] = profile.base_url
-    default["api_key_env"] = profile.api_key_env
+    default["api_key_env"] = LLM_API_KEY_ENV
 
     if config_path.is_symlink():
         raise RuntimeError(f"config file must not be a symlink: {config_path}")
-    paths.atomic_write_private_text(config_path, tomlkit.dumps(document))
     if profile.api_key:
-        env_file.write_env_values(env_path, {profile.api_key_env: profile.api_key})
+        env_file.write_env_values(env_path, {LLM_API_KEY_ENV: profile.api_key})
+    paths.atomic_write_private_text(config_path, tomlkit.dumps(document))
 
 
 def profile_dict(profile: ResolvedLLMProfile) -> dict[str, Any]:

--- a/src/persome/providers.py
+++ b/src/persome/providers.py
@@ -14,13 +14,18 @@ from typing import Any, Literal
 
 LLMProtocol = Literal["anthropic", "openai"]
 
+LLM_API_KEY_ENV = "PERSOME_LLM_API_KEY"
+LLM_BASE_URL_ENV = "PERSOME_LLM_BASE_URL"
+_LEGACY_ANTHROPIC_API_KEY_ENV = "ANTHROPIC_API_KEY"
+_LEGACY_ANTHROPIC_BASE_URL_ENV = "ANTHROPIC_BASE_URL"
+
 
 @dataclass(frozen=True)
 class ProviderSpec:
     id: str
     label: str
     protocol: LLMProtocol
-    api_key_env: str
+    discovery_api_key_env: str
     base_url: str
     default_model: str
     description: str
@@ -33,8 +38,8 @@ class ProviderSpec:
     def resolved_base_url_env(self) -> str:
         if self.base_url_env:
             return self.base_url_env
-        if self.api_key_env.endswith("_API_KEY"):
-            return f"{self.api_key_env[:-8]}_BASE_URL"
+        if self.discovery_api_key_env.endswith("_API_KEY"):
+            return f"{self.discovery_api_key_env[:-8]}_BASE_URL"
         return ""
 
 
@@ -279,6 +284,7 @@ class ResolvedLLMProfile:
     api_key: str | None = field(default=None, repr=False)
     key_required: bool = True
     legacy: bool = False
+    credential_source_env: str = field(default="", repr=False)
 
     @property
     def wire_model(self) -> str:
@@ -295,6 +301,14 @@ class ResolvedLLMProfile:
     @property
     def credential_ready(self) -> bool:
         return bool(self.api_key) or not self.key_required
+
+    @property
+    def credential_migration_required(self) -> bool:
+        return bool(
+            self.api_key
+            and self.credential_source_env
+            and self.credential_source_env != LLM_API_KEY_ENV
+        )
 
     def client_api_key(self) -> str:
         """Return an SDK-safe key or raise before any hosted network call."""
@@ -333,8 +347,14 @@ def infer_provider(model: str) -> str:
 
 
 def provider_api_key(provider: str) -> str | None:
+    """Return a provider-specific key for auxiliary provider integrations.
+
+    The active Runtime profile uses ``PERSOME_LLM_API_KEY``. This helper stays
+    provider-specific because dense retrieval may use OpenAI independently of
+    the selected Runtime provider.
+    """
     spec = provider_spec(provider)
-    return os.environ.get(spec.api_key_env) if spec else None
+    return os.environ.get(spec.discovery_api_key_env) if spec else None
 
 
 def provider_base_url(provider: str) -> str | None:
@@ -356,24 +376,30 @@ def _legacy_anthropic_profile(model_cfg: Any) -> ResolvedLLMProfile | None:
     explicit = any(str(getattr(model_cfg, name, "") or "") for name in ("provider", "protocol"))
     if explicit:
         return None
-    key = os.environ.get("ANTHROPIC_API_KEY")
+    key = os.environ.get(LLM_API_KEY_ENV)
+    credential_source_env = LLM_API_KEY_ENV if key else ""
+    if not key:
+        key = os.environ.get(_LEGACY_ANTHROPIC_API_KEY_ENV)
+        credential_source_env = _LEGACY_ANTHROPIC_API_KEY_ENV if key else ""
     model = str(getattr(model_cfg, "model", "") or "")
     provider = infer_provider(model)
     spec = provider_spec(provider)
     base_url = str(getattr(model_cfg, "base_url", "") or "")
-    base_url = base_url or os.environ.get("ANTHROPIC_BASE_URL", "")
+    base_url = base_url or os.environ.get(LLM_BASE_URL_ENV, "")
+    base_url = base_url or os.environ.get(_LEGACY_ANTHROPIC_BASE_URL_ENV, "")
     if not base_url:
         base_url = _BY_ID["anthropic"].base_url
     return ResolvedLLMProfile(
         provider=provider,
-        provider_label=f"{spec.label if spec else provider} (legacy Anthropic route)",
+        provider_label=f"{spec.label if spec else provider} (legacy route)",
         protocol="anthropic",
         model=model,
         base_url=base_url,
-        api_key_env="ANTHROPIC_API_KEY",
+        api_key_env=LLM_API_KEY_ENV,
         api_key=key,
         key_required=True,
         legacy=True,
+        credential_source_env=credential_source_env,
     )
 
 
@@ -390,7 +416,17 @@ def resolve_profile(model_cfg: Any) -> ResolvedLLMProfile:
         spec = _BY_ID["custom-openai"]
     protocol_raw = str(getattr(model_cfg, "protocol", "") or "") or spec.protocol
     protocol: LLMProtocol = "anthropic" if protocol_raw == "anthropic" else "openai"
-    api_key_env = str(getattr(model_cfg, "api_key_env", "") or "") or spec.api_key_env
+    configured_key_env = str(getattr(model_cfg, "api_key_env", "") or "")
+    if configured_key_env == LLM_API_KEY_ENV:
+        credential_candidates = (LLM_API_KEY_ENV,)
+    elif configured_key_env:
+        credential_candidates = (configured_key_env, LLM_API_KEY_ENV)
+    else:
+        credential_candidates = (LLM_API_KEY_ENV, spec.discovery_api_key_env)
+    credential_source_env = next(
+        (name for name in dict.fromkeys(credential_candidates) if os.environ.get(name)),
+        "",
+    )
     base_url = str(getattr(model_cfg, "base_url", "") or "")
     if not base_url and spec.resolved_base_url_env:
         base_url = os.environ.get(spec.resolved_base_url_env, "")
@@ -401,9 +437,10 @@ def resolve_profile(model_cfg: Any) -> ResolvedLLMProfile:
         protocol=protocol,
         model=model or spec.default_model,
         base_url=base_url,
-        api_key_env=api_key_env,
-        api_key=os.environ.get(api_key_env),
+        api_key_env=LLM_API_KEY_ENV,
+        api_key=os.environ.get(credential_source_env) if credential_source_env else None,
         key_required=spec.key_required,
+        credential_source_env=credential_source_env,
     )
 
 
@@ -436,4 +473,10 @@ def detected_providers() -> list[ProviderSpec]:
     Region/protocol variants intentionally remain separate even when they use
     the same key variable; guessing the wrong endpoint is worse than prompting.
     """
-    return [spec for spec in PROVIDERS if not spec.local and os.environ.get(spec.api_key_env)]
+    return [
+        spec
+        for spec in PROVIDERS
+        if not spec.local
+        and spec.discovery_api_key_env != LLM_API_KEY_ENV
+        and os.environ.get(spec.discovery_api_key_env)
+    ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,13 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 
+@pytest.fixture(autouse=True)
+def isolate_runtime_llm_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep developer credentials and cross-test writes out of unit tests."""
+    monkeypatch.delenv("PERSOME_LLM_API_KEY", raising=False)
+    monkeypatch.delenv("PERSOME_LLM_BASE_URL", raising=False)
+
+
 @pytest.fixture
 def ac_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     root = tmp_path / "persome"

--- a/tests/test_api_status_cache.py
+++ b/tests/test_api_status_cache.py
@@ -60,7 +60,7 @@ def test_status_provider_ping_refreshes_after_ttl(monkeypatch) -> None:
 
 def test_status_cache_key_never_contains_provider_secret(monkeypatch) -> None:
     routes._model_ping_cache.clear()
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "secret-value-must-not-be-retained")
+    monkeypatch.setenv("PERSOME_LLM_API_KEY", "secret-value-must-not-be-retained")
     monkeypatch.setattr(llm_mod, "ping_stage", _ok_ping)
 
     routes._status_model_pings(Config())

--- a/tests/test_chat_ttft.py
+++ b/tests/test_chat_ttft.py
@@ -61,7 +61,7 @@ class _FakeRunner:
 
 
 def _make_agent(monkeypatch, runner: _FakeRunner) -> ChatAgent:
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "synthetic")
+    monkeypatch.setenv("PERSOME_LLM_API_KEY", "synthetic")
     agent = ChatAgent(ChatConfig(), all_schemas=[], all_handlers={})
 
     def fake_tool_runner(**_kw: Any) -> _FakeRunner:

--- a/tests/test_clean_cli.py
+++ b/tests/test_clean_cli.py
@@ -101,7 +101,7 @@ def test_clean_all_keeps_only_install_configuration_and_custom_skills(ac_root) -
     _seed_capture()
     _seed_model()
     paths.config_file().write_text("[capture]\n")
-    paths.env_file().write_text("ANTHROPIC_API_KEY=synthetic\n")
+    paths.env_file().write_text("PERSOME_LLM_API_KEY=synthetic\n")
     (paths.root() / "venv").mkdir()
     paths.skills_dir().mkdir()
     (paths.skills_dir() / "custom.md").write_text("Synthetic skill.")

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -15,18 +15,18 @@ from persome import cli, paths
 def test_chat_loads_runtime_env_before_building_agent(
     ac_root: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    monkeypatch.delenv("PERSOME_LLM_API_KEY", raising=False)
+    monkeypatch.delenv("PERSOME_LLM_BASE_URL", raising=False)
     paths.env_file().write_text(
-        "ANTHROPIC_API_KEY=sk-test-from-env-file\n"
-        "ANTHROPIC_BASE_URL=https://gateway.example/anthropic\n"
+        "PERSOME_LLM_API_KEY=sk-test-from-env-file\n"
+        "PERSOME_LLM_BASE_URL=https://gateway.example/anthropic\n"
     )
 
     seen: dict[str, str | None] = {}
 
     def capture_env(_cfg: object) -> None:
-        seen["api_key"] = os.environ.get("ANTHROPIC_API_KEY")
-        seen["base_url"] = os.environ.get("ANTHROPIC_BASE_URL")
+        seen["api_key"] = os.environ.get("PERSOME_LLM_API_KEY")
+        seen["base_url"] = os.environ.get("PERSOME_LLM_BASE_URL")
 
     monkeypatch.setattr(chat_mod, "run_chat_sync", capture_env)
 

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -68,21 +68,21 @@ def test_status_loads_env_file_before_probe(ac_root: Path, monkeypatch: pytest.M
     """status sources ~/.persome/env before the per-stage model probe.
 
     Regression: the probe used to run in the `status` process without loading the
-    env file, so ping_stage built the Anthropic client with no ANTHROPIC_API_KEY
+    env file, so ping_stage built the client with no PERSOME_LLM_API_KEY
     and every stage falsely reported "Could not resolve authentication method" —
     even when the daemon (which loads env in start()) was healthy.
     """
     monkeypatch.delenv("PERSOME_LLM_MOCK", raising=False)
     # load_env_file does not overwrite an already-set var, so clear it first.
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("PERSOME_LLM_API_KEY", raising=False)
     env_path = paths.env_file()
     env_path.parent.mkdir(parents=True, exist_ok=True)
-    env_path.write_text("ANTHROPIC_API_KEY=sk-test-from-env-file\n")
+    env_path.write_text("PERSOME_LLM_API_KEY=sk-test-from-env-file\n")
 
     seen: dict[str, str | None] = {}
 
     def capture_ping(cfg, stage, *, timeout=5.0):  # noqa: ARG001
-        seen[stage] = os.environ.get("ANTHROPIC_API_KEY")
+        seen[stage] = os.environ.get("PERSOME_LLM_API_KEY")
         return llm_mod.PingResult(
             stage=stage,
             model=cfg.model_for(stage).model,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -80,7 +80,7 @@ api_key_env = "OPENAI_API_KEY"
 api_key = "sk-old"
 
 [chat]
-api_key_env = "ANTHROPIC_API_KEY"
+api_key_env = "LEGACY_CHAT_API_KEY"
 api_key = "sk-old"
 base_url = "https://api.example/anthropic"
 """
@@ -108,20 +108,18 @@ def test_write_default_creates_file(tmp_path: Path) -> None:
     text = p.read_text()
     assert "[models.default]" in text
     assert "persome llm setup" in text
-    assert "api_key_env" in text
+    assert "PERSOME_LLM_API_KEY" in text
     # idempotent
     assert not config.write_default_if_missing(p)
 
 
 def test_provider_helpers_read_env(monkeypatch) -> None:
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "k-ant")
-    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://ant")
     monkeypatch.setenv("OPENAI_API_KEY", "k-oai")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://openai.example/v1")
     monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
 
-    assert config.provider_api_key("anthropic") == "k-ant"
-    assert config.provider_base_url("anthropic") == "https://ant"
     assert config.provider_api_key("openai") == "k-oai"
+    assert config.provider_base_url("openai") == "https://openai.example/v1"
     assert config.provider_api_key("deepseek") is None
     assert config.provider_api_key("unknown") is None
 
@@ -146,7 +144,7 @@ provider = "openrouter"
 protocol = "openai"
 model = "anthropic/claude-sonnet-4"
 base_url = "https://openrouter.ai/api/v1"
-api_key_env = "OPENROUTER_API_KEY"
+api_key_env = "PERSOME_LLM_API_KEY"
 
 [chat]
 thinking_budget = 0
@@ -156,4 +154,4 @@ thinking_budget = 0
     assert cfg.chat.provider == "openrouter"
     assert cfg.chat.protocol == "openai"
     assert cfg.chat.model == "anthropic/claude-sonnet-4"
-    assert cfg.chat.api_key_env == "OPENROUTER_API_KEY"
+    assert cfg.chat.api_key_env == "PERSOME_LLM_API_KEY"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -21,19 +21,19 @@ import pytest
 from persome import doctor, paths
 from persome.capture import ocr_health, ocr_local, screen_recording
 from persome.config import CaptureConfig
-from persome.providers import PROVIDERS
+from persome.providers import LLM_API_KEY_ENV, LLM_BASE_URL_ENV, PROVIDERS
 
 
 @pytest.fixture
 def clean_llm_env(monkeypatch: pytest.MonkeyPatch) -> None:
     variables = {
-        "ANTHROPIC_API_KEY",
-        "ANTHROPIC_BASE_URL",
+        LLM_API_KEY_ENV,
+        LLM_BASE_URL_ENV,
         "PERSOME_SCREENSHOT_KEY",
         "PERSOME_LOCAL_API_TOKEN",
     }
     for spec in PROVIDERS:
-        variables.add(spec.api_key_env)
+        variables.add(spec.discovery_api_key_env)
         if spec.resolved_base_url_env:
             variables.add(spec.resolved_base_url_env)
     for var in variables:
@@ -52,21 +52,21 @@ def test_env_file_missing_fails(ac_root: Path, clean_llm_env: None) -> None:
 def test_env_file_missing_but_shell_key_warns(
     ac_root: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-synthetic")
+    monkeypatch.setenv(LLM_API_KEY_ENV, "sk-test-synthetic")
     c = doctor.check_env_file()
     assert c.status == "warn"
 
 
 def test_env_file_0600_ok(ac_root: Path) -> None:
     p = paths.env_file()
-    p.write_text("ANTHROPIC_API_KEY=sk-test-synthetic\n")
+    p.write_text(f"{LLM_API_KEY_ENV}=sk-test-synthetic\n")
     p.chmod(0o600)
     assert doctor.check_env_file().status == "ok"
 
 
 def test_env_file_loose_perms_fail(ac_root: Path) -> None:
     p = paths.env_file()
-    p.write_text("ANTHROPIC_API_KEY=sk-test-synthetic\n")
+    p.write_text(f"{LLM_API_KEY_ENV}=sk-test-synthetic\n")
     p.chmod(0o644)
     c = doctor.check_env_file()
     assert c.status == "fail"
@@ -75,7 +75,7 @@ def test_env_file_loose_perms_fail(ac_root: Path) -> None:
 
 def test_env_file_owner_only_stricter_than_0600_ok(ac_root: Path) -> None:
     p = paths.env_file()
-    p.write_text("ANTHROPIC_API_KEY=sk-test-synthetic\n")
+    p.write_text(f"{LLM_API_KEY_ENV}=sk-test-synthetic\n")
     p.chmod(0o400)
     assert doctor.check_env_file().status == "ok"
 
@@ -84,7 +84,7 @@ def test_env_file_owner_only_stricter_than_0600_ok(ac_root: Path) -> None:
 
 
 def test_api_key_set_ok(ac_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-synthetic")
+    monkeypatch.setenv(LLM_API_KEY_ENV, "sk-test-synthetic")
     c = doctor.check_api_key()
     assert c.status == "ok"
     # never leak the key value
@@ -149,7 +149,7 @@ def test_base_url_reachable_ok(
     monkeypatch.setattr(httpx, "head", fake_head)
     c = doctor.check_base_url()
     assert c.status == "ok"
-    assert "legacy Anthropic route" in c.detail
+    assert "legacy route" in c.detail
 
 
 def test_base_url_unreachable_warns_never_fails(
@@ -157,7 +157,7 @@ def test_base_url_unreachable_warns_never_fails(
 ) -> None:
     import httpx
 
-    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://gateway.invalid/anthropic")
+    monkeypatch.setenv(LLM_BASE_URL_ENV, "https://gateway.invalid/anthropic")
 
     def fake_head(url: str, **kw: object) -> object:
         raise httpx.ConnectError("boom")
@@ -426,7 +426,7 @@ def test_run_checks_merges_env_file_first(
 
     p = paths.env_file()
     p.write_text(
-        "ANTHROPIC_API_KEY=sk-test-synthetic\n"
+        f"{LLM_API_KEY_ENV}=sk-test-synthetic\n"
         "PERSOME_LOCAL_API_TOKEN=local-token-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
     )
     p.chmod(0o600)
@@ -454,10 +454,10 @@ provider = "openai"
 protocol = "openai"
 model = "gpt-4.1-mini"
 base_url = "https://gateway.example/v1"
-api_key_env = "OPENAI_API_KEY"
+api_key_env = "PERSOME_LLM_API_KEY"
 """
     )
-    monkeypatch.setenv("OPENAI_API_KEY", "synthetic")
+    monkeypatch.setenv(LLM_API_KEY_ENV, "synthetic")
     seen: list[str] = []
     monkeypatch.setattr(httpx, "head", lambda url, **kw: seen.append(url) or object())
 

--- a/tests/test_env_file.py
+++ b/tests/test_env_file.py
@@ -87,14 +87,14 @@ def test_write_env_values_upserts_atomically(
 
 def test_ensure_screenshot_key_generates_owner_only_file(tmp_path: Path) -> None:
     path = tmp_path / "env"
-    path.write_text("ANTHROPIC_API_KEY=synthetic\n")
+    path.write_text("PERSOME_LLM_API_KEY=synthetic\n")
 
     status = env_file.ensure_screenshot_key(path)
 
     assert status == "generated"
     assert path.stat().st_mode & 0o777 == 0o600
     lines = path.read_text().splitlines()
-    assert "ANTHROPIC_API_KEY=synthetic" in lines
+    assert "PERSOME_LLM_API_KEY=synthetic" in lines
     generated = next(
         line.partition("=")[2]
         for line in lines

--- a/tests/test_llm_setup.py
+++ b/tests/test_llm_setup.py
@@ -10,7 +10,7 @@ from typer.testing import CliRunner
 from persome import config, paths
 from persome.cli import app
 from persome.llm_setup import ProbeResult, probe_profile, save_profile
-from persome.providers import make_profile
+from persome.providers import LLM_API_KEY_ENV, make_profile
 
 
 def _profile(api_key: str = "synthetic-secret"):  # type: ignore[no-untyped-def]
@@ -18,7 +18,7 @@ def _profile(api_key: str = "synthetic-secret"):  # type: ignore[no-untyped-def]
         "openai",
         model="gpt-4.1-mini",
         base_url="https://gateway.example/v1",
-        api_key_env="OPENAI_API_KEY",
+        api_key_env=LLM_API_KEY_ENV,
         api_key=api_key,
         protocol="openai",
     )
@@ -35,7 +35,8 @@ def test_save_profile_keeps_secret_out_of_toml(tmp_path: Path) -> None:
     assert "synthetic-secret" not in text
     assert 'provider = "openai"' in text
     assert "interval_minutes = 3" in text
-    assert env_path.read_text() == "OPENAI_API_KEY=synthetic-secret\n"
+    assert f'api_key_env = "{LLM_API_KEY_ENV}"' in text
+    assert env_path.read_text() == f"{LLM_API_KEY_ENV}=synthetic-secret\n"
     assert stat.S_IMODE(env_path.stat().st_mode) == 0o600
     loaded = config.load(config_path).model_for("default")
     assert loaded.protocol == "openai"
@@ -125,11 +126,47 @@ def test_setup_cli_uses_provider_defaults_and_persists_profile(ac_root: Path, mo
     assert selected.provider == "openai"
     assert selected.model == "gpt-4.1-mini"
     assert selected.base_url == "https://api.openai.com/v1"
-    assert paths.env_file().read_text().count("OPENAI_API_KEY=") == 1
+    env_text = paths.env_file().read_text()
+    assert env_text.count(f"{LLM_API_KEY_ENV}=") == 1
+    assert "OPENAI_API_KEY=" not in env_text
+    assert selected.api_key_env == LLM_API_KEY_ENV
+
+
+def test_setup_migrates_existing_provider_specific_key(ac_root: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    paths.config_file().write_text(
+        """
+[models.default]
+provider = "anthropic"
+protocol = "anthropic"
+model = "claude-sonnet-4-5"
+base_url = "https://api.anthropic.com"
+api_key_env = "ANTHROPIC_API_KEY"
+"""
+    )
+    paths.env_file().write_text("ANTHROPIC_API_KEY=legacy-secret\n")
+    paths.env_file().chmod(0o600)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv(LLM_API_KEY_ENV, raising=False)
+
+    result = CliRunner().invoke(
+        app,
+        ["llm", "setup", "--yes", "--skip-check"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "legacy-secret" not in result.output
+    selected = config.load().model_for("default")
+    assert selected.api_key_env == LLM_API_KEY_ENV
+    assert f"{LLM_API_KEY_ENV}=legacy-secret" in paths.env_file().read_text()
+    status = CliRunner().invoke(app, ["llm", "status"])
+    assert status.exit_code == 0
+    assert LLM_API_KEY_ENV in status.output
+    assert "ANTHROPIC_API_KEY" not in status.output
 
 
 def test_interactive_preset_setup_only_asks_for_provider_key(ac_root: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv(LLM_API_KEY_ENV, raising=False)
     monkeypatch.setattr("persome.cli._interactive_terminal", lambda: True)
 
     result = CliRunner().invoke(
@@ -146,7 +183,7 @@ def test_interactive_preset_setup_only_asks_for_provider_key(ac_root: Path, monk
     selected = config.load().model_for("default")
     assert selected.model == "gpt-4.1-mini"
     assert selected.base_url == "https://api.openai.com/v1"
-    assert paths.env_file().read_text() == "OPENAI_API_KEY=synthetic-secret\n"
+    assert paths.env_file().read_text() == f"{LLM_API_KEY_ENV}=synthetic-secret\n"
 
 
 def test_interactive_custom_setup_is_explicitly_advanced(ac_root: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
@@ -216,6 +253,8 @@ def test_provider_list_hides_routing_details_by_default(ac_root: Path) -> None:
     assert detailed.exit_code == 0
     assert "Endpoint:" in detailed.output
     assert "Default model:" in detailed.output
+    assert f"Runtime credential: {LLM_API_KEY_ENV}" in detailed.output
+    assert "ANTHROPIC_API_KEY" not in detailed.output
 
 
 def test_setup_cli_does_not_save_failed_probe(ac_root: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -260,7 +260,7 @@ def test_run_turn_tools_are_sorted_and_last_has_cache_control(monkeypatch) -> No
         async def close(self) -> None:
             pass
 
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "synthetic")
+    monkeypatch.setenv("PERSOME_LLM_API_KEY", "synthetic")
     cfg = ChatConfig(model="deepseek-chat")
     agent = ChatAgent(cfg, schemas, handlers)
     agent.client = _FakeClient()  # type: ignore[assignment]

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -3,25 +3,26 @@ from __future__ import annotations
 import pytest
 
 from persome.config import ModelConfig
-from persome.providers import PROVIDERS, detected_providers, resolve_profile
+from persome.providers import LLM_API_KEY_ENV, PROVIDERS, detected_providers, resolve_profile
 
 
 def _clear_provider_env(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     for spec in PROVIDERS:
-        monkeypatch.delenv(spec.api_key_env, raising=False)
+        monkeypatch.delenv(spec.discovery_api_key_env, raising=False)
         if spec.resolved_base_url_env:
             monkeypatch.delenv(spec.resolved_base_url_env, raising=False)
+    monkeypatch.delenv(LLM_API_KEY_ENV, raising=False)
 
 
 def test_explicit_deepseek_profile_uses_openai_compatibility(monkeypatch) -> None:
     _clear_provider_env(monkeypatch)
-    monkeypatch.setenv("DEEPSEEK_API_KEY", "synthetic")
+    monkeypatch.setenv(LLM_API_KEY_ENV, "synthetic")
     profile = resolve_profile(
         ModelConfig(
             provider="deepseek",
             protocol="openai",
             model="deepseek-chat",
-            api_key_env="DEEPSEEK_API_KEY",
+            api_key_env=LLM_API_KEY_ENV,
         )
     )
     assert profile.protocol == "openai"
@@ -38,7 +39,8 @@ def test_legacy_config_keeps_anthropic_wire_semantics(monkeypatch) -> None:
     assert profile.legacy is True
     assert profile.provider == "deepseek"
     assert profile.protocol == "anthropic"
-    assert profile.api_key_env == "ANTHROPIC_API_KEY"
+    assert profile.api_key_env == LLM_API_KEY_ENV
+    assert profile.credential_migration_required is True
     assert profile.base_url == "https://gateway.example/anthropic"
 
 
@@ -49,7 +51,7 @@ def test_openrouter_preserves_nested_model_provider_prefix(monkeypatch) -> None:
             provider="openrouter",
             protocol="openai",
             model="anthropic/claude-sonnet-4",
-            api_key_env="OPENROUTER_API_KEY",
+            api_key_env=LLM_API_KEY_ENV,
         )
     )
     assert profile.wire_model == "anthropic/claude-sonnet-4"
@@ -62,7 +64,7 @@ def test_selected_provider_routing_prefix_is_removed(monkeypatch) -> None:
             provider="openai",
             protocol="openai",
             model="openai/gpt-4.1-mini",
-            api_key_env="OPENAI_API_KEY",
+            api_key_env=LLM_API_KEY_ENV,
         )
     )
     assert profile.wire_model == "gpt-4.1-mini"
@@ -75,7 +77,7 @@ def test_local_provider_does_not_require_a_key(monkeypatch) -> None:
             provider="ollama",
             protocol="openai",
             model="qwen3:8b",
-            api_key_env="OLLAMA_API_KEY",
+            api_key_env=LLM_API_KEY_ENV,
         )
     )
     assert profile.api_key is None
@@ -90,11 +92,46 @@ def test_hosted_profile_fails_before_network_when_key_is_missing(monkeypatch) ->
             provider="openai",
             protocol="openai",
             model="gpt-4.1-mini",
-            api_key_env="OPENAI_API_KEY",
+            api_key_env=LLM_API_KEY_ENV,
         )
     )
-    with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
+    with pytest.raises(RuntimeError, match=LLM_API_KEY_ENV):
         profile.client_api_key()
+
+
+def test_explicit_provider_specific_key_is_a_migration_fallback(monkeypatch) -> None:
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "legacy-provider-key")
+
+    profile = resolve_profile(
+        ModelConfig(
+            provider="deepseek",
+            protocol="openai",
+            model="deepseek-chat",
+            api_key_env="DEEPSEEK_API_KEY",
+        )
+    )
+
+    assert profile.api_key == "legacy-provider-key"
+    assert profile.api_key_env == LLM_API_KEY_ENV
+    assert profile.credential_migration_required is True
+
+
+def test_canonical_profile_does_not_fall_back_to_provider_key(monkeypatch) -> None:
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "provider-specific-key")
+
+    profile = resolve_profile(
+        ModelConfig(
+            provider="openai",
+            protocol="openai",
+            model="gpt-4.1-mini",
+            api_key_env=LLM_API_KEY_ENV,
+        )
+    )
+
+    assert profile.api_key is None
+    assert profile.credential_ready is False
 
 
 def test_detected_providers_keeps_region_choices_for_shared_credential(monkeypatch) -> None:
@@ -103,3 +140,10 @@ def test_detected_providers_keeps_region_choices_for_shared_credential(monkeypat
     monkeypatch.setenv("OPENAI_API_KEY", "synthetic")
     detected = detected_providers()
     assert [spec.id for spec in detected] == ["openai", "qwen-cn", "qwen-us"]
+
+
+def test_generic_key_does_not_guess_a_provider(monkeypatch) -> None:
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv(LLM_API_KEY_ENV, "synthetic")
+
+    assert detected_providers() == []

--- a/tests/test_writer_llm_ping.py
+++ b/tests/test_writer_llm_ping.py
@@ -27,7 +27,7 @@ def _patch_anthropic(monkeypatch: pytest.MonkeyPatch, create: Callable[..., Any]
     Returns a list capturing each ``messages.create`` kwargs dict."""
     import anthropic
 
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "synthetic")
+    monkeypatch.setenv("PERSOME_LLM_API_KEY", "synthetic")
     calls: list[dict] = []
 
     class _FakeMessages:
@@ -180,14 +180,14 @@ def test_ping_stage_openai_compatible_uses_selected_endpoint(
 
 def test_ping_stage_reports_missing_selected_credential(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("PERSOME_LLM_MOCK", raising=False)
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("PERSOME_LLM_API_KEY", raising=False)
     cfg = Config(
         models={
             "default": ModelConfig(
                 provider="openai",
                 protocol="openai",
                 model="gpt-4.1-mini",
-                api_key_env="OPENAI_API_KEY",
+                api_key_env="PERSOME_LLM_API_KEY",
             )
         }
     )
@@ -196,4 +196,4 @@ def test_ping_stage_reports_missing_selected_credential(monkeypatch: pytest.Monk
 
     assert result.ok is False
     assert result.error is not None
-    assert "OPENAI_API_KEY" in result.error
+    assert "PERSOME_LLM_API_KEY" in result.error


### PR DESCRIPTION
## Summary
- make `PERSOME_LLM_API_KEY` the canonical active Runtime credential for every provider
- treat provider-specific variables as onboarding discovery and legacy migration inputs only
- migrate existing profiles through `persome llm setup` without exposing or losing secrets
- update CLI status, configuration docs, README, developer tooling, and regression coverage

## Validation
- `PERSOME_LLM_MOCK=1 uv run pytest -m "not macos and not integration" -q` (`1640 passed, 15 deselected`)
- `uv run ruff check .`
- `uv run ruff format --check .`
- PII, secret, language, documentation-link, OpenAPI drift, and DB-schema drift checks
- wheel build with hash-constrained build backend
- live completion + tool-call probe against the configured provider
- real `persome chat` turn in an isolated `PERSOME_ROOT`

## Compatibility
Existing provider-specific `api_key_env` configurations remain readable. Re-running `persome llm setup` copies the active key to `PERSOME_LLM_API_KEY` and updates the non-secret profile. Canonical profiles never silently fall back to a different provider key.