### PR TITLE
docs: add manual contributor acknowledgements

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -20,6 +20,83 @@
         "code",
         "maintenance"
       ]
+    },
+    {
+      "login": "AMTso7aw",
+      "name": "Zhiheng Chen",
+      "avatar_url": "https://avatars.githubusercontent.com/u/113247039?v=4",
+      "profile": "https://github.com/AMTso7aw",
+      "contributions": []
+    },
+    {
+      "login": "Carri1Sun",
+      "name": "Kaiyi",
+      "avatar_url": "https://avatars.githubusercontent.com/u/169393340?v=4",
+      "profile": "https://github.com/Carri1Sun",
+      "contributions": []
+    },
+    {
+      "login": "doubleBlack2",
+      "name": "doubleBlack2",
+      "avatar_url": "https://avatars.githubusercontent.com/u/108928143?v=4",
+      "profile": "https://github.com/doubleBlack2",
+      "contributions": []
+    },
+    {
+      "login": "GouBuliya",
+      "name": "Li_Xufeng",
+      "avatar_url": "https://avatars.githubusercontent.com/u/163627234?v=4",
+      "profile": "https://github.com/GouBuliya",
+      "contributions": []
+    },
+    {
+      "login": "huachenjie238-oss",
+      "name": "huachenjie238-oss",
+      "avatar_url": "https://avatars.githubusercontent.com/u/261379605?v=4",
+      "profile": "https://github.com/huachenjie238-oss",
+      "contributions": []
+    },
+    {
+      "login": "JingYangGit",
+      "name": "Jing@Meowy",
+      "avatar_url": "https://avatars.githubusercontent.com/u/169429757?v=4",
+      "profile": "https://github.com/JingYangGit",
+      "contributions": []
+    },
+    {
+      "login": "kevinaimonster",
+      "name": "kevinaimonster",
+      "avatar_url": "https://avatars.githubusercontent.com/u/172621334?v=4",
+      "profile": "https://github.com/kevinaimonster",
+      "contributions": []
+    },
+    {
+      "login": "marukowanzi",
+      "name": "marukowanzi",
+      "avatar_url": "https://avatars.githubusercontent.com/u/126929595?v=4",
+      "profile": "https://github.com/marukowanzi",
+      "contributions": []
+    },
+    {
+      "login": "realGuantum",
+      "name": "Guantum",
+      "avatar_url": "https://avatars.githubusercontent.com/u/42232104?v=4",
+      "profile": "https://github.com/realGuantum",
+      "contributions": []
+    },
+    {
+      "login": "SiyiZhu1",
+      "name": "SiyiZhu1",
+      "avatar_url": "https://avatars.githubusercontent.com/u/132850441?v=4",
+      "profile": "https://github.com/SiyiZhu1",
+      "contributions": []
+    },
+    {
+      "login": "syleemanet",
+      "name": "syleemanet",
+      "avatar_url": "https://avatars.githubusercontent.com/u/150102494?v=4",
+      "profile": "https://github.com/syleemanet",
+      "contributions": []
     }
   ],
   "contributorsPerLine": 2,

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,27 @@
+{
+  "projectName": "personal-model",
+  "projectOwner": "Intuition-Lab",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "badge": false,
+  "imageSize": 100,
+  "commit": false,
+  "commitConvention": "angular",
+  "contributors": [
+    {
+      "login": "Singularity-tian",
+      "name": "Singularity",
+      "avatar_url": "https://avatars.githubusercontent.com/u/113085728?v=4",
+      "profile": "https://github.com/Singularity-tian",
+      "contributions": [
+        "code",
+        "maintenance"
+      ]
+    }
+  ],
+  "contributorsPerLine": 7,
+  "linkToUsage": false
+}

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -17,16 +17,6 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/113085728?v=4",
       "profile": "https://github.com/Singularity-tian",
       "contributions": [
-        "code",
-        "maintenance"
-      ]
-    },
-    {
-      "login": "AMTso7aw",
-      "name": "Zhiheng Chen",
-      "avatar_url": "https://avatars.githubusercontent.com/u/113247039?v=4",
-      "profile": "https://github.com/AMTso7aw",
-      "contributions": [
         "code"
       ]
     },
@@ -35,6 +25,24 @@
       "name": "Li_Xufeng",
       "avatar_url": "https://avatars.githubusercontent.com/u/163627234?v=4",
       "profile": "https://github.com/GouBuliya",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "SiyiZhu1",
+      "name": "Siyi",
+      "avatar_url": "https://avatars.githubusercontent.com/u/132850441?v=4",
+      "profile": "https://github.com/SiyiZhu1",
+      "contributions": [
+        "design"
+      ]
+    },
+    {
+      "login": "AMTso7aw",
+      "name": "Zhiheng Chen",
+      "avatar_url": "https://avatars.githubusercontent.com/u/113247039?v=4",
+      "profile": "https://github.com/AMTso7aw",
       "contributions": [
         "code"
       ]
@@ -63,22 +71,6 @@
       "contributions": [
         "code"
       ]
-    },
-    {
-      "login": "SiyiZhu1",
-      "name": "Siyi",
-      "avatar_url": "https://avatars.githubusercontent.com/u/132850441?v=4",
-      "profile": "https://github.com/SiyiZhu1",
-      "contributions": [
-        "design"
-      ]
-    },
-    {
-      "login": "syleemanet",
-      "name": "syleemanet",
-      "avatar_url": "https://avatars.githubusercontent.com/u/150102494?v=4",
-      "profile": "https://github.com/syleemanet",
-      "contributions": []
     }
   ],
   "contributorsPerLine": 3,

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -7,7 +7,7 @@
     "README.md"
   ],
   "badge": false,
-  "imageSize": 100,
+  "imageSize": 56,
   "commit": false,
   "commitConvention": "angular",
   "contributors": [
@@ -22,6 +22,6 @@
       ]
     }
   ],
-  "contributorsPerLine": 7,
+  "contributorsPerLine": 2,
   "linkToUsage": false
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -39,10 +39,10 @@
       ]
     },
     {
-      "login": "AMTso7aw",
-      "name": "Zhiheng Chen",
-      "avatar_url": "https://avatars.githubusercontent.com/u/113247039?v=4",
-      "profile": "https://github.com/AMTso7aw",
+      "login": "kevinaimonster",
+      "name": "Kevin",
+      "avatar_url": "https://avatars.githubusercontent.com/u/172621334?v=4",
+      "profile": "https://github.com/kevinaimonster",
       "contributions": [
         "code"
       ]
@@ -52,7 +52,9 @@
       "name": "huachenjie238-oss",
       "avatar_url": "https://avatars.githubusercontent.com/u/261379605?v=4",
       "profile": "https://github.com/huachenjie238-oss",
-      "contributions": []
+      "contributions": [
+        "growth"
+      ]
     },
     {
       "login": "JingYangGit",
@@ -64,10 +66,10 @@
       ]
     },
     {
-      "login": "kevinaimonster",
-      "name": "Kevin",
-      "avatar_url": "https://avatars.githubusercontent.com/u/172621334?v=4",
-      "profile": "https://github.com/kevinaimonster",
+      "login": "AMTso7aw",
+      "name": "Zhiheng Chen",
+      "avatar_url": "https://avatars.githubusercontent.com/u/113247039?v=4",
+      "profile": "https://github.com/AMTso7aw",
       "contributions": [
         "code"
       ]

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -26,28 +26,18 @@
       "name": "Zhiheng Chen",
       "avatar_url": "https://avatars.githubusercontent.com/u/113247039?v=4",
       "profile": "https://github.com/AMTso7aw",
-      "contributions": []
-    },
-    {
-      "login": "Carri1Sun",
-      "name": "Kaiyi",
-      "avatar_url": "https://avatars.githubusercontent.com/u/169393340?v=4",
-      "profile": "https://github.com/Carri1Sun",
-      "contributions": []
-    },
-    {
-      "login": "doubleBlack2",
-      "name": "doubleBlack2",
-      "avatar_url": "https://avatars.githubusercontent.com/u/108928143?v=4",
-      "profile": "https://github.com/doubleBlack2",
-      "contributions": []
+      "contributions": [
+        "code"
+      ]
     },
     {
       "login": "GouBuliya",
       "name": "Li_Xufeng",
       "avatar_url": "https://avatars.githubusercontent.com/u/163627234?v=4",
       "profile": "https://github.com/GouBuliya",
-      "contributions": []
+      "contributions": [
+        "code"
+      ]
     },
     {
       "login": "huachenjie238-oss",
@@ -61,35 +51,27 @@
       "name": "Jing@Meowy",
       "avatar_url": "https://avatars.githubusercontent.com/u/169429757?v=4",
       "profile": "https://github.com/JingYangGit",
-      "contributions": []
+      "contributions": [
+        "growth"
+      ]
     },
     {
       "login": "kevinaimonster",
-      "name": "kevinaimonster",
+      "name": "Kevin",
       "avatar_url": "https://avatars.githubusercontent.com/u/172621334?v=4",
       "profile": "https://github.com/kevinaimonster",
-      "contributions": []
-    },
-    {
-      "login": "marukowanzi",
-      "name": "marukowanzi",
-      "avatar_url": "https://avatars.githubusercontent.com/u/126929595?v=4",
-      "profile": "https://github.com/marukowanzi",
-      "contributions": []
-    },
-    {
-      "login": "realGuantum",
-      "name": "Guantum",
-      "avatar_url": "https://avatars.githubusercontent.com/u/42232104?v=4",
-      "profile": "https://github.com/realGuantum",
-      "contributions": []
+      "contributions": [
+        "code"
+      ]
     },
     {
       "login": "SiyiZhu1",
-      "name": "SiyiZhu1",
+      "name": "Siyi",
       "avatar_url": "https://avatars.githubusercontent.com/u/132850441?v=4",
       "profile": "https://github.com/SiyiZhu1",
-      "contributions": []
+      "contributions": [
+        "design"
+      ]
     },
     {
       "login": "syleemanet",
@@ -99,6 +81,6 @@
       "contributions": []
     }
   ],
-  "contributorsPerLine": 2,
+  "contributorsPerLine": 3,
   "linkToUsage": false
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,25 @@ is allowlisted because changing it would break local OCR.
    verified).
 4. CI must be green: offline test gate + PII scan on ubuntu and macos runners.
 
+## Contributor acknowledgements
+
+The contributor cards in `README.md` follow the
+[All Contributors](https://allcontributors.org/) specification. They recognize
+code and non-code work and are maintained separately from GitHub's automatic
+commit-author contributor graph.
+
+Maintainers can add or update a GitHub profile with the CLI:
+
+```bash
+npx all-contributors-cli add <github-login> <contribution-type[,contribution-type]>
+```
+
+For example, `code`, `doc`, `design`, `ideas`, `maintenance`, `projectManagement`,
+and `review` are useful contribution types for this project. Commit both the
+generated `README.md` table and `.all-contributorsrc`. Organization membership
+can make a profile easier to find, but acknowledgement should reflect a real
+contribution rather than membership alone.
+
 ## DCO — sign your commits
 
 This project uses the [Developer Certificate of Origin](https://developercertificate.org/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,13 +86,17 @@ Maintainers can add or update a GitHub profile with the CLI:
 
 ```bash
 npx all-contributors-cli add <github-login> <contribution-type[,contribution-type]>
+uv run python scripts/render_contributors.py
 ```
 
 For example, `code`, `doc`, `design`, `ideas`, `maintenance`, `projectManagement`,
-and `review` are useful contribution types for this project. Commit both the
-generated `README.md` table and `.all-contributorsrc`. Organization membership
-can make a profile easier to find, but acknowledgement should reflect a real
-contribution rather than membership alone.
+and `review` are useful contribution types for this project. The second command
+restores Persome's compact card layout after the CLI updates the contributor
+data. Verify the generated cards with
+`uv run python scripts/render_contributors.py --check`, then commit both
+`README.md` and `.all-contributorsrc`. Organization membership can make a
+profile easier to find, but acknowledgement should reflect a real contribution
+rather than membership alone.
 
 ## DCO — sign your commits
 

--- a/README.md
+++ b/README.md
@@ -440,6 +440,72 @@ Persome is shaped by people across engineering, design, research, and community.
   &nbsp;&nbsp;<sub>💻&nbsp;Code &nbsp;·&nbsp; 🚧&nbsp;Maintenance</sub>
 </p>
 <br clear="left" />
+<p>
+  <a href="https://github.com/AMTso7aw"><img src="https://avatars.githubusercontent.com/u/113247039?v=4&amp;size=112" width="56" align="left" alt="Zhiheng Chen" /></a>
+  &nbsp;&nbsp;<strong><a href="https://github.com/AMTso7aw">Zhiheng Chen</a></strong><br />
+  &nbsp;&nbsp;<sub>✨&nbsp;Contributor</sub>
+</p>
+<br clear="left" />
+<p>
+  <a href="https://github.com/Carri1Sun"><img src="https://avatars.githubusercontent.com/u/169393340?v=4&amp;size=112" width="56" align="left" alt="Kaiyi" /></a>
+  &nbsp;&nbsp;<strong><a href="https://github.com/Carri1Sun">Kaiyi</a></strong><br />
+  &nbsp;&nbsp;<sub>✨&nbsp;Contributor</sub>
+</p>
+<br clear="left" />
+<p>
+  <a href="https://github.com/doubleBlack2"><img src="https://avatars.githubusercontent.com/u/108928143?v=4&amp;size=112" width="56" align="left" alt="doubleBlack2" /></a>
+  &nbsp;&nbsp;<strong><a href="https://github.com/doubleBlack2">doubleBlack2</a></strong><br />
+  &nbsp;&nbsp;<sub>✨&nbsp;Contributor</sub>
+</p>
+<br clear="left" />
+<p>
+  <a href="https://github.com/GouBuliya"><img src="https://avatars.githubusercontent.com/u/163627234?v=4&amp;size=112" width="56" align="left" alt="Li_Xufeng" /></a>
+  &nbsp;&nbsp;<strong><a href="https://github.com/GouBuliya">Li_Xufeng</a></strong><br />
+  &nbsp;&nbsp;<sub>✨&nbsp;Contributor</sub>
+</p>
+<br clear="left" />
+<p>
+  <a href="https://github.com/huachenjie238-oss"><img src="https://avatars.githubusercontent.com/u/261379605?v=4&amp;size=112" width="56" align="left" alt="huachenjie238-oss" /></a>
+  &nbsp;&nbsp;<strong><a href="https://github.com/huachenjie238-oss">huachenjie238-oss</a></strong><br />
+  &nbsp;&nbsp;<sub>✨&nbsp;Contributor</sub>
+</p>
+<br clear="left" />
+<p>
+  <a href="https://github.com/JingYangGit"><img src="https://avatars.githubusercontent.com/u/169429757?v=4&amp;size=112" width="56" align="left" alt="Jing@Meowy" /></a>
+  &nbsp;&nbsp;<strong><a href="https://github.com/JingYangGit">Jing@Meowy</a></strong><br />
+  &nbsp;&nbsp;<sub>✨&nbsp;Contributor</sub>
+</p>
+<br clear="left" />
+<p>
+  <a href="https://github.com/kevinaimonster"><img src="https://avatars.githubusercontent.com/u/172621334?v=4&amp;size=112" width="56" align="left" alt="kevinaimonster" /></a>
+  &nbsp;&nbsp;<strong><a href="https://github.com/kevinaimonster">kevinaimonster</a></strong><br />
+  &nbsp;&nbsp;<sub>✨&nbsp;Contributor</sub>
+</p>
+<br clear="left" />
+<p>
+  <a href="https://github.com/marukowanzi"><img src="https://avatars.githubusercontent.com/u/126929595?v=4&amp;size=112" width="56" align="left" alt="marukowanzi" /></a>
+  &nbsp;&nbsp;<strong><a href="https://github.com/marukowanzi">marukowanzi</a></strong><br />
+  &nbsp;&nbsp;<sub>✨&nbsp;Contributor</sub>
+</p>
+<br clear="left" />
+<p>
+  <a href="https://github.com/realGuantum"><img src="https://avatars.githubusercontent.com/u/42232104?v=4&amp;size=112" width="56" align="left" alt="Guantum" /></a>
+  &nbsp;&nbsp;<strong><a href="https://github.com/realGuantum">Guantum</a></strong><br />
+  &nbsp;&nbsp;<sub>✨&nbsp;Contributor</sub>
+</p>
+<br clear="left" />
+<p>
+  <a href="https://github.com/SiyiZhu1"><img src="https://avatars.githubusercontent.com/u/132850441?v=4&amp;size=112" width="56" align="left" alt="SiyiZhu1" /></a>
+  &nbsp;&nbsp;<strong><a href="https://github.com/SiyiZhu1">SiyiZhu1</a></strong><br />
+  &nbsp;&nbsp;<sub>✨&nbsp;Contributor</sub>
+</p>
+<br clear="left" />
+<p>
+  <a href="https://github.com/syleemanet"><img src="https://avatars.githubusercontent.com/u/150102494?v=4&amp;size=112" width="56" align="left" alt="syleemanet" /></a>
+  &nbsp;&nbsp;<strong><a href="https://github.com/syleemanet">syleemanet</a></strong><br />
+  &nbsp;&nbsp;<sub>✨&nbsp;Contributor</sub>
+</p>
+<br clear="left" />
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 <sub>Contribution labels follow the

--- a/README.md
+++ b/README.md
@@ -429,6 +429,31 @@ secrets, personal data, non-English source text, contract drift, lint failures,
 and offline regressions. Third-party Actions are pinned to reviewed commit SHAs
 and workflow permissions default to read-only.
 
+## Contributors ✨
+
+Thanks goes to these wonderful people
+([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/Singularity-tian"><img src="https://avatars.githubusercontent.com/u/113085728?v=4?s=100" width="100px;" alt="Singularity"/><br /><sub><b>Singularity</b></sub></a><br /><a href="https://github.com/Intuition-Lab/personal-model/commits?author=Singularity-tian" title="Code">💻</a> <a href="#maintenance-Singularity-tian" title="Maintenance">🚧</a></td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the
+[all-contributors](https://github.com/all-contributors/all-contributors)
+specification. Contributions of any kind are welcome!
+
 ### Support Persome
 
 If an inspectable, user-owned personal model is useful to your agents,

--- a/README.md
+++ b/README.md
@@ -434,10 +434,10 @@ and workflow permissions default to read-only.
 Persome is shaped by people across engineering, design, research, and community.
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-<table>
+<table width="100%">
   <tbody>
     <tr>
-      <td valign="middle">
+      <td valign="middle" width="50.00%">
         <a href="https://github.com/Singularity-tian"><img src="https://avatars.githubusercontent.com/u/113085728?v=4&amp;size=112" width="56" align="left" alt="Singularity" /></a>
         &nbsp;<strong><a href="https://github.com/Singularity-tian">Singularity</a></strong><br />
         &nbsp;<sub>💻&nbsp;Code &nbsp;·&nbsp; 🚧&nbsp;Maintenance</sub>

--- a/README.md
+++ b/README.md
@@ -440,11 +440,6 @@ Persome is shaped by people across engineering, design, research, and community.
       <td valign="middle">
         <a href="https://github.com/Singularity-tian"><img src="https://avatars.githubusercontent.com/u/113085728?v=4&amp;size=112" width="56" align="left" alt="Singularity" /></a>
         &nbsp;&nbsp;<strong><a href="https://github.com/Singularity-tian">Singularity</a></strong><br />
-        &nbsp;&nbsp;<sub>💻&nbsp;Code &nbsp;·&nbsp; 🚧&nbsp;Maintenance</sub>
-      </td>
-      <td valign="middle">
-        <a href="https://github.com/AMTso7aw"><img src="https://avatars.githubusercontent.com/u/113247039?v=4&amp;size=112" width="56" align="left" alt="Zhiheng Chen" /></a>
-        &nbsp;&nbsp;<strong><a href="https://github.com/AMTso7aw">Zhiheng Chen</a></strong><br />
         &nbsp;&nbsp;<sub>💻&nbsp;Code</sub>
       </td>
       <td valign="middle">
@@ -452,8 +447,18 @@ Persome is shaped by people across engineering, design, research, and community.
         &nbsp;&nbsp;<strong><a href="https://github.com/GouBuliya">Li_Xufeng</a></strong><br />
         &nbsp;&nbsp;<sub>💻&nbsp;Code</sub>
       </td>
+      <td valign="middle">
+        <a href="https://github.com/SiyiZhu1"><img src="https://avatars.githubusercontent.com/u/132850441?v=4&amp;size=112" width="56" align="left" alt="Siyi" /></a>
+        &nbsp;&nbsp;<strong><a href="https://github.com/SiyiZhu1">Siyi</a></strong><br />
+        &nbsp;&nbsp;<sub>🎨&nbsp;Design</sub>
+      </td>
     </tr>
     <tr>
+      <td valign="middle">
+        <a href="https://github.com/AMTso7aw"><img src="https://avatars.githubusercontent.com/u/113247039?v=4&amp;size=112" width="56" align="left" alt="Zhiheng Chen" /></a>
+        &nbsp;&nbsp;<strong><a href="https://github.com/AMTso7aw">Zhiheng Chen</a></strong><br />
+        &nbsp;&nbsp;<sub>💻&nbsp;Code</sub>
+      </td>
       <td valign="middle">
         <a href="https://github.com/huachenjie238-oss"><img src="https://avatars.githubusercontent.com/u/261379605?v=4&amp;size=112" width="56" align="left" alt="huachenjie238-oss" /></a>
         &nbsp;&nbsp;<strong><a href="https://github.com/huachenjie238-oss">huachenjie238-oss</a></strong><br />
@@ -464,22 +469,12 @@ Persome is shaped by people across engineering, design, research, and community.
         &nbsp;&nbsp;<strong><a href="https://github.com/JingYangGit">Jing@Meowy</a></strong><br />
         &nbsp;&nbsp;<sub>📈&nbsp;Growth</sub>
       </td>
+    </tr>
+    <tr>
       <td valign="middle">
         <a href="https://github.com/kevinaimonster"><img src="https://avatars.githubusercontent.com/u/172621334?v=4&amp;size=112" width="56" align="left" alt="Kevin" /></a>
         &nbsp;&nbsp;<strong><a href="https://github.com/kevinaimonster">Kevin</a></strong><br />
         &nbsp;&nbsp;<sub>💻&nbsp;Code</sub>
-      </td>
-    </tr>
-    <tr>
-      <td valign="middle">
-        <a href="https://github.com/SiyiZhu1"><img src="https://avatars.githubusercontent.com/u/132850441?v=4&amp;size=112" width="56" align="left" alt="Siyi" /></a>
-        &nbsp;&nbsp;<strong><a href="https://github.com/SiyiZhu1">Siyi</a></strong><br />
-        &nbsp;&nbsp;<sub>🎨&nbsp;Design</sub>
-      </td>
-      <td valign="middle">
-        <a href="https://github.com/syleemanet"><img src="https://avatars.githubusercontent.com/u/150102494?v=4&amp;size=112" width="56" align="left" alt="syleemanet" /></a>
-        &nbsp;&nbsp;<strong><a href="https://github.com/syleemanet">syleemanet</a></strong><br />
-        &nbsp;&nbsp;<sub>✨&nbsp;Contributor</sub>
       </td>
     </tr>
   </tbody>

--- a/README.md
+++ b/README.md
@@ -429,30 +429,27 @@ secrets, personal data, non-English source text, contract drift, lint failures,
 and offline regressions. Third-party Actions are pinned to reviewed commit SHAs
 and workflow permissions default to read-only.
 
-## Contributors ✨
+## Contributors
 
-Thanks goes to these wonderful people
-([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+Persome is shaped by people across engineering, design, research, and community.
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-<!-- prettier-ignore-start -->
-<!-- markdownlint-disable -->
 <table>
   <tbody>
     <tr>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/Singularity-tian"><img src="https://avatars.githubusercontent.com/u/113085728?v=4?s=100" width="100px;" alt="Singularity"/><br /><sub><b>Singularity</b></sub></a><br /><a href="https://github.com/Intuition-Lab/personal-model/commits?author=Singularity-tian" title="Code">💻</a> <a href="#maintenance-Singularity-tian" title="Maintenance">🚧</a></td>
+      <td valign="middle">
+        <a href="https://github.com/Singularity-tian"><img src="https://avatars.githubusercontent.com/u/113085728?v=4&amp;size=112" width="56" align="left" alt="Singularity" /></a>
+        &nbsp;<strong><a href="https://github.com/Singularity-tian">Singularity</a></strong><br />
+        &nbsp;<sub>💻&nbsp;Code &nbsp;·&nbsp; 🚧&nbsp;Maintenance</sub>
+      </td>
     </tr>
   </tbody>
 </table>
-
-<!-- markdownlint-restore -->
-<!-- prettier-ignore-end -->
-
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
-This project follows the
-[all-contributors](https://github.com/all-contributors/all-contributors)
-specification. Contributions of any kind are welcome!
+<sub>Contribution labels follow the
+[All Contributors](https://allcontributors.org/docs/en/emoji-key) convention.
+Contributions of every kind are welcome.</sub>
 
 ### Support Persome
 

--- a/README.md
+++ b/README.md
@@ -434,78 +434,56 @@ and workflow permissions default to read-only.
 Persome is shaped by people across engineering, design, research, and community.
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-<p>
-  <a href="https://github.com/Singularity-tian"><img src="https://avatars.githubusercontent.com/u/113085728?v=4&amp;size=112" width="56" align="left" alt="Singularity" /></a>
-  &nbsp;&nbsp;<strong><a href="https://github.com/Singularity-tian">Singularity</a></strong><br />
-  &nbsp;&nbsp;<sub>💻&nbsp;Code &nbsp;·&nbsp; 🚧&nbsp;Maintenance</sub>
-</p>
-<br clear="left" />
-<p>
-  <a href="https://github.com/AMTso7aw"><img src="https://avatars.githubusercontent.com/u/113247039?v=4&amp;size=112" width="56" align="left" alt="Zhiheng Chen" /></a>
-  &nbsp;&nbsp;<strong><a href="https://github.com/AMTso7aw">Zhiheng Chen</a></strong><br />
-  &nbsp;&nbsp;<sub>✨&nbsp;Contributor</sub>
-</p>
-<br clear="left" />
-<p>
-  <a href="https://github.com/Carri1Sun"><img src="https://avatars.githubusercontent.com/u/169393340?v=4&amp;size=112" width="56" align="left" alt="Kaiyi" /></a>
-  &nbsp;&nbsp;<strong><a href="https://github.com/Carri1Sun">Kaiyi</a></strong><br />
-  &nbsp;&nbsp;<sub>✨&nbsp;Contributor</sub>
-</p>
-<br clear="left" />
-<p>
-  <a href="https://github.com/doubleBlack2"><img src="https://avatars.githubusercontent.com/u/108928143?v=4&amp;size=112" width="56" align="left" alt="doubleBlack2" /></a>
-  &nbsp;&nbsp;<strong><a href="https://github.com/doubleBlack2">doubleBlack2</a></strong><br />
-  &nbsp;&nbsp;<sub>✨&nbsp;Contributor</sub>
-</p>
-<br clear="left" />
-<p>
-  <a href="https://github.com/GouBuliya"><img src="https://avatars.githubusercontent.com/u/163627234?v=4&amp;size=112" width="56" align="left" alt="Li_Xufeng" /></a>
-  &nbsp;&nbsp;<strong><a href="https://github.com/GouBuliya">Li_Xufeng</a></strong><br />
-  &nbsp;&nbsp;<sub>✨&nbsp;Contributor</sub>
-</p>
-<br clear="left" />
-<p>
-  <a href="https://github.com/huachenjie238-oss"><img src="https://avatars.githubusercontent.com/u/261379605?v=4&amp;size=112" width="56" align="left" alt="huachenjie238-oss" /></a>
-  &nbsp;&nbsp;<strong><a href="https://github.com/huachenjie238-oss">huachenjie238-oss</a></strong><br />
-  &nbsp;&nbsp;<sub>✨&nbsp;Contributor</sub>
-</p>
-<br clear="left" />
-<p>
-  <a href="https://github.com/JingYangGit"><img src="https://avatars.githubusercontent.com/u/169429757?v=4&amp;size=112" width="56" align="left" alt="Jing@Meowy" /></a>
-  &nbsp;&nbsp;<strong><a href="https://github.com/JingYangGit">Jing@Meowy</a></strong><br />
-  &nbsp;&nbsp;<sub>✨&nbsp;Contributor</sub>
-</p>
-<br clear="left" />
-<p>
-  <a href="https://github.com/kevinaimonster"><img src="https://avatars.githubusercontent.com/u/172621334?v=4&amp;size=112" width="56" align="left" alt="kevinaimonster" /></a>
-  &nbsp;&nbsp;<strong><a href="https://github.com/kevinaimonster">kevinaimonster</a></strong><br />
-  &nbsp;&nbsp;<sub>✨&nbsp;Contributor</sub>
-</p>
-<br clear="left" />
-<p>
-  <a href="https://github.com/marukowanzi"><img src="https://avatars.githubusercontent.com/u/126929595?v=4&amp;size=112" width="56" align="left" alt="marukowanzi" /></a>
-  &nbsp;&nbsp;<strong><a href="https://github.com/marukowanzi">marukowanzi</a></strong><br />
-  &nbsp;&nbsp;<sub>✨&nbsp;Contributor</sub>
-</p>
-<br clear="left" />
-<p>
-  <a href="https://github.com/realGuantum"><img src="https://avatars.githubusercontent.com/u/42232104?v=4&amp;size=112" width="56" align="left" alt="Guantum" /></a>
-  &nbsp;&nbsp;<strong><a href="https://github.com/realGuantum">Guantum</a></strong><br />
-  &nbsp;&nbsp;<sub>✨&nbsp;Contributor</sub>
-</p>
-<br clear="left" />
-<p>
-  <a href="https://github.com/SiyiZhu1"><img src="https://avatars.githubusercontent.com/u/132850441?v=4&amp;size=112" width="56" align="left" alt="SiyiZhu1" /></a>
-  &nbsp;&nbsp;<strong><a href="https://github.com/SiyiZhu1">SiyiZhu1</a></strong><br />
-  &nbsp;&nbsp;<sub>✨&nbsp;Contributor</sub>
-</p>
-<br clear="left" />
-<p>
-  <a href="https://github.com/syleemanet"><img src="https://avatars.githubusercontent.com/u/150102494?v=4&amp;size=112" width="56" align="left" alt="syleemanet" /></a>
-  &nbsp;&nbsp;<strong><a href="https://github.com/syleemanet">syleemanet</a></strong><br />
-  &nbsp;&nbsp;<sub>✨&nbsp;Contributor</sub>
-</p>
-<br clear="left" />
+<table>
+  <tbody>
+    <tr>
+      <td valign="middle">
+        <a href="https://github.com/Singularity-tian"><img src="https://avatars.githubusercontent.com/u/113085728?v=4&amp;size=112" width="56" align="left" alt="Singularity" /></a>
+        &nbsp;&nbsp;<strong><a href="https://github.com/Singularity-tian">Singularity</a></strong><br />
+        &nbsp;&nbsp;<sub>💻&nbsp;Code &nbsp;·&nbsp; 🚧&nbsp;Maintenance</sub>
+      </td>
+      <td valign="middle">
+        <a href="https://github.com/AMTso7aw"><img src="https://avatars.githubusercontent.com/u/113247039?v=4&amp;size=112" width="56" align="left" alt="Zhiheng Chen" /></a>
+        &nbsp;&nbsp;<strong><a href="https://github.com/AMTso7aw">Zhiheng Chen</a></strong><br />
+        &nbsp;&nbsp;<sub>💻&nbsp;Code</sub>
+      </td>
+      <td valign="middle">
+        <a href="https://github.com/GouBuliya"><img src="https://avatars.githubusercontent.com/u/163627234?v=4&amp;size=112" width="56" align="left" alt="Li_Xufeng" /></a>
+        &nbsp;&nbsp;<strong><a href="https://github.com/GouBuliya">Li_Xufeng</a></strong><br />
+        &nbsp;&nbsp;<sub>💻&nbsp;Code</sub>
+      </td>
+    </tr>
+    <tr>
+      <td valign="middle">
+        <a href="https://github.com/huachenjie238-oss"><img src="https://avatars.githubusercontent.com/u/261379605?v=4&amp;size=112" width="56" align="left" alt="huachenjie238-oss" /></a>
+        &nbsp;&nbsp;<strong><a href="https://github.com/huachenjie238-oss">huachenjie238-oss</a></strong><br />
+        &nbsp;&nbsp;<sub>✨&nbsp;Contributor</sub>
+      </td>
+      <td valign="middle">
+        <a href="https://github.com/JingYangGit"><img src="https://avatars.githubusercontent.com/u/169429757?v=4&amp;size=112" width="56" align="left" alt="Jing@Meowy" /></a>
+        &nbsp;&nbsp;<strong><a href="https://github.com/JingYangGit">Jing@Meowy</a></strong><br />
+        &nbsp;&nbsp;<sub>📈&nbsp;Growth</sub>
+      </td>
+      <td valign="middle">
+        <a href="https://github.com/kevinaimonster"><img src="https://avatars.githubusercontent.com/u/172621334?v=4&amp;size=112" width="56" align="left" alt="Kevin" /></a>
+        &nbsp;&nbsp;<strong><a href="https://github.com/kevinaimonster">Kevin</a></strong><br />
+        &nbsp;&nbsp;<sub>💻&nbsp;Code</sub>
+      </td>
+    </tr>
+    <tr>
+      <td valign="middle">
+        <a href="https://github.com/SiyiZhu1"><img src="https://avatars.githubusercontent.com/u/132850441?v=4&amp;size=112" width="56" align="left" alt="Siyi" /></a>
+        &nbsp;&nbsp;<strong><a href="https://github.com/SiyiZhu1">Siyi</a></strong><br />
+        &nbsp;&nbsp;<sub>🎨&nbsp;Design</sub>
+      </td>
+      <td valign="middle">
+        <a href="https://github.com/syleemanet"><img src="https://avatars.githubusercontent.com/u/150102494?v=4&amp;size=112" width="56" align="left" alt="syleemanet" /></a>
+        &nbsp;&nbsp;<strong><a href="https://github.com/syleemanet">syleemanet</a></strong><br />
+        &nbsp;&nbsp;<sub>✨&nbsp;Contributor</sub>
+      </td>
+    </tr>
+  </tbody>
+</table>
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 <sub>Contribution labels follow the

--- a/README.md
+++ b/README.md
@@ -455,14 +455,14 @@ Persome is shaped by people across engineering, design, research, and community.
     </tr>
     <tr>
       <td valign="middle">
-        <a href="https://github.com/AMTso7aw"><img src="https://avatars.githubusercontent.com/u/113247039?v=4&amp;size=112" width="56" align="left" alt="Zhiheng Chen" /></a>
-        &nbsp;&nbsp;<strong><a href="https://github.com/AMTso7aw">Zhiheng Chen</a></strong><br />
+        <a href="https://github.com/kevinaimonster"><img src="https://avatars.githubusercontent.com/u/172621334?v=4&amp;size=112" width="56" align="left" alt="Kevin" /></a>
+        &nbsp;&nbsp;<strong><a href="https://github.com/kevinaimonster">Kevin</a></strong><br />
         &nbsp;&nbsp;<sub>💻&nbsp;Code</sub>
       </td>
       <td valign="middle">
         <a href="https://github.com/huachenjie238-oss"><img src="https://avatars.githubusercontent.com/u/261379605?v=4&amp;size=112" width="56" align="left" alt="huachenjie238-oss" /></a>
         &nbsp;&nbsp;<strong><a href="https://github.com/huachenjie238-oss">huachenjie238-oss</a></strong><br />
-        &nbsp;&nbsp;<sub>✨&nbsp;Contributor</sub>
+        &nbsp;&nbsp;<sub>📈&nbsp;Growth</sub>
       </td>
       <td valign="middle">
         <a href="https://github.com/JingYangGit"><img src="https://avatars.githubusercontent.com/u/169429757?v=4&amp;size=112" width="56" align="left" alt="Jing@Meowy" /></a>
@@ -472,8 +472,8 @@ Persome is shaped by people across engineering, design, research, and community.
     </tr>
     <tr>
       <td valign="middle">
-        <a href="https://github.com/kevinaimonster"><img src="https://avatars.githubusercontent.com/u/172621334?v=4&amp;size=112" width="56" align="left" alt="Kevin" /></a>
-        &nbsp;&nbsp;<strong><a href="https://github.com/kevinaimonster">Kevin</a></strong><br />
+        <a href="https://github.com/AMTso7aw"><img src="https://avatars.githubusercontent.com/u/113247039?v=4&amp;size=112" width="56" align="left" alt="Zhiheng Chen" /></a>
+        &nbsp;&nbsp;<strong><a href="https://github.com/AMTso7aw">Zhiheng Chen</a></strong><br />
         &nbsp;&nbsp;<sub>💻&nbsp;Code</sub>
       </td>
     </tr>

--- a/README.md
+++ b/README.md
@@ -434,17 +434,12 @@ and workflow permissions default to read-only.
 Persome is shaped by people across engineering, design, research, and community.
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-<table width="100%">
-  <tbody>
-    <tr>
-      <td valign="middle" width="50.00%">
-        <a href="https://github.com/Singularity-tian"><img src="https://avatars.githubusercontent.com/u/113085728?v=4&amp;size=112" width="56" align="left" alt="Singularity" /></a>
-        &nbsp;<strong><a href="https://github.com/Singularity-tian">Singularity</a></strong><br />
-        &nbsp;<sub>💻&nbsp;Code &nbsp;·&nbsp; 🚧&nbsp;Maintenance</sub>
-      </td>
-    </tr>
-  </tbody>
-</table>
+<p>
+  <a href="https://github.com/Singularity-tian"><img src="https://avatars.githubusercontent.com/u/113085728?v=4&amp;size=112" width="56" align="left" alt="Singularity" /></a>
+  &nbsp;&nbsp;<strong><a href="https://github.com/Singularity-tian">Singularity</a></strong><br />
+  &nbsp;&nbsp;<sub>💻&nbsp;Code &nbsp;·&nbsp; 🚧&nbsp;Maintenance</sub>
+</p>
+<br clear="left" />
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 <sub>Contribution labels follow the

--- a/scripts/render_contributors.py
+++ b/scripts/render_contributors.py
@@ -69,6 +69,8 @@ def render_contributors(config: dict[str, object]) -> str:
         if not isinstance(contributions, list):
             raise ValueError("contributions must be a list")
         labels = " &nbsp;·&nbsp; ".join(_label(str(item)) for item in contributions)
+        if not labels:
+            labels = "✨&nbsp;Contributor"
         cards.append(
             "\n".join(
                 (

--- a/scripts/render_contributors.py
+++ b/scripts/render_contributors.py
@@ -62,6 +62,7 @@ def render_contributors(config: dict[str, object]) -> str:
         raise ValueError("imageSize must be at least 1")
 
     cards: list[str] = []
+    card_width = 100 / per_line
     for raw in contributors:
         if not isinstance(raw, dict):
             raise ValueError("each contributor must be an object")
@@ -75,7 +76,7 @@ def render_contributors(config: dict[str, object]) -> str:
         cards.append(
             "\n".join(
                 (
-                    '      <td valign="middle">',
+                    f'      <td valign="middle" width="{card_width:.2f}%">',
                     f'        <a href="{profile}"><img src="{avatar}" width="{image_size}" align="left" alt="{name}" /></a>',
                     f'        &nbsp;<strong><a href="{profile}">{name}</a></strong><br />',
                     f"        &nbsp;<sub>{labels}</sub>",
@@ -88,7 +89,7 @@ def render_contributors(config: dict[str, object]) -> str:
         "\n".join(("    <tr>", *cards[index : index + per_line], "    </tr>"))
         for index in range(0, len(cards), per_line)
     ]
-    return "\n".join(("<table>", "  <tbody>", *rows, "  </tbody>", "</table>"))
+    return "\n".join(('<table width="100%">', "  <tbody>", *rows, "  </tbody>", "</table>"))
 
 
 def update_readme(readme: str, rendered: str) -> str:

--- a/scripts/render_contributors.py
+++ b/scripts/render_contributors.py
@@ -1,0 +1,129 @@
+"""Render the compact README contributor cards from .all-contributorsrc."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+from pathlib import Path
+
+START = "<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->"
+END = "<!-- ALL-CONTRIBUTORS-LIST:END -->"
+
+CONTRIBUTION_LABELS = {
+    "a11y": ("♿", "Accessibility"),
+    "bug": ("🐛", "Bug reports"),
+    "code": ("💻", "Code"),
+    "content": ("🖋️", "Content"),
+    "data": ("🔣", "Data"),
+    "design": ("🎨", "Design"),
+    "doc": ("📖", "Documentation"),
+    "ideas": ("🤔", "Ideas and feedback"),
+    "infra": ("🚇", "Infrastructure"),
+    "maintenance": ("🚧", "Maintenance"),
+    "mentoring": ("🧑‍🏫", "Mentoring"),
+    "platform": ("📦", "Packaging"),
+    "projectManagement": ("📆", "Project management"),
+    "promotion": ("📣", "Promotion"),
+    "question": ("💬", "Community support"),
+    "research": ("🔬", "Research"),
+    "review": ("👀", "Review"),
+    "security": ("🛡️", "Security"),
+    "test": ("⚠️", "Tests"),
+    "tool": ("🔧", "Tools"),
+    "translation": ("🌍", "Translation"),
+    "tutorial": ("✅", "Tutorials"),
+    "userTesting": ("📓", "User testing"),
+}
+
+
+def _label(contribution: str) -> str:
+    icon, label = CONTRIBUTION_LABELS.get(
+        contribution, ("✨", contribution.replace("_", " ").strip().title())
+    )
+    return f"{icon}&nbsp;{html.escape(label)}"
+
+
+def _avatar_url(url: str, size: int) -> str:
+    separator = "&" if "?" in url else "?"
+    return f"{url}{separator}size={size * 2}"
+
+
+def render_contributors(config: dict[str, object]) -> str:
+    contributors = config.get("contributors", [])
+    if not isinstance(contributors, list):
+        raise ValueError("contributors must be a list")
+
+    per_line = int(config.get("contributorsPerLine", 2))
+    image_size = int(config.get("imageSize", 56))
+    if per_line < 1:
+        raise ValueError("contributorsPerLine must be at least 1")
+    if image_size < 1:
+        raise ValueError("imageSize must be at least 1")
+
+    cards: list[str] = []
+    for raw in contributors:
+        if not isinstance(raw, dict):
+            raise ValueError("each contributor must be an object")
+        name = html.escape(str(raw["name"]))
+        profile = html.escape(str(raw["profile"]), quote=True)
+        avatar = html.escape(_avatar_url(str(raw["avatar_url"]), image_size), quote=True)
+        contributions = raw.get("contributions", [])
+        if not isinstance(contributions, list):
+            raise ValueError("contributions must be a list")
+        labels = " &nbsp;·&nbsp; ".join(_label(str(item)) for item in contributions)
+        cards.append(
+            "\n".join(
+                (
+                    '      <td valign="middle">',
+                    f'        <a href="{profile}"><img src="{avatar}" width="{image_size}" align="left" alt="{name}" /></a>',
+                    f'        &nbsp;<strong><a href="{profile}">{name}</a></strong><br />',
+                    f"        &nbsp;<sub>{labels}</sub>",
+                    "      </td>",
+                )
+            )
+        )
+
+    rows = [
+        "\n".join(("    <tr>", *cards[index : index + per_line], "    </tr>"))
+        for index in range(0, len(cards), per_line)
+    ]
+    return "\n".join(("<table>", "  <tbody>", *rows, "  </tbody>", "</table>"))
+
+
+def update_readme(readme: str, rendered: str) -> str:
+    start = readme.find(START)
+    end = readme.find(END)
+    if start == -1 or end == -1 or end < start:
+        raise ValueError("README contributor markers are missing or out of order")
+    end += len(END)
+    replacement = f"{START}\n{rendered}\n{END}"
+    return f"{readme[:start]}{replacement}{readme[end:]}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="fail if README is not up to date")
+    args = parser.parse_args()
+
+    root = Path(__file__).resolve().parents[1]
+    config_path = root / ".all-contributorsrc"
+    readme_path = root / "README.md"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    current = readme_path.read_text(encoding="utf-8")
+    updated = update_readme(current, render_contributors(config))
+
+    if args.check:
+        if updated != current:
+            print("README contributor cards are out of date.")
+            return 1
+        print("README contributor cards are up to date.")
+        return 0
+
+    readme_path.write_text(updated, encoding="utf-8")
+    print("Rendered README contributor cards.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_contributors.py
+++ b/scripts/render_contributors.py
@@ -54,15 +54,11 @@ def render_contributors(config: dict[str, object]) -> str:
     if not isinstance(contributors, list):
         raise ValueError("contributors must be a list")
 
-    per_line = int(config.get("contributorsPerLine", 2))
     image_size = int(config.get("imageSize", 56))
-    if per_line < 1:
-        raise ValueError("contributorsPerLine must be at least 1")
     if image_size < 1:
         raise ValueError("imageSize must be at least 1")
 
     cards: list[str] = []
-    card_width = 100 / per_line
     for raw in contributors:
         if not isinstance(raw, dict):
             raise ValueError("each contributor must be an object")
@@ -76,20 +72,17 @@ def render_contributors(config: dict[str, object]) -> str:
         cards.append(
             "\n".join(
                 (
-                    f'      <td valign="middle" width="{card_width:.2f}%">',
-                    f'        <a href="{profile}"><img src="{avatar}" width="{image_size}" align="left" alt="{name}" /></a>',
-                    f'        &nbsp;<strong><a href="{profile}">{name}</a></strong><br />',
-                    f"        &nbsp;<sub>{labels}</sub>",
-                    "      </td>",
+                    "<p>",
+                    f'  <a href="{profile}"><img src="{avatar}" width="{image_size}" align="left" alt="{name}" /></a>',
+                    f'  &nbsp;&nbsp;<strong><a href="{profile}">{name}</a></strong><br />',
+                    f"  &nbsp;&nbsp;<sub>{labels}</sub>",
+                    "</p>",
+                    '<br clear="left" />',
                 )
             )
         )
 
-    rows = [
-        "\n".join(("    <tr>", *cards[index : index + per_line], "    </tr>"))
-        for index in range(0, len(cards), per_line)
-    ]
-    return "\n".join(('<table width="100%">', "  <tbody>", *rows, "  </tbody>", "</table>"))
+    return "\n".join(cards)
 
 
 def update_readme(readme: str, rendered: str) -> str:

--- a/scripts/render_contributors.py
+++ b/scripts/render_contributors.py
@@ -18,6 +18,7 @@ CONTRIBUTION_LABELS = {
     "data": ("🔣", "Data"),
     "design": ("🎨", "Design"),
     "doc": ("📖", "Documentation"),
+    "growth": ("📈", "Growth"),
     "ideas": ("🤔", "Ideas and feedback"),
     "infra": ("🚇", "Infrastructure"),
     "maintenance": ("🚧", "Maintenance"),
@@ -54,7 +55,10 @@ def render_contributors(config: dict[str, object]) -> str:
     if not isinstance(contributors, list):
         raise ValueError("contributors must be a list")
 
+    per_line = int(config.get("contributorsPerLine", 3))
     image_size = int(config.get("imageSize", 56))
+    if per_line < 1:
+        raise ValueError("contributorsPerLine must be at least 1")
     if image_size < 1:
         raise ValueError("imageSize must be at least 1")
 
@@ -74,17 +78,20 @@ def render_contributors(config: dict[str, object]) -> str:
         cards.append(
             "\n".join(
                 (
-                    "<p>",
-                    f'  <a href="{profile}"><img src="{avatar}" width="{image_size}" align="left" alt="{name}" /></a>',
-                    f'  &nbsp;&nbsp;<strong><a href="{profile}">{name}</a></strong><br />',
-                    f"  &nbsp;&nbsp;<sub>{labels}</sub>",
-                    "</p>",
-                    '<br clear="left" />',
+                    '      <td valign="middle">',
+                    f'        <a href="{profile}"><img src="{avatar}" width="{image_size}" align="left" alt="{name}" /></a>',
+                    f'        &nbsp;&nbsp;<strong><a href="{profile}">{name}</a></strong><br />',
+                    f"        &nbsp;&nbsp;<sub>{labels}</sub>",
+                    "      </td>",
                 )
             )
         )
 
-    return "\n".join(cards)
+    rows = [
+        "\n".join(("    <tr>", *cards[index : index + per_line], "    </tr>"))
+        for index in range(0, len(cards), per_line)
+    ]
+    return "\n".join(("<table>", "  <tbody>", *rows, "  </tbody>", "</table>"))
 
 
 def update_readme(readme: str, rendered: str) -> str:

--- a/tests/test_render_contributors.py
+++ b/tests/test_render_contributors.py
@@ -38,3 +38,22 @@ def test_compact_cards_escape_profile_data_and_wrap_rows() -> None:
     assert "version=1&amp;size=112" in rendered
     assert "💻&nbsp;Code" in rendered
     assert "🤔&nbsp;Ideas and feedback" in rendered
+
+
+def test_contributor_without_assigned_types_gets_neutral_label() -> None:
+    rendered = render_contributors(
+        {
+            "contributors": [
+                {
+                    "login": "example",
+                    "name": "Example",
+                    "avatar_url": "https://example.com/avatar.png",
+                    "profile": "https://example.com/",
+                    "contributions": [],
+                }
+            ],
+            "imageSize": 56,
+        }
+    )
+
+    assert "✨&nbsp;Contributor" in rendered

--- a/tests/test_render_contributors.py
+++ b/tests/test_render_contributors.py
@@ -31,7 +31,8 @@ def test_compact_cards_escape_profile_data_and_wrap_rows() -> None:
     )
 
     assert rendered.count("<tr>") == 2
-    assert rendered.count('<td valign="middle">') == 3
+    assert '<table width="100%">' in rendered
+    assert rendered.count('<td valign="middle" width="50.00%">') == 3
     assert "Example &lt;Person&gt;" in rendered
     assert "&quot;profile&quot;" in rendered
     assert "version=1&amp;size=112" in rendered

--- a/tests/test_render_contributors.py
+++ b/tests/test_render_contributors.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.render_contributors import render_contributors, update_readme
+
+
+def test_committed_contributor_cards_match_config() -> None:
+    root = Path(__file__).resolve().parents[1]
+    config = json.loads((root / ".all-contributorsrc").read_text(encoding="utf-8"))
+    readme = (root / "README.md").read_text(encoding="utf-8")
+
+    assert update_readme(readme, render_contributors(config)) == readme
+
+
+def test_compact_cards_escape_profile_data_and_wrap_rows() -> None:
+    contributor = {
+        "login": "example",
+        "name": "Example <Person>",
+        "avatar_url": "https://example.com/avatar.png?version=1",
+        "profile": 'https://example.com/?q="profile"',
+        "contributions": ["code", "ideas"],
+    }
+    rendered = render_contributors(
+        {
+            "contributors": [contributor, contributor, contributor],
+            "contributorsPerLine": 2,
+            "imageSize": 56,
+        }
+    )
+
+    assert rendered.count("<tr>") == 2
+    assert rendered.count('<td valign="middle">') == 3
+    assert "Example &lt;Person&gt;" in rendered
+    assert "&quot;profile&quot;" in rendered
+    assert "version=1&amp;size=112" in rendered
+    assert "💻&nbsp;Code" in rendered
+    assert "🤔&nbsp;Ideas and feedback" in rendered

--- a/tests/test_render_contributors.py
+++ b/tests/test_render_contributors.py
@@ -25,19 +25,39 @@ def test_compact_cards_escape_profile_data_and_wrap_rows() -> None:
     rendered = render_contributors(
         {
             "contributors": [contributor, contributor, contributor],
-            "contributorsPerLine": 2,
+            "contributorsPerLine": 3,
             "imageSize": 56,
         }
     )
 
-    assert "<table" not in rendered
-    assert rendered.count("<p>") == 3
-    assert rendered.count('<br clear="left" />') == 3
+    assert rendered.count("<tr>") == 1
+    assert rendered.count('<td valign="middle">') == 3
     assert "Example &lt;Person&gt;" in rendered
     assert "&quot;profile&quot;" in rendered
     assert "version=1&amp;size=112" in rendered
     assert "💻&nbsp;Code" in rendered
     assert "🤔&nbsp;Ideas and feedback" in rendered
+
+
+def test_compact_cards_start_a_new_row_after_three_people() -> None:
+    contributor = {
+        "login": "example",
+        "name": "Example",
+        "avatar_url": "https://example.com/avatar.png",
+        "profile": "https://example.com/",
+        "contributions": ["growth"],
+    }
+
+    rendered = render_contributors(
+        {
+            "contributors": [contributor, contributor, contributor, contributor],
+            "contributorsPerLine": 3,
+            "imageSize": 56,
+        }
+    )
+
+    assert rendered.count("<tr>") == 2
+    assert "📈&nbsp;Growth" in rendered
 
 
 def test_contributor_without_assigned_types_gets_neutral_label() -> None:

--- a/tests/test_render_contributors.py
+++ b/tests/test_render_contributors.py
@@ -30,9 +30,9 @@ def test_compact_cards_escape_profile_data_and_wrap_rows() -> None:
         }
     )
 
-    assert rendered.count("<tr>") == 2
-    assert '<table width="100%">' in rendered
-    assert rendered.count('<td valign="middle" width="50.00%">') == 3
+    assert "<table" not in rendered
+    assert rendered.count("<p>") == 3
+    assert rendered.count('<br clear="left" />') == 3
     assert "Example &lt;Person&gt;" in rendered
     assert "&quot;profile&quot;" in rendered
     assert "version=1&amp;size=112" in rendered


### PR DESCRIPTION
## What

- add an All Contributors configuration for the public repository
- add a compact, borderless contributor profile list to the README
- add a deterministic local renderer so contributor data and the custom UI stay in sync
- document the maintainer workflow and the boundary from GitHub automatic contributor stats
- seed only the repository contributor currently supported by commit evidence

## Why

Persome needs a maintainable way to credit code and non-code contributors without relying on commit authorship or hand-editing README HTML. Organization membership remains a lookup aid, not evidence of contribution.

## How verified

- `uv run python scripts/render_contributors.py --check`
- `uv run pytest tests/test_render_contributors.py -q`
- `uv run ruff check scripts/render_contributors.py tests/test_render_contributors.py`
- `uv run ruff format --check scripts/render_contributors.py tests/test_render_contributors.py`
- `uv run python scripts/check_doc_links.py`
- `uv run python scripts/secret_scan.py`
- `uv run python scripts/pii_scan.py`
- `uv run python scripts/language_scan.py`
- visual verification on the rendered GitHub branch README

## Follow-up before ready

Add the agreed contributor handles and contribution types to this branch.