### PR TITLE
Recover all derived FTS indexes safely

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -60,11 +60,14 @@ upgrade, and gives its LaunchAgent umask `0077`.
 ## Startup recovery
 
 When the Runtime is stopped, startup validates `index.db` before opening it.
-If only the derived `captures_fts` search index is malformed, Persome rebuilds
-that index in place from the authoritative `captures` rows. Core database
-damage is still quarantined as `index.db.corrupt.<timestamp>` for inspection.
-The running daemon owns active SQLite writes, so `persome status`, MCP clients,
-and a second `persome start` do not repair or quarantine an open database.
+If only a derived search index is malformed, Persome rebuilds `captures_fts`
+from authoritative `captures` rows and `entries` from Markdown/evo_nodes. It
+also handles older SQLite builds that collapse both damaged FTS projections
+into a generic malformed-database error, while verifying every regular table
+before the narrow index reset. Core database damage is still quarantined as
+`index.db.corrupt.<timestamp>` for inspection. The running daemon owns active
+SQLite writes, so `persome status`, MCP clients, and a second `persome start`
+do not repair or quarantine an open database.
 
 ## Lifecycle and first recall
 

--- a/src/persome/integrity.py
+++ b/src/persome/integrity.py
@@ -259,16 +259,18 @@ def _try_rebuild_derived_fts(db_path: Path) -> bool | None:
         if not damaged_fts:
             return False
 
-        from .store import fts
-
         if requires_full_schema_reset or "entries" in damaged_fts:
             conn.close()
             conn = None
             _rebuild_derived_fts_via_schema_reset(db_path)
         elif "captures_fts" in damaged_fts:
-            conn.execute("BEGIN IMMEDIATE")
-            fts.rebuild_captures_fts(conn)
-            conn.commit()
+            # A normal DROP/CREATE can still leave older macOS SQLite builds
+            # unable to construct the replacement virtual table on the next
+            # connection. The narrow schema reset plus VACUUM removes those
+            # unreachable shadow pages before recreating the derived index.
+            conn.close()
+            conn = None
+            _rebuild_captures_fts_via_schema_reset(db_path)
         else:
             return False
         # Older macOS SQLite builds can retain the malformed virtual-table

--- a/src/persome/integrity.py
+++ b/src/persome/integrity.py
@@ -36,8 +36,12 @@ _log = get("persome.daemon")
 # Cap the integrity_check work so a huge DB can't blow the <500ms startup
 # budget. The first N problems are enough to decide "corrupt".
 _INTEGRITY_CHECK_LIMIT = 100
-_CAPTURES_FTS_INTEGRITY_ERROR = "malformed inverted index for FTS5 table main.captures_fts"
-_CAPTURES_FTS_VTABLE_ERROR = "vtable constructor failed: captures_fts"
+_DERIVED_FTS_INTEGRITY_ERRORS = {
+    "malformed inverted index for FTS5 table main.entries": "entries",
+    "malformed inverted index for FTS5 table main.captures_fts": "captures_fts",
+}
+_DERIVED_FTS_TABLES = frozenset(_DERIVED_FTS_INTEGRITY_ERRORS.values())
+_GENERIC_MALFORMED_DB_ERROR = "database disk image is malformed"
 
 
 @dataclass(frozen=True)
@@ -122,16 +126,54 @@ def _db_corruption_reason(db_path: Path) -> str | None:
             conn.close()
 
 
-def _is_captures_fts_only_damage(results: list[str]) -> bool:
-    """Return whether every integrity failure belongs to the derived capture FTS."""
-    return bool(results) and all(
-        result.strip() == _CAPTURES_FTS_INTEGRITY_ERROR for result in results
-    )
+def _derived_fts_damage(results: list[str]) -> set[str] | None:
+    """Return damaged derived FTS tables, or ``None`` for core DB damage."""
+    if not results:
+        return None
+    damaged: set[str] = set()
+    for result in results:
+        table = _DERIVED_FTS_INTEGRITY_ERRORS.get(result.strip())
+        if table is None:
+            return None
+        damaged.add(table)
+    return damaged
 
 
-def _is_captures_fts_vtable_failure(error: sqlite3.DatabaseError) -> bool:
-    """Return whether SQLite could not construct only the derived capture FTS."""
-    return _CAPTURES_FTS_VTABLE_ERROR in str(error)
+def _derived_fts_vtable_failure(error: sqlite3.DatabaseError) -> set[str]:
+    """Return derived FTS tables SQLite could not construct."""
+    message = str(error)
+    return {
+        table for table in _DERIVED_FTS_TABLES if f"vtable constructor failed: {table}" in message
+    }
+
+
+def _canonical_tables_are_readable(conn: sqlite3.Connection) -> bool:
+    """Check every non-FTS table before repairing a generic SQLite error."""
+    from .store import fts
+
+    rows = conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    for (name,) in rows:
+        if name == "sqlite_sequence" or name in fts.DERIVED_FTS_SCHEMA_OBJECTS:
+            continue
+        quoted = '"' + str(name).replace('"', '""') + '"'
+        conn.execute(f"SELECT count(*) FROM {quoted}").fetchone()  # noqa: S608
+    return True
+
+
+def _is_generic_derived_fts_failure(conn: sqlite3.Connection, error: sqlite3.DatabaseError) -> bool:
+    """Recognize the old SQLite error emitted when both FTS projections fail.
+
+    SQLite sometimes collapses multiple damaged FTS virtual tables into the
+    generic ``database disk image is malformed`` error. We accept that as a
+    derived-index repair candidate only after every regular table remains
+    readable; final ``integrity_check`` validation still decides success.
+    """
+    if _GENERIC_MALFORMED_DB_ERROR not in str(error).lower():
+        return False
+    try:
+        return _canonical_tables_are_readable(conn)
+    except sqlite3.DatabaseError:
+        return False
 
 
 def _rebuild_captures_fts_via_schema_reset(db_path: Path) -> None:
@@ -158,18 +200,39 @@ def _rebuild_captures_fts_via_schema_reset(db_path: Path) -> None:
         conn.close()
 
 
-def _try_rebuild_captures_fts(db_path: Path) -> bool | None:
-    """Repair a malformed derived capture FTS index without touching user data.
+def _rebuild_derived_fts_via_schema_reset(db_path: Path) -> None:
+    """Recreate both derived FTS projections from their canonical sources."""
+    from .store import fts
 
-    The raw ``captures`` table is authoritative; ``captures_fts`` is an
-    external-content FTS5 index that can be recreated from it. ``None`` means
-    the data is intact but the rebuild must be retried (for example, another
-    local reader owns the database); ``False`` means the failure was not
-    limited to this derived index.
+    conn = sqlite3.connect(db_path, timeout=5.0)
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        fts.reset_corrupt_derived_fts_schema(conn)
+        conn.commit()
+        # The old shadow pages are unreachable after the narrow schema reset.
+        # Vacuum before recreating either virtual table so integrity_check reads
+        # only canonical tables plus freshly built FTS segments.
+        conn.execute("VACUUM")
+    finally:
+        conn.close()
+
+    # fts.connect recreates the capture index and rebuilds entries from
+    # Markdown/evo_nodes when their FTS table is absent.
+    with fts.cursor(db_path):
+        pass
+
+
+def _try_rebuild_derived_fts(db_path: Path) -> bool | None:
+    """Repair malformed derived FTS indexes without touching user data.
+
+    ``captures_fts`` is derived from ``captures`` and ``entries`` from the
+    Markdown/evo_nodes projection. ``None`` means the data is intact but the
+    rebuild must be retried (for example, another local reader owns the
+    database); ``False`` means the failure was not limited to these indexes.
     """
     conn: sqlite3.Connection | None = None
-    captures_fts_only = False
-    requires_schema_reset = False
+    damaged_fts: set[str] | None = None
+    requires_full_schema_reset = False
     try:
         conn = sqlite3.connect(db_path, timeout=5.0)
         try:
@@ -180,28 +243,34 @@ def _try_rebuild_captures_fts(db_path: Path) -> bool | None:
                 ).fetchall()
             ]
         except sqlite3.DatabaseError as exc:
-            if not _is_captures_fts_vtable_failure(exc):
+            damaged_fts = _derived_fts_vtable_failure(exc)
+            if damaged_fts:
+                requires_full_schema_reset = "entries" in damaged_fts
+            elif _is_generic_derived_fts_failure(conn, exc):
+                # Both FTS tables can collapse to this generic error on older
+                # SQLite. The canonical-table preflight above bounds the reset
+                # to derived data; a fresh integrity_check validates it later.
+                damaged_fts = set(_DERIVED_FTS_TABLES)
+                requires_full_schema_reset = True
+            else:
                 raise
-            # Some bundled SQLite versions reject PRAGMA integrity_check before
-            # returning the equivalent malformed-index row. The table name in
-            # this error is still narrow enough to rebuild the derived index.
-            captures_fts_only = True
-            requires_schema_reset = True
         else:
-            captures_fts_only = _is_captures_fts_only_damage(results)
-        if not captures_fts_only:
+            damaged_fts = _derived_fts_damage(results)
+        if not damaged_fts:
             return False
 
         from .store import fts
 
-        if requires_schema_reset:
+        if requires_full_schema_reset or "entries" in damaged_fts:
             conn.close()
             conn = None
-            _rebuild_captures_fts_via_schema_reset(db_path)
-        else:
+            _rebuild_derived_fts_via_schema_reset(db_path)
+        elif "captures_fts" in damaged_fts:
             conn.execute("BEGIN IMMEDIATE")
             fts.rebuild_captures_fts(conn)
             conn.commit()
+        else:
+            return False
         # Older macOS SQLite builds can retain the malformed virtual-table
         # constructor in this connection after DROP/CREATE. Validate from a
         # fresh connection so that cache cannot turn a successful rebuild into
@@ -214,16 +283,16 @@ def _try_rebuild_captures_fts(db_path: Path) -> bool | None:
             for row in conn.execute(f"PRAGMA integrity_check({_INTEGRITY_CHECK_LIMIT})").fetchall()
         ]
         if repaired != ["ok"]:
-            return None if _is_captures_fts_only_damage(repaired) else False
+            return None if _derived_fts_damage(repaired) else False
         return True
     except (RuntimeError, sqlite3.DatabaseError) as exc:
         if conn is not None and conn.in_transaction:
             conn.rollback()
         _log.warning(
-            "integrity: derived captures FTS repair failed",
+            "integrity: derived FTS repair failed",
             extra={"path": str(db_path), "error": str(exc)},
         )
-        return None if captures_fts_only else False
+        return None if damaged_fts else False
     finally:
         if conn is not None:
             conn.close()
@@ -278,8 +347,8 @@ def check_and_recover() -> list[QuarantinedFile]:
 
     db_path = paths.index_db()
     config_path = paths.config_file()
-    rebuilt_captures_fts = False
-    deferred_captures_fts_repair = False
+    rebuilt_derived_fts = False
+    deferred_derived_fts_repair = False
 
     try:
         db_reason = _db_corruption_reason(db_path)
@@ -287,17 +356,17 @@ def check_and_recover() -> list[QuarantinedFile]:
         db_reason = None
         _log.warning("integrity: DB check errored, assuming healthy", extra={"error": str(e)})
     if db_reason is not None:
-        capture_fts_repair = _try_rebuild_captures_fts(db_path)
-        if capture_fts_repair is True:
-            rebuilt_captures_fts = True
+        derived_fts_repair = _try_rebuild_derived_fts(db_path)
+        if derived_fts_repair is True:
+            rebuilt_derived_fts = True
             _log.warning(
-                "integrity: rebuilt derived captures FTS index",
+                "integrity: rebuilt derived FTS indexes",
                 extra={"path": str(db_path), "reason": db_reason},
             )
-        elif capture_fts_repair is None:
-            deferred_captures_fts_repair = True
+        elif derived_fts_repair is None:
+            deferred_derived_fts_repair = True
             _log.warning(
-                "integrity: deferred derived captures FTS repair",
+                "integrity: deferred derived FTS repair",
                 extra={"path": str(db_path), "reason": db_reason},
             )
         else:
@@ -346,15 +415,15 @@ def check_and_recover() -> list[QuarantinedFile]:
         extra={
             "elapsed_ms": round(elapsed_ms, 1),
             "recovered": len(quarantined),
-            "derived_repaired": int(rebuilt_captures_fts),
-            "derived_repair_deferred": int(deferred_captures_fts_repair),
+            "derived_repaired": int(rebuilt_derived_fts),
+            "derived_repair_deferred": int(deferred_derived_fts_repair),
             "status": (
                 "recovered"
                 if quarantined
                 else "repaired_derived"
-                if rebuilt_captures_fts
+                if rebuilt_derived_fts
                 else "degraded_derived"
-                if deferred_captures_fts_repair
+                if deferred_derived_fts_repair
                 else "ok"
             ),
         },

--- a/src/persome/store/fts.py
+++ b/src/persome/store/fts.py
@@ -20,6 +20,14 @@ logger = get("persome.store")
 _MIN_SECURE_FTS_SQLITE = (3, 42, 0)
 _FTS_TABLES = ("entries", "captures_fts")
 _SECURE_FTS_MIGRATION_VERSION = 20260711
+_ENTRIES_FTS_OBJECTS = (
+    "entries",
+    "entries_data",
+    "entries_idx",
+    "entries_content",
+    "entries_docsize",
+    "entries_config",
+)
 _CAPTURES_FTS_OBJECTS = (
     "captures_fts",
     "captures_fts_data",
@@ -27,6 +35,19 @@ _CAPTURES_FTS_OBJECTS = (
     "captures_fts_docsize",
     "captures_fts_config",
 )
+# These indexes are projections. Their canonical sources are Markdown/evo_nodes
+# for entries and captures for screen-context search.
+DERIVED_FTS_SCHEMA_OBJECTS = _ENTRIES_FTS_OBJECTS + _CAPTURES_FTS_OBJECTS
+
+
+def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
+    return (
+        conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)
+        ).fetchone()
+        is not None
+    )
+
 
 _CAPTURES_FTS_STATEMENTS = tuple(
     dedent(statement).strip()
@@ -332,11 +353,14 @@ def connect(db_path: Path | None = None) -> sqlite3.Connection:
     # the daemon calls ``checkpoint()`` from the daily tick so the
     # ``.db-wal`` and ``.db-shm`` sidecars don't drift unbounded.
     conn.execute("PRAGMA wal_autocheckpoint=1000")
-    had_captures_fts = (
-        conn.execute(
-            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='captures_fts'"
-        ).fetchone()
-        is not None
+    had_entries_fts = _table_exists(conn, "entries")
+    had_captures_fts = _table_exists(conn, "captures_fts")
+    # A new DB has neither source table. An interrupted FTS reset keeps at
+    # least one of these canonical projections, which makes it safe to rebuild
+    # entries after SCHEMA recreates the virtual table.
+    has_entry_sources = _table_exists(conn, "evo_nodes") or (
+        _table_exists(conn, "files")
+        and conn.execute("SELECT 1 FROM files LIMIT 1").fetchone() is not None
     )
     conn.executescript(SCHEMA)
     # A schema-level FTS recovery may have removed only this derived table
@@ -378,6 +402,13 @@ def connect(db_path: Path | None = None) -> sqlite3.Connection:
     from . import vectors as vectors_mod
 
     vectors_mod.ensure_schema(conn)
+    if not had_entries_fts and has_entry_sources:
+        # An interrupted derived-index recovery can leave entries absent after
+        # its canonical evo_nodes/Markdown sources remain intact. Do not run
+        # this projection step on a brand-new DB before its authority is ready.
+        from . import entries as entries_mod
+
+        entries_mod.rebuild_index(conn)
     if within_data_root:
         paths.ensure_private_file(db_path)
         paths.ensure_private_file(db_path.with_name(f"{db_path.name}-wal"))
@@ -429,6 +460,30 @@ def reset_corrupt_captures_fts_schema(conn: sqlite3.Connection) -> None:
         conn.execute(
             f"DELETE FROM sqlite_master WHERE name IN ({placeholders})",  # noqa: S608
             _CAPTURES_FTS_OBJECTS,
+        )
+        conn.execute(f"PRAGMA schema_version={schema_version + 1}")
+    finally:
+        conn.execute("PRAGMA writable_schema=OFF")
+
+
+def reset_corrupt_derived_fts_schema(conn: sqlite3.Connection) -> None:
+    """Remove both unloadable FTS projections without touching canonical data.
+
+    ``entries`` is rebuilt from Markdown/evo_nodes and ``captures_fts`` from
+    ``captures``. This handles the older SQLite failure mode where damage in
+    more than one FTS table is surfaced only as a generic malformed-database
+    error, so ordinary ``DROP TABLE`` is unavailable.
+    """
+    conn.execute("SELECT 1 FROM captures LIMIT 1")
+    for trigger in ("captures_ai", "captures_ad", "captures_au"):
+        conn.execute(f"DROP TRIGGER IF EXISTS {trigger}")
+    schema_version = int(conn.execute("PRAGMA schema_version").fetchone()[0])
+    placeholders = ", ".join("?" for _ in DERIVED_FTS_SCHEMA_OBJECTS)
+    conn.execute("PRAGMA writable_schema=ON")
+    try:
+        conn.execute(
+            f"DELETE FROM sqlite_master WHERE name IN ({placeholders})",  # noqa: S608
+            DERIVED_FTS_SCHEMA_OBJECTS,
         )
         conn.execute(f"PRAGMA schema_version={schema_version + 1}")
     finally:

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -11,7 +11,7 @@ import pytest
 
 from persome import config as config_mod
 from persome import integrity, paths
-from persome.store import fts
+from persome.store import entries, fts
 
 
 def _make_healthy_db() -> Path:
@@ -165,6 +165,46 @@ def test_connect_rebuilds_missing_derived_captures_fts(ac_root: Path) -> None:
     assert [hit.id for hit in hits] == ["capture-missing-fts-test"]
 
 
+def test_schema_reset_rebuilds_all_derived_fts_from_canonical_sources(ac_root: Path) -> None:
+    _make_healthy_db()
+    with fts.cursor() as conn:
+        entries.create_file(
+            conn,
+            name="project-derived-fts.md",
+            description="Derived FTS recovery",
+            tags=[],
+        )
+        memory_id = entries.append_entry(
+            conn,
+            name="project-derived-fts.md",
+            content="durable entry index recovery",
+            tags=[],
+        )
+        fts.insert_capture(
+            conn,
+            id="capture-all-derived-fts-test",
+            timestamp="2026-07-12T00:00:00+00:00",
+            app_name="Test App",
+            bundle_id="com.persome.test",
+            window_title="All derived index recovery",
+            focused_role="AXTextArea",
+            focused_value="needle",
+            visible_text="capture index recovery survives",
+            url="https://example.test/all-derived",
+        )
+        conn.execute("DELETE FROM entries_data WHERE id > 1")
+        conn.execute("DELETE FROM captures_fts_data WHERE id > 1")
+
+    integrity._rebuild_derived_fts_via_schema_reset(paths.index_db())
+
+    with fts.cursor() as conn:
+        assert [row[0] for row in conn.execute("PRAGMA integrity_check")] == ["ok"]
+        entry_hits = fts.search(conn, query="durable")
+        capture_hits = fts.search_captures(conn, query="capture")
+    assert [hit.id for hit in entry_hits] == [memory_id]
+    assert [hit.id for hit in capture_hits] == ["capture-all-derived-fts-test"]
+
+
 def test_derived_captures_fts_repair_defers_instead_of_quarantining(
     ac_root: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -178,7 +218,7 @@ def test_derived_captures_fts_repair_defers_instead_of_quarantining(
     )
     monkeypatch.setattr(
         integrity,
-        "_try_rebuild_captures_fts",
+        "_try_rebuild_derived_fts",
         lambda _db_path: None,
     )
 
@@ -189,13 +229,33 @@ def test_derived_captures_fts_repair_defers_instead_of_quarantining(
     assert list(ac_root.glob("index.db.corrupt.*")) == []
 
 
-def test_captures_fts_vtable_constructor_error_is_rebuildable() -> None:
-    assert integrity._is_captures_fts_vtable_failure(
+def test_derived_fts_vtable_constructor_error_is_rebuildable() -> None:
+    assert integrity._derived_fts_vtable_failure(
         sqlite3.DatabaseError("vtable constructor failed: captures_fts")
-    )
-    assert not integrity._is_captures_fts_vtable_failure(
+    ) == {"captures_fts"}
+    assert integrity._derived_fts_vtable_failure(
         sqlite3.DatabaseError("vtable constructor failed: entries")
+    ) == {"entries"}
+    assert (
+        integrity._derived_fts_vtable_failure(
+            sqlite3.DatabaseError("vtable constructor failed: unrelated")
+        )
+        == set()
     )
+
+
+def test_generic_malformed_error_requires_readable_canonical_tables(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _make_healthy_db()
+    conn = sqlite3.connect(paths.index_db())
+    error = sqlite3.DatabaseError("database disk image is malformed")
+    try:
+        assert integrity._is_generic_derived_fts_failure(conn, error)
+        monkeypatch.setattr(integrity, "_canonical_tables_are_readable", lambda _conn: False)
+        assert not integrity._is_generic_derived_fts_failure(conn, error)
+    finally:
+        conn.close()
 
 
 def test_corrupt_config_is_quarantined_and_default_rebuilt(ac_root: Path) -> None:


### PR DESCRIPTION
## What changed
- Treat both entries and captures_fts as rebuildable projections during startup recovery.
- Recognize old SQLite generic malformed-database errors only after every canonical table can still be read.
- Rebuild both FTS indexes from Markdown/evo_nodes and captures, then validate from a fresh connection.

## Why
A damaged pair of FTS indexes could be misclassified as whole-database corruption and quarantine an otherwise intact personal model.

## Validation
- PERSOME_LLM_MOCK=1 uv run pytest -m not macos and not integration (1536 passed)
- uv run ruff check .
- uv run ruff format --check .
- uv run python scripts/pii_scan.py
- uv run python scripts/language_scan.py
- Real preserved database copy repaired to integrity-check OK and a ready 4763-point model.