### PR TITLE
Remove stale provider comments during LLM migration

### DIFF
--- a/src/persome/llm_setup.py
+++ b/src/persome/llm_setup.py
@@ -169,11 +169,20 @@ def save_profile(
         default = tomlkit.table()
         models["default"] = default
 
-    default["provider"] = profile.provider
-    default["protocol"] = profile.protocol
-    default["model"] = profile.model
-    default["base_url"] = profile.base_url
-    default["api_key_env"] = LLM_API_KEY_ENV
+    managed_values = {
+        "provider": profile.provider,
+        "protocol": profile.protocol,
+        "model": profile.model,
+        "base_url": profile.base_url,
+        "api_key_env": LLM_API_KEY_ENV,
+    }
+    for key, value in managed_values.items():
+        default[key] = value
+        # These fields are owned by onboarding. Drop stale provider-specific
+        # inline comments retained by tomlkit when an existing value is replaced.
+        item = default.item(key)
+        item.trivia.comment_ws = ""
+        item.trivia.comment = ""
 
     if config_path.is_symlink():
         raise RuntimeError(f"config file must not be a symlink: {config_path}")

--- a/tests/test_llm_setup.py
+++ b/tests/test_llm_setup.py
@@ -139,8 +139,8 @@ def test_setup_migrates_existing_provider_specific_key(ac_root: Path, monkeypatc
 provider = "anthropic"
 protocol = "anthropic"
 model = "claude-sonnet-4-5"
-base_url = "https://api.anthropic.com"
-api_key_env = "ANTHROPIC_API_KEY"
+base_url = "https://api.anthropic.com" # legacy provider endpoint
+api_key_env = "ANTHROPIC_API_KEY" # legacy credential name
 """
     )
     paths.env_file().write_text("ANTHROPIC_API_KEY=legacy-secret\n")
@@ -157,6 +157,8 @@ api_key_env = "ANTHROPIC_API_KEY"
     assert "legacy-secret" not in result.output
     selected = config.load().model_for("default")
     assert selected.api_key_env == LLM_API_KEY_ENV
+    assert "legacy provider endpoint" not in paths.config_file().read_text()
+    assert "legacy credential name" not in paths.config_file().read_text()
     assert f"{LLM_API_KEY_ENV}=legacy-secret" in paths.env_file().read_text()
     status = CliRunner().invoke(app, ["llm", "status"])
     assert status.exit_code == 0


### PR DESCRIPTION
## Summary
- clear obsolete inline comments from the five LLM profile fields owned by onboarding
- keep comments elsewhere in the user configuration untouched
- cover migration from provider-specific endpoint and credential comments

## Validation
- `uv run pytest tests/test_llm_setup.py tests/test_providers.py tests/test_config.py -q` (`31 passed`)
- ruff check and format check
- secret scan and documentation-link check