### PR TITLE
Remove dead code: unused helpers, write-only fields, stale duplicate

### DIFF
--- a/src/persome/api/model_view.py
+++ b/src/persome/api/model_view.py
@@ -88,6 +88,3 @@ def render_memory_view(base_path: str = "/model/") -> str:
     if _MODEL_BASE_RE.fullmatch(base_path) is None:
         raise ValueError("invalid model viewer base path")
     return _MEMORY_VIEW_TEMPLATE.replace("__PERSOME_MODEL_BASE__", base_path)
-
-
-MEMORY_VIEW_HTML = render_memory_view()

--- a/src/persome/capture/ocr_subprocess.py
+++ b/src/persome/capture/ocr_subprocess.py
@@ -217,12 +217,3 @@ def _startup_timeout_from_env() -> float:
         return float(os.environ.get("PERSOME_OCR_WORKER_STARTUP_TIMEOUT", "120"))
     except ValueError:
         return 120.0
-
-
-def reset_client_for_tests(client: OCRWorkerClient | None) -> None:
-    """Swap the module singleton (tests only)."""
-    global _client
-    with _client_lock:
-        if _client is not None:
-            _client.shutdown()
-        _client = client

--- a/src/persome/capture/timestamps.py
+++ b/src/persome/capture/timestamps.py
@@ -83,17 +83,6 @@ def parse_capture_stem(stem: str) -> datetime | None:
     return parse_capture_timestamp(_stem_iso_value(match)) if match is not None else None
 
 
-def capture_stem_is_ambiguous_local_time(stem: str) -> bool:
-    """Whether a naive legacy ID falls in a local DST gap/repeated hour."""
-    match = _STEM_RE.fullmatch(stem)
-    if match is None:
-        return False
-    has_timezone = any(match.group(name) is not None for name in ("marker", "legacy_hour", "zulu"))
-    if has_timezone:
-        return False
-    return capture_timestamp_is_ambiguous_local_time(_stem_iso_value(match))
-
-
 def capture_timestamp_is_ambiguous_local_time(value: str) -> bool:
     """Whether a naive ISO value maps to two local offsets at a DST edge."""
     try:

--- a/src/persome/evomem/relation_extractor.py
+++ b/src/persome/evomem/relation_extractor.py
@@ -35,7 +35,6 @@ class ExtractionResult:
     deterministic_count: int = 0
     llm_count: int = 0
     reinforced: int = 0  # open edges whose evidence-count strength grew this run
-    skipped: int = 0
 
     @property
     def written_count(self) -> int:
@@ -69,7 +68,6 @@ class _Activity:
     identity: str
     label: str
     quote: str
-    status: str
     participants: list[str]  # canonical person identities (consolidated only)
     ts: str | None = None  # source-event time — the activity edge's valid_from
     source_kind: str = ""
@@ -215,7 +213,6 @@ def _load_terminal_activities(conn, people: _People) -> list[_Activity]:
                 identity=event.stable_id,
                 label="activity",
                 quote=event.summary,
-                status="completed",
                 participants=participants,
                 ts=event.occurred_at,
                 source_kind=event.source_kind,

--- a/src/persome/mcp/captures.py
+++ b/src/persome/mcp/captures.py
@@ -20,7 +20,6 @@ from .. import paths
 from ..capture import screenshot_crypto
 from ..capture.timestamps import (
     parse_capture_path_timestamp,
-    parse_capture_stem,
     parse_capture_timestamp,
 )
 from ..store import fts as fts_store
@@ -29,11 +28,6 @@ from ..store import fts as fts_store
 # return is tagged with this provenance — DATA the agent reads, never instructions
 # (spec 2026-06-25-agent-native-persome-design §7). One definition for all return sites.
 CAPTURE_PROVENANCE = "observed"
-
-
-def _parse_stem(stem: str) -> datetime | None:
-    """Invert ``scheduler._safe_filename``. Returns None on malformed input."""
-    return parse_capture_stem(stem)
 
 
 def _parse_at(text: str) -> datetime:

--- a/src/persome/store/files.py
+++ b/src/persome/store/files.py
@@ -177,7 +177,6 @@ class ParsedFile:
     entry_count: int
     needs_compact: bool
     entries: list[ParsedEntry] = field(default_factory=list)
-    raw_frontmatter: dict[str, Any] = field(default_factory=dict)
 
 
 def memory_path(name: str) -> Path:
@@ -256,7 +255,6 @@ def read_file(path: Path) -> ParsedFile:
         entry_count=int(fm.get("entry_count", len(entries)) or 0),
         needs_compact=bool(fm.get("needs_compact", False)),
         entries=entries,
-        raw_frontmatter=fm,
     )
 
 

--- a/src/persome/timeline/aggregator.py
+++ b/src/persome/timeline/aggregator.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 from .. import paths
 from ..capture.ax_models import ax_tree_to_markdown
-from ..capture.timestamps import parse_capture_path_timestamp, parse_capture_stem
+from ..capture.timestamps import parse_capture_path_timestamp
 from ..config import Config
 from ..logger import get
 from ..parsers import parser_for_capture
@@ -208,18 +208,6 @@ def _focus_structured_with_outcome(
     if fallback_bundle is not None:
         return "", fallback_bundle, "fallback", None
     return "", None, None, None
-
-
-def _capture_stem_in_window(stem: str, start: datetime, end: datetime) -> bool:
-    """Parse the filename stem back to a datetime and check window membership."""
-    ts = _stem_to_dt(stem)
-    if ts is None:
-        return False
-    return start <= ts < end
-
-
-def _stem_to_dt(stem: str) -> datetime | None:
-    return parse_capture_stem(stem)
 
 
 def captures_in_window(start: datetime, end: datetime) -> list[Path]:

--- a/src/persome/writer/contradiction_check.py
+++ b/src/persome/writer/contradiction_check.py
@@ -76,7 +76,6 @@ class ContradictionRunResult:
     candidates: int = 0
     judged: int = 0
     flagged: int = 0
-    skipped_seen: int = 0
 
 
 def _bigrams(text: str) -> set[str]:
@@ -187,7 +186,6 @@ def run_contradiction_check(
     if not cfg.evomem.contradiction_check_enabled:
         return result
     seen = contradictions_store.seen_pairs(conn)
-    result.skipped_seen = len(seen)
     pairs = find_candidate_pairs(conn, max_pairs=cfg.evomem.contradiction_max_pairs, skip=seen)
     result.candidates = len(pairs)
     if not pairs:

--- a/src/persome/writer/cross_domain_sweeper.py
+++ b/src/persome/writer/cross_domain_sweeper.py
@@ -44,7 +44,6 @@ _W_ACTIONS = 0.4
 _W_HOURS = 0.2
 
 _CENTRAL_MARKER = "central:"
-_SUMMARY_MARKER = "summary:"
 
 
 @dataclass

--- a/src/persome/writer/tools.py
+++ b/src/persome/writer/tools.py
@@ -369,16 +369,6 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
 
 TOOL_NAMES = {t["function"]["name"] for t in TOOL_SCHEMAS}
 
-# Re-exported for callers that need to know which tools are concurrency-safe
-# without importing from llm.py (avoid circular deps).
-CONCURRENCY_SAFE_TOOLS: frozenset[str] = frozenset(
-    {
-        "read_memory",
-        "search_memory",
-        "drill_chat_captures",
-    }
-)
-
 
 def _validate_tool_args(name: str, args: dict[str, Any]) -> dict[str, Any] | None:
     """Validate tool args with Pydantic. Returns error dict on failure, None if valid."""


### PR DESCRIPTION
Removes dead symbols with **zero references** anywhere in `src`, `tests`, `scripts`, `docs`, or configs. Each was verified with `vulture` + a whole-repo reference search and an independent adversarial re-check (dynamic dispatch, dataclass serialization, and committed-contract drift all considered).

### Removed
| Symbol | Why dead |
|---|---|
| `capture/timestamps.py::capture_stem_is_ambiguous_local_time` | Orphaned; live callers use the path-based variant. `parse_capture_stem` **kept** (covered by `test_capture_timestamp_compat`). |
| `timeline/aggregator.py::_capture_stem_in_window`, `_stem_to_dt` | Dead cluster — only caller of each was the other. |
| `mcp/captures.py::_parse_stem` (+ import) | Unused thin wrapper. |
| `capture/ocr_subprocess.py::reset_client_for_tests` | Intended test helper, but no test uses it (tests monkeypatch `get_client`). |
| `api/model_view.py::MEMORY_VIEW_HTML` | Eager constant; callers use `render_memory_view()` directly. |
| `store/files.py::ParsedFile.raw_frontmatter` | Write-only dataclass field, never read. |
| `writer/contradiction_check.py::ContradictionRunResult.skipped_seen` | Write-only stat, never consumed. |
| `evomem/relation_extractor.py::ExtractionResult.skipped`, `_Activity.status` | Write-only dataclass fields, never read. |
| `writer/cross_domain_sweeper.py::_SUMMARY_MARKER` | Unused constant (sibling `_CENTRAL_MARKER` is live). |
| `writer/tools.py::CONCURRENCY_SAFE_TOOLS` | Stale duplicate whose contents had diverged; the live copy in `writer/llm.py` is what everything imports. |

### Validation
- `PERSOME_LLM_MOCK=1 uv run pytest -m "not macos and not integration"` → **1515 passed**
- `ruff check` / `ruff format --check` clean
- `secret_scan` / `pii_scan` / `language_scan` clean

No behavior change — deletions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)