### PR TITLE
Remove dead hybrid_enabled() accessor in store/fts.py

### DIFF
--- a/src/persome/store/fts.py
+++ b/src/persome/store/fts.py
@@ -906,10 +906,6 @@ def _apply_recency(
     return [eid for _s, _r, eid in scored]
 
 
-def hybrid_enabled() -> bool:
-    return bool(_HYBRID["enabled"])
-
-
 def wire_read_path(cfg: Any) -> None:
     from ..writer import embeddings_client  # lazy: avoid an import cycle at module load
     from . import vectors as vectors_mod


### PR DESCRIPTION
Round-3 dead-code sweep of the newest `main`.

### Finding
`store/fts.py::hybrid_enabled()` — a `return bool(_HYBRID["enabled"])` accessor — has **zero callers** anywhere in `src`, `tests`, `scripts`, or `docs`. All `hybrid_enabled` references are either the `cfg.search.hybrid_enabled` **config field** (a name collision) or direct `_HYBRID["enabled"]` reads inside the search functions. Both `vulture` and an LLM sweep miss it *because* of that collision; an independent grep (bare `hybrid_enabled(` calls = 0, no imports, not in `__all__`) confirmed it dead.

`_HYBRID` remains live (read directly at `fts.py:1085` / `1389`), so the removal is self-contained — no cascade.

### Rest of the scan
No other removable dead code. The new-since-last-scan files (`onboarding.py`, `integrity.py`, FTS-repair additions in `fts.py`) are clean; `RuntimeProof.ocr`/`.health` are test-only (kept). Previously-removed symbols do not reappear.

### Validation
`ruff` check/format clean; secret/PII/language gates clean; offline suite otherwise green (1536 passed). One unrelated failure (`test_local_api_auth::test_browser_bootstrap_is_single_use_...`) reproduces **identically on unmodified `main`** — a local-environment issue (corrupt `~/.persome/index.db`), not from this change; it passes on clean CI runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)