### PR TITLE
Make onboarding prove permissions and runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,10 @@ Requirements: macOS 13 or newer, Xcode Command Line Tools, and a Python build
 with SQLite 3.42+ (the installer verifies the secure FTS capability). The installer
 finds or installs `uv`, provisions Python 3.11-3.13, compiles the Swift AX
 helpers, generates the local screenshot-encryption key, enables and verifies
-local OCR, requests Screen Recording, and offers to register detected MCP
-clients. Its fallback `uv` download is version-pinned and checked
+local OCR, and offers to register detected MCP clients. Before it reports
+success, a native onboarding flow explains and requests Accessibility and
+Screen Recording separately, starts Persome, checks local health, and writes a
+fresh capture. Its fallback `uv` download is version-pinned and checked
 against repository-pinned SHA-256 digests; the Runtime environment is installed
 from the committed `uv.lock`, and the complete build-backend closure is
 hash-constrained rather than resolved afresh.
@@ -85,21 +87,21 @@ cd persome-core
 bash install.sh
 
 persome doctor
+persome onboard
 persome ocr status --check
-persome start
 persome model open
 ```
 
-Grant **Accessibility** to the terminal or app that launches Persome in
-**System Settings -> Privacy & Security -> Accessibility**. This permission is
-required to read focused AX text and structure. The installer enables bundled
-local OCR, requests **Screen Recording**, verifies the isolated OCR worker, and
-opens the correct settings pane when permission remains denied. OCR supplies
-text for AX-poor apps such as WeChat and Feishu; pixels never enter an LLM
-prompt. Persome does not require Full Disk Access.
+`persome onboard` is the repeatable recovery path. It shows one plain-language
+macOS dialog before each system permission request and does not complete until
+**Accessibility** and **Screen Recording** are granted. It then verifies the
+isolated OCR worker, leaves the daemon running, polls `GET /health`, and forces
+one fresh capture. OCR supplies text for AX-poor apps such as WeChat and Feishu;
+pixels never enter an LLM prompt. Persome does not require Full Disk Access.
 
 ```bash
 # Recheck or repair OCR onboarding; disable is always explicit and reversible.
+persome onboard
 persome ocr setup
 persome ocr status --check
 persome ocr disable

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -77,10 +77,12 @@ After installing the Swift helpers and granting Accessibility permission:
 
 ```bash
 bash install.sh
+persome onboard
 persome llm status --check
 persome ocr status --check
 persome doctor
-persome start
+persome status
+persome capture-once
 
 # Work normally while the daemon performs incremental modeling.
 persome model status
@@ -125,8 +127,12 @@ PERSOME_ROOT=/tmp/persome-wheel-root \
   /tmp/persome-wheel-venv/bin/persome llm providers
 ```
 
-`install.sh` runs `persome ocr setup`, which requests Screen Recording and
-performs a full bundled worker initialization on Apple Silicon.
+In an interactive macOS session, `install.sh` runs `persome onboard`. The
+onboarding command separately requests Accessibility and Screen Recording,
+performs a full bundled OCR worker initialization on Apple Silicon, starts the
+daemon, polls the canonical local health endpoint, and requires a fresh capture
+record before it succeeds. Non-interactive packaging environments must run the
+command later from a logged-in macOS session.
 `persome ocr-selftest <image>` remains available for a known-image inference
 check.
 

--- a/docs/capture.md
+++ b/docs/capture.md
@@ -4,8 +4,10 @@ Capture is the only layer that touches the outside world. It produces one JSON f
 
 Live capture requires macOS Accessibility permission for the process that runs
 Persome. Screen Recording is additionally required when screenshots or OCR are
-enabled. `install.sh` enables and verifies bundled OCR on supported Apple
-Silicon Macs, then requests Screen Recording from the same Runtime identity.
+enabled. In an interactive install, `persome onboard` explains and requests
+Accessibility and Screen Recording separately, verifies bundled OCR on
+supported Apple Silicon Macs, starts the daemon, checks local health, and proves
+one fresh capture before returning success.
 
 ## Two signal sources
 
@@ -29,9 +31,11 @@ The same capture scheduler also invokes `SessionManager.on_event` (wired as a `p
 
 ## Local OCR fallback
 
-The installer runs `persome ocr setup`, which checks the native Runtime and
-bundled weights, requests Screen Recording, starts the isolated worker, and
-writes `enable_ocr_fallback = true` only after the worker initializes. The
+The installer runs `persome onboard`, whose OCR step checks the native Runtime
+and bundled weights, requests Screen Recording after an explicit explanation,
+starts the isolated worker, and writes `enable_ocr_fallback = true` only after
+the worker initializes. The standalone `persome ocr setup` repair command keeps
+the same worker and persistence checks. The
 focused screenshot is used locally and is never placed in an LLM prompt. The
 OCR path is:
 
@@ -50,6 +54,7 @@ loaded at all. `PERSOME_OCR_IN_PROCESS=1` exists only for debugging and removes
 that isolation.
 
 ```bash
+persome onboard            # permissions + OCR + daemon + health + fresh capture
 persome ocr setup          # enable, request permission, verify worker
 persome ocr status         # quick config/runtime/model/TCC state
 persome ocr status --check # also start and verify the worker engine

--- a/docs/config.md
+++ b/docs/config.md
@@ -131,7 +131,9 @@ cmux_source_enabled = true
   no OS watcher. The producer must obtain `PERSOME_LOCAL_API_TOKEN` through an
   owner-approved local secret channel and must never put it in a URL.
 - Accessibility permission is required for daemon AX capture. `install.sh`
-  requests Screen Recording and enables OCR after its worker initializes.
+  runs `persome onboard` in interactive sessions: it asks for Accessibility and
+  Screen Recording separately, enables OCR after its worker initializes, starts
+  the daemon, and proves local health plus one fresh capture.
 - Paddle inference runs in a local worker subprocess so a native crash does not
   kill the daemon. OCR text is backfilled into capture search and consumed by
   timeline/modeling; pixels are not sent to an LLM stage. The source-level

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -28,9 +28,11 @@ Grant permissions to the executable that launches Persome. If a terminal starts
 the daemon, grant that terminal. If launchd later owns the daemon, rerun
 `persome doctor` after the handoff and confirm live capture.
 
-`install.sh` requests Screen Recording during OCR onboarding. Verify the whole
-local path with `persome ocr status --check`; use `persome ocr disable` for an
-explicit opt-out.
+Interactive `install.sh` runs `persome onboard`. It presents separate native
+dialogs for Accessibility and Screen Recording, waits for both live TCC probes,
+verifies the OCR worker, starts the daemon, polls local health, and writes one
+fresh capture. Rerun `persome onboard` after changing the launcher identity;
+use `persome ocr disable` for an explicit OCR opt-out.
 
 ## Local paths
 
@@ -58,6 +60,7 @@ upgrade, and gives its LaunchAgent umask `0077`.
 ## Lifecycle and first recall
 
 ```bash
+persome onboard
 persome llm status --check
 persome ocr status --check
 persome doctor

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -43,6 +43,7 @@ Read the console output. Common culprits:
 Most common cause: **Accessibility permission not granted** to the terminal you launched from.
 
 ```bash
+persome onboard
 persome capture-once
 cat ~/.persome/capture-buffer/*.json | jq '.ax_tree | length' | head
 ```
@@ -56,10 +57,11 @@ fallback for old installs or a changed TCC principal.
 
 Second most common cause: **`ax_depth` too shallow for Electron apps.** See [capture.md](capture.md#ax-depth-the-1-footgun).
 
-The installer normally enables local OCR and requests Screen Recording. Check
-the complete state first:
+The installer normally completes Accessibility, local OCR, daemon health, and a
+fresh capture through `persome onboard`. Rerun that end-to-end gate first:
 
 ```bash
+persome onboard
 persome ocr status --check
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,7 @@ INSTALL_BIN_DIR=""
 PYTHON_TARGET=""
 INSTALL_TRANSACTION_ACTIVE=0
 OLD_VENV_BACKUP=""
+ONBOARDING_COMPLETED=0
 
 rollback_uncommitted_install() {
   local status=$?
@@ -57,8 +58,8 @@ usage() {
 Usage: bash install.sh [options]
 
 Installs Persome into a dedicated virtualenv, compiles the macOS AX
-helpers, creates a `persome` shim, and optionally injects MCP config
-into detected clients.
+helpers, creates a `persome` shim, runs permission/runtime onboarding in an
+interactive session, and optionally injects MCP config into detected clients.
 
 Options:
   --python <version>       Python version to target when a managed runtime is needed
@@ -519,19 +520,25 @@ PY
   echo "you never need to enter or manage it manually."
 }
 
-configure_ocr() {
-  echo ""
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "  Local OCR Setup"
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo ""
-  echo "Persome enables bundled PP-OCRv6 for AX-poor apps such as WeChat and"
-  echo "Feishu. Recognition runs in an isolated local process with no API key,"
-  echo "upload, or network model download. macOS will request Screen Recording."
-  echo ""
-  if ! PERSOME_ROOT="${INSTALL_HOME}" "${INSTALL_BIN_DIR}/persome" ocr setup --tier tiny; then
-    warn "OCR is not ready; grant Screen Recording and rerun 'persome ocr setup'"
+run_onboarding() {
+  if [[ ! -t 0 ]]; then
+    log "non-interactive install: run 'persome onboard' from a logged-in macOS session"
+    return 0
   fi
+
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  Permission and Runtime Onboarding"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+  echo "Persome will explain and request Accessibility and Screen Recording in"
+  echo "separate macOS dialogs. It then verifies local OCR, starts the daemon,"
+  echo "checks the local health endpoint, and writes one fresh capture."
+  echo ""
+  if ! PERSOME_ROOT="${INSTALL_HOME}" "${INSTALL_BIN_DIR}/persome" onboard --tier tiny; then
+    die "onboarding is incomplete; rerun 'persome onboard' to finish permissions and runtime verification"
+  fi
+  ONBOARDING_COMPLETED=1
 }
 
 ensure_screenshot_key() {
@@ -596,18 +603,9 @@ Virtualenv   : ${VENV_DIR}
 CLI shim     : ${INSTALL_BIN_DIR}/persome
 
 Next steps:
-  1. Grant Accessibility so Persome can read focused AX text and structure:
-     System Settings -> Privacy & Security -> Accessibility
-     The installer requested Screen Recording for on-device OCR and encrypted
-     screenshot capture. If it is still denied, enable the terminal or Persome
-     runtime entry shown by macOS under:
-     System Settings -> Privacy & Security -> Screen Recording
-     Persome does not require Full Disk Access or Automation permission.
-  2. Start the daemon:
-     persome start
-  3. Check status:
+  1. Check status:
      persome status
-  4. Open the live personal-model viewer:
+  2. Open the live personal-model viewer:
      persome model open
 
 Event memory can appear during a session's five-minute flushes. Points and Lines
@@ -630,6 +628,25 @@ Change or verify the LLM provider:
   persome llm setup
   persome llm status --check
 EOF
+
+  if [[ ${ONBOARDING_COMPLETED} -eq 1 ]]; then
+    cat <<'EOF'
+
+Onboarding proof:
+  - Accessibility was granted for focused AX text and structure.
+  - Screen Recording and the isolated local OCR worker were verified.
+  - Persome was started, its local health endpoint passed, and a fresh capture
+    record was written. Persome does not require Full Disk Access or Automation.
+EOF
+  else
+    cat <<'EOF'
+
+Onboarding pending:
+  This non-interactive install could not request macOS permissions. From a
+  logged-in macOS session, run `persome onboard`; it will not report success
+  until Accessibility, local OCR, daemon health, and a fresh capture all pass.
+EOF
+  fi
 
   case ":${PATH}:" in
     *":${INSTALL_BIN_DIR}:"*)
@@ -658,7 +675,7 @@ main() {
   install_shim
   inject_detected_clients
   maybe_configure_llm
-  configure_ocr
+  run_onboarding
   print_summary
 }
 

--- a/resources/mac-ax-watcher.swift
+++ b/resources/mac-ax-watcher.swift
@@ -707,6 +707,13 @@ func observerCallback(
 // MARK: - Main
 
 func main() {
+    if CommandLine.arguments.contains("--request-accessibility") {
+        let trusted = AXIsProcessTrustedWithOptions(
+            [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
+        )
+        exit(trusted ? 0 : 2)
+    }
+
     // Check accessibility permission
     let trusted = AXIsProcessTrustedWithOptions(
         [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary

--- a/src/persome/capture/watcher.py
+++ b/src/persome/capture/watcher.py
@@ -69,6 +69,31 @@ def _resolve_watcher_path() -> Path | None:
     return None
 
 
+def request_accessibility_permission() -> bool:
+    """Ask macOS for the Accessibility grant used by the Runtime.
+
+    The long-running watcher is the native AX principal already shipped with
+    Persome.  Its one-shot request mode triggers the system prompt without
+    leaving a watcher process behind.  The caller still rechecks the grant:
+    macOS normally returns ``False`` until the user approves it in Settings.
+    """
+    watcher_path = _resolve_watcher_path()
+    if watcher_path is None:
+        return False
+    try:
+        result = subprocess.run(
+            [str(watcher_path), "--request-accessibility"],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=15,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.warning("Accessibility permission request failed: %s", exc)
+        return False
+    return result.returncode == 0
+
+
 class AXWatcherProcess:
     """Owns the mac-ax-watcher subprocess and a reader thread.
 

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -484,6 +484,35 @@ def doctor() -> None:
         raise typer.Exit(code=1)
 
 
+@app.command()
+def onboard(
+    tier: str = typer.Option("tiny", "--tier", help="OCR tier: tiny | small | medium."),
+    gui: bool = typer.Option(
+        True,
+        "--gui/--no-gui",
+        help="Use native macOS dialogs (falls back to terminal prompts).",
+    ),
+) -> None:
+    """Grant capture permissions, verify OCR, start Persome, and prove capture."""
+    from . import onboarding as onboarding_mod
+
+    _init()
+    env_file_mod.load_env_file(paths.env_file())
+    try:
+        proof = onboarding_mod.onboard(tier=tier, gui=gui)
+    except onboarding_mod.OnboardingCancelled as exc:
+        console.print(f"[yellow]Onboarding stopped: {exc}.[/yellow]")
+        raise typer.Exit(1) from exc
+    except onboarding_mod.OnboardingError as exc:
+        console.print(f"[red]Onboarding failed: {exc}.[/red]")
+        raise typer.Exit(1) from exc
+
+    console.print("[green]✓ Accessibility granted[/green]")
+    console.print("[green]✓ Local OCR and Screen Recording ready[/green]")
+    console.print(f"[green]✓ Persome running and healthy[/green] (pid {proof.pid})")
+    console.print(f"[green]✓ Fresh capture verified[/green] ({proof.capture_path})")
+
+
 def _ping_stages(cfg: config_mod.Config, stages: tuple[str, ...]) -> dict:
     """Probe each stage's configured model, deduping identical configs.
 
@@ -567,17 +596,9 @@ app.add_typer(ocr_app, name="ocr")
 
 
 def _open_screen_recording_settings() -> None:
-    if sys.platform != "darwin":
-        return
-    subprocess.run(
-        [
-            "open",
-            "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture",
-        ],
-        check=False,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
+    from .onboarding import open_screen_recording_settings
+
+    open_screen_recording_settings()
 
 
 @ocr_app.command("setup")

--- a/src/persome/onboarding.py
+++ b/src/persome/onboarding.py
@@ -1,0 +1,393 @@
+"""Interactive macOS permission onboarding and runtime proof.
+
+The installer delegates here so it cannot claim success after merely printing
+privacy instructions.  Each sensitive request gets a separate, plain-language
+native dialog.  Completion requires live Accessibility and Screen Recording
+grants, a working isolated OCR worker, a healthy daemon, and a fresh capture.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, Protocol
+
+from . import paths
+
+PermissionAction = Literal["cancel", "open_settings", "check_again"]
+
+_CONFIRM_SCRIPT = """
+on run argv
+    set dialogTitle to item 1 of argv
+    set dialogMessage to item 2 of argv
+    set actionLabel to item 3 of argv
+    try
+        set chosen to button returned of (display dialog dialogMessage with title dialogTitle buttons {"Cancel", actionLabel} default button actionLabel cancel button "Cancel" with icon note)
+        return chosen
+    on error number -128
+        return "Cancel"
+    end try
+end run
+"""
+
+_WAIT_SCRIPT = """
+on run argv
+    set dialogTitle to item 1 of argv
+    set dialogMessage to item 2 of argv
+    try
+        set chosen to button returned of (display dialog dialogMessage with title dialogTitle buttons {"Cancel", "Open Settings", "Check Again"} default button "Check Again" cancel button "Cancel" with icon caution)
+        return chosen
+    on error number -128
+        return "Cancel"
+    end try
+end run
+"""
+
+_INFO_SCRIPT = """
+on run argv
+    display dialog (item 2 of argv) with title (item 1 of argv) buttons {"Done"} default button "Done" with icon note
+    return "Done"
+end run
+"""
+
+
+class OnboardingError(RuntimeError):
+    """The required onboarding proof could not be completed."""
+
+
+class OnboardingCancelled(OnboardingError):
+    """The user explicitly cancelled a permission request."""
+
+
+class PermissionUI(Protocol):
+    def confirm(self, *, title: str, message: str, action: str) -> bool: ...
+
+    def wait_for_permission(self, *, title: str, message: str) -> PermissionAction: ...
+
+
+class OnboardingUI:
+    """Native macOS dialogs with a terminal fallback for remote shells."""
+
+    def __init__(self, *, gui: bool = True) -> None:
+        self.gui = gui and sys.platform == "darwin" and shutil.which("osascript") is not None
+
+    def _osascript(self, script: str, *args: str) -> str | None:
+        if not self.gui:
+            return None
+        try:
+            result = subprocess.run(
+                ["osascript", "-e", script, *args],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        except OSError:
+            return None
+        if result.returncode != 0:
+            return None
+        return result.stdout.strip()
+
+    @staticmethod
+    def _terminal_confirm(title: str, message: str, action: str) -> bool:
+        print(f"\n{title}\n{message}")
+        if not sys.stdin.isatty():
+            return False
+        reply = input(f"{action}? [Y/n] ").strip().lower()
+        return reply in {"", "y", "yes"}
+
+    def confirm(self, *, title: str, message: str, action: str) -> bool:
+        result = self._osascript(_CONFIRM_SCRIPT, title, message, action)
+        if result is not None:
+            return result == action
+        return self._terminal_confirm(title, message, action)
+
+    def wait_for_permission(self, *, title: str, message: str) -> PermissionAction:
+        result = self._osascript(_WAIT_SCRIPT, title, message)
+        if result == "Open Settings":
+            return "open_settings"
+        if result == "Check Again":
+            return "check_again"
+        if result is not None:
+            return "cancel"
+
+        print(f"\n{title}\n{message}")
+        if not sys.stdin.isatty():
+            return "cancel"
+        reply = input("[O]pen Settings, [C]heck Again, or [Q]uit? ").strip().lower()
+        if reply in {"o", "open"}:
+            return "open_settings"
+        if reply in {"", "c", "check"}:
+            return "check_again"
+        return "cancel"
+
+    def success(self, message: str) -> None:
+        if self._osascript(_INFO_SCRIPT, "Persome is ready", message) is None:
+            print(f"\nPersome is ready\n{message}")
+
+
+def _open_privacy_settings(pane: str) -> None:
+    if sys.platform != "darwin":
+        return
+    subprocess.run(
+        ["open", f"x-apple.systempreferences:com.apple.preference.security?{pane}"],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def open_accessibility_settings() -> None:
+    _open_privacy_settings("Privacy_Accessibility")
+
+
+def open_screen_recording_settings() -> None:
+    _open_privacy_settings("Privacy_ScreenCapture")
+
+
+def _ensure_permission(
+    *,
+    label: str,
+    check: Callable[[], bool],
+    request: Callable[[], bool],
+    open_settings: Callable[[], None],
+    ui: PermissionUI,
+    explanation: str,
+) -> bool:
+    """Request one permission and do not return until its live probe passes."""
+    if check():
+        return True
+    if not ui.confirm(
+        title=f"Persome needs {label}",
+        message=explanation,
+        action=f"Request {label}",
+    ):
+        raise OnboardingCancelled(f"{label} request was cancelled")
+
+    request()
+    while not check():
+        action = ui.wait_for_permission(
+            title=f"Finish {label} setup",
+            message=(
+                f"Enable the terminal or Persome entry under Privacy & Security -> {label}. "
+                "Return here and choose Check Again. Persome will not continue until macOS "
+                "reports that the permission is granted."
+            ),
+        )
+        if action == "cancel":
+            raise OnboardingCancelled(f"{label} was not granted")
+        if action == "open_settings":
+            open_settings()
+    return True
+
+
+def ensure_accessibility(ui: PermissionUI) -> None:
+    from .capture import ax_capture, watcher
+
+    _ensure_permission(
+        label="Accessibility",
+        check=ax_capture.ax_trusted,
+        request=watcher.request_accessibility_permission,
+        open_settings=open_accessibility_settings,
+        ui=ui,
+        explanation=(
+            "Persome uses macOS Accessibility to read the focused app's visible text and "
+            "structure. It does not use this permission to type, click, or control your Mac. "
+            "macOS will show its own permission request next."
+        ),
+    )
+
+
+def ensure_local_ocr(*, tier: str, ui: PermissionUI) -> bool:
+    """Grant Screen Recording, warm OCR, persist it, and return whether config changed."""
+    from .capture import ocr_health, ocr_local, screen_recording
+    from .config import load
+    from .ocr_setup import VALID_TIERS, save_ocr_config
+
+    if tier not in VALID_TIERS:
+        raise OnboardingError(f"unsupported OCR tier {tier!r}: choose {', '.join(VALID_TIERS)}")
+    if ocr_local.disabled_by_environment():
+        raise OnboardingError("OCR is disabled by PERSOME_DISABLE_OCR")
+    if not ocr_local.runtime_available():
+        raise OnboardingError("the local Paddle OCR runtime is unavailable on this architecture")
+    if not ocr_local.models_available(tier):
+        raise OnboardingError(f"bundled PP-OCRv6 {tier} model weights are missing")
+
+    _ensure_permission(
+        label="Screen Recording",
+        check=screen_recording.has_screen_recording,
+        request=screen_recording.request_screen_recording,
+        open_settings=open_screen_recording_settings,
+        ui=ui,
+        explanation=(
+            "Persome uses Screen Recording only to run bundled PP-OCRv6 on this Mac when an "
+            "app's Accessibility text is incomplete. Pixels are not sent to an LLM or uploaded. "
+            "macOS will show its own permission request next."
+        ),
+    )
+
+    if not ocr_local.warm(tier):
+        raise OnboardingError("the isolated local OCR worker could not initialize")
+
+    before = load().capture
+    changed = not before.enable_ocr_fallback or before.ocr_tier != tier
+    save_ocr_config(enabled=True, tier=tier, config_path=paths.config_file())
+    health = ocr_health.inspect(load().capture)
+    if not health.ready:
+        raise OnboardingError(f"local OCR verification failed: {health.state}: {health.detail}")
+    return changed
+
+
+@dataclass(frozen=True)
+class RuntimeProof:
+    pid: int
+    health: str
+    ocr: str
+    capture_path: Path
+
+
+def _running_daemon_pid() -> int | None:
+    try:
+        pid = int(paths.pid_file().read_text(encoding="utf-8").strip())
+    except (FileNotFoundError, OSError, ValueError):
+        return None
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return None
+    except PermissionError:
+        return pid
+    return pid
+
+
+def _cli_prefix() -> list[str]:
+    if getattr(sys, "frozen", False):
+        return [sys.executable]
+    return [sys.executable, "-m", "persome"]
+
+
+def _run_cli(*args: str, timeout: float = 180.0) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [*_cli_prefix(), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _health_payload(host: str, port: int) -> dict[str, str] | None:
+    try:
+        import httpx
+
+        response = httpx.get(f"http://{host}:{port}/health", timeout=2.0)
+        response.raise_for_status()
+        data = response.json().get("data")
+    except Exception:  # noqa: BLE001 - the bounded poll reports a useful final error
+        return None
+    if not isinstance(data, dict):
+        return None
+    return {str(key): str(value) for key, value in data.items()}
+
+
+def _latest_capture() -> Path | None:
+    directory = paths.capture_buffer_dir()
+    if not directory.exists():
+        return None
+    captures = [path for path in directory.iterdir() if path.suffix == ".json"]
+    return max(captures, key=lambda path: path.stat().st_mtime, default=None)
+
+
+def ensure_runtime(*, restart: bool, timeout: float = 45.0) -> RuntimeProof:
+    """Leave the daemon running and prove HTTP health plus one fresh capture."""
+    from .config import load
+
+    cfg = load()
+    pid = _running_daemon_pid()
+    if restart and pid is not None:
+        _run_cli("stop", "--timeout", "20", timeout=25)
+        deadline = time.monotonic() + 25
+        while _running_daemon_pid() is not None and time.monotonic() < deadline:
+            time.sleep(0.2)
+        pid = _running_daemon_pid()
+
+    if pid is None:
+        result = _run_cli("start", timeout=30)
+        if result.returncode != 0 and _running_daemon_pid() is None:
+            detail = result.stderr.strip() or result.stdout.strip() or "unknown start failure"
+            raise OnboardingError(f"Persome could not start: {detail}")
+
+    deadline = time.monotonic() + timeout
+    payload: dict[str, str] | None = None
+    while time.monotonic() < deadline:
+        pid = _running_daemon_pid()
+        payload = _health_payload(cfg.mcp.host, cfg.mcp.port)
+        if pid is not None and payload is not None:
+            break
+        time.sleep(0.25)
+    if pid is None or payload is None:
+        raise OnboardingError("the daemon did not become healthy before the timeout")
+    if payload.get("status") != "ok" or payload.get("ocr") != "ready":
+        raise OnboardingError(
+            f"the daemon is degraded (status={payload.get('status')}, ocr={payload.get('ocr')})"
+        )
+
+    started_at = time.time()
+    capture = _run_cli("capture-once", timeout=180)
+    if capture.returncode != 0:
+        detail = capture.stderr.strip() or capture.stdout.strip() or "capture failed"
+        raise OnboardingError(f"fresh capture verification failed: {detail}")
+    capture_path = _latest_capture()
+    if capture_path is None or capture_path.stat().st_mtime < started_at - 1:
+        raise OnboardingError("fresh capture verification did not create a capture record")
+
+    payload = _health_payload(cfg.mcp.host, cfg.mcp.port)
+    pid = _running_daemon_pid()
+    if pid is None or payload is None or payload.get("status") != "ok":
+        raise OnboardingError("the daemon lost health after the capture smoke test")
+
+    # Verify the record is readable JSON before treating it as onboarding proof.
+    try:
+        record = json.loads(capture_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise OnboardingError(f"fresh capture record is unreadable: {exc}") from exc
+    if not isinstance(record, dict):
+        raise OnboardingError("fresh capture record is not a JSON object")
+    meta = record.get("window_meta")
+    has_context = bool(
+        (isinstance(meta, dict) and (meta.get("app_name") or meta.get("title")))
+        or record.get("visible_text")
+        or record.get("focused_element")
+        or record.get("ax_tree")
+        or record.get("ocr_submitted")
+    )
+    if not record.get("timestamp") or not has_context:
+        raise OnboardingError("fresh capture record contains no usable screen context")
+
+    return RuntimeProof(
+        pid=pid,
+        health=payload["status"],
+        ocr=payload.get("ocr", "unknown"),
+        capture_path=capture_path,
+    )
+
+
+def onboard(*, tier: str = "tiny", gui: bool = True) -> RuntimeProof:
+    """Run the complete permission, OCR, daemon, and capture onboarding gate."""
+    if sys.platform != "darwin":
+        raise OnboardingError("live Persome onboarding requires macOS")
+    ui = OnboardingUI(gui=gui)
+    ensure_accessibility(ui)
+    ocr_changed = ensure_local_ocr(tier=tier, ui=ui)
+    proof = ensure_runtime(restart=ocr_changed)
+    ui.success(
+        "Accessibility and local OCR are ready. Persome is running, its local health endpoint "
+        "is OK, and a fresh capture was written successfully."
+    )
+    return proof

--- a/tests/test_ocr_onboarding.py
+++ b/tests/test_ocr_onboarding.py
@@ -133,9 +133,9 @@ def test_disable_preserves_tier(ac_root: Path) -> None:
     assert capture.ocr_tier == "small"
 
 
-def test_install_runs_ocr_onboarding_without_an_opt_in_prompt() -> None:
+def test_install_routes_ocr_through_the_complete_onboarding_gate() -> None:
     script = (Path(__file__).resolve().parents[1] / "install.sh").read_text(encoding="utf-8")
 
-    assert "configure_ocr()" in script
-    assert 'persome" ocr setup --tier tiny' in script
-    assert "configure_ocr\n  print_summary" in script
+    assert "run_onboarding()" in script
+    assert 'persome" onboard --tier tiny' in script
+    assert "run_onboarding\n  print_summary" in script

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1,0 +1,196 @@
+"""Permission dialogs and the post-onboarding runtime proof."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from persome import config, onboarding, paths
+from persome.capture import ocr_health, ocr_local, screen_recording
+from persome.cli import app
+
+
+class ScriptedUI:
+    def __init__(
+        self,
+        *,
+        confirm: bool = True,
+        actions: list[onboarding.PermissionAction] | None = None,
+    ) -> None:
+        self.confirm_result = confirm
+        self.actions = list(actions or [])
+        self.confirmed: list[str] = []
+        self.success_messages: list[str] = []
+
+    def confirm(self, *, title: str, message: str, action: str) -> bool:
+        self.confirmed.append(action)
+        return self.confirm_result
+
+    def wait_for_permission(self, *, title: str, message: str) -> onboarding.PermissionAction:
+        return self.actions.pop(0)
+
+    def success(self, message: str) -> None:  # pragma: no cover - protocol completeness
+        self.success_messages.append(message)
+
+
+def test_permission_flow_explains_requests_and_waits_for_live_grant() -> None:
+    states = iter([False, False, False, True])
+    opened: list[bool] = []
+    requested: list[bool] = []
+    ui = ScriptedUI(actions=["open_settings", "check_again"])
+
+    onboarding._ensure_permission(
+        label="Accessibility",
+        check=lambda: next(states),
+        request=lambda: requested.append(True) or False,
+        open_settings=lambda: opened.append(True),
+        ui=ui,
+        explanation="Synthetic privacy explanation.",
+    )
+
+    assert ui.confirmed == ["Request Accessibility"]
+    assert requested == [True]
+    assert opened == [True]
+
+
+def test_permission_flow_cancellation_is_a_hard_stop() -> None:
+    ui = ScriptedUI(confirm=False)
+
+    with pytest.raises(onboarding.OnboardingCancelled):
+        onboarding._ensure_permission(
+            label="Screen Recording",
+            check=lambda: False,
+            request=lambda: False,
+            open_settings=lambda: None,
+            ui=ui,
+            explanation="Synthetic privacy explanation.",
+        )
+
+
+def test_local_ocr_is_saved_only_after_permission_and_worker_proof(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(ocr_local, "disabled_by_environment", lambda: False)
+    monkeypatch.setattr(ocr_local, "runtime_available", lambda: True)
+    monkeypatch.setattr(ocr_local, "models_available", lambda tier: tier == "tiny")
+    monkeypatch.setattr(ocr_local, "warm", lambda tier: tier == "tiny")
+    monkeypatch.setattr(screen_recording, "has_screen_recording", lambda: True)
+    monkeypatch.setattr(ocr_health.sys, "platform", "darwin")
+
+    changed = onboarding.ensure_local_ocr(tier="tiny", ui=ScriptedUI())
+
+    assert changed is True
+    assert config.load().capture.enable_ocr_fallback is True
+    assert config.load().capture.ocr_tier == "tiny"
+
+
+def test_runtime_proof_requires_health_and_fresh_readable_capture(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    capture_path = paths.capture_buffer_dir() / "fresh.json"
+    capture_path.parent.mkdir(parents=True, exist_ok=True)
+    capture_path.write_text(
+        '{"timestamp":"2026-07-12T00:00:00+00:00","window_meta":{"app_name":"Terminal"}}',
+        encoding="utf-8",
+    )
+    calls: list[tuple[str, ...]] = []
+
+    monkeypatch.setattr(onboarding, "_running_daemon_pid", lambda: 4242)
+    monkeypatch.setattr(
+        onboarding,
+        "_health_payload",
+        lambda host, port: {"status": "ok", "ocr": "ready"},
+    )
+    monkeypatch.setattr(onboarding, "_latest_capture", lambda: capture_path)
+
+    def fake_cli(*args: str, timeout: float = 180.0) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr(onboarding, "_run_cli", fake_cli)
+
+    proof = onboarding.ensure_runtime(restart=False)
+
+    assert proof.pid == 4242
+    assert proof.health == "ok"
+    assert proof.ocr == "ready"
+    assert proof.capture_path == capture_path
+    assert calls == [("capture-once",)]
+
+
+def test_runtime_proof_rejects_degraded_ocr(ac_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(onboarding, "_running_daemon_pid", lambda: 4242)
+    monkeypatch.setattr(
+        onboarding,
+        "_health_payload",
+        lambda host, port: {"status": "degraded", "ocr": "permission_required"},
+    )
+
+    with pytest.raises(onboarding.OnboardingError, match="degraded"):
+        onboarding.ensure_runtime(restart=False, timeout=0.01)
+
+
+def test_complete_onboarding_orders_permissions_before_runtime_proof(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ui = ScriptedUI()
+    calls: list[str] = []
+    capture_path = ac_root / "capture-buffer" / "fresh.json"
+    proof = onboarding.RuntimeProof(4242, "ok", "ready", capture_path)
+    monkeypatch.setattr(onboarding.sys, "platform", "darwin")
+    monkeypatch.setattr(onboarding, "OnboardingUI", lambda gui: ui)
+    monkeypatch.setattr(
+        onboarding,
+        "ensure_accessibility",
+        lambda active_ui: calls.append("accessibility"),
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "ensure_local_ocr",
+        lambda tier, ui: calls.append("ocr") or True,
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "ensure_runtime",
+        lambda restart: calls.append(f"runtime:{restart}") or proof,
+    )
+
+    assert onboarding.onboard() == proof
+    assert calls == ["accessibility", "ocr", "runtime:True"]
+    assert ui.success_messages
+
+
+def test_cli_onboard_reports_each_completed_gate(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    capture_path = ac_root / "capture-buffer" / "fresh.json"
+    monkeypatch.setattr(
+        onboarding,
+        "onboard",
+        lambda tier, gui: onboarding.RuntimeProof(
+            pid=4242,
+            health="ok",
+            ocr="ready",
+            capture_path=capture_path,
+        ),
+    )
+
+    result = CliRunner().invoke(app, ["onboard"])
+
+    assert result.exit_code == 0, result.output
+    assert "Accessibility granted" in result.output
+    assert "Local OCR and Screen Recording ready" in result.output
+    assert "Persome running and healthy" in result.output
+    assert "Fresh capture verified" in result.output
+
+
+def test_installer_runs_strict_onboarding_gate() -> None:
+    script = (Path(__file__).resolve().parents[1] / "install.sh").read_text(encoding="utf-8")
+
+    assert "run_onboarding()" in script
+    assert 'persome" onboard --tier tiny' in script
+    assert "run_onboarding\n  print_summary" in script
+    assert 'die "onboarding is incomplete' in script

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import json
 import logging
 import os
+import subprocess
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -207,3 +209,22 @@ def test_resolve_watcher_path_darwin_smoke() -> None:
     """On real macOS, resolution returns a Path or None without raising."""
     result = watcher._resolve_watcher_path()
     assert result is None or hasattr(result, "is_file")
+
+
+def test_request_accessibility_uses_one_shot_native_watcher(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    binary = tmp_path / "mac-ax-watcher"
+    binary.write_text("", encoding="utf-8")
+    binary.chmod(0o755)
+    seen: list[list[str]] = []
+    monkeypatch.setattr(watcher, "_resolve_watcher_path", lambda: binary)
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        seen.append(command)
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(watcher.subprocess, "run", fake_run)
+
+    assert watcher.request_accessibility_permission() is True
+    assert seen == [[str(binary), "--request-accessibility"]]


### PR DESCRIPTION
## What changed

- add `persome onboard` as a strict macOS onboarding gate
- show separate native dialogs before Accessibility and Screen Recording requests
- wait for both live permission probes, then warm and verify the isolated OCR worker
- start or restart Persome, poll the canonical local health endpoint, force a fresh capture, and validate the capture record
- route interactive `install.sh` through the complete gate and report an honest pending state for non-interactive installs
- document the repeatable onboarding and recovery flow

## Why

The previous installer could finish after printing Accessibility instructions and warning about denied OCR. It also did not prove that the daemon was running or that capture worked. A first-time user could therefore reach a success summary with permissions or runtime still incomplete.

## User impact

Interactive macOS installs now explain each privacy request separately and do not report onboarding success until Accessibility, local OCR/Screen Recording, daemon health, and one real capture are all verified. `persome onboard` can be rerun after a launcher or permission change.

## Validation

- `PERSOME_LLM_MOCK=1 uv run pytest -m "not macos and not integration"` — 1524 passed, 15 deselected
- focused onboarding/doctor/status/watcher suite — 84 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- OpenAPI and DB schema drift tests
- secret, PII, language, and documentation-link scans
- `bash -n install.sh`
- Apple Silicon Swift compilation of `mac-ax-watcher.swift`
- wheel build/content smoke and packaged CLI command check
