### PR TITLE
docs: update stale repo URLs to Intuition-Lab/personal-model

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Setup help and questions
-    url: https://github.com/Persome-ai/persome-core/discussions
+    url: https://github.com/Intuition-Lab/personal-model/discussions
     about: Ask questions and share integration patterns in Discussions.
   - name: Security vulnerability
-    url: https://github.com/Persome-ai/persome-core/security/advisories/new
+    url: https://github.com/Intuition-Lab/personal-model/security/advisories/new
     about: Report vulnerabilities privately. Never attach personal capture data.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,11 +4,11 @@ title: "Persome Runtime"
 type: software
 version: "0.2.2"
 license: Apache-2.0
-repository-code: "https://github.com/Persome-ai/persome-core"
-url: "https://github.com/Persome-ai/persome-core"
+repository-code: "https://github.com/Intuition-Lab/personal-model"
+url: "https://github.com/Intuition-Lab/personal-model"
 identifiers:
   - type: url
-    value: "https://github.com/Persome-ai/persome-core/releases/tag/v0.2.2"
+    value: "https://github.com/Intuition-Lab/personal-model/releases/tag/v0.2.2"
     description: "Persome Runtime v0.2.2 release"
 abstract: >-
   Local-first screen-context memory daemon for macOS. It captures Accessibility

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@ Requirements: macOS 13+ (for the full capture stack; the Python daemon and its
 offline tests also run on Linux), Python 3.11, [uv](https://docs.astral.sh/uv/).
 
 ```bash
-git clone https://github.com/Persome-ai/persome-core.git
-cd persome-core
+git clone https://github.com/Intuition-Lab/personal-model.git
+cd personal-model
 uv sync --all-extras
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 you already use, turns cross-app activity into an inspectable model of a real
 person, and serves that model to MCP agents.
 
-[![CI](https://github.com/Persome-ai/persome-core/actions/workflows/ci.yml/badge.svg)](https://github.com/Persome-ai/persome-core/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/github/v/release/Persome-ai/persome-core)](https://github.com/Persome-ai/persome-core/releases)
+[![CI](https://github.com/Intuition-Lab/personal-model/actions/workflows/ci.yml/badge.svg)](https://github.com/Intuition-Lab/personal-model/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/Intuition-Lab/personal-model)](https://github.com/Intuition-Lab/personal-model/releases)
 [![License: Apache-2.0](https://img.shields.io/badge/code-Apache--2.0-blue)](LICENSE)
 [![macOS 13+](https://img.shields.io/badge/macOS-13%2B-black)](#platform-support)
 [![MCP](https://img.shields.io/badge/interface-MCP-0b7285)](MCP.md)
 
-**[Star Persome on GitHub](https://github.com/Persome-ai/persome-core)** to
+**[Star Persome on GitHub](https://github.com/Intuition-Lab/personal-model)** to
 follow the Runtime and help prioritize the next MCP integrations.
 
 ![Persome local personal-model viewer rendering a dense synthetic Point, Line, Face, Volume, and Root graph](docs/assets/persome-model-hero.png)
@@ -42,8 +42,8 @@ your real `~/.persome` data. This path requires Git and
 [`uv`](https://docs.astral.sh/uv/getting-started/installation/):
 
 ```bash
-git clone https://github.com/Persome-ai/persome-core.git
-cd persome-core
+git clone https://github.com/Intuition-Lab/personal-model.git
+cd personal-model
 uv run python scripts/sample_demo.py
 ```
 
@@ -82,8 +82,8 @@ from the committed `uv.lock`, and the complete build-backend closure is
 hash-constrained rather than resolved afresh.
 
 ```bash
-git clone https://github.com/Persome-ai/persome-core.git
-cd persome-core
+git clone https://github.com/Intuition-Lab/personal-model.git
+cd personal-model
 bash install.sh
 
 persome doctor
@@ -398,9 +398,9 @@ The public roadmap is issue-driven:
 - Intel and future-macOS compatibility evidence;
 - a separate, reproducible personal-model benchmark suite.
 
-Browse [starter issues](https://github.com/Persome-ai/persome-core/issues) or
+Browse [starter issues](https://github.com/Intuition-Lab/personal-model/issues) or
 start a design question in
-[Discussions](https://github.com/Persome-ai/persome-core/discussions).
+[Discussions](https://github.com/Intuition-Lab/personal-model/discussions).
 
 ## Contributing and community
 
@@ -414,9 +414,9 @@ and workflow permissions default to read-only.
 ### Support Persome
 
 If an inspectable, user-owned personal model is useful to your agents,
-**[star Persome on GitHub](https://github.com/Persome-ai/persome-core)** and
+**[star Persome on GitHub](https://github.com/Intuition-Lab/personal-model)** and
 share the MCP client or workflow you want supported in
-[Discussions](https://github.com/Persome-ai/persome-core/discussions).
+[Discussions](https://github.com/Intuition-Lab/personal-model/discussions).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ Linux CI covers the offline Python pipeline only.
 ## Reporting a vulnerability
 
 Use GitHub's private vulnerability reporting:
-https://github.com/Persome-ai/persome-core/security/advisories/new.
+https://github.com/Intuition-Lab/personal-model/security/advisories/new.
 
 Do not include vulnerabilities or personal capture data in a public issue.
 Private vulnerability reporting is enabled for this repository.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -3,11 +3,11 @@
 Use the channel that matches the report:
 
 - **Bug or reproducible runtime problem:** open a
-  [bug report](https://github.com/Persome-ai/persome-core/issues/new?template=bug_report.yml).
+  [bug report](https://github.com/Intuition-Lab/personal-model/issues/new?template=bug_report.yml).
 - **Integration request:** open an
-  [integration request](https://github.com/Persome-ai/persome-core/issues/new?template=integration_request.yml).
+  [integration request](https://github.com/Intuition-Lab/personal-model/issues/new?template=integration_request.yml).
 - **Question, setup help, or idea:** start a
-  [GitHub Discussion](https://github.com/Persome-ai/persome-core/discussions).
+  [GitHub Discussion](https://github.com/Intuition-Lab/personal-model/discussions).
 - **Security vulnerability:** follow [SECURITY.md](SECURITY.md); never disclose
   personal captures or credentials in a public issue.
 

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -9,8 +9,8 @@ Requirements: Python 3.11+, SQLite 3.42+ with FTS5, `uv`, and macOS 13+ for live
 capture. The offline Runtime tests also run on Linux.
 
 ```bash
-git clone https://github.com/Persome-ai/persome-core.git
-cd persome-core
+git clone https://github.com/Intuition-Lab/personal-model.git
+cd personal-model
 uv sync --all-extras --locked
 ```
 
@@ -145,13 +145,13 @@ tag, and hosted runner:
 shasum -a 256 --check SHA256SUMS
 TAG=vX.Y.Z
 gh attestation verify persome_core-*.whl \
-  --repo Persome-ai/persome-core \
-  --signer-workflow Persome-ai/persome-core/.github/workflows/release.yml \
+  --repo Intuition-Lab/personal-model \
+  --signer-workflow Intuition-Lab/personal-model/.github/workflows/release.yml \
   --source-ref "refs/tags/${TAG}" \
   --deny-self-hosted-runners
 gh attestation verify persome_core-*.tar.gz \
-  --repo Persome-ai/persome-core \
-  --signer-workflow Persome-ai/persome-core/.github/workflows/release.yml \
+  --repo Intuition-Lab/personal-model \
+  --signer-workflow Intuition-Lab/personal-model/.github/workflows/release.yml \
   --source-ref "refs/tags/${TAG}" \
   --deny-self-hosted-runners
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,10 +56,10 @@ dependencies = [
 persome = "persome.cli:app"
 
 [project.urls]
-Homepage = "https://github.com/Persome-ai/persome-core"
-Repository = "https://github.com/Persome-ai/persome-core"
-Issues = "https://github.com/Persome-ai/persome-core/issues"
-Documentation = "https://github.com/Persome-ai/persome-core/tree/main/docs"
+Homepage = "https://github.com/Intuition-Lab/personal-model"
+Repository = "https://github.com/Intuition-Lab/personal-model"
+Issues = "https://github.com/Intuition-Lab/personal-model/issues"
+Documentation = "https://github.com/Intuition-Lab/personal-model/tree/main/docs"
 
 [build-system]
 requires = ["hatchling==1.31.0"]


### PR DESCRIPTION
Finishes the repo-rename cleanup (`Persome-ai/persome-core` → `Intuition-Lab/personal-model`) across the remaining files, and audits the whole repo for broken URLs.

### Renamed URL references
`README.md`, `CONTRIBUTING.md`, `SECURITY.md`, `SUPPORT.md`, `VALIDATION.md` (incl. the `gh attestation verify` `--repo`/`--signer-workflow` identity), `CITATION.cff`, `pyproject.toml` `[project.urls]`, and `.github/ISSUE_TEMPLATE/config.yml`. Clone-dir instructions fixed too (`cd persome-core` → `cd personal-model`).

### Intentionally kept
- **Package name** `persome-core` (pyproject `name`, `persome_core-*.whl` artifacts, `importlib.metadata.distribution("persome-core")`) — an identifier, not a URL.
- **`.github/releases/v0.2.2.md`** — historical release note; its old URL redirects.

### Broken-URL audit (whole repo, 180 unique URLs)
All updated project URLs verified **HTTP 200** (repo, issues, discussions, releases, `v0.2.2` tag, security advisories, bug-report template, docs tree, release badge). Remaining non-200s are **not** actionable:
- LLM provider **API base URLs** (`api.openai.com/v1`, etc.) — correct endpoints that 404 on a bare GET.
- **Test/placeholder** domains (`attacker.invalid`, `acme-dev/acme-mono`, `persome-web.vercel.app` — all in tests).
- Dead **reference citations inside vendored Three.js** (`resources/model_assets/three.module.js`) — third-party, not modified.

Text-only; no code changes. `ruff`, format, and secret/PII/language gates pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)