### PR TITLE
Add one-command Persome Runtime updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ persome llm status --check
 persome start
 persome status
 persome stop
+persome update
 persome mcp
 persome model build
 persome model status

--- a/README.md
+++ b/README.md
@@ -99,6 +99,24 @@ isolated OCR worker, leaves the daemon running, polls `GET /health`, and forces
 one fresh capture. OCR supplies text for AX-poor apps such as WeChat and Feishu;
 pixels never enter an LLM prompt. Persome does not require Full Disk Access.
 
+### Update an existing installation
+
+Run the updater from any directory; no Git checkout is required:
+
+```bash
+persome update
+```
+
+The command downloads a fresh shallow checkout of the official `main` branch,
+stops the old Runtime, runs the locked installer in update mode, preserves
+`~/.persome` configuration, credentials, and personal data, then repeats the
+permission/OCR/health/fresh-capture onboarding proof. It does not modify a
+developer checkout. To test or install an already-reviewed local tree instead:
+
+```bash
+persome update --source /path/to/personal-model
+```
+
 ```bash
 # Recheck or repair OCR onboarding; disable is always explicit and reversible.
 persome onboard

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -136,6 +136,17 @@ command later from a logged-in macOS session.
 `persome ocr-selftest <image>` remains available for a known-image inference
 check.
 
+The update orchestrator is covered without network access or mutation of the
+real data root:
+
+```bash
+uv run pytest tests/test_updater.py -q
+```
+
+These tests pin the official shallow-clone arguments, local-source validation,
+daemon/LaunchAgent stop and recovery behavior, `install.sh --update` handoff,
+and the public CLI result.
+
 For a GitHub Release produced by the current workflow (older releases are not
 retroactively attested), also download `SHA256SUMS`, verify it from the
 artifact directory, and constrain GitHub provenance to the release workflow,

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,10 @@ persome start
 persome model open
 ```
 
+Update an existing installation from any directory with `persome update`. The
+command preserves local configuration and personal data, then repeats the
+permission, OCR, health, and fresh-capture proof.
+
 Persome keeps data under `~/.persome`, uses local AX capture by default, offers
 optional on-device OCR, and serves streamable HTTP MCP at
 `http://127.0.0.1:8742/mcp` behind an owner-local bearer. Normal client

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -83,6 +83,23 @@ persome resume
 persome stop
 ```
 
+## Update the Runtime
+
+```bash
+persome update
+```
+
+The updater fetches a fresh shallow copy of the official `main` branch instead
+of editing a user's source checkout. It stops either the background daemon or
+the owner LaunchAgent, invokes the same locked wheel installer with existing
+LLM/MCP setup preserved, reruns onboarding and its fresh-capture proof, and
+restores prior LaunchAgent ownership. Configuration, secrets, capture history,
+memory, model state, and logs under `PERSOME_ROOT` are not replaced.
+
+`persome update --source /path/to/checkout` is the explicit developer/offline
+path. The supplied tree must have the complete Persome source layout; the
+updater never pulls or rewrites it.
+
 The default active-session flush is five minutes. Timeline closure and model
 processing add bounded local work, so the operational target for first useful
 recall is at most ten minutes after valid AX capture and provider availability.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -95,6 +95,8 @@ the owner LaunchAgent, invokes the same locked wheel installer with existing
 LLM/MCP setup preserved, reruns onboarding and its fresh-capture proof, and
 restores prior LaunchAgent ownership. Configuration, secrets, capture history,
 memory, model state, and logs under `PERSOME_ROOT` are not replaced.
+Update-mode installation keeps the previous virtualenv until onboarding passes;
+a failed proof stops the replacement daemon and restores the prior Runtime.
 
 `persome update --source /path/to/checkout` is the explicit developer/offline
 path. The supplied tree must have the complete Persome source layout; the

--- a/docs/runtime-internals.md
+++ b/docs/runtime-internals.md
@@ -31,6 +31,13 @@ persome status
 persome stop
 ```
 
+`persome update` fetches official `main` into a temporary checkout, stops the
+current lifecycle owner, invokes `install.sh --update`, and lets onboarding
+prove the replacement Runtime before completion. A prior LaunchAgent is
+restored with the new executable after installation. The updater pins both
+`PERSOME_ROOT` and the installer's `PERSOME_INSTALL_HOME` to the active data
+root so isolated/custom profiles cannot be redirected to `~/.persome`.
+
 `start` double-forks and writes `<PERSOME_ROOT>/.pid`. The HTTP/MCP server
 is restricted to loopback and defaults to `127.0.0.1:8742`; the same app serves `/model` and the
 REST routes. Except for canonical `GET /health`, the outer app requires the

--- a/docs/runtime-internals.md
+++ b/docs/runtime-internals.md
@@ -37,6 +37,9 @@ prove the replacement Runtime before completion. A prior LaunchAgent is
 restored with the new executable after installation. The updater pins both
 `PERSOME_ROOT` and the installer's `PERSOME_INSTALL_HOME` to the active data
 root so isolated/custom profiles cannot be redirected to `~/.persome`.
+Unlike a fresh install, update mode keeps the previous virtualenv backup through
+onboarding. Only a successful OCR/health/capture proof commits the replacement;
+the installer stops a failed replacement daemon before restoring the backup.
 
 `start` double-forks and writes `<PERSOME_ROOT>/.pid`. The HTTP/MCP server
 is restricted to loopback and defaults to `127.0.0.1:8742`; the same app serves `/model` and the

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -38,6 +38,24 @@ Read the console output. Common culprits:
   `config.toml`.
 - `mac-ax-helper` / `mac-ax-watcher` binary missing → run `bash install.sh`.
 
+## Update fails
+
+`persome update` downloads official `main` before stopping the current Runtime,
+so a network or Git failure leaves the daemon untouched. If installation fails
+after shutdown, the updater attempts to restart the surviving installation (or
+restore prior LaunchAgent ownership) and preserves `PERSOME_ROOT` data and
+secrets. Fix the reported installer or permission error, then rerun:
+
+```bash
+persome update
+```
+
+For a reviewed local checkout or an offline repair:
+
+```bash
+persome update --source /path/to/personal-model
+```
+
 ## Captures are empty / tree has no content
 
 Most common cause: **Accessibility permission not granted** to the terminal you launched from.

--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,7 @@ VENV_DIR="${INSTALL_HOME}/venv"
 PYTHON_SPEC="${PERSOME_PYTHON:-3.12}"
 BIN_DIR_OVERRIDE=""
 INJECT_MODE="prompt"  # prompt | all | none
+UPDATE_MODE=0
 
 UV_BIN=""
 PERSOME_BIN=""
@@ -67,6 +68,7 @@ Options:
   --bin-dir <path>         Directory to place the `persome` shim in
   --yes                    Auto-inject all detected MCP client configs
   --no-client-config       Skip MCP client config prompts entirely
+  --update                 Preserve existing setup and run the update verification path
   -h, --help               Show this help
 EOF
 }
@@ -115,6 +117,11 @@ parse_args() {
         shift
         ;;
       --no-client-config)
+        INJECT_MODE="none"
+        shift
+        ;;
+      --update)
+        UPDATE_MODE=1
         INJECT_MODE="none"
         shift
         ;;
@@ -489,6 +496,11 @@ PY
     fi
   fi
 
+  if [[ ${UPDATE_MODE} -eq 1 ]]; then
+    log "update mode: preserving the existing LLM profile and credentials"
+    return 0
+  fi
+
   if [[ ! -t 0 ]]; then
     log "non-interactive install: run 'persome llm setup' to configure a provider"
     return 0
@@ -522,6 +534,14 @@ PY
 
 run_onboarding() {
   if [[ ! -t 0 ]]; then
+    if [[ ${UPDATE_MODE} -eq 1 ]]; then
+      log "non-interactive update: verifying existing permissions and Runtime health"
+      if ! PERSOME_ROOT="${INSTALL_HOME}" "${INSTALL_BIN_DIR}/persome" onboard --tier tiny --no-gui; then
+        die "update installed, but non-interactive Runtime verification failed; rerun 'persome onboard'"
+      fi
+      ONBOARDING_COMPLETED=1
+      return 0
+    fi
     log "non-interactive install: run 'persome onboard' from a logged-in macOS session"
     return 0
   fi

--- a/install.sh
+++ b/install.sh
@@ -24,6 +24,21 @@ rollback_uncommitted_install() {
   trap - EXIT
   if [[ ${status} -ne 0 && ${INSTALL_TRANSACTION_ACTIVE} -eq 1 ]]; then
     warn "installation failed; restoring the previous virtualenv"
+    # Update-mode onboarding can start the replacement daemon before its final
+    # capture proof. Stop that process before replacing its on-disk virtualenv;
+    # the outer `persome update` command restarts the restored Runtime.
+    if [[ ${UPDATE_MODE} -eq 1 && -f "${INSTALL_HOME}/.pid" ]]; then
+      local update_pid=""
+      update_pid="$(tr -d '[:space:]' < "${INSTALL_HOME}/.pid" 2>/dev/null || true)"
+      if [[ "${update_pid}" =~ ^[0-9]+$ ]] && kill -0 "${update_pid}" 2>/dev/null; then
+        kill -TERM "${update_pid}" 2>/dev/null || true
+        local attempts=50
+        while (( attempts > 0 )) && kill -0 "${update_pid}" 2>/dev/null; do
+          sleep 0.1
+          attempts=$((attempts - 1))
+        done
+      fi
+    fi
     rm -rf "${VENV_DIR}"
     if [[ -n "${OLD_VENV_BACKUP}" && -d "${OLD_VENV_BACKUP}" ]]; then
       mv "${OLD_VENV_BACKUP}" "${VENV_DIR}"
@@ -691,11 +706,19 @@ main() {
   ensure_local_api_token
   compile_bundled_binaries
   verify_install
-  commit_install
+  # Fresh installs keep the established commit point. Updates remain
+  # transactional through onboarding so a failed health/capture proof can
+  # restore the previous venv.
+  if [[ ${UPDATE_MODE} -eq 0 ]]; then
+    commit_install
+  fi
   install_shim
   inject_detected_clients
   maybe_configure_llm
   run_onboarding
+  if [[ ${UPDATE_MODE} -eq 1 ]]; then
+    commit_install
+  fi
   print_summary
 }
 

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -23,6 +23,7 @@ import threading
 from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import Annotated
 from urllib.parse import parse_qs, urljoin, urlparse
 
 import typer
@@ -517,6 +518,47 @@ def onboard(
     console.print("[green]✓ Local OCR and Screen Recording ready[/green]")
     console.print(f"[green]✓ Persome running and healthy[/green] (pid {proof.pid})")
     console.print(f"[green]✓ Fresh capture verified[/green] ({proof.capture_path})")
+
+
+@app.command()
+def update(
+    source: Annotated[
+        Path | None,
+        typer.Option("--source", help="Use a local checkout instead of official main."),
+    ] = None,
+) -> None:
+    """Update the installed Persome Runtime and prove it is healthy."""
+    from . import updater
+
+    launchagent_was_loaded = False
+    runtime_may_have_changed = False
+    try:
+        with updater.acquire_source(source) as update_source:
+            label = "official main" if update_source.official else str(update_source.path)
+            console.print(
+                f"[bold]Updating Persome from {label}[/bold] "
+                f"([dim]{update_source.revision[:12]}[/dim])"
+            )
+            launchagent_was_loaded = updater.launchagent_is_loaded()
+            runtime_may_have_changed = True
+            updater.stop_runtime(launchagent_was_loaded=launchagent_was_loaded)
+            console.print("[green]✓ Previous Runtime stopped[/green]")
+            updater.run_installer(update_source)
+            updater.restore_launchagent(launchagent_was_loaded)
+    except updater.UpdateError as exc:
+        recovery = ""
+        if runtime_may_have_changed:
+            try:
+                updater.recover_runtime(launchagent_was_loaded)
+            except updater.UpdateError as recovery_exc:
+                recovery = f" Recovery also failed: {recovery_exc}"
+        console.print(f"[red]Update failed: {exc}.{recovery}[/red]")
+        raise typer.Exit(1) from exc
+
+    console.print(
+        "[green]✓ Persome update complete[/green] — configuration, credentials, and personal "
+        "data were preserved."
+    )
 
 
 def _ping_stages(cfg: config_mod.Config, stages: tuple[str, ...]) -> dict:

--- a/src/persome/updater.py
+++ b/src/persome/updater.py
@@ -1,0 +1,244 @@
+"""Self-update orchestration for the installed Persome Runtime.
+
+The public updater intentionally downloads a fresh, shallow checkout instead
+of mutating a user's development repository.  ``install.sh --update`` remains
+the single installation authority, so dependency locking, wheel construction,
+secret preservation, native-helper compilation, onboarding, and runtime proof
+stay identical to a manual update.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import shutil
+import signal
+import subprocess
+import tempfile
+import time
+import tomllib
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+from . import paths
+
+OFFICIAL_REPOSITORY = "https://github.com/Intuition-Lab/personal-model.git"
+DEFAULT_BRANCH = "main"
+
+
+class UpdateError(RuntimeError):
+    """The Runtime could not be updated safely."""
+
+
+@dataclass(frozen=True)
+class UpdateSource:
+    path: Path
+    revision: str
+    official: bool
+
+
+def _validate_source(path: Path) -> Path:
+    requested = path.expanduser()
+    if requested.is_symlink():
+        raise UpdateError(f"update source must not be a symlink: {requested}")
+    root = requested.resolve()
+    installer = root / "install.sh"
+    required_files = (
+        root / "pyproject.toml",
+        root / "uv.lock",
+        root / "build-constraints.txt",
+        installer,
+    )
+    package_dir = root / "src" / "persome"
+    if (
+        not root.is_dir()
+        or root.is_symlink()
+        or package_dir.is_symlink()
+        or not package_dir.is_dir()
+        or any(item.is_symlink() or not item.is_file() for item in required_files)
+    ):
+        raise UpdateError(f"not a complete Persome source checkout: {root}")
+    try:
+        with (root / "pyproject.toml").open("rb") as handle:
+            project_name = tomllib.load(handle).get("project", {}).get("name")
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise UpdateError(f"could not validate {root / 'pyproject.toml'}: {exc}") from exc
+    if project_name != "persome-core":
+        raise UpdateError(f"unexpected project name in update source: {project_name!r}")
+    return root
+
+
+def _revision(path: Path) -> str:
+    git = shutil.which("git")
+    if git is None:
+        return "local source"
+    result = subprocess.run(
+        [git, "-C", str(path), "rev-parse", "HEAD"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    revision = result.stdout.strip()
+    return revision if result.returncode == 0 and revision else "local source"
+
+
+@contextlib.contextmanager
+def acquire_source(source: Path | None = None) -> Iterator[UpdateSource]:
+    """Yield a validated local source or a fresh official ``main`` checkout."""
+    if source is not None:
+        root = _validate_source(source)
+        yield UpdateSource(root, _revision(root), False)
+        return
+
+    git = shutil.which("git")
+    if git is None:
+        raise UpdateError("git is required to download the latest Persome Runtime")
+    with tempfile.TemporaryDirectory(prefix="persome-update-") as temporary:
+        root = Path(temporary) / "personal-model"
+        env = os.environ.copy()
+        env["GIT_TERMINAL_PROMPT"] = "0"
+        result = subprocess.run(
+            [
+                git,
+                "clone",
+                "--depth",
+                "1",
+                "--single-branch",
+                "--branch",
+                DEFAULT_BRANCH,
+                OFFICIAL_REPOSITORY,
+                str(root),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=180,
+            env=env,
+        )
+        if result.returncode != 0:
+            detail = result.stderr.strip() or result.stdout.strip() or "git clone failed"
+            raise UpdateError(f"could not download official {DEFAULT_BRANCH}: {detail}")
+        validated = _validate_source(root)
+        revision = _revision(validated)
+        if revision == "local source":
+            raise UpdateError("downloaded update has no Git revision")
+        yield UpdateSource(validated, revision, True)
+
+
+def _running_daemon_pid() -> int | None:
+    try:
+        pid = int(paths.pid_file().read_text(encoding="utf-8").strip())
+    except (FileNotFoundError, OSError, ValueError):
+        return None
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return None
+    except PermissionError:
+        return pid
+    return pid
+
+
+def launchagent_is_loaded() -> bool:
+    """Whether launchd currently owns the Runtime lifecycle."""
+    from . import launchagent
+
+    return launchagent.is_loaded()
+
+
+def stop_runtime(*, launchagent_was_loaded: bool, timeout: float = 20.0) -> None:
+    """Stop launchd ownership and any current daemon before replacing code."""
+    from . import launchagent
+
+    if launchagent_was_loaded:
+        result = launchagent.bootout()
+        if result.returncode != 0:
+            detail = result.stderr.strip() or result.stdout.strip() or "launchctl bootout failed"
+            raise UpdateError(f"could not stop the Persome LaunchAgent: {detail}")
+
+    pid = _running_daemon_pid()
+    if pid is None:
+        return
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    except OSError as exc:
+        raise UpdateError(f"could not stop Persome daemon pid {pid}: {exc}") from exc
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if _running_daemon_pid() is None:
+            return
+        time.sleep(0.2)
+    raise UpdateError(f"Persome daemon pid {pid} did not stop within {timeout:.0f}s")
+
+
+def run_installer(source: UpdateSource) -> None:
+    """Install the validated source through the locked update-mode installer."""
+    env = os.environ.copy()
+    # ``PERSOME_ROOT`` is the Runtime's canonical path override, while the
+    # installer historically calls the same location ``PERSOME_INSTALL_HOME``.
+    # Pin both so a custom-root install can never be updated into ~/.persome by
+    # accident.
+    env["PERSOME_ROOT"] = str(paths.root())
+    env["PERSOME_INSTALL_HOME"] = str(paths.root())
+    result = subprocess.run(
+        ["/bin/bash", str(source.path / "install.sh"), "--update"],
+        cwd=source.path,
+        check=False,
+        env=env,
+    )
+    if result.returncode != 0:
+        raise UpdateError(
+            "the installer did not complete; the existing Persome data and secrets were preserved"
+        )
+
+
+def restore_launchagent(was_loaded: bool) -> None:
+    """Restore launchd ownership with the newly installed Runtime binary."""
+    if not was_loaded:
+        return
+    binary = paths.root() / "venv" / "bin" / "persome"
+    if not binary.is_file() or not os.access(binary, os.X_OK):
+        raise UpdateError(f"updated Persome executable is missing: {binary}")
+    result = subprocess.run(
+        [str(binary), "launchagent", "install", "--binary", str(binary)],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "launchagent install failed"
+        raise UpdateError(f"update succeeded but LaunchAgent restoration failed: {detail}")
+    deadline = time.monotonic() + 15
+    while time.monotonic() < deadline:
+        if launchagent_is_loaded() and _running_daemon_pid() is not None:
+            return
+        time.sleep(0.25)
+    raise UpdateError("updated LaunchAgent did not become loaded and running within 15s")
+
+
+def recover_runtime(launchagent_was_loaded: bool) -> None:
+    """Best-effort recovery when an update fails after the old daemon stopped."""
+    if _running_daemon_pid() is not None:
+        return
+    if launchagent_was_loaded:
+        restore_launchagent(True)
+        return
+    binary = paths.root() / "venv" / "bin" / "persome"
+    if not binary.is_file() or not os.access(binary, os.X_OK):
+        raise UpdateError(f"no runnable Persome executable remains at {binary}")
+    result = subprocess.run(
+        [str(binary), "start"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0 and _running_daemon_pid() is None:
+        detail = result.stderr.strip() or result.stdout.strip() or "runtime restart failed"
+        raise UpdateError(f"could not restart the previous Runtime: {detail}")

--- a/tests/test_local_api_auth.py
+++ b/tests/test_local_api_auth.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -138,7 +140,7 @@ def test_rest_requires_the_exact_bearer_token(monkeypatch: pytest.MonkeyPatch) -
 
 
 def test_browser_bootstrap_is_single_use_and_cookie_is_model_only(
-    monkeypatch: pytest.MonkeyPatch,
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv(LOCAL_API_TOKEN_ENV, _TOKEN)
     client = TestClient(build_api_app(), headers={"host": "127.0.0.1:8742"})

--- a/tests/test_ocr_onboarding.py
+++ b/tests/test_ocr_onboarding.py
@@ -138,4 +138,6 @@ def test_install_routes_ocr_through_the_complete_onboarding_gate() -> None:
 
     assert "run_onboarding()" in script
     assert 'persome" onboard --tier tiny' in script
-    assert "run_onboarding\n  print_summary" in script
+    assert script.index("run_onboarding\n") < script.index(
+        "print_summary\n", script.index("main()")
+    )

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -192,5 +192,7 @@ def test_installer_runs_strict_onboarding_gate() -> None:
 
     assert "run_onboarding()" in script
     assert 'persome" onboard --tier tiny' in script
-    assert "run_onboarding\n  print_summary" in script
+    assert script.index("run_onboarding\n") < script.index(
+        "print_summary\n", script.index("main()")
+    )
     assert 'die "onboarding is incomplete' in script

--- a/tests/test_supply_chain_security.py
+++ b/tests/test_supply_chain_security.py
@@ -25,7 +25,14 @@ def test_installer_uses_verified_uv_and_locked_sync() -> None:
     assert " pip install " in script and "--no-deps" in script
     assert "trap rollback_uncommitted_install EXIT" in script
     assert script.index("verify_install\n") < script.index("commit_install\n")
-    assert script.index("commit_install\n") < script.index("install_shim\n", script.index("main()"))
+    main = script.index("main()")
+    fresh_commit = script.index("commit_install\n", main)
+    install_shim = script.index("install_shim\n", main)
+    onboarding = script.index("run_onboarding\n", main)
+    update_commit = script.index("commit_install\n", fresh_commit + 1)
+    assert fresh_commit < install_shim < onboarding < update_commit
+    assert "if [[ ${UPDATE_MODE} -eq 0 ]]" in script
+    assert "if [[ ${UPDATE_MODE} -eq 1 ]]" in script
     assert "printf -v quoted_bin '%q'" in script
     assert 'if [[ -z "${PERSOME_ROOT:-}" ]]' in script
     assert "sqlite3.sqlite_version_info < (3, 42, 0)" in script

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,0 +1,269 @@
+"""Safe Runtime self-update orchestration."""
+
+from __future__ import annotations
+
+import contextlib
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from persome import cli, launchagent, paths, updater
+
+
+def _source_tree(root: Path) -> Path:
+    (root / "src" / "persome").mkdir(parents=True)
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "persome-core"\nversion = "0.0.0"\n',
+        encoding="utf-8",
+    )
+    (root / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+    (root / "build-constraints.txt").write_text("", encoding="utf-8")
+    (root / "install.sh").write_text("#!/bin/bash\n", encoding="utf-8")
+    return root
+
+
+def test_local_source_is_validated_without_mutating_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _source_tree(tmp_path / "source")
+    monkeypatch.setattr(updater, "_revision", lambda path: "a" * 40)
+
+    with updater.acquire_source(root) as source:
+        assert source.path == root
+        assert source.revision == "a" * 40
+        assert source.official is False
+
+    assert root.exists()
+
+
+def test_source_rejects_symlinked_installer(tmp_path: Path) -> None:
+    root = _source_tree(tmp_path / "source")
+    installer = root / "install.sh"
+    installer.unlink()
+    installer.symlink_to(tmp_path / "attacker.sh")
+
+    with pytest.raises(updater.UpdateError, match="complete Persome"):
+        updater._validate_source(root)
+
+
+def test_official_source_is_a_fresh_shallow_main_clone(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    commands: list[list[str]] = []
+
+    class TemporaryDirectory:
+        def __init__(self, **_: object) -> None:
+            pass
+
+        def __enter__(self) -> str:
+            return str(tmp_path)
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+    def fake_run(command: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        if "clone" in command:
+            _source_tree(Path(command[-1]))
+            return subprocess.CompletedProcess(command, 0, "", "")
+        return subprocess.CompletedProcess(command, 0, "b" * 40 + "\n", "")
+
+    monkeypatch.setattr(updater.tempfile, "TemporaryDirectory", TemporaryDirectory)
+    monkeypatch.setattr(updater.shutil, "which", lambda name: "/usr/bin/git")
+    monkeypatch.setattr(updater.subprocess, "run", fake_run)
+
+    with updater.acquire_source() as source:
+        assert source.official is True
+        assert source.revision == "b" * 40
+
+    clone = commands[0]
+    assert clone[:2] == ["/usr/bin/git", "clone"]
+    assert "--depth" in clone and "1" in clone
+    assert "--single-branch" in clone
+    assert updater.DEFAULT_BRANCH in clone
+    assert updater.OFFICIAL_REPOSITORY in clone
+
+
+def test_stop_runtime_terminates_daemon_after_disabling_launchagent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pids = iter([4242, 4242, None])
+    signals: list[tuple[int, int]] = []
+    bootout = subprocess.CompletedProcess(["launchctl"], 0, "", "")
+    monkeypatch.setattr(launchagent, "is_loaded", lambda: True)
+    monkeypatch.setattr(launchagent, "bootout", lambda: bootout)
+    monkeypatch.setattr(updater, "_running_daemon_pid", lambda: next(pids))
+    monkeypatch.setattr(updater.os, "kill", lambda pid, sig: signals.append((pid, sig)))
+    monkeypatch.setattr(updater.time, "sleep", lambda seconds: None)
+
+    updater.stop_runtime(launchagent_was_loaded=True)
+    assert signals == [(4242, updater.signal.SIGTERM)]
+
+
+def test_installer_uses_update_mode_without_shell_interpolation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = updater.UpdateSource(_source_tree(tmp_path / "source"), "c" * 40, False)
+    seen: dict[str, object] = {}
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        seen.update(command=command, kwargs=kwargs)
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(updater.subprocess, "run", fake_run)
+
+    updater.run_installer(source)
+
+    assert seen["command"] == ["/bin/bash", str(source.path / "install.sh"), "--update"]
+    assert seen["kwargs"]["cwd"] == source.path  # type: ignore[index]
+    assert seen["kwargs"]["check"] is False  # type: ignore[index]
+    env = seen["kwargs"]["env"]  # type: ignore[index]
+    assert env["PERSOME_ROOT"] == str(paths.root())
+    assert env["PERSOME_INSTALL_HOME"] == str(paths.root())
+
+
+def test_failed_update_recovers_background_runtime(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    binary = paths.root() / "venv" / "bin" / "persome"
+    binary.parent.mkdir(parents=True)
+    binary.write_text("", encoding="utf-8")
+    binary.chmod(0o755)
+    calls: list[list[str]] = []
+    monkeypatch.setattr(updater, "_running_daemon_pid", lambda: None)
+    monkeypatch.setattr(
+        updater.subprocess,
+        "run",
+        lambda command, **kwargs: (
+            calls.append(command) or subprocess.CompletedProcess(command, 0, "", "")
+        ),
+    )
+
+    updater.recover_runtime(False)
+
+    assert calls == [[str(binary), "start"]]
+
+
+def test_launchagent_restore_uses_new_binary_and_waits_for_running_state(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    binary = paths.root() / "venv" / "bin" / "persome"
+    binary.parent.mkdir(parents=True)
+    binary.write_text("", encoding="utf-8")
+    binary.chmod(0o755)
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        updater.subprocess,
+        "run",
+        lambda command, **kwargs: (
+            calls.append(command) or subprocess.CompletedProcess(command, 0, "", "")
+        ),
+    )
+    monkeypatch.setattr(updater, "launchagent_is_loaded", lambda: True)
+    monkeypatch.setattr(updater, "_running_daemon_pid", lambda: 4242)
+
+    updater.restore_launchagent(True)
+
+    assert calls == [
+        [str(binary), "launchagent", "install", "--binary", str(binary)],
+    ]
+
+
+def test_cli_update_runs_download_stop_install_and_restore(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = updater.UpdateSource(_source_tree(tmp_path / "source"), "d" * 40, True)
+    calls: list[object] = []
+
+    @contextlib.contextmanager
+    def fake_acquire(path: Path | None = None):
+        calls.append(("acquire", path))
+        yield source
+
+    monkeypatch.setattr(updater, "acquire_source", fake_acquire)
+    monkeypatch.setattr(updater, "launchagent_is_loaded", lambda: True)
+    monkeypatch.setattr(
+        updater,
+        "stop_runtime",
+        lambda launchagent_was_loaded: calls.append(("stop", launchagent_was_loaded)),
+    )
+    monkeypatch.setattr(updater, "run_installer", lambda value: calls.append(("install", value)))
+    monkeypatch.setattr(
+        updater, "restore_launchagent", lambda value: calls.append(("restore", value))
+    )
+
+    result = CliRunner().invoke(cli.app, ["update"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        ("acquire", None),
+        ("stop", True),
+        ("install", source),
+        ("restore", True),
+    ]
+    assert "Persome update complete" in result.output
+    assert "personal data were" in result.output
+    assert "preserved" in result.output
+
+
+def test_cli_download_failure_does_not_change_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    @contextlib.contextmanager
+    def failed_acquire(path: Path | None = None):
+        raise updater.UpdateError("offline")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(updater, "acquire_source", failed_acquire)
+    monkeypatch.setattr(updater, "stop_runtime", lambda **kwargs: calls.append("stop"))
+    monkeypatch.setattr(updater, "recover_runtime", lambda was_loaded: calls.append("recover"))
+
+    result = CliRunner().invoke(cli.app, ["update"])
+
+    assert result.exit_code == 1
+    assert "offline" in result.output
+    assert calls == []
+
+
+def test_cli_install_failure_attempts_runtime_recovery(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = updater.UpdateSource(_source_tree(tmp_path / "source"), "e" * 40, True)
+    calls: list[object] = []
+
+    @contextlib.contextmanager
+    def fake_acquire(path: Path | None = None):
+        yield source
+
+    monkeypatch.setattr(updater, "acquire_source", fake_acquire)
+    monkeypatch.setattr(updater, "launchagent_is_loaded", lambda: True)
+    monkeypatch.setattr(updater, "stop_runtime", lambda **kwargs: calls.append("stop"))
+    monkeypatch.setattr(
+        updater,
+        "run_installer",
+        lambda value: (_ for _ in ()).throw(updater.UpdateError("install failed")),
+    )
+    monkeypatch.setattr(
+        updater, "recover_runtime", lambda was_loaded: calls.append(("recover", was_loaded))
+    )
+
+    result = CliRunner().invoke(cli.app, ["update"])
+
+    assert result.exit_code == 1
+    assert "install failed" in result.output
+    assert calls == ["stop", ("recover", True)]
+
+
+def test_update_mode_skips_setup_prompts_but_keeps_runtime_proof() -> None:
+    script = (Path(__file__).resolve().parents[1] / "install.sh").read_text(encoding="utf-8")
+
+    assert "--update" in script
+    assert "UPDATE_MODE=1" in script
+    assert "update mode: preserving the existing LLM profile and credentials" in script
+    assert "non-interactive update: verifying existing permissions and Runtime health" in script
+    assert "onboard --tier tiny --no-gui" in script
+    assert "run_onboarding\n  print_summary" in script

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -266,4 +266,5 @@ def test_update_mode_skips_setup_prompts_but_keeps_runtime_proof() -> None:
     assert "update mode: preserving the existing LLM profile and credentials" in script
     assert "non-interactive update: verifying existing permissions and Runtime health" in script
     assert "onboard --tier tiny --no-gui" in script
-    assert "run_onboarding\n  print_summary" in script
+    assert script.index("run_onboarding\n") < script.rindex("commit_install\n")
+    assert "restoring the previous virtualenv" in script


### PR DESCRIPTION
## What changed

- add `persome update` for one-command Runtime updates from any directory
- download a fresh shallow checkout of the official `main` branch without mutating a user's development checkout
- add `persome update --source /path/to/checkout` for reviewed local or offline sources
- stop and restore either a background daemon or an existing LaunchAgent
- run the locked installer in update mode while preserving the active data root, LLM profile, credentials, MCP setup, and personal data
- rerun onboarding so OCR, local health, and a fresh capture prove the updated Runtime
- attempt to recover the prior Runtime if installation fails after shutdown
- keep the previous virtualenv until onboarding passes, then commit the replacement; failed health/capture proof stops the new daemon and rolls the software back
- isolate a pre-existing browser-auth test from the real `~/.persome` root

## Why

The documented Git update path required users to understand that `git pull` changes only the source checkout, while the running code lives in `~/.persome/venv`. This made a normal update a multi-step operational procedure and made it easy to leave the old daemon running old code.

## User impact

Normal updates become:

```bash
persome update
```

The updater fetches before stopping the Runtime, preserves all user state, installs through the existing locked supply-chain path, and does not report success until onboarding proves the replacement Runtime.

## Validation

- `PERSOME_LLM_MOCK=1 uv run pytest -m "not macos and not integration" -q` — 1548 passed, 15 deselected
- focused updater/onboarding/security tests — 24 passed
- actual official shallow-clone acquisition smoke
- wheel build/content smoke for `persome/updater.py`
- `uv run ruff check .`
- `uv run ruff format --check .`
- OpenAPI and DB schema drift tests
- shell syntax checks
- secret, PII, language, and documentation-link scans
