### PR TITLE
Polish after the Chat removal

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -45,7 +45,7 @@ use `persome ocr disable` for an explicit OCR opt-out.
 | `capture-buffer/` | AX text and optional encrypted screenshot payloads |
 | `memory/` | readable Markdown memory |
 | `index.db` | FTS, canonical evomem nodes, relations, sessions, and geometry |
-| `chat-history/`, `skills/` | legacy Chat-era data from older releases; purged by `persome clean all` |
+| `chat-history/`, `skills/` | legacy Chat-era data from older releases; purged by `persome clean all` (stale Chat-era `logs/chat.log*` files are removed at startup) |
 | `exports/` | redacted model exports by default; mode `0600` |
 | `backup/` | SQLite safety snapshots containing personal model state |
 | `logs/` | daemon and launchd logs; may contain operational context |

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -2872,6 +2872,7 @@ def clean_all(
         f"  - {tlb_count} timeline block(s)\n"
         f"  - {memory_count} memory file(s) and {entry_count} index entries\n"
         "  - canonical model, exports, backups, and logs\n"
+        "  - legacy Chat-era chat-history/ and skills/ trees (if present)\n"
         "[bold]Config, env, and the installed venv are kept.[/bold]"
     )
     if not _confirm("Proceed with full wipe?", yes):

--- a/src/persome/logger.py
+++ b/src/persome/logger.py
@@ -12,6 +12,7 @@ eye during development. Console output is always human-readable.
 
 from __future__ import annotations
 
+import contextlib
 import datetime as _dt
 import json
 import logging
@@ -118,11 +119,22 @@ def _sink(
     return logger
 
 
+def _remove_stale_chat_logs() -> None:
+    """Drop ``chat.log*`` left behind by the removed Chat feature's sink.
+
+    No sink writes there anymore, so rotation would never reclaim these files;
+    they are personal data and must not linger on upgraded installs."""
+    for stale in paths.logs_dir().glob("chat.log*"):
+        with contextlib.suppress(OSError):
+            stale.unlink()
+
+
 def setup(*, console: bool = True, verbose: bool = False) -> None:
     global _INITIALIZED
     if _INITIALIZED:
         return
     paths.ensure_dirs()
+    _remove_stale_chat_logs()
 
     level = logging.DEBUG if verbose else logging.INFO
     # File sinks emit JSON by default; DEBUG=1 or --verbose makes them readable.

--- a/src/persome/paths.py
+++ b/src/persome/paths.py
@@ -318,7 +318,7 @@ def _migrate_existing_permissions() -> None:
                             f"permission migration refuses hard-linked data file: {item}"
                         )
                     # Restore owner read/write and preserve only the owner's
-                    # execute bit (custom skill tools may be executable).
+                    # execute bit (legacy Chat-era skill tools may be executable).
                     item.chmod(_PRIVATE_FILE_MODE | (metadata.st_mode & 0o100))
 
     # Root-level databases, state, locks, config and quarantine copies are also

--- a/tests/test_api_middleware_asgi.py
+++ b/tests/test_api_middleware_asgi.py
@@ -5,14 +5,15 @@ breaks long-lived streaming responses: a client disconnect
 surfaces as ``RuntimeError("No response returned")`` and uvicorn logs a spurious HTTP
 500. These tests pin the transport behavior without depending on a product event route.
 These tests pin the fix: (1) the API app carries no ``BaseHTTPMiddleware``, and (2) a
-streaming response passes cleanly *through* the three pure-ASGI middleware. The
-middleware's actual behaviour (trace id, access log, origin/host guard) stays covered
-by ``test_trace_middleware.py`` and ``test_api_origin_guard.py``.
+streaming response passes cleanly *through* the three pure-ASGI middleware. Trace-id
+and origin/host-guard behaviour stays covered by ``test_trace_middleware.py`` and
+``test_api_origin_guard.py``; the access-log 4xx WARNING trail is covered here.
 """
 
 from __future__ import annotations
 
 import json
+import logging
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -68,3 +69,43 @@ def test_sse_streams_through_all_three_middleware() -> None:
     body = resp.text
     assert '{"n": 1}' in body
     assert '{"n": 2}' in body
+
+
+def test_access_log_middleware_warns_on_4xx_and_skips_2xx() -> None:
+    """The surviving access trail: 4xx/5xx log a WARNING on ``persome.api.access``;
+    2xx/3xx responses are skipped entirely (eg. /health polling noise)."""
+    records: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    # Attach directly to the named logger: daemon logging init sets
+    # propagate=False on sink-backed loggers, so root-level capture is not
+    # reliable across test ordering.
+    access_logger = logging.getLogger("persome.api.access")
+    handler = _Capture()
+    access_logger.addHandler(handler)
+    previous_level = access_logger.level
+    access_logger.setLevel(logging.INFO)
+    try:
+        app = FastAPI()
+        app.add_middleware(_AccessLogMiddleware)
+
+        @app.get("/ok")
+        async def _ok() -> dict[str, bool]:
+            return {"ok": True}
+
+        client = TestClient(app, headers={"host": "127.0.0.1"})
+        assert client.get("/ok").status_code == 200
+        assert client.get("/missing").status_code == 404
+    finally:
+        access_logger.removeHandler(handler)
+        access_logger.setLevel(previous_level)
+
+    messages = [(r.levelno, r.getMessage()) for r in records]
+    assert any(
+        level == logging.WARNING and "/missing" in message and "404" in message
+        for level, message in messages
+    ), messages
+    assert not any("/ok" in message for _, message in messages), messages

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -169,3 +169,23 @@ def test_log_handler_rejects_symlink_without_touching_victim(ac_root: Path) -> N
 
     assert victim.read_text(encoding="utf-8") == "ORIGINAL\n"
     assert stat.S_IMODE(victim.stat().st_mode) == 0o644
+
+
+def test_setup_time_cleanup_removes_stale_chat_logs(ac_root: Path) -> None:
+    """chat.log* from a Chat-era install has no sink anymore — setup() must
+    sweep it while leaving live sinks' files alone."""
+    from persome import paths
+
+    # Fresh module state so setup() actually runs (same pattern as above).
+    logger_mod._INITIALIZED = False
+    logging.getLogger().handlers.clear()
+
+    (paths.logs_dir() / "chat.log").write_text("stale", encoding="utf-8")
+    (paths.logs_dir() / "chat.log.2").write_text("stale rotation", encoding="utf-8")
+    (paths.logs_dir() / "api.log").write_text("live", encoding="utf-8")
+
+    logger_mod.setup(console=False)
+
+    assert not (paths.logs_dir() / "chat.log").exists()
+    assert not (paths.logs_dir() / "chat.log.2").exists()
+    assert (paths.logs_dir() / "api.log").read_text(encoding="utf-8") == "live"

--- a/tests/test_openai_protocol_http.py
+++ b/tests/test_openai_protocol_http.py
@@ -30,10 +30,7 @@ class _Handler(BaseHTTPRequestHandler):
                 "body": body,
             }
         )
-        if body.get("stream"):
-            self._stream(body)
-        else:
-            self._json_completion(body)
+        self._json_completion(body)
 
     def _json_completion(self, body: dict[str, Any]) -> None:
         message: dict[str, Any] = {"role": "assistant", "content": "ok"}
@@ -68,45 +65,6 @@ class _Handler(BaseHTTPRequestHandler):
         raw = json.dumps(payload).encode()
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(raw)))
-        self.end_headers()
-        self.wfile.write(raw)
-
-    def _stream(self, body: dict[str, Any]) -> None:
-        has_tool_result = any(message.get("role") == "tool" for message in body["messages"])
-        if has_tool_result:
-            delta: dict[str, Any] = {"role": "assistant", "content": "tool result received"}
-            finish_reason = "stop"
-        else:
-            delta = {
-                "role": "assistant",
-                "tool_calls": [
-                    {
-                        "index": 0,
-                        "id": "call_1",
-                        "type": "function",
-                        "function": {"name": "lookup", "arguments": '{"query":"project"}'},
-                    }
-                ],
-            }
-            finish_reason = "tool_calls"
-        chunk = {
-            "id": "chatcmpl-stream",
-            "object": "chat.completion.chunk",
-            "created": int(time.time()),
-            "model": "test-model",
-            "choices": [
-                {
-                    "index": 0,
-                    "delta": delta,
-                    "finish_reason": finish_reason,
-                }
-            ],
-        }
-        raw = f"data: {json.dumps(chunk)}\n\ndata: [DONE]\n\n".encode()
-        self.send_response(200)
-        self.send_header("Content-Type", "text/event-stream")
-        self.send_header("Cache-Control", "no-cache")
         self.send_header("Content-Length", str(len(raw)))
         self.end_headers()
         self.wfile.write(raw)

--- a/tests/test_storage_security.py
+++ b/tests/test_storage_security.py
@@ -31,6 +31,28 @@ def test_ensure_dirs_repairs_private_directory_modes(ac_root: Path) -> None:
         assert _mode(directory) == 0o700
 
 
+def test_ensure_dirs_hardens_existing_legacy_chat_era_trees(ac_root: Path) -> None:
+    """Legacy chat-history/ and skills/ trees from Chat-era installs are never
+    created, but when present they must come out of ensure_dirs owner-only."""
+    legacy_trees = (ac_root / "chat-history", ac_root / "skills")
+    for tree in legacy_trees:
+        tree.mkdir()
+        (tree / "leftover.md").write_text("legacy")
+        tree.chmod(0o755)
+
+    paths.ensure_dirs()
+
+    for tree in legacy_trees:
+        assert _mode(tree) == 0o700
+
+
+def test_ensure_dirs_does_not_create_legacy_chat_era_trees(ac_root: Path) -> None:
+    paths.ensure_dirs()
+
+    assert not (ac_root / "chat-history").exists()
+    assert not (ac_root / "skills").exists()
+
+
 def test_permission_marker_symlink_cannot_overwrite_target(ac_root: Path) -> None:
     marker = ac_root / ".permissions-v1"
     marker.unlink()


### PR DESCRIPTION
## Summary

Follow-up to #24, addressing the five minor findings from its post-merge code review:

1. **`persome clean all` banner** now discloses the legacy Chat-era `chat-history/` and `skills/` purge it performs, matching the docs and the actual `known_personal_data` list.
2. **Dead test scaffolding removed**: the fake OpenAI provider's `_stream` branch in `tests/test_openai_protocol_http.py` was only exercised by the ChatAgent streaming test deleted in #24.
3. **Access-log coverage**: corrected the middleware test docstring's coverage claim and added a direct test that 4xx responses log a WARNING on `persome.api.access` while 2xx responses are skipped. The test attaches its handler to the named logger because sink loggers set `propagate=False`.
4. **Legacy-tree hardening pinned**: new tests assert `ensure_dirs()` repairs pre-existing legacy `chat-history/`/`skills/` trees to `0700` and never creates them; the stale "custom skill tools" comment in `paths.py` now says "legacy Chat-era skill tools".
5. **Stale `logs/chat.log*` cleanup**: `logger.setup()` now unlinks Chat-era log files at startup — no sink writes there anymore, so rotation would never reclaim that personal data on upgraded installs. Documented in `docs/operations.md` and tested through `setup()` itself so the wiring is pinned.

A second code review of this branch returned "Ready to merge: Yes" with three minor notes; two were applied (drive the log-sweep test through `setup()`, add the doc trace) and one was declined as out of proportion (a directory named `chat.log` would survive the sweep — `clean all` removes `logs/` wholesale).

## Verification

- `PERSOME_LLM_MOCK=1 uv run pytest -m "not macos and not integration"`: **1519 passed** (4 new tests)
- `ruff check` / `ruff format --check` / secret / PII / language scans: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)