### PR TITLE
docs: point site links to the current repo name

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,4 +3,4 @@ description: Local-first Personal Model Runtime for macOS
 theme: jekyll-theme-minimal
 show_downloads: true
 github:
-  repository_url: https://github.com/Persome-ai/persome-core
+  repository_url: https://github.com/Intuition-Lab/personal-model

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,14 +15,14 @@ clients.
 The image is a real Runtime screenshot generated from synthetic fixtures. Open
 the authenticated real-data viewer with `persome model open` after installation.
 
-**[Star Persome on GitHub](https://github.com/Persome-ai/persome-core)** to
+**[Star Persome on GitHub](https://github.com/Intuition-Lab/personal-model)** to
 follow releases and help prioritize the next MCP integrations.
 
 ## Try the synthetic model
 
 ```bash
-git clone https://github.com/Persome-ai/persome-core.git
-cd persome-core
+git clone https://github.com/Intuition-Lab/personal-model.git
+cd personal-model
 uv run python scripts/sample_demo.py
 ```
 
@@ -44,14 +44,14 @@ installers use stdio and do not copy that credential.
 
 ## Read next
 
-- [Product experience and Quick Start](https://github.com/Persome-ai/persome-core#readme)
+- [Product experience and Quick Start](https://github.com/Intuition-Lab/personal-model#readme)
 - [Architecture](architecture.md)
 - [LLM provider configuration](config.md#providers-and-stage-models)
 - [MCP clients](mcp-clients.md)
 - [Operations and data control](operations.md)
 - [Benchmark scope](benchmarks.md)
-- [Security and privacy](https://github.com/Persome-ai/persome-core/blob/main/SECURITY_PRIVACY.md)
-- [Releases](https://github.com/Persome-ai/persome-core/releases)
+- [Security and privacy](https://github.com/Intuition-Lab/personal-model/blob/main/SECURITY_PRIVACY.md)
+- [Releases](https://github.com/Intuition-Lab/personal-model/releases)
 
 Persome is the project and Runtime name. Personome is the research term for the
 learned personal model. Publication artifacts and research benchmarks are


### PR DESCRIPTION
Fixes the stale repository references on the Jekyll docs site after the `Persome-ai/persome-core` → `Intuition-Lab/personal-model` rename.

- `docs/_config.yml`: `repository_url` → `Intuition-Lab/personal-model`
- `docs/index.md`: star link, clone URL, Quick Start / Security / Releases links → current repo; `cd persome-core` → `cd personal-model`

**Also (repo setting, already applied):** the repo's *website* field was `https://personal-model-lab.github.io/personal-model/` — a **nonexistent org** that 404s. It now points at the live Pages URL `https://intuition-lab.github.io/personal-model/` (HTTP 200, built from `main` `/docs`).

Docs-only; no code changes. All updated links verified HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)