### PR TITLE
fix: preserve temporal history on rebuild

### DIFF
--- a/src/persome/evomem/backfill.py
+++ b/src/persome/evomem/backfill.py
@@ -119,7 +119,7 @@ def map_entry_to_node(
     agent_id: str,
 ) -> MemoryNode:
     superseded = entries_mod._superseded_from_tags(e)
-    content = entries_mod._strip_strike(e.body) if superseded else e.body
+    content = entries_mod._content_from_markdown_entry(e, superseded=superseded)
     chain_is_latest = 0 if superseded else 1
     ts = _parse_minute_iso(e.timestamp)
     schema_summary = schema_inferences = schema_confidence = None

--- a/src/persome/evomem/inversion.py
+++ b/src/persome/evomem/inversion.py
@@ -425,7 +425,11 @@ def supersede_entry(
     new_tags += entries_mod._metadata_tags(confidence, conflicted, occurred_at)
 
     body = new_content.strip()
-    content_md = f"{body}\n<!-- supersedes: {old_entry_id}; reason: {reason} -->"
+    provenance = entries_mod._render_supersede_provenance(
+        old_entry_id=old_entry_id,
+        reason=reason,
+    )
+    content_md = f"{body}\n{provenance}" if body else provenance
     node = _node_from_write(
         entry_id=new_id,
         ts=ts,
@@ -476,6 +480,21 @@ def mark_entry_deleted(conn: sqlite3.Connection, *, name: str, entry_id: str) ->
     ts = entries_mod._now_iso_minute()
     with files_mod.file_lock(path):
         engine.commit_retire(entry_id, valid_until=ts)
+        retired = engine.store.get(entry_id)
+        if retired is not None:
+            from ..store import projector
+
+            file_nodes = _load_file_nodes(conn, path.name)
+            ts_by_id = {n.node_id: projector._heading_ts(n) for n in file_nodes}
+            rendered_tags = projector._render_tags(
+                retired,
+                prefix=prefix,
+                ts_by_id=ts_by_id,
+            )
+            conn.execute(
+                "UPDATE entries SET tags=? WHERE id=?",
+                (" ".join(rendered_tags), entry_id),
+            )
         entries_mod.derived_retire_rows(conn, entry_id=entry_id, ts=ts)
         if was_active:
             # Repeated retirement is idempotent and does not rewrite the file.

--- a/src/persome/store/entries.py
+++ b/src/persome/store/entries.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import contextlib
 import hashlib
+import html
 import os
 import re
 import sqlite3
+import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -73,6 +75,100 @@ def _metadata_tags(confidence: str | None, conflicted: bool, occurred_at: str | 
     return out
 
 
+def _render_supersede_provenance(*, old_entry_id: str, reason: str) -> str:
+    # Keep the structural marker on one valid HTML-comment line. In particular,
+    # an untrusted ``-->`` in a model-generated reason must not close the marker
+    # early and make rebuild treat its tail as searchable personal content.
+    safe_reason = html.escape(reason.replace("\r", " ").replace("\n", " "), quote=False)
+    safe_reason = safe_reason.replace("--", "&#45;&#45;")
+    return f"<!-- supersedes: {old_entry_id}; reason: {safe_reason} -->"
+
+
+def _insert_derived_entry(
+    conn: sqlite3.Connection,
+    *,
+    entry_id: str,
+    path_name: str,
+    prefix: str,
+    ts: str,
+    tags_str: str,
+    content: str,
+) -> None:
+    """Atomically claim an entry id and insert its FTS projection once.
+
+    Markdown is written before the derived DB rows. If rebuild ingests that
+    Markdown while the original writer is paused, the temporal PK claim makes
+    the resumed writer observe and validate the existing projection instead of
+    adding a duplicate row to the FTS5 table (whose ``id`` is not unique).
+    """
+    savepoint = "persome_derived_entry_insert"
+    conn.execute(f"SAVEPOINT {savepoint}")
+    try:
+        claimed = (
+            conn.execute(
+                "INSERT OR IGNORE INTO entry_temporal(entry_id, valid_from) VALUES (?, ?)",
+                (entry_id, ts),
+            ).rowcount
+            == 1
+        )
+        candidate = (entry_id, path_name, prefix, ts, tags_str, content, 0)
+        if claimed:
+            fts.insert_entry(
+                conn,
+                id=entry_id,
+                path=path_name,
+                prefix=prefix,
+                timestamp=ts,
+                tags=tags_str,
+                content=content,
+                superseded=0,
+            )
+        else:
+            temporal = conn.execute(
+                "SELECT valid_from, valid_until FROM entry_temporal WHERE entry_id=?",
+                (entry_id,),
+            ).fetchone()
+            if temporal is None or (temporal["valid_from"], temporal["valid_until"]) != (ts, None):
+                raise sqlite3.IntegrityError(f"entry id collision for {entry_id!r}")
+            rows = conn.execute(
+                "SELECT id, path, prefix, timestamp, tags, content, superseded "
+                "FROM entries WHERE id=?",
+                (entry_id,),
+            ).fetchall()
+            existing = [
+                (
+                    row["id"],
+                    row["path"],
+                    row["prefix"],
+                    row["timestamp"],
+                    row["tags"],
+                    row["content"],
+                    int(row["superseded"] or 0),
+                )
+                for row in rows
+            ]
+            if not existing:
+                fts.insert_entry(
+                    conn,
+                    id=entry_id,
+                    path=path_name,
+                    prefix=prefix,
+                    timestamp=ts,
+                    tags=tags_str,
+                    content=content,
+                    superseded=0,
+                )
+            elif existing != [candidate]:
+                raise sqlite3.IntegrityError(f"entry id collision for {entry_id!r}")
+        conn.execute(f"RELEASE SAVEPOINT {savepoint}")
+    except BaseException:
+        with contextlib.suppress(sqlite3.Error):
+            conn.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+        with contextlib.suppress(sqlite3.Error):
+            conn.execute(f"RELEASE SAVEPOINT {savepoint}")
+        raise
+
+
 def derived_append_rows(
     conn: sqlite3.Connection,
     *,
@@ -86,19 +182,14 @@ def derived_append_rows(
     conflicted: bool = False,
     occurred_at: str | None = None,
 ) -> None:
-    fts.insert_entry(
+    _insert_derived_entry(
         conn,
-        id=entry_id,
-        path=path_name,
+        entry_id=entry_id,
+        path_name=path_name,
         prefix=prefix,
-        timestamp=ts,
-        tags=tags_str,
+        ts=ts,
+        tags_str=tags_str,
         content=content,
-        superseded=0,
-    )
-    conn.execute(
-        "INSERT OR IGNORE INTO entry_temporal(entry_id, valid_from) VALUES (?, ?)",
-        (entry_id, ts),
     )
     # Meta-cognition derived row (Hy-Memory migration). Same writer as the
     # rebuild replay, so {incremental entry_metadata} ≡ {fresh rebuild}.
@@ -135,19 +226,14 @@ def derived_supersede_rows(
         "UPDATE entry_temporal SET valid_until=? WHERE entry_id=? AND valid_until IS NULL",
         (ts, old_entry_id),
     )
-    fts.insert_entry(
+    _insert_derived_entry(
         conn,
-        id=new_entry_id,
-        path=path_name,
+        entry_id=new_entry_id,
+        path_name=path_name,
         prefix=prefix,
-        timestamp=ts,
-        tags=tags_str,
+        ts=ts,
+        tags_str=tags_str,
         content=content,
-        superseded=0,
-    )
-    conn.execute(
-        "INSERT OR IGNORE INTO entry_temporal(entry_id, valid_from) VALUES (?, ?)",
-        (new_entry_id, ts),
     )
     # Meta-cognition for the NEW head (the old entry keeps its own heading tags,
     # so its entry_metadata row survives a rebuild untouched).
@@ -367,6 +453,19 @@ def append_entry(
     return entry_id
 
 
+def _append_entry_heading_tag(text: str, *, entry_id: str, tag: str) -> str:
+    """Append ``tag`` to the exact entry heading identified by ``entry_id``."""
+    rendered_tag = f"#{tag}"
+    for match in files_mod.ENTRY_HEADING_RE.finditer(text):
+        if match.group("id") != entry_id:
+            continue
+        if rendered_tag in (match.group("tags") or "").split():
+            return text
+        updated_heading = match.group(0).rstrip() + f" {rendered_tag}"
+        return text[: match.start()] + updated_heading + text[match.end() :]
+    return text
+
+
 def _strike_entry_body(text: str, *, entry_id: str, body: str) -> str:
     """Wrap one entry's body in ``~~...~~`` ANCHORED to its ``{id: entry_id}`` marker.
 
@@ -476,8 +575,11 @@ def supersede_entry(
         # 1) append #superseded-by to old heading (only if not already present)
         old_heading = target.heading_line
         if f"superseded-by:{new_id}" not in old_heading:
-            updated_heading = old_heading.rstrip() + f" #superseded-by:{new_id}"
-            text = text.replace(old_heading, updated_heading, 1)
+            text = _append_entry_heading_tag(
+                text,
+                entry_id=old_entry_id,
+                tag=f"superseded-by:{new_id}",
+            )
         # 2) wrap old body in ~~...~~ (only if not already) — anchored to the
         # entry's own {id} region so a duplicate body elsewhere isn't struck (bug_009).
         if target.body and not target.body.startswith("~~"):
@@ -485,9 +587,12 @@ def supersede_entry(
 
         # 3) Append the new entry at the end
         body = new_content.strip()
-        new_block = (
-            f"\n\n{new_heading}\n{body}\n<!-- supersedes: {old_entry_id}; reason: {reason} -->\n"
+        provenance = _render_supersede_provenance(
+            old_entry_id=old_entry_id,
+            reason=reason,
         )
+        projected_content = f"{body}\n{provenance}" if body else provenance
+        new_block = f"\n\n{new_heading}\n{projected_content}\n"
         if not text.endswith("\n"):
             text += "\n"
         text += new_block
@@ -549,17 +654,61 @@ def mark_entry_deleted(conn: sqlite3.Connection, *, name: str, entry_id: str) ->
         if target is None:
             raise ValueError(f"entry {entry_id} not found in {path.name}")
 
+        body_is_struck = _body_is_striked(target.body)
+        explicit_until = _encoded_tag_value(target.tags, "valid-until:")
+        explicit_status = _encoded_tag_value(target.tags, "status:")
+        temporal_row = conn.execute(
+            "SELECT valid_until FROM entry_temporal WHERE entry_id=?", (entry_id,)
+        ).fetchone()
+        stored_until = temporal_row["valid_until"] if temporal_row is not None else None
+        # A repeated call on legacy struck Markdown should retain its original
+        # retirement time. A first deletion gets a fresh timestamp even if a
+        # stale side-table value somehow exists.
+        ts = explicit_until or (stored_until if body_is_struck else None) or _now_iso_minute()
+        temporal_tag = f"valid-until:{ts}"
+        encode_temporal_tag = explicit_until is None and not target.superseded_by
+        encode_shadow_status = (
+            bool(target.refined_from)
+            and not target.superseded_by
+            and explicit_status not in {"shadow", "archived", "superseded"}
+        )
+        status_retires_refinement = (
+            bool(target.refined_from)
+            and not target.superseded_by
+            and (encode_shadow_status or explicit_status in {"shadow", "archived", "superseded"})
+        )
+        strike_body = not body_is_struck and not status_retires_refinement
+        updated_tags = list(target.tags)
+        if encode_shadow_status:
+            updated_tags.append("status:shadow")
+        if encode_temporal_tag:
+            updated_tags.append(temporal_tag)
+
         # Strike the old body in the markdown, ANCHORED to this entry's {id} region
         # (bug_009 — never strike a byte-identical body belonging to another entry).
         # An empty body has no markdown to wrap and (unlike supersede_entry) no
         # #superseded-by successor tag to fall back on, so the helper inserts a
         # durable ``~~~~`` sentinel — otherwise a rebuild would revive it
-        # (merged_bug_002a). Bump the frontmatter ``updated`` and refresh the
-        # files-table FileRow in the same atomic write (merged_bug_002b) so the
-        # files row / list ordering don't drift from a fresh rebuild.
-        if not target.body.startswith("~~"):
+        # (merged_bug_002a). The exact retirement timestamp is encoded in the
+        # same atomic Markdown write, closing the file/DB race and making a
+        # fresh restore lossless. Bump ``updated`` and refresh the files row in
+        # the same write (merged_bug_002b).
+        if strike_body or encode_temporal_tag or encode_shadow_status:
             text = path.read_text()
-            text = _strike_entry_body(text, entry_id=entry_id, body=target.body)
+            if encode_shadow_status:
+                text = _append_entry_heading_tag(
+                    text,
+                    entry_id=entry_id,
+                    tag="status:shadow",
+                )
+            if encode_temporal_tag:
+                text = _append_entry_heading_tag(
+                    text,
+                    entry_id=entry_id,
+                    tag=temporal_tag,
+                )
+            if strike_body:
+                text = _strike_entry_body(text, entry_id=entry_id, body=target.body)
             post = frontmatter.loads(text)
             post.metadata["updated"] = files_mod.today()
             files_mod.atomic_write_text(path, frontmatter.dumps(post) + "\n")
@@ -580,28 +729,192 @@ def mark_entry_deleted(conn: sqlite3.Connection, *, name: str, entry_id: str) ->
             )
 
         # FTS + temporal: mirror supersede_entry's retire half (no new entry).
-        ts = _now_iso_minute()
+        # Keep the encoded tag in the incremental projection too, so it is
+        # already byte-equivalent to the next rebuild.
+        conn.execute("UPDATE entries SET tags=? WHERE id=?", (" ".join(updated_tags), entry_id))
         derived_retire_rows(conn, entry_id=entry_id, ts=ts)
 
         evo_shadow.after_write(conn, name=name, entry_ids=[entry_id])
 
 
+class _RebuildSourceChanged(RuntimeError):
+    """A Markdown source changed between rebuild preflight and ingestion."""
+
+
+def _retryable_rebuild_error(exc: BaseException) -> bool:
+    if isinstance(exc, _RebuildSourceChanged):
+        return True
+    if not isinstance(exc, sqlite3.OperationalError):
+        return False
+    code = getattr(exc, "sqlite_errorcode", None)
+    if isinstance(code, int) and (code & 0xFF) in (sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED):
+        return True
+    message = str(exc).lower()
+    return "locked" in message or "busy" in message
+
+
 def rebuild_index(conn: sqlite3.Connection) -> tuple[int, int]:
-    if evo_inversion.evomem_active():
-        result = _rebuild_from_evo_nodes(conn)
-    else:
-        result = _rebuild_from_markdown(conn)
-    # Rebuild is a reconciliation boundary. Derived rows for source entries
-    # that no longer exist must not retain deleted personal text or vectors.
-    conn.execute("DELETE FROM entry_retrieval_stats WHERE entry_id NOT IN (SELECT id FROM entries)")
-    for table in ("entry_vectors", "vector_queue"):
+    max_attempts = 5
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return _rebuild_index_once(conn)
+        except BaseException as exc:
+            if attempt == max_attempts or not _retryable_rebuild_error(exc):
+                raise
+            logger.warning(
+                "rebuild source changed or was busy; retrying (%d/%d)",
+                attempt + 1,
+                max_attempts,
+            )
+            time.sleep(min(0.05 * attempt, 0.2))
+    raise AssertionError("unreachable")
+
+
+def _rebuild_index_once(conn: sqlite3.Connection) -> tuple[int, int]:
+    savepoint = "persome_rebuild_index"
+    conn.execute(f"SAVEPOINT {savepoint}")
+    try:
+        if evo_inversion.evomem_active():
+            result = _rebuild_from_evo_nodes(conn)
+        else:
+            result = _rebuild_from_markdown(conn)
+        # Rebuild is a reconciliation boundary. Derived rows for source entries
+        # that no longer exist must not retain deleted personal text or vectors.
         conn.execute(
-            f"DELETE FROM {table} WHERE entry_id NOT IN (SELECT id FROM entries WHERE superseded=0)"
+            "DELETE FROM entry_retrieval_stats WHERE entry_id NOT IN (SELECT id FROM entries)"
         )
+        for table in ("entry_vectors", "vector_queue"):
+            conn.execute(
+                f"DELETE FROM {table} "
+                "WHERE entry_id NOT IN (SELECT id FROM entries WHERE superseded=0)"
+            )
+        conn.execute(f"RELEASE SAVEPOINT {savepoint}")
+    except BaseException:
+        # ``cursor`` connections autocommit, so the savepoint is what keeps a
+        # failed rebuild from leaving an empty or half-populated projection.
+        with contextlib.suppress(sqlite3.Error):
+            conn.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+        with contextlib.suppress(sqlite3.Error):
+            conn.execute(f"RELEASE SAVEPOINT {savepoint}")
+        raise
     return result
 
 
-def _ingest_markdown_file(conn: sqlite3.Connection, path: Path, prefix: str) -> int:
+def _encoded_tag_value(tags: list[str], prefix: str) -> str | None:
+    """Return the last non-empty projection override for ``prefix``.
+
+    Projected Markdown uses colon tags for temporal bounds that differ from
+    the values implied by the entry heading / supersede chain. Match the
+    projector's last-tag-wins behavior while treating an empty override as
+    absent.
+    """
+    value: str | None = None
+    for tag in tags:
+        if tag.startswith(prefix):
+            value = tag.split(":", 1)[1] or None
+    return value
+
+
+def _prior_valid_until(conn: sqlite3.Connection) -> dict[str, str]:
+    return {
+        row["entry_id"]: row["valid_until"]
+        for row in conn.execute(
+            "SELECT entry_id, valid_until FROM entry_temporal WHERE valid_until IS NOT NULL"
+        ).fetchall()
+    }
+
+
+def _temporal_source_state(
+    entry: files_mod.ParsedEntry,
+) -> tuple[str, str | None, int, str | None, str | None]:
+    """Return the lightweight Markdown fields that determine temporal bounds."""
+    return (
+        entry.timestamp,
+        entry.superseded_by,
+        _superseded_from_tags(entry),
+        _encoded_tag_value(entry.tags, "valid-from:"),
+        _encoded_tag_value(entry.tags, "valid-until:"),
+    )
+
+
+def _markdown_temporal_bounds(
+    sources: list[tuple[Path, str]],
+    *,
+    conn: sqlite3.Connection,
+    external_timestamp_by_id: dict[str, str] | None = None,
+) -> tuple[
+    dict[str, tuple[str, str | None]],
+    dict[str, tuple[str, str | None, int, str | None, str | None]],
+]:
+    """Derive temporal bounds from a complete set of Markdown sources.
+
+    ``external_timestamp_by_id`` supplies canonical evomem nodes when this is
+    used for direct-Markdown fallbacks (for example event logs). It also lets us
+    reject an ID collision before destructive projection deletes.
+    """
+    timestamp_by_id = dict(external_timestamp_by_id or {})
+    source_by_id = {entry_id: "the canonical evomem store" for entry_id in timestamp_by_id}
+    source_state_by_id: dict[str, tuple[str, str | None, int, str | None, str | None]] = {}
+    for path, _prefix in sources:
+        parsed = files_mod.read_file(path)
+        for entry in parsed.entries:
+            previous_source = source_by_id.get(entry.id)
+            if previous_source is not None:
+                raise ValueError(
+                    f"duplicate entry id {entry.id!r} in {previous_source!r} and {path.name!r}"
+                )
+            source_by_id[entry.id] = path.name
+            timestamp_by_id[entry.id] = entry.timestamp
+            source_state_by_id[entry.id] = _temporal_source_state(entry)
+
+    # Delay the first side-table read until after the filesystem preflight, so
+    # ordinary concurrent writes do not stale a long-lived WAL read snapshot.
+    prior_valid_until = _prior_valid_until(conn)
+    temporal_by_id: dict[str, tuple[str, str | None]] = {}
+    for entry_id, state in source_state_by_id.items():
+        timestamp, superseded_by, superseded, explicit_from, explicit_until = state
+        valid_from = explicit_from or timestamp
+        successor_until = timestamp_by_id.get(superseded_by) if superseded_by else None
+        if explicit_until is not None:
+            valid_until = explicit_until
+        elif successor_until is not None:
+            valid_until = successor_until
+        elif superseded and entry_id in prior_valid_until:
+            # Covers legacy orphan strikes and damaged/dangling chains. In
+            # both cases the side table is the only remaining exact bound.
+            valid_until = prior_valid_until[entry_id]
+        elif superseded:
+            valid_until = timestamp
+            if superseded_by:
+                logger.warning(
+                    "rebuild: entry %s points to missing successor %s and has no "
+                    "recoverable retirement time; using its heading timestamp",
+                    entry_id,
+                    superseded_by,
+                )
+            else:
+                logger.warning(
+                    "rebuild: entry %s has no recoverable retirement time; "
+                    "using its heading timestamp",
+                    entry_id,
+                )
+        else:
+            valid_until = None
+        temporal_by_id[entry_id] = (valid_from, valid_until)
+    return temporal_by_id, source_state_by_id
+
+
+def _ingest_markdown_file(
+    conn: sqlite3.Connection,
+    path: Path,
+    prefix: str,
+    *,
+    temporal_by_id: dict[str, tuple[str, str | None]] | None = None,
+    expected_source_state: (
+        dict[str, tuple[str, str | None, int, str | None, str | None]] | None
+    ) = None,
+    supersedes_by_id: dict[str, set[str]] | None = None,
+) -> int:
     parsed = files_mod.read_file(path)
     fts.upsert_file(
         conn,
@@ -618,11 +931,19 @@ def _ingest_markdown_file(conn: sqlite3.Connection, path: Path, prefix: str) -> 
         ),
     )
     for e in parsed.entries:
+        if expected_source_state is not None:
+            expected = expected_source_state.get(e.id)
+            if expected is None or _temporal_source_state(e) != expected:
+                raise _RebuildSourceChanged(f"Markdown source {path.name!r} changed during rebuild")
         superseded = _superseded_from_tags(e)
         # Only strip the strike markers off entries we judged superseded —
         # a refined-from / live entry keeps its body verbatim so a legitimate
         # inline ``~~strike~~`` in the prose is preserved (EVO-02).
-        content = _strip_strike(e.body) if superseded else e.body
+        content = _fts_content_from_markdown_entry(
+            e,
+            superseded=superseded,
+            supersedes=(supersedes_by_id or {}).get(e.id, set()),
+        )
         fts.insert_entry(
             conn,
             id=e.id,
@@ -633,9 +954,14 @@ def _ingest_markdown_file(conn: sqlite3.Connection, path: Path, prefix: str) -> 
             content=content,
             superseded=superseded,
         )
+        valid_from, valid_until = (
+            temporal_by_id[e.id]
+            if temporal_by_id is not None
+            else (e.timestamp, e.timestamp if superseded else None)
+        )
         conn.execute(
             "INSERT INTO entry_temporal(entry_id, valid_from, valid_until) VALUES (?, ?, ?)",
-            (e.id, e.timestamp, e.timestamp if superseded else None),
+            (e.id, valid_from, valid_until),
         )
         # Replay meta-cognition through the SAME writer the incremental path
         # uses, so a fresh rebuild reproduces entry_metadata row-for-row.
@@ -650,21 +976,49 @@ def _ingest_markdown_file(conn: sqlite3.Connection, path: Path, prefix: str) -> 
 
 
 def _rebuild_from_markdown(conn: sqlite3.Connection) -> tuple[int, int]:
-    conn.execute("DELETE FROM entry_temporal")
-    conn.execute("DELETE FROM entry_metadata")
-    conn.execute("DELETE FROM entries")
-    conn.execute("DELETE FROM files")
-    file_count = 0
-    entry_count = 0
-    for path in files_mod.list_memory_files():
+    # Parse every valid source before deleting the derived projection. Besides
+    # avoiding a partial wipe on a read/duplicate failure, the global pass is
+    # required because a superseded entry may point to a successor in another
+    # Markdown file.
+    memory_files = files_mod.list_memory_files()
+    source_names = {path.name for path in memory_files}
+    sources: list[tuple[Path, str]] = []
+    for path in memory_files:
         try:
             prefix = _ensure_prefix(path.name)
         except ValueError as exc:
             logger.warning("skipping %s: %s", path.name, exc)
             continue
-        entry_count += _ingest_markdown_file(conn, path, prefix)
-        file_count += 1
-    return file_count, entry_count
+        sources.append((path, prefix))
+
+    # Preserve the last known retirement bound only when Markdown cannot
+    # reconstruct one. Resolvable chain entries never use this fallback: their
+    # successor timestamp repairs even a previously corrupted side-table value.
+    temporal_by_id, expected_source_state = _markdown_temporal_bounds(
+        sources,
+        conn=conn,
+    )
+    supersedes_by_id = _supersedes_by_id(expected_source_state)
+
+    conn.execute("DELETE FROM entry_temporal")
+    conn.execute("DELETE FROM entry_metadata")
+    conn.execute("DELETE FROM entries")
+    conn.execute("DELETE FROM files")
+    entry_count = 0
+    for path, prefix in sources:
+        entry_count += _ingest_markdown_file(
+            conn,
+            path,
+            prefix,
+            temporal_by_id=temporal_by_id,
+            expected_source_state=expected_source_state,
+            supersedes_by_id=supersedes_by_id,
+        )
+    if entry_count != len(temporal_by_id):
+        raise _RebuildSourceChanged("Markdown entries changed during rebuild")
+    if {path.name for path in files_mod.list_memory_files()} != source_names:
+        raise _RebuildSourceChanged("Markdown file set changed during rebuild")
+    return len(sources), entry_count
 
 
 def _rebuild_from_evo_nodes(conn: sqlite3.Connection) -> tuple[int, int]:
@@ -672,9 +1026,6 @@ def _rebuild_from_evo_nodes(conn: sqlite3.Connection) -> tuple[int, int]:
     from ..evomem.store import _row_to_node
     from . import projector
 
-    conn.execute("DELETE FROM entry_temporal")
-    conn.execute("DELETE FROM entry_metadata")
-    conn.execute("DELETE FROM entries")
     groups: dict[str, list] = {}
     for r in conn.execute(
         "SELECT * FROM evo_nodes WHERE user_id='default' AND agent_id='default' ORDER BY node_id"
@@ -684,14 +1035,43 @@ def _rebuild_from_evo_nodes(conn: sqlite3.Connection) -> tuple[int, int]:
             continue
         groups.setdefault(node.file_name, []).append(node)
 
-    file_count = 0
-    entry_count = 0
-    for file_name in sorted(groups):
+    group_prefixes: dict[str, str] = {}
+    external_timestamp_by_id: dict[str, str] = {}
+    for file_name, nodes in groups.items():
         try:
-            prefix = _ensure_prefix(file_name)
+            group_prefixes[file_name] = _ensure_prefix(file_name)
         except ValueError as exc:
             logger.warning("skipping evo file group %s: %s", file_name, exc)
             continue
+        for node in nodes:
+            external_timestamp_by_id[node.node_id] = projector._heading_ts(node)
+
+    memory_files = files_mod.list_memory_files()
+    source_names = {path.name for path in memory_files}
+    markdown_sources: list[tuple[Path, str]] = []
+    for path in memory_files:
+        if path.name in groups:
+            continue
+        try:
+            prefix = _ensure_prefix(path.name)
+        except ValueError as exc:
+            logger.warning("skipping %s: %s", path.name, exc)
+            continue
+        markdown_sources.append((path, prefix))
+    markdown_temporal, expected_source_state = _markdown_temporal_bounds(
+        markdown_sources,
+        conn=conn,
+        external_timestamp_by_id=external_timestamp_by_id,
+    )
+    markdown_supersedes_by_id = _supersedes_by_id(expected_source_state)
+
+    conn.execute("DELETE FROM entry_temporal")
+    conn.execute("DELETE FROM entry_metadata")
+    conn.execute("DELETE FROM entries")
+    file_count = 0
+    entry_count = 0
+    for file_name in sorted(group_prefixes):
+        prefix = group_prefixes[file_name]
         nodes = sorted(groups[file_name], key=lambda n: (projector._heading_ts(n), n.node_id))
         ts_by_id = {n.node_id: projector._heading_ts(n) for n in nodes}
         for n in nodes:
@@ -703,7 +1083,10 @@ def _rebuild_from_evo_nodes(conn: sqlite3.Connection) -> tuple[int, int]:
                 prefix=prefix,
                 timestamp=projector._heading_ts(n),
                 tags=" ".join(projector._render_tags(n, prefix=prefix, ts_by_id=ts_by_id)),
-                content=n.content,
+                content=_fts_content_without_provenance(
+                    n.content,
+                    supersedes=set(n.supersedes),
+                ),
                 superseded=superseded,
             )
             conn.execute(
@@ -760,23 +1143,30 @@ def _rebuild_from_evo_nodes(conn: sqlite3.Connection) -> tuple[int, int]:
                 )
         file_count += 1
 
-    for path in files_mod.list_memory_files():
-        if path.name in groups:
-            continue
-        try:
-            prefix = _ensure_prefix(path.name)
-        except ValueError as exc:
-            logger.warning("skipping %s: %s", path.name, exc)
-            continue
-        entry_count += _ingest_markdown_file(conn, path, prefix)
+    markdown_entry_count = 0
+    for path, prefix in markdown_sources:
+        count = _ingest_markdown_file(
+            conn,
+            path,
+            prefix,
+            temporal_by_id=markdown_temporal,
+            expected_source_state=expected_source_state,
+            supersedes_by_id=markdown_supersedes_by_id,
+        )
+        markdown_entry_count += count
+        entry_count += count
         file_count += 1
+    if markdown_entry_count != len(markdown_temporal):
+        raise _RebuildSourceChanged("Markdown entries changed during rebuild")
+    if {path.name for path in files_mod.list_memory_files()} != source_names:
+        raise _RebuildSourceChanged("Markdown file set changed during rebuild")
 
     # the file-level metadata truth). But a row that once had nodes, now has NONE
     # in evo_nodes (all moved out / file deleted) AND is not on disk falls into
     # neither `groups` nor `list_memory_files()` above — so its stale entry_count
     # never gets refreshed and the row lingers forever. Prune those orphan rows so
     # rebuild stays idempotent and converges to the truth state.
-    valid_names = set(groups) | {p.name for p in files_mod.list_memory_files()}
+    valid_names = set(groups) | source_names
     orphans = [
         r[0] for r in conn.execute("SELECT path FROM files").fetchall() if r[0] not in valid_names
     ]
@@ -792,6 +1182,11 @@ def _rebuild_from_evo_nodes(conn: sqlite3.Connection) -> tuple[int, int]:
 
 
 _STRIKE_RE = re.compile(r"~~(.+?)~~", re.DOTALL)
+_SUPERSEDES_COMMENT_RE = re.compile(
+    r"(?:\n)?<!-- supersedes: (?P<old_id>[a-zA-Z0-9-]+); "
+    r"reason: (?:(?!-->).)* -->\Z",
+    re.DOTALL,
+)
 
 
 def _body_is_striked(body: str) -> bool:
@@ -800,18 +1195,20 @@ def _body_is_striked(body: str) -> bool:
 
 
 def _superseded_from_tags(e: files_mod.ParsedEntry) -> int:
-    """Three-way superseded judgment from an entry's markdown tags (EVO-02).
+    """Superseded judgment from an entry's Markdown projection (EVO-02).
 
-        if superseded-by:  1   (retired by a successor)
-        elif refined-from: 0   (a refinement — forced live, even if struck)
-        else:              1 if whole-body struck else 0   (orphan strike fallback)
+        if explicit non-active status: 1   (retired refinement / archive)
+        elif superseded-by:             1   (retired by a successor)
+        elif refined-from:              0   (refinement forced live)
+        else: whole-body strike         1   (orphan retirement fallback)
 
-    The ``refined-from → 0`` branch short-circuits BEFORE the strike fallback, so a
-    refined-from entry whose body happens to be struck still reads live. Existing
-    data carries no ``refined-from`` tag, so branch ② is dead code and this is
-    byte-for-byte equivalent to the previous ``superseded_by or _body_is_striked``
-    expression (the zero-regression guarantee).
+    A status override is the durable deletion signal for a refined head; without
+    it, ``refined-from`` still short-circuits before the strike fallback so
+    legitimate struck prose remains live.
     """
+    status = _encoded_tag_value(e.tags, "status:")
+    if status in {"shadow", "archived", "superseded"}:
+        return 1
     if e.superseded_by:
         return 1
     if e.refined_from:
@@ -820,7 +1217,57 @@ def _superseded_from_tags(e: files_mod.ParsedEntry) -> int:
 
 
 def _strip_strike(body: str) -> str:
-    return _STRIKE_RE.sub(r"\1", body)
+    if _body_is_striked(body):
+        # Retirement wraps the complete body in one outer ``~~`` pair. Remove
+        # only that pair so legitimate inline strike Markdown remains intact.
+        stripped = body.strip()
+        return stripped[2:-2]
+    return body
+
+
+def _content_from_markdown_entry(e: files_mod.ParsedEntry, *, superseded: int) -> str:
+    status = _encoded_tag_value(e.tags, "status:")
+    status_retired_refinement = (
+        bool(e.refined_from)
+        and not e.superseded_by
+        and status in {"shadow", "archived", "superseded"}
+    )
+    if superseded and not status_retired_refinement:
+        return _strip_strike(e.body)
+    return e.body
+
+
+def _fts_content_from_markdown_entry(
+    e: files_mod.ParsedEntry,
+    *,
+    superseded: int,
+    supersedes: set[str],
+) -> str:
+    content = _content_from_markdown_entry(e, superseded=superseded)
+    return _fts_content_without_provenance(content, supersedes=supersedes)
+
+
+def _fts_content_without_provenance(content: str, *, supersedes: set[str]) -> str:
+    match = _SUPERSEDES_COMMENT_RE.search(content)
+    if match is not None and match.group("old_id") in supersedes:
+        return content[: match.start()]
+    return content
+
+
+def _supersedes_by_id(
+    source_state_by_id: dict[str, tuple[str, str | None, int, str | None, str | None]],
+) -> dict[str, set[str]]:
+    out: dict[str, set[str]] = {}
+    for old_id, (
+        _timestamp,
+        successor,
+        _superseded,
+        _valid_from,
+        _valid_until,
+    ) in source_state_by_id.items():
+        if successor:
+            out.setdefault(successor, set()).add(old_id)
+    return out
 
 
 def write_preset_files(conn: sqlite3.Connection) -> None:

--- a/tests/test_evomem/inversion_harness.py
+++ b/tests/test_evomem/inversion_harness.py
@@ -18,11 +18,10 @@ FROZEN_MINUTE = "2026-06-11T10:00"
 
 
 _MARKER_LINE_RE = re.compile(r"^projected: .*\n", re.MULTILINE)
-_VALID_UNTIL_TAG_RE = re.compile(r" #valid-until:\S+")
 
 
 def normalize_projection(text: str) -> str:
-    return _VALID_UNTIL_TAG_RE.sub("", _MARKER_LINE_RE.sub("", text))
+    return _MARKER_LINE_RE.sub("", text)
 
 
 @dataclass

--- a/tests/test_evomem/test_projector.py
+++ b/tests/test_evomem/test_projector.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import dataclasses
-import re
 from datetime import datetime
 from pathlib import Path
 
@@ -269,7 +268,7 @@ def test_projection_byte_identical_to_real_markdown(
         assert projected == original, name
 
 
-def test_projection_orphan_retire_diff_is_only_valid_until_tag(
+def test_projection_orphan_retire_round_trips_valid_until_tag(
     ac_root: Path, tmp_path: Path, _deterministic_ids
 ) -> None:
     with fts.cursor() as conn:
@@ -285,7 +284,5 @@ def test_projection_orphan_retire_diff_is_only_valid_until_tag(
 
     original = (paths.memory_dir() / "person-bob.md").read_text()
     projected = (out / "person-bob.md").read_text()
-    assert projected != original
-    stripped = re.sub(r" #valid-until:\S+", "", projected)
-    assert stripped == original
-    assert re.search(r"#valid-until:\d{4}-\d{2}-\d{2}T\d{2}:\d{2}", projected)
+    assert projected == original
+    assert "#valid-until:" in projected

--- a/tests/test_rebuild_temporal.py
+++ b/tests/test_rebuild_temporal.py
@@ -1,0 +1,665 @@
+"""Temporal-history regressions for rebuilding the Markdown projection."""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+
+import pytest
+
+from persome.evomem import backfill
+from persome.evomem.store import NodeStore
+from persome.store import entries as entries_mod
+from persome.store import files as files_mod
+from persome.store import fts, projector
+
+
+def _temporal(conn: sqlite3.Connection, *entry_ids: str) -> dict[str, tuple[str, str | None]]:
+    placeholders = ", ".join("?" for _ in entry_ids)
+    rows = conn.execute(
+        f"SELECT entry_id, valid_from, valid_until FROM entry_temporal "
+        f"WHERE entry_id IN ({placeholders})",
+        entry_ids,
+    ).fetchall()
+    return {row["entry_id"]: (row["valid_from"], row["valid_until"]) for row in rows}
+
+
+def _write_raw_file(name: str, body: str) -> None:
+    path = files_mod.memory_path(name)
+    frontmatter = files_mod.default_frontmatter(description="temporal fixture", tags=[])
+    files_mod.write_file(path, frontmatter, body)
+
+
+def test_rebuild_repairs_and_preserves_multistep_supersede_history(
+    ac_root, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    times = iter(("2026-07-11T10:00", "2026-07-11T11:00", "2026-07-11T12:00"))
+    monkeypatch.setattr(entries_mod, "_now_iso_minute", lambda: next(times))
+
+    with fts.cursor() as conn:
+        entries_mod.create_file(conn, name="project-chain.md", description="chain", tags=[])
+        old = entries_mod.append_entry(conn, name="project-chain.md", content="v1", tags=[])
+        middle = entries_mod.supersede_entry(
+            conn,
+            name="project-chain.md",
+            old_entry_id=old,
+            new_content="v2",
+            reason="update",
+            tags=[],
+        )
+        head = entries_mod.supersede_entry(
+            conn,
+            name="project-chain.md",
+            old_entry_id=middle,
+            new_content="v3",
+            reason="update",
+            tags=[],
+        )
+        expected = {
+            old: ("2026-07-11T10:00", "2026-07-11T11:00"),
+            middle: ("2026-07-11T11:00", "2026-07-11T12:00"),
+            head: ("2026-07-11T12:00", None),
+        }
+        assert _temporal(conn, old, middle, head) == expected
+
+        # Simulate rows already corrupted by the old rebuild implementation.
+        conn.execute(
+            "UPDATE entry_temporal SET valid_until=valid_from WHERE entry_id IN (?, ?)",
+            (old, middle),
+        )
+        entries_mod.rebuild_index(conn)
+        assert _temporal(conn, old, middle, head) == expected
+
+        # A second production rebuild must be byte-for-byte idempotent.
+        entries_mod.rebuild_index(conn)
+        assert _temporal(conn, old, middle, head) == expected
+
+    # Backfill consumes entry_temporal directly, so verify the repaired bound
+    # reaches the canonical node rather than becoming a durable zero-width row.
+    report = backfill.run_backfill()
+    assert report.ok
+    old_node = NodeStore().get(old)
+    middle_node = NodeStore().get(middle)
+    assert old_node is not None and old_node.valid_until == "2026-07-11T11:00"
+    assert middle_node is not None and middle_node.valid_until == "2026-07-11T12:00"
+
+
+def test_rebuild_preserves_legacy_orphan_retirement_when_available(
+    ac_root, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    times = iter(("2026-07-11T10:00", "2026-07-11T13:30"))
+    monkeypatch.setattr(entries_mod, "_now_iso_minute", lambda: next(times))
+
+    with fts.cursor() as conn:
+        entries_mod.create_file(conn, name="project-orphan.md", description="orphan", tags=[])
+        orphan = entries_mod.append_entry(
+            conn, name="project-orphan.md", content="retired", tags=[]
+        )
+        entries_mod.mark_entry_deleted(conn, name="project-orphan.md", entry_id=orphan)
+        assert _temporal(conn, orphan) == {orphan: ("2026-07-11T10:00", "2026-07-11T13:30")}
+
+        # New deletions persist the exact bound in Markdown, so even a fresh
+        # projection with no side-table state can recover it losslessly.
+        memory_path = files_mod.memory_path("project-orphan.md")
+        parsed = files_mod.read_file(memory_path)
+        assert "valid-until:2026-07-11T13:30" in parsed.entries[0].tags
+        conn.execute("DELETE FROM entry_temporal")
+        entries_mod.rebuild_index(conn)
+        assert _temporal(conn, orphan) == {orphan: ("2026-07-11T10:00", "2026-07-11T13:30")}
+
+        # Legacy Markdown encodes this as a strike without a successor or an
+        # explicit valid-until tag. An in-place rebuild must retain the side
+        # table's only copy of the exact retirement time.
+        legacy_text = memory_path.read_text().replace(" #valid-until:2026-07-11T13:30", "", 1)
+        files_mod.atomic_write_text(memory_path, legacy_text)
+        parsed = files_mod.read_file(memory_path)
+        assert parsed.entries[0].superseded_by is None
+        assert not any(tag.startswith("valid-until:") for tag in parsed.entries[0].tags)
+        entries_mod.rebuild_index(conn)
+        assert _temporal(conn, orphan) == {orphan: ("2026-07-11T10:00", "2026-07-11T13:30")}
+
+        # With no side-table state, the historical compatibility fallback is
+        # necessarily the entry timestamp; there is no exact time in Markdown.
+        conn.execute("DELETE FROM entry_temporal")
+        entries_mod.rebuild_index(conn)
+        assert _temporal(conn, orphan) == {orphan: ("2026-07-11T10:00", "2026-07-11T10:00")}
+
+
+def test_delete_markdown_bound_closes_pre_db_rebuild_race(
+    ac_root, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    times = iter(("2026-07-11T10:00", "2026-07-11T13:30"))
+    monkeypatch.setattr(entries_mod, "_now_iso_minute", lambda: next(times))
+
+    with fts.cursor() as conn:
+        entries_mod.create_file(conn, name="project-delete-race.md", description="race", tags=[])
+        entry_id = entries_mod.append_entry(
+            conn, name="project-delete-race.md", content="retire me", tags=[]
+        )
+        real_retire = entries_mod.derived_retire_rows
+
+        def rebuild_before_db_retire(
+            inner_conn: sqlite3.Connection, *, entry_id: str, ts: str
+        ) -> None:
+            entries_mod.rebuild_index(inner_conn)
+            real_retire(inner_conn, entry_id=entry_id, ts=ts)
+
+        monkeypatch.setattr(entries_mod, "derived_retire_rows", rebuild_before_db_retire)
+        entries_mod.mark_entry_deleted(conn, name="project-delete-race.md", entry_id=entry_id)
+
+        assert _temporal(conn, entry_id) == {entry_id: ("2026-07-11T10:00", "2026-07-11T13:30")}
+
+
+def test_delete_anchors_temporal_tag_to_the_real_heading(
+    ac_root, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_raw_file(
+        "project-heading-anchor.md",
+        "\n".join(
+            (
+                "## [2026-07-11T09:00] {id: quoted}",
+                "quoted: ## [2026-07-11T10:00] {id: target-id}",
+                "",
+                "## [2026-07-11T10:00] {id: target-id}",
+                "actual target",
+            )
+        ),
+    )
+    monkeypatch.setattr(entries_mod, "_now_iso_minute", lambda: "2026-07-11T13:30")
+
+    with fts.cursor() as conn:
+        entries_mod.rebuild_index(conn)
+        entries_mod.mark_entry_deleted(conn, name="project-heading-anchor.md", entry_id="target-id")
+        memory_path = files_mod.memory_path("project-heading-anchor.md")
+        parsed = files_mod.read_file(memory_path)
+        target = next(entry for entry in parsed.entries if entry.id == "target-id")
+        assert "valid-until:2026-07-11T13:30" in target.tags
+        assert "quoted: ## [2026-07-11T10:00] {id: target-id} #valid-until" not in (
+            memory_path.read_text()
+        )
+
+        conn.execute("DELETE FROM entry_temporal")
+        entries_mod.rebuild_index(conn)
+        assert _temporal(conn, "target-id") == {
+            "target-id": ("2026-07-11T10:00", "2026-07-11T13:30")
+        }
+
+
+def test_delete_refined_head_stays_retired_after_rebuild(
+    ac_root, tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    times = iter(("2026-07-11T10:00", "2026-07-11T11:00", "2026-07-11T13:30"))
+    monkeypatch.setattr(entries_mod, "_now_iso_minute", lambda: next(times))
+
+    with fts.cursor() as conn:
+        entries_mod.create_file(conn, name="project-refined.md", description="refined", tags=[])
+        old = entries_mod.append_entry(conn, name="project-refined.md", content="rough", tags=[])
+        refined = entries_mod.supersede_entry(
+            conn,
+            name="project-refined.md",
+            old_entry_id=old,
+            new_content="refined ~~detail~~",
+            reason="refine",
+            refined_from=old,
+            tags=[],
+        )
+        entries_mod.mark_entry_deleted(conn, name="project-refined.md", entry_id=refined)
+        parsed = files_mod.read_file(files_mod.memory_path("project-refined.md"))
+        refined_entry = next(entry for entry in parsed.entries if entry.id == refined)
+        assert "status:shadow" in refined_entry.tags
+        assert refined_entry.body.startswith("refined ~~detail~~")
+        assert not entries_mod._body_is_striked(refined_entry.body)
+        original_projection = files_mod.memory_path("project-refined.md").read_text()
+        assert (
+            conn.execute("SELECT superseded FROM entries WHERE id=?", (refined,)).fetchone()[0] == 1
+        )
+        assert (
+            "~~detail~~"
+            in conn.execute("SELECT content FROM entries WHERE id=?", (refined,)).fetchone()[0]
+        )
+
+        entries_mod.rebuild_index(conn)
+        assert (
+            conn.execute("SELECT superseded FROM entries WHERE id=?", (refined,)).fetchone()[0] == 1
+        )
+
+    report = backfill.run_backfill()
+    assert report.ok
+    with fts.cursor() as conn:
+        projector.project_all(conn, out_dir=tmp_path / "projection")
+    assert (tmp_path / "projection" / "project-refined.md").read_text() == original_projection
+
+
+def test_delete_refined_whole_strike_preserves_legitimate_markdown(
+    ac_root, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_raw_file(
+        "project-refined-strike.md",
+        "## [2026-07-11T10:00] {id: refined-strike} "
+        "#refined-from:source-id\n~~legitimate struck prose~~\n",
+    )
+    monkeypatch.setattr(entries_mod, "_now_iso_minute", lambda: "2026-07-11T13:30")
+
+    with fts.cursor() as conn:
+        entries_mod.rebuild_index(conn)
+        assert (
+            conn.execute("SELECT content FROM entries WHERE id='refined-strike'").fetchone()[0]
+            == "~~legitimate struck prose~~"
+        )
+        entries_mod.mark_entry_deleted(
+            conn,
+            name="project-refined-strike.md",
+            entry_id="refined-strike",
+        )
+        entries_mod.rebuild_index(conn)
+        row = conn.execute(
+            "SELECT content, superseded FROM entries WHERE id='refined-strike'"
+        ).fetchone()
+        assert (row["content"], row["superseded"]) == (
+            "~~legitimate struck prose~~",
+            1,
+        )
+
+
+def test_delete_body_starting_with_inline_strike_stays_retired(
+    ac_root, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    times = iter(("2026-07-11T10:00", "2026-07-11T13:30"))
+    monkeypatch.setattr(entries_mod, "_now_iso_minute", lambda: next(times))
+
+    with fts.cursor() as conn:
+        entries_mod.create_file(conn, name="project-inline.md", description="inline", tags=[])
+        entry_id = entries_mod.append_entry(
+            conn,
+            name="project-inline.md",
+            content="~~draft~~ but still live",
+            tags=[],
+        )
+        entries_mod.mark_entry_deleted(conn, name="project-inline.md", entry_id=entry_id)
+        entries_mod.rebuild_index(conn)
+        assert (
+            conn.execute("SELECT superseded FROM entries WHERE id=?", (entry_id,)).fetchone()[0]
+            == 1
+        )
+        assert (
+            conn.execute("SELECT content FROM entries WHERE id=?", (entry_id,)).fetchone()[0]
+            == "~~draft~~ but still live"
+        )
+
+
+def test_delete_already_superseded_entry_is_projection_idempotent(
+    ac_root, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    times = iter(("2026-07-11T10:00", "2026-07-11T11:00"))
+    monkeypatch.setattr(entries_mod, "_now_iso_minute", lambda: next(times))
+
+    with fts.cursor() as conn:
+        entries_mod.create_file(conn, name="project-repeat.md", description="repeat", tags=[])
+        old = entries_mod.append_entry(conn, name="project-repeat.md", content="old", tags=[])
+        head = entries_mod.supersede_entry(
+            conn,
+            name="project-repeat.md",
+            old_entry_id=old,
+            new_content="head",
+            reason="update",
+            tags=[],
+        )
+        memory_path = files_mod.memory_path("project-repeat.md")
+        before = memory_path.read_text()
+        entries_mod.mark_entry_deleted(conn, name="project-repeat.md", entry_id=old)
+        assert memory_path.read_text() == before
+        parsed = files_mod.read_file(memory_path)
+        old_entry = next(entry for entry in parsed.entries if entry.id == old)
+        assert not any(tag.startswith("valid-until:") for tag in old_entry.tags)
+        entries_mod.rebuild_index(conn)
+        assert _temporal(conn, old, head) == {
+            old: ("2026-07-11T10:00", "2026-07-11T11:00"),
+            head: ("2026-07-11T11:00", None),
+        }
+
+
+def test_rebuild_uses_global_successors_and_explicit_temporal_overrides(ac_root) -> None:
+    _write_raw_file(
+        "project-old.md",
+        "\n".join(
+            (
+                "## [2026-07-11T10:00] {id: old-cross} #superseded-by:new-head",
+                "~~old cross-file value~~",
+                "",
+                "## [2026-07-11T10:05] {id: old-explicit} "
+                "#superseded-by:new-head #valid-from:2026-07-11T09:00 "
+                "#valid-until:2026-07-11T10:30",
+                "~~old explicitly bounded value~~",
+            )
+        ),
+    )
+    _write_raw_file(
+        "project-new.md",
+        "## [2026-07-11T11:00] {id: new-head}\ncurrent value\n",
+    )
+
+    with fts.cursor() as conn:
+        entries_mod.rebuild_index(conn)
+        assert _temporal(conn, "old-cross", "old-explicit", "new-head") == {
+            "old-cross": ("2026-07-11T10:00", "2026-07-11T11:00"),
+            "old-explicit": ("2026-07-11T09:00", "2026-07-11T10:30"),
+            "new-head": ("2026-07-11T11:00", None),
+        }
+
+
+def test_dangling_successor_preserves_last_known_temporal_state(ac_root) -> None:
+    _write_raw_file(
+        "project-dangling.md",
+        "## [2026-07-11T10:00] {id: old-dangling} #superseded-by:missing-head\n~~old value~~\n",
+    )
+
+    with fts.cursor() as conn:
+        entries_mod.rebuild_index(conn)
+        conn.execute(
+            "UPDATE entry_temporal SET valid_until=? WHERE entry_id=?",
+            ("2026-07-11T15:00", "old-dangling"),
+        )
+        entries_mod.rebuild_index(conn)
+        assert _temporal(conn, "old-dangling") == {
+            "old-dangling": ("2026-07-11T10:00", "2026-07-11T15:00")
+        }
+
+
+def test_duplicate_id_preflight_leaves_existing_projection_untouched(ac_root) -> None:
+    with fts.cursor() as conn:
+        entries_mod.create_file(conn, name="project-first.md", description="first", tags=[])
+        entry_id = entries_mod.append_entry(
+            conn, name="project-first.md", content="original", tags=[]
+        )
+        before_entries = [tuple(row) for row in conn.execute("SELECT * FROM entries")]
+        before_files = [tuple(row) for row in conn.execute("SELECT * FROM files")]
+        before_temporal = [tuple(row) for row in conn.execute("SELECT * FROM entry_temporal")]
+
+        _write_raw_file(
+            "project-second.md",
+            f"## [2026-07-11T12:00] {{id: {entry_id}}}\nduplicate\n",
+        )
+
+        with pytest.raises(ValueError, match="duplicate entry id"):
+            entries_mod.rebuild_index(conn)
+
+        assert [tuple(row) for row in conn.execute("SELECT * FROM entries")] == before_entries
+        assert [tuple(row) for row in conn.execute("SELECT * FROM files")] == before_files
+        assert [
+            tuple(row) for row in conn.execute("SELECT * FROM entry_temporal")
+        ] == before_temporal
+
+
+def test_evomem_authority_rebuild_preserves_direct_markdown_event_history(
+    ac_root, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    times = iter(("2026-07-11T10:00", "2026-07-11T11:00"))
+    monkeypatch.setattr(entries_mod, "_now_iso_minute", lambda: next(times))
+
+    with fts.cursor() as conn:
+        entries_mod.create_file(conn, name="event-2026-07-11.md", description="events", tags=[])
+        old = entries_mod.append_entry(conn, name="event-2026-07-11.md", content="v1", tags=[])
+        head = entries_mod.supersede_entry(
+            conn,
+            name="event-2026-07-11.md",
+            old_entry_id=old,
+            new_content="v2",
+            reason="correction",
+            tags=[],
+        )
+        expected = {
+            old: ("2026-07-11T10:00", "2026-07-11T11:00"),
+            head: ("2026-07-11T11:00", None),
+        }
+        assert _temporal(conn, old, head) == expected
+
+    NodeStore()  # ensure the canonical table exists even though event files are skipped
+    (ac_root / "config.toml").write_text('[evomem]\nwrite_authority = "evomem"\n')
+    with fts.cursor() as conn:
+        entries_mod.rebuild_index(conn)
+        assert _temporal(conn, old, head) == expected
+        entries_mod.rebuild_index(conn)
+        assert _temporal(conn, old, head) == expected
+
+
+def test_failed_ingest_rolls_back_the_entire_projection(
+    ac_root, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with fts.cursor() as conn:
+        entries_mod.create_file(conn, name="project-rollback.md", description="r", tags=[])
+        entries_mod.append_entry(conn, name="project-rollback.md", content="first", tags=[])
+        entries_mod.append_entry(conn, name="project-rollback.md", content="second", tags=[])
+        queries = {
+            "entries": "SELECT * FROM entries ORDER BY id",
+            "entry_temporal": "SELECT * FROM entry_temporal ORDER BY entry_id",
+            "entry_metadata": "SELECT * FROM entry_metadata ORDER BY entry_id",
+            "files": "SELECT * FROM files ORDER BY path",
+        }
+        before = {
+            table: [tuple(row) for row in conn.execute(query)] for table, query in queries.items()
+        }
+
+        real_insert = fts.insert_entry
+        calls = 0
+
+        def fail_second_insert(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise RuntimeError("injected ingest failure")
+            return real_insert(*args, **kwargs)
+
+        monkeypatch.setattr(fts, "insert_entry", fail_second_insert)
+        with pytest.raises(RuntimeError, match="injected ingest failure"):
+            entries_mod.rebuild_index(conn)
+
+        after = {
+            table: [tuple(row) for row in conn.execute(query)] for table, query in queries.items()
+        }
+        assert after == before
+
+
+def test_source_change_during_rebuild_retries_without_stale_projection(
+    ac_root, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = files_mod.memory_path("project-race.md")
+    with fts.cursor() as conn:
+        entries_mod.create_file(conn, name=path.name, description="race", tags=[])
+        original_id = entries_mod.append_entry(conn, name=path.name, content="original", tags=[])
+
+        real_read = files_mod.read_file
+        injected = False
+
+        def read_then_inject(source_path):
+            nonlocal injected
+            parsed = real_read(source_path)
+            if not injected and source_path == path:
+                injected = True
+                updated = source_path.read_text().rstrip()
+                updated += "\n\n## [2026-07-11T12:00] {id: concurrent-new}\nconcurrent content\n"
+                files_mod.atomic_write_text(source_path, updated)
+            return parsed
+
+        monkeypatch.setattr(files_mod, "read_file", read_then_inject)
+        files_count, entries_count = entries_mod.rebuild_index(conn)
+
+        assert injected
+        assert (files_count, entries_count) == (1, 2)
+        assert (
+            conn.execute("SELECT content FROM entries WHERE id=?", (original_id,)).fetchone()[0]
+            == "original"
+        )
+        concurrent = conn.execute(
+            "SELECT content FROM entries WHERE id='concurrent-new'"
+        ).fetchone()
+        assert concurrent is not None and concurrent[0] == "concurrent content"
+        assert _temporal(conn, "concurrent-new") == {"concurrent-new": ("2026-07-11T12:00", None)}
+
+
+def test_writers_paused_after_markdown_do_not_duplicate_rebuilt_entries(
+    ac_root, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    now = {"value": "2026-07-11T10:00"}
+    monkeypatch.setattr(entries_mod, "_now_iso_minute", lambda: now["value"])
+    with fts.cursor() as conn:
+        entries_mod.create_file(conn, name="project-writer-race.md", description="race", tags=[])
+
+    def run_paused_write(derived_name, write):
+        real_derived = getattr(entries_mod, derived_name)
+        markdown_written = threading.Event()
+        resume_db_write = threading.Event()
+        results: list[str] = []
+        errors: list[BaseException] = []
+
+        def paused_derived(*args, **kwargs):
+            markdown_written.set()
+            if not resume_db_write.wait(timeout=10):
+                raise TimeoutError("timed out waiting to resume derived DB write")
+            return real_derived(*args, **kwargs)
+
+        def writer() -> None:
+            try:
+                with fts.cursor() as writer_conn:
+                    results.append(write(writer_conn))
+            except BaseException as exc:  # surfaced on the main test thread below
+                errors.append(exc)
+
+        monkeypatch.setattr(entries_mod, derived_name, paused_derived)
+        thread = threading.Thread(target=writer, daemon=True)
+        thread.start()
+        assert markdown_written.wait(timeout=10)
+        try:
+            with fts.cursor() as rebuild_conn:
+                entries_mod.rebuild_index(rebuild_conn)
+        finally:
+            resume_db_write.set()
+        thread.join(timeout=10)
+        monkeypatch.setattr(entries_mod, derived_name, real_derived)
+        assert not thread.is_alive()
+        assert errors == []
+        assert len(results) == 1
+        return results[0]
+
+    appended = run_paused_write(
+        "derived_append_rows",
+        lambda conn: entries_mod.append_entry(
+            conn,
+            name="project-writer-race.md",
+            content="first",
+            tags=[],
+        ),
+    )
+    with fts.cursor() as conn:
+        assert (
+            conn.execute("SELECT COUNT(*) FROM entries WHERE id=?", (appended,)).fetchone()[0] == 1
+        )
+
+    now["value"] = "2026-07-11T11:00"
+    head = run_paused_write(
+        "derived_supersede_rows",
+        lambda conn: entries_mod.supersede_entry(
+            conn,
+            name="project-writer-race.md",
+            old_entry_id=appended,
+            new_content="",
+            reason="empty -->\nreplacement -- reason",
+            tags=[],
+        ),
+    )
+    raw = files_mod.memory_path("project-writer-race.md").read_text()
+    assert "reason: empty &#45;&#45;&gt; replacement &#45;&#45; reason -->" in raw
+    assert "reason: empty -->" not in raw
+    with fts.cursor() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM entries WHERE id=?", (head,)).fetchone()[0] == 1
+        content = conn.execute("SELECT content FROM entries WHERE id=?", (head,)).fetchone()[0]
+        assert content == ""
+        entries_mod.rebuild_index(conn)
+        assert (
+            conn.execute("SELECT content FROM entries WHERE id=?", (head,)).fetchone()[0] == content
+        )
+
+
+def test_plain_content_shaped_like_provenance_survives_rebuild(
+    ac_root, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(entries_mod, "_now_iso_minute", lambda: "2026-07-11T10:00")
+    literal = "user-authored\n<!-- supersedes: fake-id; reason: literal text -->"
+    with fts.cursor() as conn:
+        entries_mod.create_file(conn, name="project-literal.md", description="literal", tags=[])
+        entry_id = entries_mod.append_entry(
+            conn,
+            name="project-literal.md",
+            content=literal,
+            tags=[],
+        )
+        entries_mod.rebuild_index(conn)
+        assert (
+            conn.execute("SELECT content FROM entries WHERE id=?", (entry_id,)).fetchone()[0]
+            == literal
+        )
+
+
+def test_evomem_supersede_paused_before_derived_rows_matches_rebuild(
+    ac_root, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    now = {"value": "2026-07-11T10:00"}
+    monkeypatch.setattr(entries_mod, "_now_iso_minute", lambda: now["value"])
+    with fts.cursor() as conn:
+        entries_mod.create_file(conn, name="project-evo-race.md", description="race", tags=[])
+        old = entries_mod.append_entry(
+            conn,
+            name="project-evo-race.md",
+            content="v1",
+            tags=[],
+        )
+    assert backfill.run_backfill().ok
+    (ac_root / "config.toml").write_text('[evomem]\nwrite_authority = "evomem"\n')
+    now["value"] = "2026-07-11T11:00"
+
+    real_derived = entries_mod.derived_supersede_rows
+    canonical_written = threading.Event()
+    resume_projection = threading.Event()
+    results: list[str] = []
+    errors: list[BaseException] = []
+
+    def paused_derived(*args, **kwargs):
+        canonical_written.set()
+        if not resume_projection.wait(timeout=10):
+            raise TimeoutError("timed out waiting to resume evomem derived rows")
+        return real_derived(*args, **kwargs)
+
+    def writer() -> None:
+        try:
+            with fts.cursor() as conn:
+                results.append(
+                    entries_mod.supersede_entry(
+                        conn,
+                        name="project-evo-race.md",
+                        old_entry_id=old,
+                        new_content="v2",
+                        reason="evomem race",
+                        tags=[],
+                    )
+                )
+        except BaseException as exc:
+            errors.append(exc)
+
+    monkeypatch.setattr(entries_mod, "derived_supersede_rows", paused_derived)
+    thread = threading.Thread(target=writer, daemon=True)
+    thread.start()
+    assert canonical_written.wait(timeout=10)
+    try:
+        with fts.cursor() as conn:
+            entries_mod.rebuild_index(conn)
+    finally:
+        resume_projection.set()
+    thread.join(timeout=10)
+    assert not thread.is_alive()
+    assert errors == []
+    assert len(results) == 1
+    head = results[0]
+    with fts.cursor() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM entries WHERE id=?", (head,)).fetchone()[0] == 1
+        assert conn.execute("SELECT content FROM entries WHERE id=?", (head,)).fetchone()[0] == "v2"
+        entries_mod.rebuild_index(conn)
+        assert conn.execute("SELECT content FROM entries WHERE id=?", (head,)).fetchone()[0] == "v2"


### PR DESCRIPTION
# What

Preserve bitemporal entry history when rebuilding the Markdown/evomem projection. Rebuild now resolves bounds from explicit projection tags and global successor timestamps, keeps unreconstructable legacy retirement bounds, and performs projection replacement atomically with retry-safe concurrent-writer handling.

The change also makes deletion bounds durable in Markdown, keeps refined/struck content semantics stable, and prevents structural supersede provenance from leaking into FTS content or being broken by model-generated reasons.

# Why

The previous Markdown rebuild treated every retired entry as if its `valid_until` were its own heading timestamp. A normal `10:00 -> 11:00` supersede chain therefore became a zero-width `10:00 -> 10:00` history after rebuild. Orphan deletions could lose their exact retirement time entirely.

Rebuild also deleted derived rows before all sources were validated, and a writer paused after its Markdown/canonical write could race rebuild and create duplicate FTS rows when it resumed. These cases made recovery non-idempotent and could corrupt temporal history or search projection state.

# How verified

- `PERSOME_LLM_MOCK=1 uv run --no-sync pytest -m "not macos and not integration" -q` — 1658 passed, 15 deselected on the latest `main`
- Focused temporal, store, evomem, projector, retrieval, and compaction suite — 142 passed
- `uv run --no-sync ruff check .` and `uv run --no-sync ruff format --check .`
- `uv run --no-sync python scripts/secret_scan.py`
- `uv run --no-sync python scripts/pii_scan.py`
- `uv run --no-sync python scripts/language_scan.py`
- `uv run --no-sync python scripts/check_doc_links.py`
- OpenAPI and database-schema drift tests — 4 passed
- Hash-constrained wheel build and locked dependency audit — no known vulnerabilities
- Synthetic MCP transport smoke — health, required tools, search, and receipt verification passed
- Shell syntax, lockfile, and `git diff --check` gates passed
- Independent final diff review found no blocking issues

---

- [x] Commits are signed off (`git commit -s`) — DCO required, see CONTRIBUTING.md
- [x] No real names / emails / tokens in code or test fixtures (synthetic data only)
- [x] Secret scan passes (`scripts/secret_scan.py`)
- [x] Human-authored repository text is English (`scripts/language_scan.py` passes)
