### PR TITLE
Open the authenticated viewer from persome model

### DIFF
--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -2272,6 +2272,13 @@ def model_open() -> None:
     console.print("[green]Opened the authenticated local model viewer.[/green]")
 
 
+@model_app.callback(invoke_without_command=True)
+def model_default(ctx: typer.Context) -> None:
+    """Open the authenticated model viewer when no subcommand is given."""
+    if ctx.invoked_subcommand is None:
+        model_open()
+
+
 @writer_app.command("run")
 def writer_run() -> None:
     """Reduce pending sessions and finish their personal-model stages."""

--- a/tests/test_cli_local_access.py
+++ b/tests/test_cli_local_access.py
@@ -54,6 +54,16 @@ def test_model_open_exchanges_bearer_for_one_time_browser_url(ac_root: Path, mon
     assert token not in opened[0]
 
 
+def test_bare_model_command_opens_viewer(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    opened: list[bool] = []
+    monkeypatch.setattr(cli, "model_open", lambda: opened.append(True))
+
+    result = CliRunner().invoke(cli.app, ["model"])
+
+    assert result.exit_code == 0, result.output
+    assert opened == [True]
+
+
 def test_model_open_rejects_absolute_bootstrap_url(ac_root: Path, monkeypatch) -> None:
     monkeypatch.setenv(LOCAL_API_TOKEN_ENV, "t" * 48)
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- make bare `persome model` open the authenticated local viewer
- keep `persome model --help` and all existing model subcommands unchanged
- cover the default command behavior without weakening viewer authentication

## Validation
- `PERSOME_LLM_MOCK=1 uv run pytest tests/test_cli_local_access.py tests/test_local_api_auth.py tests/test_model_routes.py -q` (`55 passed`)
- ruff check and format check
- live authenticated viewer opened and visually verified in Chrome