### PR TITLE
Harden onboarding permissions and atomic updates

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -33,9 +33,13 @@ tests can run on Linux with macOS-marked tests deselected.
 
 ## State formation
 
-1. `capture/` receives Accessibility events. Supported installs enable bundled,
-   subprocess-isolated PP-OCRv6 as a fallback when an app exposes no usable AX
-   text; AX remains the primary signal.
+1. In `capture.source="daemon"`, the source-versioned native watcher receives
+   Accessibility events and the matching helper reads focused trees. In
+   `capture.source="ingest"`, a trusted bearer-authenticated producer owns OS
+   capture and the daemon starts no watcher. Both modes converge before S1.
+   Supported Apple Silicon installs can enable bundled, subprocess-isolated
+   PP-OCRv6 as a fallback when an app exposes no usable AX text; AX remains the
+   primary daemon-mode signal.
 2. `parsers/` normalizes app-specific structures into capture records.
 3. `timeline/` groups records into one-minute blocks and preserves authored
    evidence.
@@ -50,6 +54,34 @@ The detailed stage behavior lives in
 [`docs/timeline.md`](docs/timeline.md),
 [`docs/session.md`](docs/session.md), and
 [`docs/writer.md`](docs/writer.md).
+
+## Runtime control plane
+
+`persome onboard` proves the configured mode rather than assuming one universal
+capture path. Daemon mode requests Accessibility for the actual immutable
+`mac-ax-helper` and optional `mac-ax-watcher` principals, requests Screen
+Recording only when the effective pixel policy requires it, and obtains a fresh
+capture from the running scheduler. Ingest mode proves the authenticated ingest
+runner. Intel, explicit OCR opt-out, paused/locked privacy state, and
+HTTP-disabled daemon mode each publish their truthful readiness receipt. The
+durable `[capture].ocr_policy` prevents ordinary onboarding or an update from
+silently reversing an explicit choice.
+
+Every daemon holds `<PERSOME_ROOT>/.daemon.lock` for its lifetime and publishes
+an owner-only `.runtime-state.json` with generation, phase, policy, permission,
+worker, and capture/privacy receipts. PID, current-user process identity, start
+time, executable/command, and generation are revalidated before signaling.
+LaunchAgent ownership also binds the loaded job program/PID and persistent
+`.launchagent-owner` intent marker to that Runtime.
+
+Updates build an inactive, transaction-marked virtualenv, then exchange it with
+the active venv using one same-filesystem kernel operation. The old code remains
+at the replacement path until the new final owner passes onboarding. Fsynced
+transaction phase plus the marker permit deterministic rollback even if the
+updater crashes immediately around the exchange. Swift AX binaries live outside
+either venv at immutable architecture/source-digest paths, so a same-version
+reinstall reuses the exact TCC principal, changed helper source requires an
+explicit new grant, and rollback resolves the old binary again.
 
 ## Model construction
 
@@ -86,6 +118,8 @@ written atomically with owner-only permissions.
 | `index.db` | WAL-mode FTS5, model, provenance, sessions, and vectors |
 | `model-build.json` | last reproducibility manifest |
 | `exports/*.json` | redacted model snapshots, mode `0600` |
+| `.runtime-state.json` | owner-only Runtime generation and readiness receipt |
+| `native/<source-digest>/` | immutable AX helper/watcher binaries |
 
 Markdown remains the default write authority; evomem can be selected
 explicitly. The runtime does not destructively migrate old product tables, and

--- a/README.md
+++ b/README.md
@@ -72,11 +72,14 @@ This sample path is deliberately separate from the real-data path below.
 Requirements: macOS 13 or newer, Xcode Command Line Tools, and a Python build
 with SQLite 3.42+ (the installer verifies the secure FTS capability). The installer
 finds or installs `uv`, provisions Python 3.11-3.13, compiles the Swift AX
-helpers, generates the local screenshot-encryption key, enables and verifies
-local OCR, and offers to register detected MCP clients. Before it reports
-success, a native onboarding flow explains and requests Accessibility and
-Screen Recording separately, starts Persome, checks local health, and writes a
-fresh capture. Its fallback `uv` download is version-pinned and checked
+helpers into immutable source-versioned paths under `~/.persome/native/`,
+generates the local screenshot-encryption key, configures local OCR, and offers
+to register detected MCP clients. Before it reports success, onboarding explains
+and requests Accessibility for the capture helper and event watcher separately,
+then requests Screen Recording only when the effective pixel policy needs it.
+It starts Persome, proves the final lifecycle owner and Runtime generation, and
+obtains a mode-appropriate capture receipt. Its fallback `uv` download is
+version-pinned and checked
 against repository-pinned SHA-256 digests; the Runtime environment is installed
 from the committed `uv.lock`, and the complete build-backend closure is
 hash-constrained rather than resolved afresh.
@@ -86,20 +89,40 @@ git clone https://github.com/Intuition-Lab/personal-model.git
 cd personal-model
 bash install.sh
 
-persome doctor
-persome onboard
-persome ocr status --check
+persome status
 persome model open
+
+# Repeat only to repair/recheck permissions and Runtime proof:
+persome onboard
+# Diagnostic; exits nonzero for intentionally unconfigured optional features:
+persome doctor
 ```
 
-`persome onboard` is the repeatable recovery path. It shows one plain-language
-macOS dialog before each system permission request and does not complete until
-**Accessibility** and **Screen Recording** are granted. It then verifies the
-isolated OCR worker, leaves the daemon running, polls `GET /health`, and forces
-one fresh capture. OCR supplies text for AX-poor apps such as WeChat and Feishu;
-pixels never enter an LLM prompt. The terminal reports each active stage because
-the first OCR model load can take up to two minutes, and completion never waits on
-a hidden dialog. Persome does not require Full Disk Access.
+`persome onboard` is the repeatable recovery path. In standard daemon-capture
+mode it presents a plain-language explanation before each macOS request. The
+versioned `mac-ax-helper` and, when event-driven capture is enabled,
+`mac-ax-watcher` are the Accessibility principals; the terminal and Python
+daemon are not substitutes for those grants. On Apple Silicon it also verifies
+the isolated OCR worker when OCR is enabled, leaves the daemon running, and
+forces one fresh capture through the daemon-owned runner. The authenticated
+`/permissions` result re-runs the actual helper/watcher probes and the Runtime's
+Screen Recording preflight. If HTTP auto-start is intentionally disabled, the
+same generation publishes equivalent owner-only readiness and capture receipts
+in `.runtime-state.json`. Trusted ingest, Intel without local OCR, explicit OCR/pixel
+opt-out, and paused/locked update flows report their effective mode rather than
+claiming an OCR capture occurred. OCR supplies
+text for AX-poor apps such as WeChat and Feishu; pixels never enter an LLM
+prompt. The first OCR model load can take up to two minutes; repeated onboarding
+normally finishes in seconds without warming a second worker. Completion never
+waits on a hidden final dialog. Persome does not require Full Disk Access.
+
+OCR intent is durable in `[capture].ocr_policy`: `auto` is an unconfigured fresh
+install, while `enabled` and `disabled` record an explicit choice. Ordinary
+`persome onboard` preserves an existing tier or opt-out. Running
+`persome onboard --tier tiny` or `persome ocr setup` explicitly enables OCR;
+`persome ocr disable` records the opt-out. In `source="ingest"` mode the trusted
+producer owns macOS capture permissions and Persome proves the authenticated
+ingest runner instead of pretending that its daemon produced an AX frame.
 
 ### Update an existing installation
 
@@ -109,17 +132,33 @@ Run the updater from any directory; no Git checkout is required:
 persome update
 ```
 
-The command downloads a fresh shallow checkout of the official `main` branch,
-stops the old Runtime, runs the locked installer in update mode, preserves
-`~/.persome` configuration, credentials, and personal data, then repeats the
-permission/OCR/health/fresh-capture onboarding proof. It does not modify a
-developer checkout. A failed or interrupted update atomically restores the
-previous virtualenv and restarts the previous Runtime. To test or install an
-already-reviewed local tree instead:
+The command downloads a fresh shallow checkout of the official `main` branch
+and builds a relocatable `venv.replacement.update` while the active `venv`
+remains untouched. Activation rejects a console script that still embeds the
+inactive candidate path.
+Under one owner-only update lock it stops the old Runtime, atomically exchanges
+the prepared and active directories, restores the prior lifecycle owner, and
+runs mode-aware onboarding against that exact generation. Only a successful
+permission, policy, owner, health, and capture/readiness proof commits the
+exchange. A failed, interrupted, or crash-recovered update atomically exchanges
+the old virtualenv back and restores its Runtime owner; repeated interrupts
+cannot abort recovery. Configuration, credentials, personal data, capture
+policy, and lifecycle intent under `~/.persome` are preserved, and a developer
+checkout is never modified. To install an already-reviewed local tree instead:
 
 ```bash
 persome update --source /path/to/personal-model
 ```
+
+Running `bash install.sh` again over an existing installation automatically
+delegates to this same transactional update path; it does not replace a live
+virtualenv in place or rerun LLM provider setup.
+
+The AX binaries are keyed by their source bytes and architecture. Reinstalling
+the same version reuses the exact executable (and therefore its existing macOS
+grant); a release that changes helper source uses a new path and onboarding asks
+for that new principal explicitly. If an update rolls back, the old Runtime
+resolves the old helper path again.
 
 ```bash
 # Recheck or repair OCR onboarding; disable is always explicit and reversible.
@@ -178,10 +217,10 @@ or degraded states instead of inventing geometry.
 
 ### Cross-app
 
-The Swift watcher reads the focused AX tree across native and browser apps.
-Persome normalizes focused element, visible text, window, application, URL, and
-time into one capture and session pipeline. OCR is a fallback, not a parallel
-cloud recorder.
+The source-versioned Swift watcher notices AX events and the matching helper
+reads the focused AX tree across native and browser apps. Persome normalizes
+focused element, visible text, window, application, URL, and time into one
+capture and session pipeline. OCR is a fallback, not a parallel cloud recorder.
 
 ### Agent-ready
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ macOS dialog before each system permission request and does not complete until
 **Accessibility** and **Screen Recording** are granted. It then verifies the
 isolated OCR worker, leaves the daemon running, polls `GET /health`, and forces
 one fresh capture. OCR supplies text for AX-poor apps such as WeChat and Feishu;
-pixels never enter an LLM prompt. Persome does not require Full Disk Access.
+pixels never enter an LLM prompt. The terminal reports each active stage because
+the first OCR model load can take up to two minutes, and completion never waits on
+a hidden dialog. Persome does not require Full Disk Access.
 
 ### Update an existing installation
 
@@ -111,7 +113,9 @@ The command downloads a fresh shallow checkout of the official `main` branch,
 stops the old Runtime, runs the locked installer in update mode, preserves
 `~/.persome` configuration, credentials, and personal data, then repeats the
 permission/OCR/health/fresh-capture onboarding proof. It does not modify a
-developer checkout. To test or install an already-reviewed local tree instead:
+developer checkout. A failed or interrupted update atomically restores the
+previous virtualenv and restarts the previous Runtime. To test or install an
+already-reviewed local tree instead:
 
 ```bash
 persome update --source /path/to/personal-model

--- a/SECURITY_PRIVACY.md
+++ b/SECURITY_PRIVACY.md
@@ -16,6 +16,8 @@ The default data root is `~/.persome` and can be redirected with
 | provider/local API secrets | `env` | dotenv file, mode `0600` |
 | build metadata | `model-build.json` | hashes/IDs, no API keys |
 | exported model | `exports/*.json` | redacted by default, mode `0600` |
+| Runtime receipts | `.runtime-state.json`, `.update-state.json` | owner-only generation, policy, and transaction metadata |
+| native AX binaries | `native/<source-digest>/` | immutable machine-local permission principals |
 
 The Runtime enforces mode `0700` on the data root and personal-data
 directories, and mode `0600` on databases, capture records, logs, snapshots,
@@ -26,9 +28,11 @@ artifacts are private from creation.
 Default capture retention is seven days. Screenshot payloads are stripped
 earlier by the configured screenshot retention window, except explicitly
 actionable captures covered by extended retention. On supported Apple Silicon
-installs, `install.sh` enables OCR after requesting Screen Recording and proving
-the isolated worker can load bundled PP-OCRv6 weights. Inference remains local;
-`persome ocr disable` is the explicit opt-out.
+installs, explicit onboarding can enable OCR after requesting Screen Recording
+and proving the isolated worker can load bundled PP-OCRv6 weights. Inference
+remains local. `[capture].ocr_policy` records `auto`, explicit `enabled`, or
+explicit `disabled` intent; ordinary onboarding and updates preserve explicit
+intent and tier. `persome ocr disable` is the durable opt-out.
 
 Lock-screen detection is privacy-conservative: when both macOS probes are
 unavailable or error, capture pauses until a probe can establish that the
@@ -46,6 +50,43 @@ and capture terms are removed from ordinary pages and full-text shadow indexes.
 On the first open after this security upgrade it also rebuilds both FTS indexes
 from live rows and vacuums the database, removing segment terms left by deletes
 performed by older releases.
+
+## macOS permission principals
+
+In daemon capture mode, Accessibility is granted to the native executable that
+uses the API: `mac-ax-helper` for focused-tree reads and, when event-driven
+capture is enabled, `mac-ax-watcher` for notifications. Granting the terminal,
+Python daemon, or launchd job is not a substitute. Onboarding explains, requests,
+and live-probes each required native principal separately. Screen Recording is
+preflighted by the Runtime process that obtains pixels. In trusted-ingest mode,
+the producer owns those macOS permissions and Persome proves authenticated
+ingest readiness rather than claiming a daemon grant.
+
+The wheel ships helper source. Persome derives a path from a format version,
+architecture, and source-byte digest, compiles once under
+`<PERSOME_ROOT>/native/<source-digest>/`, and publishes the executable with an
+atomic rename. A same-version reinstall reuses the exact binary and macOS grant.
+Changing helper source intentionally creates a new principal that requires an
+explicit grant. Rolling back runs the prior source version and resolves the old
+binary again; no updater overwrites an existing digest path.
+
+## Runtime and update integrity
+
+The daemon holds `.daemon.lock` for its entire lifetime. Lifecycle code treats
+`.pid` as compatibility metadata, not authority: current-user ownership,
+executable/command, process start time, and the random generation in the
+owner-only `.runtime-state.json` are verified and rechecked immediately before a
+signal. A live Persome-shaped process with ambiguous generation fails closed so
+a second writer cannot start. LaunchAgent ownership additionally binds the
+owner marker, loaded job program/PID, configured plist, and Runtime receipt.
+
+Updates hold one owner-only root lock and build an inactive, transaction-marked
+candidate while the active virtualenv remains untouched. Activation exchanges
+the two same-filesystem directories in one kernel operation. The old venv stays
+available until the new final owner passes mode-aware permission, OCR-policy,
+health, and capture/readiness proof. Fsynced phase metadata and the candidate
+marker make a crash immediately before or after exchange recoverable; rollback
+atomically exchanges the old Runtime back before restoring its lifecycle owner.
 
 ## Network egress
 
@@ -123,7 +164,7 @@ quarantine copies. Journals and orphan sidecars are removed. Explicit clean
 operations enable SQLite/FTS secure deletion, compact free pages, and truncate
 the WAL; a recovery copy that cannot be reliably scrubbed is removed rather
 than silently retaining the requested data. All clean commands refuse to run
-while the daemon PID is live.
+while the verified Runtime identity or its lifetime lock is live.
 
 ## Export caveat
 
@@ -142,7 +183,7 @@ repository are synthetic and pass the PII gate.
 | Provider exfiltration | User chooses endpoints; no-key capture/BM25 mode remains available. |
 | Prompt injection | Generated memory is served as data, never as instructions or executable tools. Consuming MCP clients must still enforce their own tool policy. |
 | Malicious MCP client | Bearer/stdio access is an explicit personal-data capability; connect only trusted clients. |
-| Supply chain | Locked dependencies and the full build-backend closure are pinned; installer fallback downloads are checksum-verified; Actions use immutable SHAs and least privilege; releases made by the current workflow are checksummed, smoke-tested, and attested from an administrator-protected tag reachable from `main`. |
+| Supply chain | Locked dependencies and the full build-backend closure are pinned; installer fallback downloads are checksum-verified; wheel smoke tests inspect bundled Swift sources, viewer assets, and OCR weights outside the checkout; Actions use immutable SHAs and least privilege; releases made by the current workflow are checksummed and attested from an administrator-protected tag reachable from `main`. |
 | Accidental publication | Synthetic fixtures, PII scan, default redaction, and owner-only export permissions. |
 
 Vulnerability reporting instructions are in [SECURITY.md](SECURITY.md).

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -56,7 +56,9 @@ uv run python scripts/language_scan.py
 uv run python scripts/check_doc_links.py
 ```
 
-`macos` tests need Accessibility permission or compiled Swift helpers.
+`macos` tests need the source-versioned Swift helpers and, for live AX tests,
+Accessibility grants for the actual `mac-ax-helper` and `mac-ax-watcher`
+executables. Granting only the terminal or daemon is not equivalent.
 `integration` tests use a real provider or the complete local OCR runtime and
 remain outside the offline gate.
 
@@ -73,7 +75,8 @@ drift tests.
 
 ## 5. Build and inspect a local model
 
-After installing the Swift helpers and granting Accessibility permission:
+After installing the Swift helpers and granting Accessibility to both native
+principals used by the configured daemon policy:
 
 ```bash
 bash install.sh
@@ -82,7 +85,6 @@ persome llm status --check
 persome ocr status --check
 persome doctor
 persome status
-persome capture-once
 
 # Work normally while the daemon performs incremental modeling.
 persome model status
@@ -103,6 +105,14 @@ Without a configured hosted credential or keyless local endpoint, capture and
 BM25 retrieval continue while semantic modeling reports degradation. A sparse
 model may correctly remain degraded until it has
 enough repeated evidence for higher geometry.
+
+`persome onboard` is the authoritative live smoke test because it invokes the
+running daemon's capture runner and binds the result to its generation and
+lifecycle owner. `persome capture-once` is only a lower-level helper diagnostic:
+it runs a new scheduler in the calling CLI, does not prove the event watcher,
+daemon ownership, generation, privacy receipt, or isolated worker readiness,
+and can race a running daemon. Stop Persome before using it in a focused helper
+test; do not use it as release or onboarding proof.
 
 ## 6. Verify the release artifact
 
@@ -125,14 +135,46 @@ PERSOME_ROOT=/tmp/persome-wheel-root \
   /tmp/persome-wheel-venv/bin/persome doctor
 PERSOME_ROOT=/tmp/persome-wheel-root \
   /tmp/persome-wheel-venv/bin/persome llm providers
+/tmp/persome-wheel-venv/bin/python - <<'PY'
+from importlib.resources import files
+
+bundled = files("persome") / "_bundled"
+required = (
+    "build-mac-ax-helper.sh",
+    "build-mac-ax-watcher.sh",
+    "mac-ax-helper.swift",
+    "mac-ax-watcher.swift",
+    "mac-url-handlers.swift",
+    "model_assets/LICENSE",
+    "model_assets/three.module.js",
+    "model_assets/layout.mjs",
+    "model_assets/viewer.css",
+    "model_assets/viewer.js",
+    "model_assets/jsm/controls/OrbitControls.js",
+    "model_assets/jsm/renderers/CSS2DRenderer.js",
+    "ocr_models/PP-OCRv6_tiny_det/inference.pdiparams",
+    "ocr_models/PP-OCRv6_tiny_rec/inference.pdiparams",
+)
+for relative in required:
+    assert (bundled / relative).is_file(), relative
+PY
 ```
 
-In an interactive macOS session, `install.sh` runs `persome onboard`. The
-onboarding command separately requests Accessibility and Screen Recording,
-performs a full bundled OCR worker initialization on Apple Silicon, starts the
-daemon, polls the canonical local health endpoint, and requires a fresh capture
-record before it succeeds. Non-interactive packaging environments must run the
-command later from a logged-in macOS session.
+In an interactive macOS session, `install.sh` runs `persome onboard`. For the
+standard Apple Silicon daemon mode, onboarding separately requests Accessibility
+for the source-versioned capture helper and event watcher, requests Screen
+Recording when the effective pixel policy needs it, starts the final owner,
+waits for its bundled OCR worker, polls canonical local health and authenticated
+permission endpoints, and requires an exact fresh-capture receipt from the
+daemon-owned runner. Repeated runs must reuse the same source-versioned native
+binaries and ready worker rather than compile new TCC principals or spawn a
+    second OCR process. The same command must also report truthfully for Intel
+    without local OCR, durable OCR/pixel opt-out, trusted ingest, paused/locked update,
+LaunchAgent-owned, and HTTP-disabled modes. HTTP-disabled daemon mode proves the
+same generation through owner-only `.runtime-state.json`; trusted ingest is
+rejected when its authenticated HTTP endpoint is disabled.
+Non-interactive packaging environments must run the command later from a
+logged-in macOS session.
 `persome ocr-selftest <image>` remains available for a known-image inference
 check.
 
@@ -144,8 +186,25 @@ uv run pytest tests/test_updater.py -q
 ```
 
 These tests pin the official shallow-clone arguments, local-source validation,
-daemon/LaunchAgent stop and recovery behavior, `install.sh --update` handoff,
-and the public CLI result.
+exclusive update ownership, inactive candidate construction, transaction-marker
+validation, one-operation directory exchange, crash recovery before/after that
+exchange, rejection of absolute candidate shebangs, execution of the relocated
+CLI after old-venv cleanup, signal-safe rollback, and final
+background/LaunchAgent ownership.
+Lifecycle tests also cover daemon lifetime locking, PID reuse, malformed live
+generation state, and owner-marker handoff. `tests/test_onboarding.py`,
+`tests/test_launchagent.py`, `tests/test_ax_capture.py`, and
+`tests/test_ocr_subprocess.py` cover the permission/mode cross-product,
+source-versioned helper reuse, durable `ocr_policy`, progress reporting, and
+daemon-owned worker/readiness receipts.
+
+For a manual native-identity regression, record the helper and watcher paths
+printed by two same-version installs and confirm they are byte-for-byte the same
+under `<PERSOME_ROOT>/native/<source-digest>/`. A deliberate helper-source
+change must resolve a different directory and require a fresh Accessibility
+grant; rolling that update back must resolve the old executable again. Never
+copy a newly compiled binary over an existing digest path to make a TCC test
+pass.
 
 For a GitHub Release produced by the current workflow (older releases are not
 retroactively attested), also download `SHA256SUMS`, verify it from the

--- a/docs/api.md
+++ b/docs/api.md
@@ -37,8 +37,12 @@ endpoint, key variable name, credential presence, and legacy-migration state.
 It never returns the credential value. Provider network probes run only for
 the explicit `GET /status?check_models=true` request and are cached briefly.
 `/status.data.ocr` reports the configured tier, Runtime and model availability,
-kill switch, Screen Recording, and effective readiness. `/health` exposes only
-the compact OCR state because it is the unauthenticated liveness route.
+kill switch, Screen Recording, and effective readiness. `/permissions` does not
+infer Accessibility from the terminal or Python daemon: in daemon mode it runs
+the source-versioned helper and optional watcher self-checks plus the Runtime's
+Screen Recording preflight. In trusted-ingest mode those OS permissions belong
+to the producer and are reported as not applicable to the daemon. `/health`
+exposes only compact OCR state because it is the unauthenticated liveness route.
 
 ## Model contract
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,9 +37,12 @@ flowchart LR
 
 ### State formation
 
-1. The Swift watcher emits AX events. `capture/event_dispatcher.py` performs
-   event deduplication, debounce, and minimum-gap control.
-2. `capture/scheduler.py` builds an S1 record. AX is primary. When explicitly
+1. With `capture.source="daemon"`, the source-versioned Swift watcher emits AX
+   events and `capture/event_dispatcher.py` performs event deduplication,
+   debounce, and minimum-gap control. With `source="ingest"`, a trusted local
+   producer owns OS capture and sends authenticated frames; the daemon starts no
+   watcher. Both modes converge in the same scheduler/commit path.
+2. `capture/scheduler.py` builds an S1 record. AX is primary in daemon mode. When explicitly
    enabled and AX text is poor, a focused screenshot is sent to an isolated
    local OCR subprocess; its text is backfilled into `captures` FTS.
 3. `timeline/aggregator.py` consults both the capture JSON and OCR backfill,
@@ -50,6 +53,39 @@ flowchart LR
 5. `writer/session_reducer.py` flushes active sessions every five minutes;
    `writer.agent.model_active_session` turns each new window into Points/Lines.
    Session end writes and models only the trailing range.
+
+### Runtime readiness and ownership
+
+The control path is generation-bound. `.daemon.lock` is acquired before start
+preflight and inherited for the complete foreground or double-forked daemon
+lifetime. The daemon publishes `.runtime-state.json` with `starting`/`ready`
+phase, random generation, current permission probes, OCR policy/worker state,
+and its last fresh-capture, ingest-readiness, paused, or locked receipt. HTTP
+onboarding reads the same data through authenticated endpoints; HTTP-disabled
+mode reads the owner-only file directly.
+
+Lifecycle operations treat `.pid` as compatibility input, then verify user,
+command/executable, process start time, and generation again before signaling.
+LaunchAgent ownership additionally requires its loaded job program/PID and
+configured plist to match the recorded Runtime; `.launchagent-owner` preserves
+intent across updates. Ambiguous live state fails closed rather than starting a
+second writer.
+
+AX permissions are similarly bound to the actual principals. The immutable
+`mac-ax-helper` and optional `mac-ax-watcher` each self-check/request
+Accessibility. Their machine-local path is derived from architecture and Swift
+source bytes, so same-version installs reuse the exact executable. Changed
+helper source resolves a new path and requires a new explicit grant; rollback
+resolves the old helper again. `[capture].ocr_policy` independently preserves
+`auto`, explicit enabled, or explicit disabled intent across onboarding/update.
+
+The updater holds a separate owner-only lock, builds a marked inactive
+`venv.replacement.update`, and atomically exchanges it with `venv`. The old code
+stays at the replacement path until the replacement's final background or
+LaunchAgent owner passes the mode-aware readiness proof. Transaction phase and
+candidate marker are fsynced, so recovery can tell whether exchange occurred
+even if the process died before recording the next phase; rollback performs the
+same atomic exchange in reverse.
 
 ### Incremental and terminal modeling
 

--- a/docs/capture.md
+++ b/docs/capture.md
@@ -2,14 +2,28 @@
 
 Capture is the only layer that touches the outside world. It produces one JSON file per observation into `~/.persome/capture-buffer/`; nothing above it ever talks to macOS directly.
 
-Live capture requires macOS Accessibility permission for the process that runs
-Persome. Screen Recording is additionally required when screenshots or OCR are
-enabled. In an interactive install, `persome onboard` explains and requests
-Accessibility and Screen Recording separately, verifies bundled OCR on
-supported Apple Silicon Macs, starts the daemon, checks local health, and proves
-one fresh capture before returning success.
+In `source="daemon"` mode, live capture requires Accessibility for the native
+`mac-ax-helper` and, when event-driven capture is enabled, the separate
+`mac-ax-watcher` executable. The terminal and Python daemon do not read AX on
+their behalf. Screen Recording is additionally required when screenshot storage
+or effective OCR needs pixels. In a standard interactive Apple Silicon install,
+`persome onboard` explains and requests each required principal separately,
+verifies bundled OCR, starts the final daemon owner, checks local health, and
+proves one fresh capture inside that daemon before returning success. The
+authenticated `/permissions` endpoint runs the actual helper/watcher trust
+checks plus the Runtime's Screen Recording preflight. With HTTP auto-start
+disabled, the same generation publishes its permission, worker, phase, and
+capture receipts to owner-only `.runtime-state.json`.
+
+In `source="ingest"` mode a trusted local producer owns macOS AX and pixel
+permissions and sends bearer-authenticated frames to `/captures/ingest`; the
+daemon starts no OS watcher. Onboarding proves that ingest runner is ready
+instead of manufacturing a daemon AX capture. This mode requires an enabled
+HTTP transport because the authenticated endpoint is its only input channel.
 
 ## Two signal sources
+
+The following two sources apply to daemon capture mode.
 
 **`mac-ax-watcher`** (primary, event-driven). A vendored Swift binary that subscribes to AX notifications across all running apps: window focus, value changes (typing), title changes, app activation. It emits one JSON object per event on stdout. The Python side reads that stream line-by-line in `capture/watcher.py` → `capture/event_dispatcher.py`.
 
@@ -33,9 +47,13 @@ The same capture scheduler also invokes `SessionManager.on_event` (wired as a `p
 
 The installer runs `persome onboard`, whose OCR step checks the native Runtime
 and bundled weights, requests Screen Recording after an explicit explanation,
-starts the isolated worker, and writes `enable_ocr_fallback = true` only after
-the worker initializes. The standalone `persome ocr setup` repair command keeps
-the same worker and persistence checks. The
+persists enabled intent, then starts the daemon and waits for the daemon-owned
+isolated worker to initialize. `[capture].ocr_policy` distinguishes `auto`
+(fresh/unconfigured), `enabled`, and `disabled` (explicit opt-out). Ordinary
+onboarding and every update preserve an explicit policy and selected tier;
+`persome onboard --tier ...` and `persome ocr setup` explicitly enable OCR,
+while `persome ocr disable` records disabled intent. The standalone setup repair
+command keeps its own explicit worker check. The
 focused screenshot is used locally and is never placed in an LLM prompt. The
 OCR path is:
 
@@ -52,6 +70,13 @@ The subprocess is the native-crash boundary: a Paddle fault fails the OCR call
 without killing the daemon. `PERSOME_DISABLE_OCR=1` prevents Paddle from being
 loaded at all. `PERSOME_OCR_IN_PROCESS=1` exists only for debugging and removes
 that isolation.
+
+The helper and watcher are compiled into immutable
+`<PERSOME_ROOT>/native/<source-digest>/` directories keyed by a format version,
+architecture, and Swift source bytes. A same-version reinstall returns the exact
+existing executables, preserving their macOS TCC identity. Changed helper source
+uses a new digest path and therefore requires a deliberate new Accessibility
+grant; rollback resolves the old wheel source and old binary again.
 
 ```bash
 persome onboard            # permissions + OCR + daemon + health + fresh capture
@@ -233,4 +258,10 @@ Drops a `~/.persome/.paused` sentinel. The watcher keeps streaming but `capture_
 persome capture-once
 ```
 
-Writes one capture immediately, prints its path. Good for confirming Accessibility permission is granted and the helper compiled correctly.
+This is a low-level developer diagnostic. It creates a provider and scheduler in
+the calling CLI, writes one immediate capture, and can confirm the one-shot
+helper returns useful AX content. It does **not** run through the active daemon's
+capture runner, prove the event watcher, bind a Runtime generation or lifecycle
+owner, validate a privacy/mode receipt, or wait for the daemon-owned OCR worker.
+It may race the running scheduler, so stop Persome before using it to isolate a
+helper problem. Use `persome onboard` for onboarding, update, and release proof.

--- a/docs/config.md
+++ b/docs/config.md
@@ -120,25 +120,42 @@ ax_depth = 100
 ax_timeout_seconds = 3
 
 enable_ocr_fallback = true
+ocr_policy = "enabled"               # auto | enabled | disabled
 ocr_tier = "tiny"                 # tiny | small | medium
 ocr_min_gap_seconds = 15.0
 ocr_structured = true
 cmux_source_enabled = true
 ```
 
-- `source="daemon"` owns macOS AX capture. `source="ingest"` accepts records
+- `source` is validated and must be `"daemon"` or `"ingest"`.
+  `source="daemon"` owns macOS AX capture. `source="ingest"` accepts records
   from the trusted bearer-authenticated `/captures/ingest` producer and starts
   no OS watcher. The producer must obtain `PERSOME_LOCAL_API_TOKEN` through an
   owner-approved local secret channel and must never put it in a URL.
-- Accessibility permission is required for daemon AX capture. `install.sh`
-  runs `persome onboard` in interactive sessions: it asks for Accessibility and
-  Screen Recording separately, enables OCR after its worker initializes, starts
-  the daemon, and proves local health plus one fresh capture.
+- Accessibility is required for the source-versioned `mac-ax-helper` and, when
+  `event_driven=true`, `mac-ax-watcher` in daemon mode. A terminal or Python
+  daemon grant does not replace either native principal. `install.sh` runs
+  `persome onboard` in interactive sessions: it asks for each Accessibility
+  principal and,
+  when screenshots or effective OCR need pixels, Screen Recording separately.
+  It persists the selected OCR policy, starts the final daemon owner, waits for
+  that daemon's isolated worker, and proves a mode-aware capture receipt.
+- `source="ingest"` requires `mcp.auto_start=true` and an HTTP transport because
+  `/captures/ingest` is its only authenticated input channel. Its trusted
+  producer owns the OS permissions; onboarding proves ingest readiness instead
+  of requiring daemon Accessibility.
+- `ocr_policy` is also validated. `auto` means a fresh or older configuration
+  has not recorded intent; `enabled` and `disabled` are durable user choices.
+  Ordinary `persome onboard` and updates preserve that choice and `ocr_tier`.
+  `persome onboard --tier tiny` or `persome ocr setup` explicitly enables OCR;
+  `persome ocr disable` records the opt-out. Do not toggle only
+  `enable_ocr_fallback` when representing user intent.
 - Paddle inference runs in a local worker subprocess so a native crash does not
   kill the daemon. OCR text is backfilled into capture search and consumed by
   timeline/modeling; pixels are not sent to an LLM stage. The source-level
-  config default remains off for unsupported/direct-library environments;
-  supported macOS installation writes the enabled state shown above.
+  config default is `enable_ocr_fallback=false`, `ocr_policy="auto"` for
+  unsupported/direct-library environments; a supported fresh macOS install
+  records the enabled state shown above after explicit onboarding.
 - `PERSOME_DISABLE_OCR=1` is the deployment kill switch.
 - `PERSOME_OCR_IN_PROCESS=1` is a debugging escape hatch that gives up crash
   isolation and should not be used for normal operation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,16 +30,26 @@ uv run python scripts/sample_demo.py
 
 ```bash
 bash install.sh
-persome llm status --check
-persome ocr status --check
+persome onboard
+persome status
+persome llm status
+persome ocr status
 persome doctor
-persome start
 persome model open
 ```
 
+The installer already runs onboarding in an interactive macOS session and
+leaves the Runtime running; the explicit `persome onboard` above is an
+idempotent recheck, not a prerequisite `stop`/`start` cycle. It requests
+Accessibility for the actual source-versioned AX helper and watcher, applies
+the durable OCR policy, proves the final Runtime owner and generation, and
+returns the receipt appropriate to daemon, ingest, paused, or locked mode.
+
 Update an existing installation from any directory with `persome update`. The
-command preserves local configuration and personal data, then repeats the
-permission, OCR, health, and fresh-capture proof.
+command builds an inactive candidate, atomically exchanges it with the active
+virtualenv, preserves local configuration and personal data, and commits only
+after the same mode-aware onboarding proof. An interrupted update exchanges the
+old Runtime back before restoring its lifecycle owner.
 
 Persome keeps data under `~/.persome`, uses local AX capture by default, offers
 optional on-device OCR, and serves streamable HTTP MCP at

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -19,22 +19,43 @@ compile the Swift AX helpers.
 
 | Permission | Required | Purpose | Effect when disabled |
 |---|---|---|---|
-| Accessibility | yes for live collection | reads the focused AX tree, application, window, selected control, and visible text | daemon remains healthy but produces no useful live captures |
-| Screen Recording | yes in the standard install | supplies focused-window pixels to the enabled local OCR worker and encrypted screenshot retention | AX collection continues, but health reports OCR degraded and AX-poor surfaces remain sparse |
+| Accessibility | yes for daemon-mode live collection | lets the source-versioned `mac-ax-helper` and optional `mac-ax-watcher` read focused AX structure and events | daemon remains healthy but produces no useful live AX captures |
+| Screen Recording | yes when screenshots or effective OCR are enabled | supplies focused-window pixels to local OCR and encrypted screenshot retention | AX collection continues; pixel features are unavailable |
 | Full Disk Access | no | not used | no effect |
 | Automation / Apple Events | no | not used by the Runtime | no effect |
 
-Grant permissions to the executable that launches Persome. If a terminal starts
-the daemon, grant that terminal. If launchd later owns the daemon, rerun
-`persome doctor` after the handoff and confirm live capture.
+Accessibility belongs to the native executables that actually call AX, not to
+the terminal or Python daemon that launches them. Onboarding requests and probes
+`mac-ax-helper` first and, when `event_driven=true`, `mac-ax-watcher` separately.
+Screen Recording is checked by the Runtime process that captures pixels. If the
+Runtime lifecycle or helper source changes, rerun `persome onboard` and let it
+name any new principal explicitly.
 
-Interactive `install.sh` runs `persome onboard`. It presents separate native
-dialogs for Accessibility and Screen Recording, waits for both live TCC probes,
-verifies the OCR worker, starts the daemon, polls local health, and writes one
-fresh capture. The terminal reports every stage because the first OCR model load
-can take up to two minutes; the final notification is non-blocking. Rerun
-`persome onboard` after changing the launcher identity; use `persome ocr disable`
-for an explicit OCR opt-out.
+Interactive `install.sh` runs `persome onboard`. Standard daemon mode presents
+separate native dialogs for the helper and watcher Accessibility grants, then
+Screen Recording when the configured pixel policy requires it. It starts the
+final lifecycle owner, verifies its isolated OCR worker when enabled, and writes
+one fresh capture through that daemon's runner. The authenticated `/permissions`
+endpoint invokes the actual helper/watcher probes and the Runtime's Screen
+Recording preflight. HTTP-disabled daemon mode publishes the same generation's
+owner-only state receipt; trusted ingest proves its authenticated runner and
+does not claim daemon-owned macOS permissions. Intel without local OCR and
+explicit OCR/pixel opt-out report their actual remaining AX/pixel capabilities.
+Updates preserve paused/locked privacy state without forcing a frame. The first
+OCR load can take up to two minutes; repeated runs publish progress and normally
+reuse the worker.
+
+`[capture].ocr_policy` makes intent durable: `auto` is a fresh/unconfigured
+state, while `enabled` and `disabled` are explicit choices. `persome onboard`
+without `--tier` preserves the current choice; `persome onboard --tier tiny` or
+`persome ocr setup` enables OCR, and `persome ocr disable` records the opt-out.
+The final notification is non-blocking.
+
+Each compiled AX helper lives at an immutable
+`native/<source-digest>/<helper-name>` path. Same-version reinstalls reuse the
+exact files and grants. A helper-source change produces a new path and requires
+an explicit new Accessibility grant; update rollback returns to the old wheel
+and old helper path.
 
 ## Local paths
 
@@ -52,6 +73,12 @@ for an explicit OCR opt-out.
 | `backup/` | SQLite safety snapshots containing personal model state |
 | `logs/` | daemon and launchd logs; may contain operational context |
 | `model-build.json` | latest build manifest and degraded-stage report |
+| `.pid`, `.runtime-state.json` | compatibility PID plus owner-only generation, phase, permission, OCR-worker, and capture/privacy receipt |
+| `.daemon.lock` | lifetime single-Runtime lock inherited across background forks |
+| `.launchagent-owner` | durable intent that launchd owns Runtime lifecycle |
+| `.update.lock`, `.update-state.json` | exclusive update lock and crash-recovery phase metadata |
+| `native/<source-digest>/` | immutable machine-local AX binaries; code, not personal data |
+| `venv.replacement.update`, `venv.previous.committed.*`, `venv.failed.update.*` | candidate, retained-old, and cleanup environments during a transaction; code, not personal data |
 | `venv/` | dedicated installer environment; code, not personal data |
 
 Treat the whole root as sensitive. Backups and exports are copies of personal
@@ -71,6 +98,14 @@ before the narrow index reset. Core database damage is still quarantined as
 SQLite writes, so `persome status`, MCP clients, and a second `persome start`
 do not repair or quarantine an open database.
 
+Runtime startup also fails closed on ambiguous process state. `.daemon.lock`
+serializes concurrent starters for the daemon's entire lifetime; `.pid` is
+resolved against current-user ownership, executable/command, process start
+time, and the generation in `.runtime-state.json` before any signal. Never
+manually signal or delete state based only on the numeric PID. Stop the owning
+Desktop app or LaunchAgent first when a live Persome process has an invalid
+generation receipt.
+
 ## Lifecycle and first recall
 
 ```bash
@@ -78,12 +113,16 @@ persome onboard
 persome llm status --check
 persome ocr status --check
 persome doctor
-persome start
 persome status
 persome pause
 persome resume
 persome stop
 ```
+
+`persome onboard` leaves the proved Runtime running. A following `persome start`
+should report that it is already running; stopping and starting again is not
+part of normal installation or update. Use `persome start` only when status says
+the Runtime is safely stopped.
 
 ## Update the Runtime
 
@@ -91,19 +130,44 @@ persome stop
 persome update
 ```
 
-The updater fetches a fresh shallow copy of the official `main` branch instead
-of editing a user's source checkout. It stops either the background daemon or
-the owner LaunchAgent, invokes the same locked wheel installer with existing
-LLM/MCP setup preserved, reruns onboarding and its fresh-capture proof, and
-restores prior LaunchAgent ownership. Configuration, secrets, capture history,
-memory, model state, and logs under `PERSOME_ROOT` are not replaced.
-Update-mode installation keeps the previous virtualenv until onboarding passes;
-a failed proof or interruption first restores the previous virtualenv with
-atomic directory renames, then restores the prior Runtime process or LaunchAgent.
+The updater fetches a fresh shallow copy of official `main` instead of editing a
+user's checkout. The installer builds a transaction-marked
+`venv.replacement.update` while `venv` remains the working old installation.
+After stopping either the background daemon or owner LaunchAgent, the updater
+atomically exchanges those directories in one same-filesystem kernel operation,
+restores the prior owner with the new executable, and runs mode-aware onboarding
+against that final generation. Configuration, secrets, capture history, memory,
+model state, logs, `ocr_policy`, and lifecycle intent under `PERSOME_ROOT` are
+not replaced.
+
+The exchanged old venv remains at `venv.replacement.update` until permission,
+OCR-policy, health, owner, and capture/readiness proof all pass. Only then is it
+renamed for post-commit cleanup. A failed proof or interruption exchanges the
+directories back before restoring and proving the prior Runtime owner. A
+transaction marker plus fsynced `preparing`/`prepared`/`activated`/`committing`
+state makes crashes on either side of the exchange deterministic to recover.
+INT, TERM, and HUP share that recovery path; further signals cannot interrupt
+rollback. Concurrent updates are serialized by the owner-only root lock.
+Invoking `bash install.sh` from a checkout when Persome is already installed
+delegates to `persome update --source <checkout>` so manual reinstalls receive
+the same stop, rollback, and post-install proof guarantees.
 
 `persome update --source /path/to/checkout` is the explicit developer/offline
 path. The supplied tree must have the complete Persome source layout; the
 updater never pulls or rewrites it.
+
+## Capture diagnostics
+
+Use `persome onboard` for an end-to-end proof. Its capture request runs inside
+the active daemon and binds permission, worker, privacy/mode receipt, generation,
+and lifecycle ownership.
+
+`persome capture-once` is a lower-level developer diagnostic. It constructs a
+new capture provider and scheduler in the calling CLI, so it does not prove the
+daemon's event watcher, lifetime lock, generation, owner, privacy receipt, or
+isolated OCR-worker readiness. It may also race a running capture scheduler.
+Stop Persome before using it to isolate helper output; a successful path is not
+an onboarding or release acceptance result.
 
 The default active-session flush is five minutes. Timeline closure and model
 processing add bounded local work, so the operational target for first useful

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -31,8 +31,10 @@ the daemon, grant that terminal. If launchd later owns the daemon, rerun
 Interactive `install.sh` runs `persome onboard`. It presents separate native
 dialogs for Accessibility and Screen Recording, waits for both live TCC probes,
 verifies the OCR worker, starts the daemon, polls local health, and writes one
-fresh capture. Rerun `persome onboard` after changing the launcher identity;
-use `persome ocr disable` for an explicit OCR opt-out.
+fresh capture. The terminal reports every stage because the first OCR model load
+can take up to two minutes; the final notification is non-blocking. Rerun
+`persome onboard` after changing the launcher identity; use `persome ocr disable`
+for an explicit OCR opt-out.
 
 ## Local paths
 
@@ -96,7 +98,8 @@ LLM/MCP setup preserved, reruns onboarding and its fresh-capture proof, and
 restores prior LaunchAgent ownership. Configuration, secrets, capture history,
 memory, model state, and logs under `PERSOME_ROOT` are not replaced.
 Update-mode installation keeps the previous virtualenv until onboarding passes;
-a failed proof stops the replacement daemon and restores the prior Runtime.
+a failed proof or interruption first restores the previous virtualenv with
+atomic directory renames, then restores the prior Runtime process or LaunchAgent.
 
 `persome update --source /path/to/checkout` is the explicit developer/offline
 path. The supplied tree must have the complete Persome source layout; the

--- a/docs/runtime-internals.md
+++ b/docs/runtime-internals.md
@@ -15,7 +15,9 @@ PERSOME_LOCAL_API_TOKEN
 
 `config.toml` contains behavior plus the provider id, protocol, model, endpoint,
 and key variable name, never the key value. `persome llm setup` writes that
-profile only after a live check. `PERSOME_ROOT`
+profile only after a live check. `[capture].ocr_policy` records OCR intent:
+`auto` is unconfigured, while `enabled` and `disabled` are durable user choices
+that ordinary onboarding and updates preserve. `PERSOME_ROOT`
 redirects the entire runtime for tests or isolated profiles.
 `install.sh` generates the machine-local screenshot key and local HTTP bearer
 automatically and preserves both across reinstalls; neither is a provider
@@ -31,17 +33,36 @@ persome status
 persome stop
 ```
 
-`persome update` fetches official `main` into a temporary checkout, stops the
-current lifecycle owner, invokes `install.sh --update`, and lets onboarding
-prove the replacement Runtime before completion. A prior LaunchAgent is
-restored with the new executable after installation. The updater pins both
-`PERSOME_ROOT` and the installer's `PERSOME_INSTALL_HOME` to the active data
-root so isolated/custom profiles cannot be redirected to `~/.persome`.
-Unlike a fresh install, update mode keeps the previous virtualenv backup through
-onboarding. Only a successful OCR/health/capture proof commits the replacement;
-the installer stops a failed replacement daemon before restoring the backup.
+`persome update` fetches official `main` into a temporary checkout and asks the
+installer to build a marked, inactive `venv.replacement.update`; the current
+`venv` remains executable throughout preparation. The candidate is created as a
+relocatable uv environment, and activation rejects any `persome` console script
+that still embeds the inactive candidate path. Under `.update.lock`, the
+updater stops the current lifecycle owner and exchanges those two same-filesystem
+directories in one kernel operation (`renameatx_np(RENAME_SWAP)` on macOS). It
+then restores the prior background/LaunchAgent owner and runs onboarding with an
+explicit owner requirement. Only a successful mode-aware permission, OCR-policy,
+health, and capture/readiness proof advances through `committing`; the old venv
+is retained at the replacement path until that point. Failure or recovery uses
+the same atomic exchange in reverse before restoring the old owner. The
+transaction id and `preparing`/`prepared`/`activated`/`committing` phase are
+fsynced in `.update-state.json`, so a crash between the exchange and phase write
+is recoverable from the candidate marker. The updater pins both `PERSOME_ROOT`
+and the installer's `PERSOME_INSTALL_HOME` to the active data root so an isolated
+profile cannot be redirected to `~/.persome`.
 
-`start` double-forks and writes `<PERSOME_ROOT>/.pid`. The HTTP/MCP server
+`start` holds `<PERSOME_ROOT>/.daemon.lock` from preflight through the entire
+foreground or double-forked daemon lifetime. This prevents two concurrent
+starters from both passing the PID check. The daemon writes a numeric `.pid` for
+one-release compatibility plus an owner-only `.runtime-state.json` containing
+its random generation, start/update times, readiness phase, effective capture
+and OCR policy, native permission probes, and the last capture/privacy receipt.
+Lifecycle operations resolve PID, current-user ownership, command/executable,
+process start time, and (when present) generation immediately before signaling.
+A dead or unrelated reused PID is stale; a live Persome-shaped process with an
+invalid generation fails closed instead of allowing a second writer.
+
+The HTTP/MCP server
 is restricted to loopback and defaults to `127.0.0.1:8742`; the same app serves `/model` and the
 REST routes. Except for canonical `GET /health`, the outer app requires the
 dedicated bearer provisioned in the owner-only env file. `persome model open`
@@ -56,9 +77,12 @@ persome launchagent uninstall
 ```
 
 The LaunchAgent label is `com.persome.runtime`; logs go to
-`<PERSOME_ROOT>/logs/launchd.{out,err}.log`. Product consumers may manage this
-lifecycle themselves, but product-specific labels, ports, and data roots do not
-belong in core.
+`<PERSOME_ROOT>/logs/launchd.{out,err}.log`. A successful install writes the
+owner-only `.launchagent-owner` intent marker. Ownership proof requires the
+loaded launchd job, its configured program, its live PID, and the recorded
+Runtime process to agree; merely finding a plist or marker is insufficient.
+Product consumers may manage this lifecycle themselves, but product-specific
+labels, ports, and data roots do not belong in core.
 
 ## Data root
 
@@ -68,7 +92,15 @@ belong in core.
 |---|---|
 | `env` | provider secrets plus generated screenshot and local-API credentials |
 | `config.toml` | runtime configuration |
-| `.pid` | direct-daemon PID |
+| `.pid` | compatibility PID receipt; never sufficient by itself for signaling |
+| `.runtime-state.json` | owner-only generation, phase, permission, OCR, and capture receipt |
+| `.daemon.lock` | lifetime single-Runtime lock inherited across background forks |
+| `.launchagent-owner` | durable launchd lifecycle intent |
+| `.update.lock`, `.update-state.json` | exclusive updater lock and crash-recovery transaction |
+| `venv/` | active installed Runtime |
+| `venv.replacement.update` | inactive candidate before exchange; retained old venv after exchange |
+| `venv.previous.committed.*`, `venv.failed.update.*` | best-effort post-commit or failed-candidate cleanup |
+| `native/<source-digest>/` | immutable machine-local AX helper and watcher binaries |
 | `capture-buffer/` | bounded AX/OCR records |
 | `memory/` | durable Markdown memory |
 | `index.db` | SQLite WAL model/index |
@@ -79,27 +111,58 @@ belong in core.
 | `backup/` | optional SQLite snapshots |
 | `logs/` | component logs |
 
-Supported installs enable OCR through `persome ocr setup`. It uses a child
-worker process managed by `capture/ocr_subprocess.py`; a native Paddle crash
-does not take down the daemon. The parent OCR submission thread only coordinates
-local inference and SQLite backfill. Quick health checks inspect configuration,
-Runtime, weights, kill switch, and Screen Recording without loading Paddle;
-`persome ocr status --check` verifies the worker engine.
+Supported installs enable OCR through `persome ocr setup` or an explicit
+`persome onboard --tier ...`. `persome ocr disable` records a durable opt-out;
+an ordinary `persome onboard` and every update preserve that policy and tier.
+The child worker managed by `capture/ocr_subprocess.py` isolates native Paddle
+faults from the daemon. Quick health checks inspect configuration, Runtime,
+weights, kill switch, and Screen Recording without loading Paddle. Run
+`persome ocr status --check` to verify the worker engine. In trusted-ingest mode,
+the producer owns the OS permission boundary; the daemon starts no AX watcher
+and requires authenticated HTTP ingest readiness.
+
+## Native helper identity
+
+The wheel ships Swift source rather than a mutable helper binary. At install or
+first resolution, Persome hashes a format version, the machine architecture,
+and the source bytes, then compiles under
+`<PERSOME_ROOT>/native/<source-digest>/`. A root-scoped build lock and atomic
+rename prevent partial or concurrent publication. Existing executable files at
+that immutable path are reused exactly, so reinstalling the same source version
+does not manufacture a new TCC principal. The capture helper and, when
+`event_driven=true`, watcher each run their own `--check-accessibility` and
+`--request-accessibility` action; the daemon or invoking terminal cannot prove
+their grants on their behalf.
+
+A helper-source change intentionally resolves a new digest path and therefore
+requires an explicit new Accessibility grant during onboarding. Rollback runs
+the old wheel source and deterministically resolves the prior binary path again.
+Never overwrite a digest path in place; that would break both the immutable
+identity contract and macOS permission diagnostics.
 
 New code must use `paths.py`; tests use a temporary `PERSOME_ROOT` and must
 never inspect the real store.
 
 ## Recovery
 
-If direct `persome start` reports an existing daemon but health is unavailable:
+If direct `persome start` reports unsafe or ambiguous lifecycle state, inspect
+without deleting or signaling from the numeric PID alone:
 
 ```bash
+persome status
 cat ~/.persome/.pid
-kill -0 "$(cat ~/.persome/.pid)" 2>/dev/null && echo alive || echo stale
-rm ~/.persome/.pid
-persome start
-curl -s http://127.0.0.1:8742/health
+cat ~/.persome/.runtime-state.json | jq .
+launchctl print "gui/$(id -u)/com.persome.runtime" 2>/dev/null || true
+lsof -nP -iTCP:8742 -sTCP:LISTEN
 ```
+
+Do not `kill $(cat .pid)` or remove `.pid`/`.runtime-state.json` while a live
+Persome-shaped process may exist: the number may have been reused, or the
+generation receipt may be the evidence preventing a second writer. Stop the
+owning Desktop app or LaunchAgent first, then rerun `persome stop` or
+`persome start`; dead and unrelated reused PIDs are treated as safely stale. If
+the port belongs to another application, stop it or change the configured port
+rather than erasing Runtime receipts.
 
 For launchd:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -12,16 +12,29 @@ persome doctor   # ✓/✗/⚠ per prerequisite; exits 1 if anything FAILS; zero
 
 ## Daemon won't start
 
-Symptom: `persome start` returns `Already running (pid N)` but the process is dead.
+Persome does not trust a PID number by itself. It checks current-user ownership,
+the executable/command shape, process start time, and the random generation in
+`.runtime-state.json`, then rechecks that identity immediately before signaling.
+It also holds `.daemon.lock` for the complete daemon lifetime so concurrent
+`start` calls cannot create two writers.
 
-Check:
+If `persome start` reports an unsafe Runtime lifecycle state, inspect it without
+deleting or signaling from `.pid` alone:
 
 ```bash
-ps -p $(cat ~/.persome/.pid) || rm ~/.persome/.pid
-persome start
+persome status
+cat ~/.persome/.pid
+cat ~/.persome/.runtime-state.json | jq .
+launchctl print "gui/$(id -u)/com.persome.runtime" 2>/dev/null || true
+lsof -nP -iTCP:8742 -sTCP:LISTEN
 ```
 
-A stale PID file is the typical cause; `stop` removes it cleanly, crashes don't.
+A dead PID or one reused by an unrelated process is safely stale and the next
+start can overwrite it. A live Persome-shaped process with an invalid generation
+receipt is intentionally ambiguous: stop its owning Desktop app or LaunchAgent,
+then retry. Do not `kill $(cat ~/.persome/.pid)` or delete `.pid`/
+`.runtime-state.json` while it may be live; that can signal a reused PID or
+remove the evidence preventing a second daemon.
 
 Symptom: foreground start immediately exits without error.
 
@@ -56,17 +69,39 @@ For a reviewed local checkout or an offline repair:
 persome update --source /path/to/personal-model
 ```
 
+The installer prepares `venv.replacement.update` without touching the active
+`venv`. After preparation, the updater stops the current owner and atomically
+exchanges the two directories; the old venv remains available at the replacement
+path until the new final owner passes mode-aware onboarding. Pressing Ctrl-C
+exchanges the old venv back before restarting it, and repeated Ctrl-C cannot
+abort rollback. Running `bash install.sh` over an existing installation delegates
+to this same transactional local-source path.
+
+If a prior process died, the next `persome update` reads the owner-only
+transaction id, phase, and candidate marker and deterministically recovers even
+when the crash happened after the atomic exchange but before its phase write.
+Do not remove `.update-state.json`, `.update.lock`, or either venv directory by
+hand. An invalid live PID/generation receipt also fails closed; stop the owning
+Desktop app/LaunchAgent, inspect `.pid` and `.runtime-state.json`, then retry.
+
 ## Captures are empty / tree has no content
 
-Most common cause: **Accessibility permission not granted** to the terminal you launched from.
+Most common cause: **Accessibility permission is missing for an actual native
+capture principal.** The source-versioned `mac-ax-helper` reads each focused AX
+tree, and `mac-ax-watcher` subscribes to events when `event_driven=true`.
 
 ```bash
 persome onboard
-persome capture-once
 cat ~/.persome/capture-buffer/*.json | jq '.ax_tree | length' | head
 ```
 
-If the tree is `{}` or tiny across the board, open System Settings → Privacy & Security → Accessibility and enable your terminal (Terminal, iTerm2, Warp, VS Code…) plus `persome` itself if it appears.
+If the tree is `{}` or tiny across the board, rerun `persome onboard` and follow
+the separate prompts for `mac-ax-helper` and `mac-ax-watcher`. Granting only
+Terminal, iTerm2, Warp, VS Code, Python, or `persome` does not prove those helper
+grants. Same-version reinstalls reuse the exact executable under
+`~/.persome/native/<source-digest>/`; if helper source changed, the new digest
+path is a new macOS principal and must be granted explicitly. A rollback resolves
+the old path and old grant again.
 
 The daemon watcher waits after an initial denial and polls the non-prompting TCC
 status. Granting Accessibility while the daemon is still running should restart
@@ -75,13 +110,21 @@ fallback for old installs or a changed TCC principal.
 
 Second most common cause: **`ax_depth` too shallow for Electron apps.** See [capture.md](capture.md#ax-depth-the-1-footgun).
 
-The installer normally completes Accessibility, local OCR, daemon health, and a
-fresh capture through `persome onboard`. Rerun that end-to-end gate first:
+In standard Apple Silicon daemon mode, the installer completes Accessibility,
+Screen Recording, local OCR, daemon health, and a fresh capture through
+`persome onboard`. Other configured modes print their own readiness receipt.
+Rerun that end-to-end gate first:
 
 ```bash
 persome onboard
 persome ocr status --check
 ```
+
+Do not substitute `persome capture-once` for this check. That command creates a
+one-shot scheduler in the calling CLI and can diagnose helper output, but it does
+not prove the running daemon's watcher, generation, lifecycle owner, privacy
+receipt, or OCR-worker readiness. Stop the Runtime before using it as an isolated
+developer diagnostic.
 
 If it reports disabled, missing permission, or an incomplete worker setup, run:
 
@@ -95,6 +138,13 @@ persome doctor
 The setup command opens Screen Recording settings when needed. OCR worker
 failures leave the daemon alive. `PERSOME_DISABLE_OCR=1` disables inference
 entirely; remove it if health reports `disabled_by_environment`.
+
+If OCR returns after you intentionally disabled it, inspect `ocr_policy` in the
+`[capture]` section. `disabled` is the durable opt-out and ordinary
+`persome onboard` preserves it. `persome onboard --tier ...` and
+`persome ocr setup` are explicit enable actions. `auto` means the install has
+not yet recorded an explicit choice. Updates preserve all three states and the
+selected tier.
 
 ## No event-daily entries appearing
 

--- a/install.sh
+++ b/install.sh
@@ -18,30 +18,36 @@ PYTHON_TARGET=""
 INSTALL_TRANSACTION_ACTIVE=0
 OLD_VENV_BACKUP=""
 ONBOARDING_COMPLETED=0
+DEFER_UPDATE_COMMIT="${PERSOME_UPDATE_DEFER_COMMIT:-0}"
+UPDATE_REPLACEMENT="${PERSOME_UPDATE_REPLACEMENT:-}"
+UPDATE_TRANSACTION_ID="${PERSOME_UPDATE_TRANSACTION_ID:-}"
+UPDATE_LOCK_FD="${PERSOME_UPDATE_LOCK_FD:-}"
 
 rollback_uncommitted_install() {
   local status=$?
   trap - EXIT INT TERM HUP
   set +e
   if [[ ${status} -ne 0 && ${INSTALL_TRANSACTION_ACTIVE} -eq 1 ]]; then
+    if [[ ${UPDATE_MODE} -eq 1 && ${DEFER_UPDATE_COMMIT} -eq 1 ]]; then
+      warn "installation failed; discarding the inactive update candidate"
+      if [[ -n "${UPDATE_REPLACEMENT}" && -d "${UPDATE_REPLACEMENT}" && ! -L "${UPDATE_REPLACEMENT}" ]]; then
+        local failed_candidate="${UPDATE_REPLACEMENT}.failed.$$.$RANDOM"
+        if mv "${UPDATE_REPLACEMENT}" "${failed_candidate}"; then
+          rm -rf "${failed_candidate}" || true
+        else
+          warn "could not quarantine the failed update candidate"
+        fi
+      fi
+      exit "${status}"
+    fi
     warn "installation failed; restoring the previous virtualenv"
     # Update-mode onboarding can start the replacement daemon before its final
     # capture proof. Stop that process before replacing its on-disk virtualenv;
     # the outer `persome update` command restarts the restored Runtime.
     if [[ ${UPDATE_MODE} -eq 1 && -f "${INSTALL_HOME}/.pid" ]]; then
-      local update_pid=""
-      update_pid="$(tr -d '[:space:]' < "${INSTALL_HOME}/.pid" 2>/dev/null || true)"
-      if [[ "${update_pid}" =~ ^[0-9]+$ ]] && kill -0 "${update_pid}" 2>/dev/null; then
-        kill -TERM "${update_pid}" 2>/dev/null || true
-        local attempts=50
-        while (( attempts > 0 )) && kill -0 "${update_pid}" 2>/dev/null; do
-          sleep 0.1
-          attempts=$((attempts - 1))
-        done
-        if kill -0 "${update_pid}" 2>/dev/null; then
-          warn "replacement Runtime did not stop cleanly; forcing it down before rollback"
-          kill -KILL "${update_pid}" 2>/dev/null || true
-        fi
+      if [[ -x "${VENV_DIR}/bin/persome" ]]; then
+        PERSOME_ROOT="${INSTALL_HOME}" "${VENV_DIR}/bin/persome" stop --timeout 5 \
+          >/dev/null 2>&1 || true
       fi
     fi
     if [[ -n "${OLD_VENV_BACKUP}" && -d "${OLD_VENV_BACKUP}" ]]; then
@@ -180,6 +186,82 @@ parse_args() {
         ;;
     esac
   done
+}
+
+validate_internal_update_flags() {
+  case "${DEFER_UPDATE_COMMIT}" in
+    0|1) ;;
+    *) die "PERSOME_UPDATE_DEFER_COMMIT must be 0 or 1" ;;
+  esac
+  if [[ ${DEFER_UPDATE_COMMIT} -eq 1 && ${UPDATE_MODE} -ne 1 ]]; then
+    die "deferred update commit requires --update"
+  fi
+  if [[ ${DEFER_UPDATE_COMMIT} -eq 1 ]]; then
+    validate_deferred_update_transaction
+  fi
+}
+
+validate_deferred_update_transaction() {
+  local expected_replacement="${INSTALL_HOME}/venv.replacement.update"
+  local state_file="${INSTALL_HOME}/.update-state.json"
+  local lock_file="${INSTALL_HOME}/.update.lock"
+  local active_python="${INSTALL_HOME}/venv/bin/python"
+  [[ "${UPDATE_REPLACEMENT}" == "${expected_replacement}" ]] \
+    || die "deferred update candidate must be ${expected_replacement}"
+  [[ "${UPDATE_TRANSACTION_ID}" =~ ^[0-9a-f]{32}$ ]] \
+    || die "deferred update requires a valid transaction ID"
+  [[ "${UPDATE_LOCK_FD}" =~ ^[0-9]+$ ]] \
+    || die "deferred update requires the inherited update-lock descriptor"
+  [[ -x "${active_python}" ]] \
+    || die "deferred update validation requires the active Runtime Python"
+  "${active_python}" - \
+    "${state_file}" "${lock_file}" "${UPDATE_LOCK_FD}" "${UPDATE_TRANSACTION_ID}" <<'PY' \
+    || die "deferred update transaction validation failed"
+import fcntl
+import json
+import os
+import stat
+import sys
+
+state_path, lock_path, lock_fd_text, expected_id = sys.argv[1:]
+lock_fd = int(lock_fd_text)
+state_stat = os.lstat(state_path)
+lock_stat = os.lstat(lock_path)
+fd_stat = os.fstat(lock_fd)
+if not stat.S_ISREG(state_stat.st_mode) or stat.S_ISLNK(state_stat.st_mode):
+    raise SystemExit("unsafe update state file")
+if state_stat.st_uid != os.getuid() or state_stat.st_mode & 0o077:
+    raise SystemExit("update state file is not owner-private")
+if not stat.S_ISREG(lock_stat.st_mode) or (lock_stat.st_dev, lock_stat.st_ino) != (
+    fd_stat.st_dev,
+    fd_stat.st_ino,
+):
+    raise SystemExit("update-lock descriptor does not match the Runtime lock")
+# First prove the lock was already held before this validator ran. Then
+# re-locking the inherited open-file description proves it is the owner rather
+# than an unrelated descriptor blocked by somebody else.
+probe_fd = os.open(lock_path, os.O_RDWR)
+try:
+    try:
+        fcntl.flock(probe_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        pass
+    else:
+        fcntl.flock(probe_fd, fcntl.LOCK_UN)
+        raise SystemExit("update lock was not held by the delegating updater")
+finally:
+    os.close(probe_fd)
+fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+with open(state_path, encoding="utf-8") as handle:
+    payload = json.load(handle)
+if payload != {
+    "schema_version": 2,
+    "launchagent_was_loaded": payload.get("launchagent_was_loaded"),
+    "phase": "preparing",
+    "transaction_id": expected_id,
+} or not isinstance(payload["launchagent_was_loaded"], bool):
+    raise SystemExit("update state does not match the delegated transaction")
+PY
 }
 
 require_repo_root() {
@@ -335,15 +417,26 @@ install_package() {
 
   mkdir -p "${INSTALL_HOME}"
   chmod 0700 "${INSTALL_HOME}"
-  OLD_VENV_BACKUP="${VENV_DIR}.previous.$$"
-  rm -rf "${OLD_VENV_BACKUP}"
-  if [[ -d "${VENV_DIR}" ]]; then
+  [[ ! -L "${VENV_DIR}" ]] || die "virtualenv path must not be a symlink: ${VENV_DIR}"
+  if [[ ${UPDATE_MODE} -eq 1 && ${DEFER_UPDATE_COMMIT} -eq 1 ]]; then
+    # Build beside the active venv. The outer updater performs one kernel-level
+    # directory exchange only after this candidate is complete and marked.
+    VENV_DIR="${UPDATE_REPLACEMENT}"
+    [[ ! -L "${VENV_DIR}" ]] || die "candidate virtualenv path must not be a symlink: ${VENV_DIR}"
+    [[ ! -e "${VENV_DIR}" ]] \
+      || die "unfinished update candidate exists at ${VENV_DIR}; refusing to overwrite it"
+    OLD_VENV_BACKUP=""
+  else
+    OLD_VENV_BACKUP="${VENV_DIR}.previous.$$"
+    rm -rf "${OLD_VENV_BACKUP}"
+  fi
+  if [[ ${DEFER_UPDATE_COMMIT} -ne 1 && -d "${VENV_DIR}" ]]; then
     mv "${VENV_DIR}" "${OLD_VENV_BACKUP}"
   fi
   INSTALL_TRANSACTION_ACTIVE=1
 
   log "creating virtualenv at ${VENV_DIR}"
-  if ! "${UV_BIN}" venv "${VENV_DIR}" --python "${python_target}"; then
+  if ! "${UV_BIN}" venv "${VENV_DIR}" --python "${python_target}" --relocatable; then
     rm -rf "${build_dir}"
     die "failed to create virtualenv"
   fi
@@ -401,6 +494,37 @@ commit_install() {
   fi
 }
 
+defer_install_commit() {
+  [[ ${UPDATE_MODE} -eq 1 && ${DEFER_UPDATE_COMMIT} -eq 1 ]] \
+    || die "deferred commit requested outside update mode"
+  [[ "${VENV_DIR}" == "${UPDATE_REPLACEMENT}" && -d "${VENV_DIR}" && ! -L "${VENV_DIR}" ]] \
+    || die "the inactive update candidate is missing or unsafe"
+  "${VENV_DIR}/bin/python" - "${VENV_DIR}/.persome-update-transaction" \
+    "${UPDATE_TRANSACTION_ID}" <<'PY' \
+    || die "could not persist the update candidate marker"
+import os
+import sys
+
+path, transaction_id = sys.argv[1:]
+descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+try:
+    os.write(descriptor, (transaction_id + "\n").encode())
+    os.fsync(descriptor)
+finally:
+    os.close(descriptor)
+directory = os.open(os.path.dirname(path), os.O_RDONLY)
+try:
+    os.fsync(directory)
+finally:
+    os.close(directory)
+PY
+  # The outer updater holds the exclusive lock and owns final activation,
+  # daemon-owned onboarding proof, exchange, commit, and rollback. Disable this
+  # shell's EXIT cleanup only after the complete candidate marker is durable.
+  INSTALL_TRANSACTION_ACTIVE=0
+  log "replacement prepared; final Runtime proof and commit are owned by persome update"
+}
+
 compile_bundled_binaries() {
   log "compiling bundled AX helper binaries"
   "${VENV_DIR}/bin/python" - <<'PY' || die "failed to compile bundled AX binaries"
@@ -453,6 +577,11 @@ install_shim() {
 }
 
 verify_install() {
+  if [[ ${UPDATE_MODE} -eq 1 && ${DEFER_UPDATE_COMMIT} -eq 1 ]]; then
+    PERSOME_ROOT="${INSTALL_HOME}" "${PERSOME_BIN}" --help >/dev/null \
+      || die "installation verification failed (new 'persome --help' did not succeed)"
+    return 0
+  fi
   PERSOME_ROOT="${INSTALL_HOME}" "${PERSOME_BIN}" status >/dev/null \
     || die "installation verification failed ('persome status' did not succeed)"
 }
@@ -601,9 +730,10 @@ run_onboarding() {
   echo "  Permission and Runtime Onboarding"
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
   echo ""
-  echo "Persome will explain and request Accessibility and Screen Recording in"
-  echo "separate macOS dialogs. It then verifies local OCR, starts the daemon,"
-  echo "checks the local health endpoint, and writes one fresh capture."
+  echo "Persome will separately explain and request Accessibility for the bundled"
+  echo "capture helper, Accessibility for the optional event watcher, and Screen"
+  echo "Recording when the configured pixel policy needs it. It then verifies local"
+  echo "OCR, the final Runtime owner, readiness, and a mode-aware capture receipt."
   echo ""
   if ! PERSOME_ROOT="${INSTALL_HOME}" "${INSTALL_BIN_DIR}/persome" onboard --tier tiny; then
     die "onboarding is incomplete; rerun 'persome onboard' to finish permissions and runtime verification"
@@ -690,12 +820,16 @@ Connect an agent (MCP):
     persome install claude-desktop
     persome install opencode
 
-Run a health check any time:
+Inspect Runtime and OCR status any time:
   persome doctor
-  persome ocr status --check
+  persome ocr status
 
 Change or verify the LLM provider:
   persome llm setup
+  persome llm status
+
+When those optional features are enabled, run their live probes with:
+  persome ocr status --check
   persome llm status --check
 EOF
 
@@ -703,10 +837,11 @@ EOF
     cat <<'EOF'
 
 Onboarding proof:
-  - Accessibility was granted for focused AX text and structure.
-  - Screen Recording and the isolated local OCR worker were verified.
-  - Persome was started, its local health endpoint passed, and a fresh capture
-    record was written. Persome does not require Full Disk Access or Automation.
+  - The configured capture mode's required macOS permissions were verified.
+  - The effective OCR/pixel policy and final Runtime lifecycle owner were proved.
+  - A mode-aware fresh-capture, ingest-readiness, or preserved-privacy receipt
+    passed through HTTP or the owner-only daemon generation state. Persome does
+    not require Full Disk Access or Automation.
 EOF
   else
     cat <<'EOF'
@@ -714,7 +849,8 @@ EOF
 Onboarding pending:
   This non-interactive install could not request macOS permissions. From a
   logged-in macOS session, run `persome onboard`; it will not report success
-  until Accessibility, local OCR, daemon health, and a fresh capture all pass.
+  until the configured mode's permissions, Runtime owner, OCR policy, and
+  capture/readiness receipt all pass.
 EOF
   fi
 
@@ -727,9 +863,45 @@ EOF
   esac
 }
 
+delegate_existing_install() {
+  if [[ ! -e "${VENV_DIR}" ]]; then
+    return 0
+  fi
+  # The current updater invokes this installer with the deferred transaction
+  # marker. Any other existing-install invocation (including --update from a
+  # previous release) must bootstrap the updater from this source tree first.
+  if [[ ${UPDATE_MODE} -eq 1 && ${DEFER_UPDATE_COMMIT} -eq 1 ]]; then
+    return 0
+  fi
+  [[ ! -L "${VENV_DIR}" ]] \
+    || die "existing virtualenv must not be a symlink: ${VENV_DIR}"
+  [[ -x "${VENV_DIR}/bin/python" ]] \
+    || die "existing installation is incomplete (missing ${VENV_DIR}/bin/python); move it aside and rerun the installer"
+  log "existing installation detected; bootstrapping the current source-tree updater"
+  export PERSOME_ROOT="${INSTALL_HOME}"
+  export PERSOME_INSTALL_HOME="${INSTALL_HOME}"
+  export PYTHONPATH="${ROOT_DIR}/src"
+  export PYTHONNOUSERSITE=1
+  if [[ ${UPDATE_MODE} -eq 1 ]]; then
+    # Compatibility only: a released updater may have booted launchd out before
+    # delegating to this source tree. A direct `bash install.sh --update` has an
+    # interactive shell as parent and must not leave a lock keeper tied to that
+    # long-lived shell.
+    local parent_command
+    parent_command="$(ps -ww -p "${PPID}" -o command= 2>/dev/null || true)"
+    if [[ "${parent_command}" =~ (^|[[:space:]])([^[:space:]]*/)?persome[[:space:]]+update([[:space:]]|$) ]] \
+      || [[ "${parent_command}" =~ [[:space:]]-m[[:space:]]+persome[[:space:]]+update([[:space:]]|$) ]]; then
+      export PERSOME_UPDATE_INFER_LAUNCHAGENT_FROM_PLIST=1
+    fi
+  fi
+  exec "${VENV_DIR}/bin/python" -m persome update --source "${ROOT_DIR}"
+}
+
 main() {
   parse_args "$@"
+  validate_internal_update_flags
   require_repo_root
+  delegate_existing_install
   check_platform
   ensure_xcode_clt
   ensure_uv
@@ -746,6 +918,10 @@ main() {
   # restore the previous venv.
   if [[ ${UPDATE_MODE} -eq 0 ]]; then
     commit_install
+  fi
+  if [[ ${UPDATE_MODE} -eq 1 && ${DEFER_UPDATE_COMMIT} -eq 1 ]]; then
+    defer_install_commit
+    return 0
   fi
   install_shim
   inject_detected_clients

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,8 @@ ONBOARDING_COMPLETED=0
 
 rollback_uncommitted_install() {
   local status=$?
-  trap - EXIT
+  trap - EXIT INT TERM HUP
+  set +e
   if [[ ${status} -ne 0 && ${INSTALL_TRANSACTION_ACTIVE} -eq 1 ]]; then
     warn "installation failed; restoring the previous virtualenv"
     # Update-mode onboarding can start the replacement daemon before its final
@@ -37,17 +38,47 @@ rollback_uncommitted_install() {
           sleep 0.1
           attempts=$((attempts - 1))
         done
+        if kill -0 "${update_pid}" 2>/dev/null; then
+          warn "replacement Runtime did not stop cleanly; forcing it down before rollback"
+          kill -KILL "${update_pid}" 2>/dev/null || true
+        fi
       fi
     fi
-    rm -rf "${VENV_DIR}"
     if [[ -n "${OLD_VENV_BACKUP}" && -d "${OLD_VENV_BACKUP}" ]]; then
-      mv "${OLD_VENV_BACKUP}" "${VENV_DIR}"
+      # Move the replacement aside first, restore the previous venv with an
+      # atomic rename, and only then do the slow recursive cleanup. This keeps
+      # the installed shim valid even when Ctrl-C initiated the rollback.
+      local failed_venv="${VENV_DIR}.failed.$$.$RANDOM"
+      local replacement_moved=0
+      if [[ -e "${VENV_DIR}" ]]; then
+        if mv "${VENV_DIR}" "${failed_venv}"; then
+          replacement_moved=1
+        else
+          warn "could not move the failed replacement virtualenv aside"
+        fi
+      fi
+      if [[ ! -e "${VENV_DIR}" ]]; then
+        if ! mv "${OLD_VENV_BACKUP}" "${VENV_DIR}"; then
+          warn "could not restore the previous virtualenv"
+          if [[ ${replacement_moved} -eq 1 && -d "${failed_venv}" ]]; then
+            mv "${failed_venv}" "${VENV_DIR}" || true
+          fi
+        fi
+      fi
+      if [[ -d "${VENV_DIR}" && -e "${failed_venv}" ]]; then
+        rm -rf "${failed_venv}" || true
+      fi
+    else
+      rm -rf "${VENV_DIR}" || true
     fi
   fi
   exit "${status}"
 }
 
 trap rollback_uncommitted_install EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 129' HUP
 
 # The fallback bootstrap downloads a specific uv release and verifies the
 # archive before executing any of its contents. Update version + both digests
@@ -359,11 +390,15 @@ PY
 }
 
 commit_install() {
-  if [[ -n "${OLD_VENV_BACKUP}" ]]; then
-    rm -rf "${OLD_VENV_BACKUP}"
-  fi
+  local committed_backup="${OLD_VENV_BACKUP}"
+  # The replacement is now authoritative. Mark the transaction committed
+  # before deleting the backup so an interrupt during cleanup cannot roll back
+  # by first deleting the working virtualenv.
   OLD_VENV_BACKUP=""
   INSTALL_TRANSACTION_ACTIVE=0
+  if [[ -n "${committed_backup}" ]]; then
+    rm -rf "${committed_backup}" || warn "could not remove old virtualenv backup"
+  fi
 }
 
 compile_bundled_binaries() {

--- a/openapi.json
+++ b/openapi.json
@@ -57,7 +57,7 @@
           "system"
         ],
         "summary": "Permissions",
-        "description": "Return the daemon's current macOS permission state.\n\nAccessibility and Screen Recording belong to the daemon process. A GUI\nonboarding flow should poll this endpoint instead of creating another TCC\nidentity. Each field is ``granted`` or ``denied``.",
+        "description": "Return the daemon's current macOS permission state.\n\nAccessibility is self-probed by the configured bundled AX helper(s);\nScreen Recording is preflighted by the Runtime executable. A GUI onboarding\nflow should poll this aggregate instead of creating another TCC identity.\nFields are ``granted``, ``denied``, or mode-aware ``not_applicable``.",
         "operationId": "permissions_permissions_get",
         "responses": {
           "200": {

--- a/resources/mac-ax-helper.swift
+++ b/resources/mac-ax-helper.swift
@@ -583,6 +583,15 @@ func parseArgs() -> Config {
 }
 
 func main() {
+    if CommandLine.arguments.contains("--request-accessibility") {
+        let trusted = AXIsProcessTrustedWithOptions(
+            [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
+        )
+        exit(trusted ? 0 : 2)
+    }
+    if CommandLine.arguments.contains("--check-accessibility") {
+        exit(AXIsProcessTrusted() ? 0 : 2)
+    }
     let config = parseArgs()
 
     // Check accessibility permission WITHOUT prompting. This helper is spawned
@@ -593,9 +602,9 @@ func main() {
     // Dropping the prompt costs no trust: which variant you call does not change
     // the TCC principal (that's the binary's code identity / responsible process),
     // so once Accessibility is granted this pure check reads it exactly as the
-    // prompting one did. The single user-facing prompt is left to the long-running
-    // mac-ax-watcher, started once per daemon session when event_driven is on (the
-    // default). Untrusted ⇒ exit(2), which the Python caller logs and skips.
+    // prompting one did. User-facing prompts belong only to the explicit
+    // onboarding request modes. Untrusted ⇒ exit(2), which the Python caller
+    // logs and skips.
     let trusted = AXIsProcessTrusted()
     if !trusted {
         fputs("Accessibility permission not granted. Please enable in System Settings.\n", stderr)

--- a/resources/mac-ax-watcher.swift
+++ b/resources/mac-ax-watcher.swift
@@ -707,6 +707,9 @@ func observerCallback(
 // MARK: - Main
 
 func main() {
+    if CommandLine.arguments.contains("--check-accessibility") {
+        exit(AXIsProcessTrusted() ? 0 : 2)
+    }
     if CommandLine.arguments.contains("--request-accessibility") {
         let trusted = AXIsProcessTrustedWithOptions(
             [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
@@ -714,10 +717,9 @@ func main() {
         exit(trusted ? 0 : 2)
     }
 
-    // Check accessibility permission
-    let trusted = AXIsProcessTrustedWithOptions(
-        [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
-    )
+    // Normal Runtime starts are pure checks. Only the explicit onboarding
+    // --request-accessibility action may ask macOS to show a permission prompt.
+    let trusted = AXIsProcessTrusted()
     if !trusted {
         fputs("Accessibility permission not granted.\n", stderr)
         exit(2)

--- a/src/persome/api/__init__.py
+++ b/src/persome/api/__init__.py
@@ -196,6 +196,12 @@ def build_api_app(cfg: Config | None = None, *, auth_enabled: bool = True) -> Fa
     Authentication is on by default.  In-process tests and schema rendering may
     disable it explicitly; the daemon mount never does.
     """
+    # Route handlers use a process-local config reference.  Reset it for every
+    # app construction so a prior test/app instance cannot leak its capture
+    # policy into this one.  Production always passes the daemon's loaded cfg;
+    # ``None`` deliberately restores the documented load-from-disk behavior.
+    _set_route_config(cfg)
+
     app = FastAPI(
         title="Persome API",
         description="Local-first screen-context memory and personal-model REST API.",

--- a/src/persome/api/routes.py
+++ b/src/persome/api/routes.py
@@ -5,7 +5,6 @@ Mounted at root ``/`` inside the MCP server's Starlette app.
 
 from __future__ import annotations
 
-import os
 import sqlite3
 import threading
 import time
@@ -19,7 +18,7 @@ from urllib.parse import urlencode
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse, Response
 
-from .. import __version__, paths
+from .. import __version__, paths, runtime_pid
 from ..capture import ax_capture, ocr_health, scheduler, screen_recording
 from ..capture.timestamps import newest_capture_path
 from ..config import Config
@@ -61,17 +60,8 @@ def _get_cfg() -> Config:
 
 
 def _read_pid() -> int | None:
-    try:
-        pid = int(paths.pid_file().read_text().strip())
-    except (FileNotFoundError, ValueError):
-        return None
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return None
-    except PermissionError:
-        return pid
-    return pid
+    process = runtime_pid.resolve_recorded_process()
+    return process.pid if process is not None else None
 
 
 def _daemon_uptime() -> str:
@@ -207,8 +197,17 @@ router = APIRouter()
 def health() -> ApiResponse:
     """Return liveness plus the configured local-OCR readiness state."""
     current = ocr_health.inspect(_get_cfg().capture)
-    status = "degraded" if current.enabled and not current.ready else "ok"
-    return ApiResponse(data={"status": status, "ocr": current.state})
+    worker = ocr_health.worker_state()
+    status = "degraded" if current.enabled and (not current.ready or worker != "ready") else "ok"
+    return ApiResponse(
+        data={
+            "status": status,
+            "ocr": current.state,
+            "ocr_worker": worker,
+            "ocr_enabled": current.enabled,
+            "ocr_tier": current.tier,
+        }
+    )
 
 
 @router.post(BROWSER_BOOTSTRAP_PATH, response_model=ApiResponse, tags=["system"])
@@ -258,13 +257,26 @@ def consume_browser_bootstrap(
 def permissions() -> ApiResponse:
     """Return the daemon's current macOS permission state.
 
-    Accessibility and Screen Recording belong to the daemon process. A GUI
-    onboarding flow should poll this endpoint instead of creating another TCC
-    identity. Each field is ``granted`` or ``denied``.
+    Accessibility is self-probed by the configured bundled AX helper(s);
+    Screen Recording is preflighted by the Runtime executable. A GUI onboarding
+    flow should poll this aggregate instead of creating another TCC identity.
+    Fields are ``granted``, ``denied``, or mode-aware ``not_applicable``.
     """
+    cfg = _get_cfg()
+    if cfg.capture.source == "ingest":
+        return ApiResponse(
+            data={
+                "accessibility": "not_applicable",
+                "screen_recording": "not_applicable",
+            }
+        )
     return ApiResponse(
         data={
-            "accessibility": "granted" if ax_capture.ax_trusted() else "denied",
+            "accessibility": (
+                "granted"
+                if ax_capture.ax_trusted(include_watcher=cfg.capture.event_driven)
+                else "denied"
+            ),
             "screen_recording": (
                 "granted" if screen_recording.has_screen_recording() else "denied"
             ),
@@ -363,6 +375,24 @@ def status(check_models: bool = False) -> ApiResponse:
 
 
 # ─── Capture ingest ───────────────────────────────────────────────────────
+
+
+@router.post("/_onboarding/capture", response_model=ApiResponse, include_in_schema=False)
+def onboarding_capture() -> ApiResponse:
+    """Force one owner-authenticated capture inside the running daemon."""
+    state = scheduler.active_runner_state(_get_cfg().capture)
+    if state == "ingest-ready":
+        return ApiResponse(data={"id": None, "mode": "ingest", "receipt": state})
+    if state == "paused":
+        raise HTTPException(status_code=409, detail="capture is paused by the owner")
+    if state == "locked":
+        raise HTTPException(status_code=423, detail="screen is locked or asleep")
+    if state != "ready":
+        raise HTTPException(status_code=503, detail="live capture runner is not ready")
+    path = scheduler.capture_now()
+    if path is None:
+        raise HTTPException(status_code=503, detail="live capture runner is not ready")
+    return ApiResponse(data={"id": path.stem, "mode": "daemon", "receipt": "fresh-capture"})
 
 
 @router.post("/captures/ingest", response_model=ApiResponse, tags=["capture"])

--- a/src/persome/capture/ax_capture.py
+++ b/src/persome/capture/ax_capture.py
@@ -8,50 +8,98 @@ resource resolution adapted for a uv/pip-installable package.
 from __future__ import annotations
 
 import contextlib
-import ctypes
+import fcntl
+import hashlib
 import json
 import os
 import platform
 import subprocess
+import tempfile
+import threading
+import time
 from pathlib import Path
 from typing import Any, Protocol
 
+from .. import paths
 from ..logger import get
 from .ax_models import AXCaptureResult
 
 logger = get("persome.capture")
 
 _SUBPROCESS_TIMEOUT = 10  # seconds (covers --timeout 3 + overhead)
+_AX_TRUST_CACHE_SECONDS = 1.0
+_ax_trust_cache: dict[bool, tuple[float, bool]] = {}
+_ax_trust_lock = threading.Lock()
 
 
-def ax_trusted() -> bool:
-    """Whether **this process** is trusted for macOS Accessibility.
+def _binary_ax_trusted(binary: Path) -> bool:
+    try:
+        result = subprocess.run(
+            [str(binary), "--check-accessibility"],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=15,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
 
-    A live TCC read of the daemon's *own* grant. This is authoritative only in
-    ``capture.source = "daemon"`` mode, where the daemon spawns ``mac-ax-helper`` /
-    ``mac-ax-watcher`` to read the AX tree. In ``capture.source = "ingest"`` mode the
-    Swift Persome app owns capture (it reads the AX tree IN-PROCESS under its own TCC
-    identity and pushes frames via ``POST /captures/ingest``); the daemon then needs
-    NO Accessibility grant, so this probe is irrelevant and the app's own
-    ``AXIsProcessTrusted()`` is the signal that matters. (Historically the GUI was
-    told NOT to read the AX tree to avoid a second TCC principal; the ingest design
-    inverts that on purpose — one app-owned principal replaces the daemon's, instead
-    of adding a second.)
 
-    Returns ``False`` on non-macOS hosts or if the framework can't be loaded.
-    Pure check: no options are passed, so the system shows no dialog.
-    """
+def ax_trusted(*, refresh: bool = False, include_watcher: bool = True) -> bool:
+    """Whether every native AX principal used by this capture policy is trusted."""
+
     if platform.system() != "Darwin":
         return False
-    try:
-        appservices = ctypes.cdll.LoadLibrary(
-            "/System/Library/Frameworks/ApplicationServices.framework/ApplicationServices"
-        )
-        appservices.AXIsProcessTrusted.restype = ctypes.c_bool
-        return bool(appservices.AXIsProcessTrusted())
-    except Exception as exc:  # noqa: BLE001 — a TCC probe must never crash the daemon
-        logger.warning("AXIsProcessTrusted probe failed: %s", exc)
+    now = time.monotonic()
+    with _ax_trust_lock:
+        if (
+            not refresh
+            and include_watcher in _ax_trust_cache
+            and now - _ax_trust_cache[include_watcher][0] < _AX_TRUST_CACHE_SECONDS
+        ):
+            return _ax_trust_cache[include_watcher][1]
+
+    helper_path = _resolve_helper_path()
+    trusted = bool(helper_path is not None and _binary_ax_trusted(helper_path))
+    if trusted and include_watcher:
+        from . import watcher
+
+        watcher_path = watcher._resolve_watcher_path()
+        trusted = bool(watcher_path is not None and _binary_ax_trusted(watcher_path))
+    with _ax_trust_lock:
+        _ax_trust_cache[include_watcher] = (now, trusted)
+    return trusted
+
+
+def request_accessibility_permission(*, include_watcher: bool = True) -> bool:
+    """Prompt/register exactly the helper binaries used by the capture policy."""
+
+    if platform.system() != "Darwin":
         return False
+    binaries: list[Path | None] = [_resolve_helper_path()]
+    if include_watcher:
+        from . import watcher
+
+        binaries.append(watcher._resolve_watcher_path())
+    requested = False
+    for binary in binaries:
+        if binary is None:
+            continue
+        try:
+            result = subprocess.run(
+                [str(binary), "--request-accessibility"],
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=15,
+            )
+            requested = requested or result.returncode == 0
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            logger.warning("Accessibility permission request failed for %s: %s", binary, exc)
+    with _ax_trust_lock:
+        _ax_trust_cache.clear()
+    return requested
 
 
 def _strip_frame_fields(value: Any) -> Any:
@@ -195,6 +243,78 @@ def _maybe_compile(swift_path: Path, binary_path: Path) -> None:
         )
 
 
+def _native_source_digest(swift_path: Path) -> str | None:
+    """Return the architecture-bound identity for one native helper source."""
+    try:
+        return hashlib.sha256(
+            b"persome-native-helper-v1\0"
+            + platform.machine().encode("utf-8")
+            + b"\0"
+            + swift_path.read_bytes()
+        ).hexdigest()
+    except OSError:
+        return None
+
+
+def _native_binary_path(swift_path: Path, name: str) -> Path | None:
+    """Expected immutable machine-local path for this exact helper source."""
+    digest = _native_source_digest(swift_path)
+    return paths.native_helpers_dir() / digest / name if digest is not None else None
+
+
+def _stable_native_binary(swift_path: Path, name: str) -> Path | None:
+    """Compile once into an immutable, source-versioned TCC-visible path.
+
+    Swift's ad-hoc linker signature can get a different CDHash on every build.
+    Recompiling inside each replacement venv would therefore invalidate an
+    otherwise valid Accessibility grant. Immutable per-source copies let same-
+    version reinstalls reuse the exact binary and let a failed update return to
+    the old binary byte-for-byte.
+    """
+    target = _native_binary_path(swift_path, name)
+    if target is None:
+        return None
+    digest = target.parent.name
+
+    root = paths.ensure_private_dir(paths.native_helpers_dir())
+    directory = paths.ensure_private_dir(root / digest)
+    lock = paths.open_private_lock_file(root / ".build.lock")
+    try:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        if target.is_symlink():
+            raise RuntimeError("native AX helper paths must not be symlinks")
+        if target.is_file() and os.access(target, os.X_OK):
+            return target
+
+        descriptor, temporary_name = tempfile.mkstemp(prefix=f".{name}.", dir=directory)
+        os.close(descriptor)
+        temporary = Path(temporary_name)
+        temporary.unlink()
+        try:
+            _maybe_compile(swift_path, temporary)
+            if not temporary.is_file() or not os.access(temporary, os.X_OK):
+                return None
+            os.chmod(temporary, 0o700)
+            binary_fd = os.open(temporary, os.O_RDONLY)
+            try:
+                os.fsync(binary_fd)
+            finally:
+                os.close(binary_fd)
+            os.replace(temporary, target)
+            directory_fd = os.open(directory, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+            return target
+        finally:
+            with contextlib.suppress(FileNotFoundError):
+                temporary.unlink()
+    finally:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+        lock.close()
+
+
 def _resolve_helper_path() -> Path | None:
     """Find or build the mac-ax-helper binary.
 
@@ -220,20 +340,19 @@ def _resolve_helper_path() -> Path | None:
         from importlib.resources import files as _pkg_files
 
         bundled_dir = Path(str(_pkg_files("persome").joinpath("_bundled")))
-        candidates.append(bundled_dir / "mac-ax-helper")
+        candidates.append(bundled_dir / "mac-ax-helper.swift")
     except (ModuleNotFoundError, ValueError):
         pass
 
     # 2. Dev source tree
     dev_root = Path(__file__).resolve().parents[3]  # .../Persome/
-    candidates.append(dev_root / "resources" / "mac-ax-helper")
+    candidates.append(dev_root / "resources" / "mac-ax-helper.swift")
 
-    for binary_path in candidates:
-        swift_path = binary_path.with_suffix(".swift")
+    for swift_path in candidates:
         if swift_path.is_file():
-            _maybe_compile(swift_path, binary_path)
-        if binary_path.is_file() and os.access(binary_path, os.X_OK):
-            return binary_path
+            binary_path = _stable_native_binary(swift_path, "mac-ax-helper")
+            if binary_path is not None:
+                return binary_path
 
     return None
 
@@ -299,7 +418,8 @@ class MacAXHelperProvider:
         if proc.returncode == 2:
             logger.warning(
                 "Accessibility permission not granted. "
-                "Grant access to your terminal in System Settings → Privacy & Security → Accessibility."
+                "Run `persome onboard` to grant mac-ax-helper in System Settings → "
+                "Privacy & Security → Accessibility."
             )
             return None
         if proc.returncode != 0:

--- a/src/persome/capture/ocr_health.py
+++ b/src/persome/capture/ocr_health.py
@@ -18,6 +18,25 @@ OCRState = Literal[
     "models_missing",
     "permission_required",
 ]
+OCRWorkerState = Literal["not_started", "warming", "ready", "failed"]
+
+_worker_state: OCRWorkerState = "not_started"
+
+
+def set_worker_state(state: OCRWorkerState) -> None:
+    """Publish the daemon-owned isolated worker state to local health checks."""
+    global _worker_state
+    _worker_state = state
+
+
+def worker_state() -> OCRWorkerState:
+    """Return the daemon process's latest isolated-worker initialization state."""
+    from . import ocr_subprocess
+
+    dynamic = ocr_subprocess.current_worker_state()
+    if dynamic != "not_started":
+        return dynamic
+    return _worker_state
 
 
 @dataclass(frozen=True)
@@ -44,7 +63,11 @@ def inspect(cfg: CaptureConfig) -> OCRHealth:
     models_ready = ocr_local.models_available(tier)
     env_disabled = ocr_local.disabled_by_environment()
 
-    if sys.platform == "darwin":
+    if cfg.source == "ingest":
+        # The trusted producer owns Screen Recording and supplies an OCR JPEG.
+        # The daemon only runs local inference over those authenticated bytes.
+        permission = "not_applicable"
+    elif sys.platform == "darwin":
         permission = "granted" if screen_recording.has_screen_recording() else "denied"
     else:
         permission = "not_applicable"
@@ -62,7 +85,7 @@ def inspect(cfg: CaptureConfig) -> OCRHealth:
     elif not models_ready:
         state = "models_missing"
         detail = f"bundled PP-OCRv6 {tier} weights are missing"
-    elif permission != "granted":
+    elif permission not in {"granted", "not_applicable"}:
         state = "permission_required"
         detail = "Screen Recording permission is required"
     else:

--- a/src/persome/capture/ocr_subprocess.py
+++ b/src/persome/capture/ocr_subprocess.py
@@ -20,6 +20,7 @@ import sys
 import threading
 import time
 from collections.abc import Callable
+from typing import Literal
 
 from ..logger import get
 from . import ocr_protocol
@@ -27,6 +28,8 @@ from . import ocr_protocol
 logger = get("persome.capture.ocr.client")
 
 Spawn = Callable[[], subprocess.Popen]
+WorkerState = Literal["not_started", "warming", "ready", "failed"]
+StateListener = Callable[[WorkerState], None]
 
 _LEN = struct.Struct(">I")
 _KILL_WAIT = 2.0  # seconds to wait for a killed worker to reap
@@ -69,6 +72,8 @@ class OCRWorkerClient:
         self._startup_timeout = timeout if startup_timeout is None else startup_timeout
         self._lock = threading.Lock()
         self._proc: subprocess.Popen | None = None
+        self._state: WorkerState = "not_started"
+        self._state_lock = threading.Lock()
 
     # ─── public API (mirrors ocr_local) ──────────────────────────────────────
 
@@ -76,16 +81,44 @@ class OCRWorkerClient:
         """OCR one image in the worker. Returns ``(texts, boxes, scores)`` or ``None``."""
         if not image_bytes:
             return None
-        return self._request(tier, image_bytes)
+        result = self._request(tier, image_bytes)
+        if result is not None:
+            self._set_state("ready")
+        return result
 
     def warm(self, tier: str) -> bool:
         """Pre-build the worker engine and report whether it became ready."""
-        return self._request(tier, b"") is not None
+        self._set_state("warming")
+        ready = self._request(tier, b"") is not None
+        self._set_state("ready" if ready else "failed")
+        return ready
+
+    def state(self) -> WorkerState:
+        """Return current process liveness without blocking an in-flight inference."""
+        with self._state_lock:
+            state = self._state
+        proc = self._proc
+        if state in {"warming", "ready"} and proc is not None and proc.poll() is not None:
+            self._set_state("failed")
+            return "failed"
+        return state
 
     def shutdown(self) -> None:
         """Terminate the worker (best-effort). The worker also exits on stdin EOF."""
         with self._lock:
             self._kill_worker_locked()
+            self._set_state("not_started")
+
+    def _set_state(self, state: WorkerState) -> None:
+        with self._state_lock:
+            self._state = state
+        with _state_listener_lock:
+            listener = _state_listener
+        if listener is not None:
+            try:
+                listener(state)
+            except Exception as exc:  # noqa: BLE001 - health publication cannot break OCR
+                logger.warning("OCR worker state listener failed: %s", exc)
 
     # ─── internals ────────────────────────────────────────────────────────────
 
@@ -101,11 +134,17 @@ class OCRWorkerClient:
             except _WorkerGone as exc:
                 logger.warning("ocr worker gone (%s); failing open, will respawn", exc)
                 self._kill_worker_locked()
+                self._set_state("failed")
                 return None
             if body is None:  # EOF — worker died (e.g. SIGSEGV) mid-request
                 logger.warning("ocr worker closed stdout mid-request; failing open, will respawn")
                 self._kill_worker_locked()
+                self._set_state("failed")
                 return None
+            # A complete framed response proves that the current worker process
+            # is responsive. ``warm`` still converts an application-level
+            # {ok:false} response back to ``failed`` below.
+            self._set_state("ready")
             return ocr_protocol.decode_response(body)
 
     def _ensure_worker_locked(self) -> tuple[subprocess.Popen | None, bool]:
@@ -116,11 +155,13 @@ class OCRWorkerClient:
             self._kill_worker_locked()
         try:
             self._proc = self._spawn()
+            self._set_state("warming")
             logger.info("spawned ocr worker (pid=%s)", self._proc.pid)
             return self._proc, True
         except Exception as exc:  # noqa: BLE001
             logger.warning("ocr worker spawn failed: %s; OCR degrades to none", exc)
             self._proc = None
+            self._set_state("failed")
             return None, False
 
     def _send(self, proc: subprocess.Popen, tier: str, image_bytes: bytes) -> None:
@@ -192,6 +233,8 @@ class _WorkerGone(Exception):
 # Module singleton — one worker per daemon.
 _client: OCRWorkerClient | None = None
 _client_lock = threading.Lock()
+_state_listener: StateListener | None = None
+_state_listener_lock = threading.Lock()
 
 
 def get_client() -> OCRWorkerClient:
@@ -203,6 +246,23 @@ def get_client() -> OCRWorkerClient:
                 startup_timeout=_startup_timeout_from_env(),
             )
         return _client
+
+
+def current_worker_state() -> WorkerState:
+    """Inspect the existing singleton without creating an OCR subprocess."""
+    with _client_lock:
+        client = _client
+    return "not_started" if client is None else client.state()
+
+
+def set_state_listener(listener: StateListener | None) -> None:
+    """Publish every worker transition to the daemon generation receipt."""
+
+    global _state_listener
+    with _state_listener_lock:
+        _state_listener = listener
+    if listener is not None:
+        listener(current_worker_state())
 
 
 def _timeout_from_env() -> float:

--- a/src/persome/capture/scheduler.py
+++ b/src/persome/capture/scheduler.py
@@ -75,6 +75,27 @@ def _set_active_runner(runner: _CaptureRunner | None) -> None:
     _active_runner = runner
 
 
+def capture_now() -> Path | None:
+    """Force one capture through the live daemon runner for onboarding proof."""
+    runner = _active_runner
+    if runner is None:
+        return None
+    return runner.capture_now()
+
+
+def active_runner_state(cfg: CaptureConfig) -> str:
+    """Return a side-effect-free onboarding state for the live capture runner."""
+    runner = _active_runner
+    if runner is None:
+        return "not-ready"
+    gate = capture_gate_reason(cfg)
+    if gate is not None:
+        return gate
+    if cfg.source == "ingest":
+        return "ingest-ready"
+    return "ready"
+
+
 def _submit_ocr_async(
     image_bytes: bytes,
     capture_id: str,
@@ -157,15 +178,20 @@ def _should_skip_capture(cfg: CaptureConfig) -> bool:
     capture rather than risking collection behind the login screen. Both checks
     default on.
     """
+    return capture_gate_reason(cfg) is not None
+
+
+def capture_gate_reason(cfg: CaptureConfig) -> str | None:
+    """Return the active privacy gate, if any, without attempting a capture."""
     paths.ensure_dirs()
     if paths.paused_flag().exists():
         logger.info("capture skipped (paused)")
-        return True
+        return "paused"
     # Privacy guardrail (spec E7): don't collect behind the lock screen / asleep.
     if cfg.pause_on_lock and screen_state.is_screen_locked():
         logger.info("capture skipped (screen locked / asleep)")
-        return True
-    return False
+        return "locked"
+    return None
 
 
 def _attach_screenshot(
@@ -589,10 +615,12 @@ class _CaptureRunner:
         provider: ax_capture.AXProvider | None,
         *,
         pre_capture_hook: Callable[[dict[str, Any]], None] | None = None,
+        capture_receipt_hook: Callable[[Path | None, str], None] | None = None,
     ) -> None:
         self._cfg = cfg
         self._provider = provider
         self._pre_capture_hook = pre_capture_hook
+        self._capture_receipt_hook = capture_receipt_hook
         self._lock = threading.Lock()
         self._last_fingerprint: str | None = None
         self._queue: queue.Queue[Any] = queue.Queue(maxsize=self._MAX_PENDING)
@@ -633,13 +661,45 @@ class _CaptureRunner:
             try:
                 if self._provider is None:
                     logger.debug("OS capture skipped: runner is ingest-only")
+                    self._publish_receipt(None, capture_gate_reason(self._cfg) or "ingest-ready")
                     return
                 out = _build_capture(self._cfg, self._provider, trigger)
                 if out is None:
+                    self._publish_receipt(None, capture_gate_reason(self._cfg) or "capture-skipped")
                     return
                 self._commit(out, trigger)
             except Exception as exc:  # noqa: BLE001
                 logger.error("capture failed: %s", exc, exc_info=True)
+
+    def capture_now(self) -> Path | None:
+        """Synchronously force a fresh record through the daemon-owned runner."""
+        with self._lock:
+            try:
+                if self._provider is None:
+                    logger.debug("forced OS capture skipped: runner is ingest-only")
+                    self._publish_receipt(None, capture_gate_reason(self._cfg) or "ingest-ready")
+                    return None
+                out = _build_capture(
+                    self._cfg,
+                    self._provider,
+                    {"event_type": "OnboardingProbe"},
+                )
+                if out is None:
+                    self._publish_receipt(None, capture_gate_reason(self._cfg) or "capture-skipped")
+                    return None
+                return self._commit(out, None, force=True)
+            except Exception as exc:  # noqa: BLE001
+                logger.error("forced capture failed: %s", exc, exc_info=True)
+                self._publish_receipt(None, "capture-failed")
+                return None
+
+    def _publish_receipt(self, path: Path | None, reason: str) -> None:
+        if self._capture_receipt_hook is None:
+            return
+        try:
+            self._capture_receipt_hook(path, reason)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("capture_receipt_hook failed: %s", exc)
 
     def commit_prebuilt(self, out: dict[str, Any]) -> str | None:
         """Persist a capture built elsewhere (the ingest path) through this runner.
@@ -656,7 +716,13 @@ class _CaptureRunner:
             path = self._commit(out, out.get("trigger"))
             return path.stem if path is not None else None
 
-    def _commit(self, out: dict[str, Any], trigger: dict[str, Any] | None) -> Path | None:
+    def _commit(
+        self,
+        out: dict[str, Any],
+        trigger: dict[str, Any] | None,
+        *,
+        force: bool = False,
+    ) -> Path | None:
         """Content-dedup → write → fire hooks. Caller must hold ``self._lock``.
 
         Returns the written capture path, or None when content-deduped against the
@@ -664,7 +730,7 @@ class _CaptureRunner:
         static screen does not refresh the session idle timer).
         """
         fingerprint = _content_fingerprint(out)
-        if fingerprint == self._last_fingerprint:
+        if not force and fingerprint == self._last_fingerprint:
             meta = out.get("window_meta") or {}
             logger.debug(
                 "capture skipped (content dedup): trigger=%s app=%r title=%r",
@@ -675,6 +741,8 @@ class _CaptureRunner:
             return None
         self._last_fingerprint = fingerprint
         path = _write_capture(out)
+        reason = str((out.get("trigger") or {}).get("event_type") or "capture")
+        self._publish_receipt(path, reason)
         if self._pre_capture_hook is not None and trigger is not None:
             try:
                 self._pre_capture_hook(trigger)
@@ -698,6 +766,7 @@ async def run_forever(
     cfg: CaptureConfig,
     *,
     pre_capture_hook: Callable[[dict[str, Any]], None] | None = None,
+    capture_receipt_hook: Callable[[Path | None, str], None] | None = None,
 ) -> None:
     """Run the capture pipeline until cancelled.
 
@@ -731,6 +800,7 @@ async def run_forever(
         cfg,
         provider,
         pre_capture_hook=pre_capture_hook,
+        capture_receipt_hook=capture_receipt_hook,
     )
     runner.start_worker()
     _set_active_runner(runner)
@@ -739,6 +809,7 @@ async def run_forever(
 
     try:
         if ingest_only:
+            runner._publish_receipt(None, capture_gate_reason(cfg) or "ingest-ready")
             logger.info(
                 "capture source=ingest — OS capture disabled (no watcher / no screenshot "
                 "grab); serving POST /captures/ingest"

--- a/src/persome/capture/screen_recording.py
+++ b/src/persome/capture/screen_recording.py
@@ -5,14 +5,16 @@ desktop wallpaper — every other app's window is blanked by the OS — so a dae
 captures screenshots stores useless wallpaper frames. A launchd background process
 calling the capture API never gets prompted, so the permission must be *requested*
 (which also registers the binary, here ``Persome Backend``, in the Screen Recording list
-so the user can toggle it on).
+so the user can toggle it on). Only explicit onboarding/setup actions call the
+request function; ordinary Runtime startup uses the preflight check only.
 
 We call CoreGraphics directly via ctypes — no pyobjc/Quartz dependency to bundle:
 - ``CGPreflightScreenCaptureAccess()`` → has the permission already been granted?
 - ``CGRequestScreenCaptureAccess()`` → register + prompt (idempotent).
 
-Both fail **open** (return ``True`` / proceed) if the symbols can't be resolved, so a
-non-Darwin host or an SDK without these symbols never blocks capture.
+Non-Darwin hosts treat the permission as not applicable. On macOS, an
+unresolvable CoreGraphics probe fails closed so onboarding can never claim a
+permission it did not actually prove.
 """
 
 from __future__ import annotations
@@ -45,22 +47,22 @@ def _coregraphics() -> ctypes.CDLL | None:
         lib.CGPreflightScreenCaptureAccess.restype = ctypes.c_bool
         lib.CGRequestScreenCaptureAccess.restype = ctypes.c_bool
         _cg = lib
-    except Exception as exc:  # noqa: BLE001 — any load failure → fail open
+    except Exception as exc:  # noqa: BLE001 — surfaced as denied on macOS
         logger.debug("CoreGraphics unavailable for screen-recording check: %s", exc)
         _cg = None
     return _cg
 
 
 def has_screen_recording() -> bool:
-    """Whether Screen Recording is granted. Fail-open (True) if unknowable."""
+    """Whether Screen Recording is granted (fail-closed on macOS)."""
     lib = _coregraphics()
     if lib is None:
-        return True
+        return sys.platform != "darwin"
     try:
         return bool(lib.CGPreflightScreenCaptureAccess())
     except Exception as exc:  # noqa: BLE001
         logger.debug("CGPreflightScreenCaptureAccess failed: %s", exc)
-        return True
+        return sys.platform != "darwin"
 
 
 def request_screen_recording() -> bool:
@@ -68,11 +70,12 @@ def request_screen_recording() -> bool:
 
     Returns whether access is granted *now* (usually False on first call — the user
     still has to flip the toggle, but the binary now appears in System Settings).
-    Idempotent; safe to call at every boot.
+    This may show a system dialog and must only be called after an explicit
+    user-facing confirmation, never during ordinary Runtime startup.
     """
     lib = _coregraphics()
     if lib is None:
-        return True
+        return sys.platform != "darwin"
     try:
         granted = bool(lib.CGRequestScreenCaptureAccess())
         if granted:

--- a/src/persome/capture/screenshot.py
+++ b/src/persome/capture/screenshot.py
@@ -30,8 +30,8 @@ def grab(max_width: int = 1920, jpeg_quality: int = 80) -> Screenshot | None:
 
     # Without Screen Recording permission macOS hands `mss` only the desktop wallpaper
     # (every other app's window is blanked), so a capture here would store a useless
-    # wallpaper frame. Skip it — `request_screen_recording()` at boot registers the daemon
-    # in the Screen Recording list + prompts; the user enables it and restarts Persome.
+    # wallpaper frame. Skip it; explicit `persome onboard` explains and requests
+    # the grant, while ordinary Runtime starts never show surprise TCC prompts.
     from . import screen_recording
 
     if not screen_recording.has_screen_recording():

--- a/src/persome/capture/watcher.py
+++ b/src/persome/capture/watcher.py
@@ -24,7 +24,7 @@ from typing import Any
 
 from ..logger import get
 from . import ax_capture
-from .ax_capture import _maybe_compile
+from .ax_capture import _stable_native_binary
 
 logger = get("persome.capture")
 
@@ -52,19 +52,18 @@ def _resolve_watcher_path() -> Path | None:
         from importlib.resources import files as _pkg_files
 
         bundled_dir = Path(str(_pkg_files("persome").joinpath("_bundled")))
-        candidates.append(bundled_dir / "mac-ax-watcher")
+        candidates.append(bundled_dir / "mac-ax-watcher.swift")
     except (ModuleNotFoundError, ValueError):
         pass
 
     dev_root = Path(__file__).resolve().parents[3]
-    candidates.append(dev_root / "resources" / "mac-ax-watcher")
+    candidates.append(dev_root / "resources" / "mac-ax-watcher.swift")
 
-    for binary_path in candidates:
-        swift_path = binary_path.with_suffix(".swift")
+    for swift_path in candidates:
         if swift_path.is_file():
-            _maybe_compile(swift_path, binary_path)
-        if binary_path.is_file() and os.access(binary_path, os.X_OK):
-            return binary_path
+            binary_path = _stable_native_binary(swift_path, "mac-ax-watcher")
+            if binary_path is not None:
+                return binary_path
 
     return None
 
@@ -201,7 +200,7 @@ class AXWatcherProcess:
             delay = min(delay * 2, self._max_reconnect_delay)
 
     def _wait_for_accessibility(self) -> bool:
-        """Poll the daemon's TCC trust without showing repeated permission dialogs."""
+        """Poll both configured native AX principals without showing dialogs."""
         logger.warning(
             "Accessibility permission not granted — waiting for approval (polling every %.0fs)",
             self._permission_poll,

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -1448,6 +1448,7 @@ def llm_setup(
 
     selected = None
     keep_current = False
+    declined_current = False
     if provider:
         selected = provider_spec(provider)
         if selected is None:
@@ -1457,11 +1458,16 @@ def llm_setup(
         if interactive:
             console.print(f"Current provider: [bold]{current.provider_label}[/bold]")
             keep_current = typer.confirm("Use and verify this provider?", default=True)
+            declined_current = not keep_current
         else:
             keep_current = True
 
     if selected is None and not keep_current:
         detected = detected_providers()
+        if declined_current:
+            # A direct "no" means choose something else. Do not immediately
+            # rediscover and silently select the same provider again.
+            detected = [spec for spec in detected if spec.id != current.provider]
         if len(detected) == 1:
             selected = detected[0]
             console.print(f"[green]Found an existing {selected.label} API key.[/green]")
@@ -1502,7 +1508,10 @@ def llm_setup(
             api_key = os.environ.get(source_key_env)
         else:
             api_key = os.environ.get(selected.discovery_api_key_env)
-            api_key = api_key or os.environ.get(LLM_API_KEY_ENV)
+            # The neutral key belongs to the active profile. Reuse it only
+            # when reconfiguring that same provider, never after a switch.
+            if api_key is None and selected.id == current.provider:
+                api_key = current.api_key
 
     selected_spec = selected or provider_spec(provider_id)
     provider_label = selected_spec.label if selected_spec is not None else current.provider_label

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -13,6 +13,7 @@ if not os.environ.get("SSL_CERT_FILE"):
         pass
 
 import contextlib
+import fcntl
 import json
 import shutil
 import signal
@@ -30,7 +31,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from . import __version__, integrity, paths
+from . import __version__, integrity, paths, runtime_pid
 from . import config as config_mod
 from . import env_file as env_file_mod
 from . import logger as logger_mod
@@ -47,14 +48,56 @@ app = typer.Typer(
 console = Console()
 
 
-def _init() -> config_mod.Config:
+def _fail_if_runtime_state_is_ambiguous() -> None:
+    problem = runtime_pid.unresolved_runtime_reason()
+    if problem is None:
+        return
+    console.print(f"[red]Unsafe Runtime lifecycle state: {problem}.[/red]")
+    console.print(
+        "[yellow]Stop the owning Desktop app or LaunchAgent and retry; "
+        "Persome will not start a second writer.[/yellow]"
+    )
+    raise typer.Exit(1)
+
+
+def _acquire_daemon_lock():  # type: ignore[no-untyped-def]
+    handle = None
+    try:
+        handle = paths.open_private_lock_file(paths.daemon_lock_file())
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (BlockingIOError, OSError, RuntimeError) as exc:
+        if handle is not None:
+            handle.close()
+        raise RuntimeError("another Persome Runtime is already starting or running") from exc
+    return handle
+
+
+def _daemon_lock_is_held() -> bool:
+    try:
+        handle = paths.open_private_lock_file(paths.daemon_lock_file())
+    except (OSError, RuntimeError):
+        return True
+    try:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            return True
+        return False
+    finally:
+        with contextlib.suppress(OSError):
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        handle.close()
+
+
+def _init(*, starting_runtime: bool = False) -> config_mod.Config:
     paths.ensure_dirs()
+    _fail_if_runtime_state_is_ambiguous()
     # Logger first so the integrity check's JSON-line output lands in daemon.log.
     logger_mod.setup(console=False)
     # The daemon owns active SQLite writes. A status/MCP/second-start invocation
     # must never quarantine or rebuild an index while that process has it open.
     # When stopped, this remains the first database-touching operation.
-    if not _read_pid():
+    if not _read_pid() and (starting_runtime or not _daemon_lock_is_held()):
         integrity.check_and_recover()
     created = config_mod.write_default_if_missing()
     if created:
@@ -63,21 +106,13 @@ def _init() -> config_mod.Config:
 
 
 def _is_pid_alive(pid: int) -> bool:
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
-    return True
+    process = runtime_pid.resolve_recorded_process()
+    return bool(process is not None and process.pid == pid)
 
 
 def _read_pid() -> int | None:
-    try:
-        pid = int(paths.pid_file().read_text().strip())
-    except (FileNotFoundError, ValueError):
-        return None
-    return pid if _is_pid_alive(pid) else None
+    process = runtime_pid.resolve_recorded_process()
+    return process.pid if process is not None else None
 
 
 def _daemon_uptime() -> str:
@@ -242,10 +277,17 @@ def start(
     # Avoid even configuration/integrity writes when the caller only asked to
     # start an already-running daemon. This is also the cross-process guard for
     # editor-launched MCP clients that share the same local database.
+    _fail_if_runtime_state_is_ambiguous()
     if pid := _read_pid():
         console.print(f"[yellow]Already running (pid {pid})[/yellow]")
         raise typer.Exit(1)
-    cfg = _init()
+    try:
+        daemon_lock = _acquire_daemon_lock()
+    except RuntimeError as exc:
+        console.print(f"[yellow]{exc}.[/yellow]")
+        raise typer.Exit(1) from exc
+    _fail_if_runtime_state_is_ambiguous()
+    cfg = _init(starting_runtime=True)
     # Source checkouts and upgrades may start without re-running install.sh.
     # Provision the local HTTP boundary before the daemon binds; the helper is
     # idempotent and preserves every unrelated provider secret in the env file.
@@ -263,6 +305,7 @@ def start(
         console.print("[bold]Persome starting in foreground[/bold] — Ctrl+C to stop.")
         _watch_parent_death()  # exit if the Persome app that spawned us (--foreground child) dies
         daemon.run(cfg, capture_only=capture_only)
+        daemon_lock.close()
         # Hard-exit instead of returning — `daemon.run` has already done the clean
         # shutdown (cancelled tasks, force-ended the session, logged "daemon
         # stopped"), so all durable state is committed (SQLite WAL is crash-safe;
@@ -292,29 +335,27 @@ def start(
     if devnull > 2:
         os.close(devnull)
     daemon.run(cfg, capture_only=capture_only)
+    daemon_lock.close()
     os._exit(0)
 
 
 @app.command()
 def stop(timeout: int = typer.Option(10, help="Seconds to wait for the daemon to exit.")) -> None:
     """Stop the daemon and wait for it to fully exit."""
-    import time
-
     _init()
-    pid = _read_pid()
-    if not pid:
+    process = runtime_pid.resolve_recorded_process()
+    if process is None:
         console.print("[yellow]Daemon not running.[/yellow]")
         raise typer.Exit(1)
-    os.kill(pid, signal.SIGTERM)
-    console.print(f"[green]Sent SIGTERM to pid {pid}.[/green]")
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if not _is_pid_alive(pid):
-            console.print("[green]Daemon stopped.[/green]")
-            return
-        time.sleep(0.2)
+    if not runtime_pid.signal_process(process, signal.SIGTERM):
+        console.print("[red]Daemon identity changed before it could be stopped.[/red]")
+        raise typer.Exit(1)
+    console.print(f"[green]Sent SIGTERM to pid {process.pid}.[/green]")
+    if runtime_pid.wait_for_exit(process, timeout):
+        console.print("[green]Daemon stopped.[/green]")
+        return
     console.print(
-        f"[yellow]Daemon (pid {pid}) did not exit within {timeout}s — it may still be running.[/yellow]"
+        f"[yellow]Daemon (pid {process.pid}) did not exit within {timeout}s — it may still be running.[/yellow]"
     )
 
 
@@ -340,6 +381,8 @@ def status() -> None:
     cfg = _init()
     # Source the env file before resolving/probing the selected provider.
     env_file_mod.load_env_file(paths.env_file())
+    from . import launchagent
+    from . import onboarding as onboarding_mod
     from .capture.ocr_health import inspect as inspect_ocr
     from .providers import resolve_profile
 
@@ -347,6 +390,27 @@ def status() -> None:
     ocr_health = inspect_ocr(cfg.capture)
     pid = _read_pid()
     paused = paths.paused_flag().exists()
+
+    runtime_state = onboarding_mod._runtime_state(pid) if pid is not None else None
+    permission_state = runtime_state.get("permissions") if runtime_state is not None else None
+    accessibility = (
+        str(permission_state.get("accessibility", "unknown"))
+        if isinstance(permission_state, dict)
+        else "not_applicable"
+        if cfg.capture.source == "ingest"
+        else "unknown"
+    )
+    runtime_generation = (
+        str(runtime_state.get("generation", "unknown")) if runtime_state is not None else "unknown"
+    )
+    owner = "background"
+    if launchagent.is_loaded():
+        binary = launchagent.configured_runtime_binary()
+        owner = (
+            "launchagent"
+            if binary is not None and launchagent.owns_recorded_runtime(binary)
+            else "launchagent (ownership mismatch)"
+        )
 
     uptime = _daemon_uptime()
     last_ts, last_app = _last_capture_info()
@@ -359,6 +423,20 @@ def status() -> None:
     table.add_row("Uptime", uptime)
     table.add_row("Health", f"[{health_style}]{health_label}[/{health_style}]")
     table.add_row("Capture", "[yellow]paused[/yellow]" if paused else "active")
+    table.add_row("Capture Source", cfg.capture.source)
+    table.add_row("Runtime Owner", owner if pid is not None else "stopped")
+    table.add_row("Generation", runtime_generation)
+    accessibility_style = (
+        "green"
+        if accessibility in {"granted", "not_applicable"}
+        else "red"
+        if accessibility == "denied"
+        else "yellow"
+    )
+    table.add_row(
+        "Accessibility",
+        f"[{accessibility_style}]{accessibility}[/{accessibility_style}]",
+    )
     ocr_style = "green" if ocr_health.ready else "yellow" if not ocr_health.enabled else "red"
     table.add_row(
         "OCR",
@@ -493,20 +571,41 @@ def doctor() -> None:
 
 @app.command()
 def onboard(
-    tier: str = typer.Option("tiny", "--tier", help="OCR tier: tiny | small | medium."),
+    tier: str | None = typer.Option(
+        None,
+        "--tier",
+        help="Enable/change OCR tier (tiny | small | medium); omitted preserves prior intent.",
+    ),
     gui: bool = typer.Option(
         True,
         "--gui/--no-gui",
         help="Use native macOS dialogs (falls back to terminal prompts).",
     ),
+    preserve_policy: bool = typer.Option(
+        False,
+        "--preserve-policy",
+        hidden=True,
+        help="Verify the existing capture policy without changing OCR configuration.",
+    ),
+    expected_owner: str = typer.Option(
+        "any",
+        "--expect-owner",
+        hidden=True,
+        help="Require final Runtime ownership (any | launchagent | background).",
+    ),
 ) -> None:
-    """Grant capture permissions, verify OCR, start Persome, and prove capture."""
+    """Verify capture permissions/policy, Runtime ownership, and live readiness."""
     from . import onboarding as onboarding_mod
 
     _init()
     env_file_mod.load_env_file(paths.env_file())
     try:
-        proof = onboarding_mod.onboard(tier=tier, gui=gui)
+        proof = onboarding_mod.onboard(
+            tier=tier,
+            gui=gui,
+            preserve_policy=preserve_policy,
+            expected_owner=expected_owner,
+        )
     except onboarding_mod.OnboardingCancelled as exc:
         console.print(f"[yellow]Onboarding stopped: {exc}.[/yellow]")
         raise typer.Exit(1) from exc
@@ -514,10 +613,38 @@ def onboard(
         console.print(f"[red]Onboarding failed: {exc}.[/red]")
         raise typer.Exit(1) from exc
 
-    console.print("[green]✓ Accessibility granted[/green]")
-    console.print("[green]✓ Local OCR and Screen Recording ready[/green]")
-    console.print(f"[green]✓ Persome running and healthy[/green] (pid {proof.pid})")
-    console.print(f"[green]✓ Fresh capture verified[/green] ({proof.capture_path})")
+    if proof.mode == "ingest":
+        console.print("[green]✓ Trusted ingest capture mode ready[/green]")
+    else:
+        console.print("[green]✓ Accessibility granted[/green]")
+        if proof.screen_recording == "granted":
+            console.print("[green]✓ Screen Recording granted[/green]")
+        if proof.ocr == "ready":
+            console.print("[green]✓ Isolated local OCR worker ready[/green]")
+        else:
+            ocr_message = {
+                "disabled": "disabled by saved policy",
+                "disabled_by_environment": "disabled by PERSOME_DISABLE_OCR",
+                "runtime_unavailable": "unavailable on this Mac",
+                "models_missing": "missing its bundled model files",
+            }.get(proof.ocr, proof.ocr)
+            console.print(f"[yellow]• AX capture ready; local OCR is {ocr_message}[/yellow]")
+    if proof.health == "ok":
+        console.print(
+            f"[green]✓ Persome running and healthy[/green] (pid {proof.pid}, owner {proof.owner})"
+        )
+    else:
+        console.print(
+            f"[yellow]✓ Persome running with {proof.health} optional features[/yellow] "
+            f"(pid {proof.pid}, owner {proof.owner})"
+        )
+    if proof.capture_path is not None:
+        console.print(f"[green]✓ Fresh capture verified[/green] ({proof.capture_path})")
+    elif proof.receipt == "ingest-ready":
+        console.print("[green]✓ Authenticated ingest runner verified[/green]")
+    else:
+        state = proof.receipt.removeprefix("privacy-")
+        console.print(f"[green]✓ Capture privacy state preserved[/green] ({state})")
 
 
 @app.command()
@@ -530,30 +657,86 @@ def update(
     """Update the installed Persome Runtime and prove it is healthy."""
     from . import updater
 
+    updater.claim_legacy_foreground()
     launchagent_was_loaded = False
     runtime_may_have_changed = False
-    try:
-        with updater.acquire_source(source) as update_source:
-            label = "official main" if update_source.official else str(update_source.path)
-            console.print(
-                f"[bold]Updating Persome from {label}[/bold] "
-                f"([dim]{update_source.revision[:12]}[/dim])"
-            )
-            launchagent_was_loaded = updater.launchagent_is_loaded()
-            runtime_may_have_changed = True
-            updater.stop_runtime(launchagent_was_loaded=launchagent_was_loaded)
-            console.print("[green]✓ Previous Runtime stopped[/green]")
-            updater.run_installer(update_source)
-            updater.restore_launchagent(launchagent_was_loaded)
-    except updater.UpdateError as exc:
-        recovery = ""
-        if runtime_may_have_changed:
-            try:
-                updater.recover_runtime(launchagent_was_loaded)
-            except updater.UpdateError as recovery_exc:
-                recovery = f" Recovery also failed: {recovery_exc}"
-        console.print(f"[red]Update failed: {exc}.{recovery}[/red]")
+
+    def fail_update(exc: BaseException, recovery_error: str = "") -> None:
+        cancelled = isinstance(
+            exc,
+            (KeyboardInterrupt, updater.UpdateCancelled, updater.UpdateSignal),
+        )
+        if cancelled:
+            if recovery_error:
+                console.print(
+                    f"[red]Update cancelled, but Runtime recovery failed: {recovery_error}[/red]"
+                )
+            else:
+                message = (
+                    "Update cancelled; the previous Runtime was restored."
+                    if runtime_may_have_changed
+                    else "Update cancelled before the Runtime was changed."
+                )
+                console.print(f"[yellow]{message}[/yellow]")
+            if isinstance(exc, (updater.UpdateCancelled, updater.UpdateSignal)):
+                code = exc.exit_code
+            else:
+                code = 130
+            raise typer.Exit(code) from exc
+        suffix = f" Recovery also failed: {recovery_error}" if recovery_error else ""
+        console.print(f"[red]Update failed: {exc}.{suffix}[/red]")
         raise typer.Exit(1) from exc
+
+    try:
+        with updater.catch_update_signals(), updater.update_lock():
+            # Recovery may already be moving virtualenv directories and
+            # lifecycle ownership. Repeated terminal signals must not leave
+            # that deterministic repair half-applied.
+            console.print("[dim]Checking for an interrupted update to recover...[/dim]")
+            with updater.ignore_update_signals():
+                updater.recover_pending_update()
+            updater.ensure_no_pending_update()
+            if source is None:
+                console.print("[dim]Downloading the latest official main revision...[/dim]")
+            else:
+                console.print(f"[dim]Inspecting local update source {source}...[/dim]")
+            with updater.acquire_source(source) as update_source:
+                try:
+                    label = "official main" if update_source.official else str(update_source.path)
+                    console.print(
+                        f"[bold]Updating Persome from {label}[/bold] "
+                        f"([dim]{update_source.revision[:12]}[/dim])"
+                    )
+                    launchagent_was_loaded = updater.launchagent_should_be_restored()
+                    updater.begin_update_transaction(launchagent_was_loaded)
+                    runtime_may_have_changed = True
+                    updater.stop_runtime(launchagent_was_loaded=launchagent_was_loaded)
+                    console.print("[green]✓ Previous Runtime stopped[/green]")
+                    updater.run_installer(update_source)
+                    updater.mark_update_phase(launchagent_was_loaded, "prepared")
+                    updater.activate_runtime(launchagent_was_loaded)
+                    updater.prove_runtime(launchagent_was_loaded)
+                    with updater.ignore_update_signals():
+                        updater.mark_update_phase(launchagent_was_loaded, "committing")
+                        cleanup = updater.commit_prepared_install()
+                        updater.clear_update_state()
+                        updater.cleanup_committed_install(cleanup)
+                    runtime_may_have_changed = False
+                except (
+                    KeyboardInterrupt,
+                    updater.UpdateError,
+                    updater.UpdateSignal,
+                ) as exc:
+                    recovery_error = ""
+                    if runtime_may_have_changed:
+                        try:
+                            with updater.ignore_update_signals():
+                                updater.rollback_and_recover(launchagent_was_loaded)
+                        except updater.UpdateError as recovery_exc:
+                            recovery_error = str(recovery_exc)
+                    fail_update(exc, recovery_error)
+    except (KeyboardInterrupt, updater.UpdateError, updater.UpdateSignal) as exc:
+        fail_update(exc)
 
     console.print(
         "[green]✓ Persome update complete[/green] — configuration, credentials, and personal "
@@ -750,7 +933,10 @@ def ocr_disable() -> None:
         tier=cfg.capture.ocr_tier,
         config_path=paths.config_file(),
     )
-    console.print("[yellow]Local OCR disabled. Restart the daemon to apply.[/yellow]")
+    console.print(
+        "[yellow]Local OCR disabled. Run `persome onboard` to apply and verify the saved "
+        "policy.[/yellow]"
+    )
 
 
 @app.command("ocr-selftest")
@@ -1463,11 +1649,10 @@ def llm_setup(
             keep_current = True
 
     if selected is None and not keep_current:
-        detected = detected_providers()
-        if declined_current:
-            # A direct "no" means choose something else. Do not immediately
-            # rediscover and silently select the same provider again.
-            detected = [spec for spec in detected if spec.id != current.provider]
+        # A direct "no" means the next provider must be an explicit user
+        # choice. Do not silently select any discovered alternative (or a
+        # regional preset that shares the current credential).
+        detected = [] if declined_current else detected_providers()
         if len(detected) == 1:
             selected = detected[0]
             console.print(f"[green]Found an existing {selected.label} API key.[/green]")

--- a/src/persome/config.py
+++ b/src/persome/config.py
@@ -68,6 +68,10 @@ class CaptureConfig:
     ax_timeout_seconds: int = 3
     # OCR fallback for AX-poor apps (WeChat, Feishu, etc.) — on-device PP-OCRv6.
     enable_ocr_fallback: bool = False
+    # ``auto`` = fresh/unconfigured; onboarding may enable the supported
+    # default. Explicit setup/disable records durable intent so repeated
+    # onboarding never silently changes the user's choice.
+    ocr_policy: str = "auto"  # auto | enabled | disabled
     ocr_tier: str = "tiny"  # tiny | small | medium (local PP-OCRv6 weights)
     ocr_min_gap_seconds: float = 15.0
     # Geometry structuring of raw OCR (zero LLM, on-device): reconstruct columns/regions
@@ -494,7 +498,19 @@ def _build_capture(raw: dict) -> CaptureConfig:
     for current, old in legacy.items():
         if current not in section and old in raw:
             section[current] = raw[old]
-    return cast(CaptureConfig, _build_dataclass(CaptureConfig, section))
+    capture = cast(CaptureConfig, _build_dataclass(CaptureConfig, section))
+    if capture.source not in {"daemon", "ingest"}:
+        raise RuntimeError(f"capture.source must be 'daemon' or 'ingest', got {capture.source!r}")
+    if capture.ocr_policy not in {"auto", "enabled", "disabled"}:
+        raise RuntimeError(
+            "capture.ocr_policy must be 'auto', 'enabled', or 'disabled', "
+            f"got {capture.ocr_policy!r}"
+        )
+    if capture.ocr_tier not in {"tiny", "small", "medium"}:
+        raise RuntimeError(
+            f"capture.ocr_tier must be 'tiny', 'small', or 'medium', got {capture.ocr_tier!r}"
+        )
+    return capture
 
 
 def load(path: Path | None = None) -> Config:
@@ -606,6 +622,7 @@ ax_timeout_seconds = 3
 # OCR fallback for apps that block Accessibility API (WeChat, Feishu, NetEase Music, etc.)
 # On-device PP-OCRv6 — the focused-window screenshot is OCR'd locally; nothing leaves the machine.
 enable_ocr_fallback = false   # install.sh verifies the worker, then writes true on supported Macs
+ocr_policy = "auto"           # auto until first setup; then enabled|disabled preserves user intent
 # Inference runs in an isolated local worker, so a native Paddle crash does not
 # kill the daemon. PERSOME_DISABLE_OCR=1 is the deployment kill switch.
 ocr_tier = "tiny"             # tiny (default) | small | medium — local PP-OCRv6 weights

--- a/src/persome/daemon.py
+++ b/src/persome/daemon.py
@@ -9,16 +9,20 @@ memory-delta modeling. A retry task recovers transient reducer failures.
 from __future__ import annotations
 
 import asyncio
+import json
 import os
+import secrets
 import signal
 import threading
+import time
 from collections.abc import Callable, Coroutine
 from contextlib import suppress
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 from . import paths
-from .capture import ocr_local
+from .capture import ocr_health, ocr_local
 from .capture import scheduler as capture_scheduler
 from .config import Config
 from .logger import get
@@ -122,10 +126,14 @@ def _hard_exit(session_manager: Any, code: int = 0) -> None:
         session_manager.force_end(reason="daemon-shutdown")
     with suppress(FileNotFoundError):
         paths.pid_file().unlink()
+    with suppress(FileNotFoundError):
+        paths.runtime_state_file().unlink()
     os._exit(code)
 
 
-def _build_task_registry() -> list[TaskDefinition]:
+def _build_task_registry(
+    capture_receipt_hook: Callable[[Path | None, str], None] | None = None,
+) -> list[TaskDefinition]:
     """Return the complete set of daemon task definitions."""
     return [
         TaskDefinition(
@@ -134,6 +142,7 @@ def _build_task_registry() -> list[TaskDefinition]:
             create=lambda cfg, sm: capture_scheduler.run_forever(
                 cfg.capture,
                 pre_capture_hook=sm.on_event,
+                capture_receipt_hook=capture_receipt_hook,
             ),
         ),
         TaskDefinition(
@@ -215,16 +224,88 @@ def _create_tasks_from_registry(
 
 async def _run(cfg: Config, *, capture_only: bool = False, hard_exit: bool = False) -> None:
     paths.ensure_dirs()
+    http_enabled = bool(cfg.mcp.auto_start and cfg.mcp.transport in ("sse", "streamable-http"))
+    if cfg.capture.source == "ingest" and not http_enabled:
+        raise RuntimeError(
+            "capture.source='ingest' requires the authenticated HTTP Runtime transport"
+        )
+    runtime_generation = secrets.token_hex(16)
+    # Keep the numeric pidfile backward-compatible with the updater/CLI from
+    # the immediately previous release. The owner-only runtime state written
+    # below binds that PID to a random generation; new lifecycle code requires
+    # both receipts before it sends a signal.
     paths.atomic_write_private_text(paths.pid_file(), str(os.getpid()))
 
-    # Register this daemon ("Persome Backend") in the macOS Screen Recording list + prompt,
-    # so screenshots capture real app windows instead of just the desktop wallpaper (and
-    # so OCR can grab AX-poor apps). Idempotent; a launchd background process won't get a
-    # modal prompt, but the binary now appears in System Settings → Privacy & Security →
-    # Screen Recording for the user to enable, then restart Persome. Never blocks boot.
-    from .capture import screen_recording
+    runtime_started_at = time.time()
+    runtime_state_lock = threading.Lock()
+    runtime_state: dict[str, Any] = {
+        "schema_version": 1,
+        "pid": os.getpid(),
+        "generation": runtime_generation,
+        "capture_mode": cfg.capture.source,
+        "http_enabled": http_enabled,
+        "ocr_worker": "not_started",
+        "ocr": "disabled",
+        "ocr_enabled": bool(cfg.capture.enable_ocr_fallback),
+        "ocr_tier": cfg.capture.ocr_tier,
+        "phase": "starting",
+        "permissions": {
+            "accessibility": "not_applicable",
+            "screen_recording": "not_applicable",
+        },
+        "last_capture_id": None,
+        "last_capture_reason": "not-yet-captured",
+        "started_at": runtime_started_at,
+        "updated_at": runtime_started_at,
+    }
 
-    screen_recording.request_screen_recording()
+    def _publish_runtime_state(
+        *,
+        worker: str | None = None,
+        capture_path: Path | None = None,
+        capture_reason: str | None = None,
+    ) -> None:
+        """Publish this exact daemon generation's owner-only readiness receipt."""
+        from .capture import ax_capture, ocr_health, screen_recording
+
+        with runtime_state_lock:
+            if worker is not None:
+                runtime_state["ocr_worker"] = worker
+            current_ocr = ocr_health.inspect(cfg.capture)
+            runtime_state["ocr"] = current_ocr.state
+            runtime_state["ocr_enabled"] = current_ocr.enabled
+            runtime_state["ocr_tier"] = current_ocr.tier
+            if capture_reason is not None:
+                if capture_path is not None:
+                    runtime_state["last_capture_id"] = capture_path.stem
+                runtime_state["last_capture_reason"] = capture_reason
+                # A receipt can only come from the capture task after storage
+                # recovery, session construction, task creation, and runner startup.
+                runtime_state["phase"] = "ready"
+            if cfg.capture.source == "daemon":
+                runtime_state["permissions"] = {
+                    "accessibility": (
+                        "granted"
+                        if ax_capture.ax_trusted(include_watcher=cfg.capture.event_driven)
+                        else "denied"
+                    ),
+                    "screen_recording": (
+                        "granted" if screen_recording.has_screen_recording() else "denied"
+                    ),
+                }
+            runtime_state["updated_at"] = time.time()
+            paths.atomic_write_private_text(
+                paths.runtime_state_file(),
+                json.dumps(runtime_state, ensure_ascii=False, sort_keys=True),
+            )
+
+    def _capture_receipt(path: Path | None, reason: str) -> None:
+        _publish_runtime_state(capture_path=path, capture_reason=reason)
+
+    # Runtime startup must never surprise the user with a TCC dialog. The
+    # explicit onboarding action is the only Screen Recording request path;
+    # ordinary starts only publish the current preflight state below.
+    _publish_runtime_state(worker="not_started")
 
     # evomem survivability base (SSOT switch design §3.3): chain-invariant
     # self-check at startup. Gated on [evomem] integrity_check_enabled (the
@@ -259,7 +340,7 @@ async def _run(cfg: Config, *, capture_only: bool = False, hard_exit: bool = Fal
     # reducer via its on_session_end callback. Built even when
     # capture_only is true so session rows still land on disk.
     session_manager = session_tick.build_manager(cfg)
-    registry = _build_task_registry()
+    registry = _build_task_registry(_capture_receipt)
     tasks = _create_tasks_from_registry(registry, cfg, session_manager, capture_only=capture_only)
 
     stop = asyncio.Event()
@@ -300,13 +381,31 @@ async def _run(cfg: Config, *, capture_only: bool = False, hard_exit: bool = Fal
     # pay the one-time graph-load latency) — but importing PaddleOCR/paddle
     # installs glog's FailureSignalHandler over ours, so re-claim the signals on
     # the loop thread once warmup finishes. Pure side channel; never blocks boot.
+    from .capture import ocr_subprocess
+
+    def _publish_worker_state(worker: str) -> None:
+        ocr_health.set_worker_state(worker)  # type: ignore[arg-type]
+        _publish_runtime_state(worker=worker)
+
+    ocr_subprocess.set_state_listener(_publish_worker_state)
+    ocr_health.set_worker_state("not_started")
+    _publish_runtime_state(worker="not_started")
     if cfg.capture.enable_ocr_fallback:
+        ocr_health.set_worker_state("warming")
+        _publish_runtime_state(worker="warming")
 
         def _warm_ocr() -> None:
             try:
-                if not ocr_local.warm(cfg.capture.ocr_tier):
+                if ocr_local.warm(cfg.capture.ocr_tier):
+                    ocr_health.set_worker_state("ready")
+                    _publish_runtime_state(worker="ready")
+                else:
+                    ocr_health.set_worker_state("failed")
+                    _publish_runtime_state(worker="failed")
                     logger.warning("boot: OCR warmup did not produce a ready engine")
             except Exception as exc:  # noqa: BLE001
+                ocr_health.set_worker_state("failed")
+                _publish_runtime_state(worker="failed")
                 logger.warning("boot: OCR warmup failed: %s", exc)
             finally:
                 # Re-take SIGTERM/SIGINT from paddle/glog (see _hard_stop).
@@ -352,8 +451,12 @@ async def _run(cfg: Config, *, capture_only: bool = False, hard_exit: bool = Fal
     with suppress(Exception):
         session_manager.force_end(reason="daemon-shutdown")
 
+    ocr_subprocess.set_state_listener(None)
+
     with suppress(FileNotFoundError):
         paths.pid_file().unlink()
+    with suppress(FileNotFoundError):
+        paths.runtime_state_file().unlink()
     logger.info("daemon stopped")
 
 

--- a/src/persome/doctor.py
+++ b/src/persome/doctor.py
@@ -20,19 +20,21 @@ Design constraints (BYO-key onboarding):
 
 from __future__ import annotations
 
+import contextlib
 import os
 import platform
 import shutil
 import socket
 import sqlite3
 import stat
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
 from . import config as config_mod
 from . import env_file as env_file_mod
-from . import paths
+from . import paths, runtime_pid
 from .providers import ResolvedLLMProfile, resolve_profile
 
 Status = Literal["ok", "fail", "warn"]
@@ -59,20 +61,36 @@ def _is_executable_file(p: Path) -> bool:
     return p.is_file() and os.access(p, os.X_OK)
 
 
-def _helper_candidates(name: str) -> list[Path]:
-    """Candidate binary locations, in the same order the capture pipeline
-    resolves them (env override → bundled wheel resource → dev source tree).
-    Existence check only — doctor never triggers the on-demand compile."""
-    candidates: list[Path] = []
+def _helper_sources(name: str) -> list[Path]:
+    """Current bundled/dev Swift sources, without compiling either one."""
+    sources: list[Path] = []
     try:
         from importlib.resources import files as _pkg_files
 
-        candidates.append(Path(str(_pkg_files("persome").joinpath("_bundled"))) / name)
+        sources.append(Path(str(_pkg_files("persome").joinpath("_bundled"))) / f"{name}.swift")
     except (ModuleNotFoundError, ValueError):
         pass
-    # Dev source tree: src/persome/doctor.py → parents[2] == repo root.
-    candidates.append(Path(__file__).resolve().parents[2] / "resources" / name)
-    return candidates
+    sources.append(Path(__file__).resolve().parents[2] / "resources" / f"{name}.swift")
+    return sources
+
+
+def _helper_candidates(name: str) -> list[Path]:
+    """Exact immutable binaries for current sources; historical cache is ignored."""
+    from .capture.ax_capture import _native_binary_path
+
+    return [
+        target
+        for source in _helper_sources(name)
+        if source.is_file() and (target := _native_binary_path(source, name)) is not None
+    ]
+
+
+def _configured_helper_path(name: str, env_var: str) -> Path | None:
+    override = os.environ.get(env_var)
+    if override:
+        candidate = Path(override).expanduser()
+        return candidate if _is_executable_file(candidate) else None
+    return next((path for path in _helper_candidates(name) if _is_executable_file(path)), None)
 
 
 def _llm_profile() -> ResolvedLLMProfile:
@@ -206,10 +224,16 @@ def check_base_url(profile: ResolvedLLMProfile | None = None) -> Check:
     return Check("LLM endpoint", "ok", label)
 
 
-def check_helpers() -> list[Check]:
+def check_helpers(capture: config_mod.CaptureConfig | None = None) -> list[Check]:
     """Check compiled helpers or the prerequisites for first-run compilation."""
     out: list[Check] = []
     for name, env_var in _HELPERS:
+        if capture is not None and capture.source == "ingest":
+            out.append(Check(name, "ok", "not applicable; trusted ingest producer owns capture"))
+            continue
+        if capture is not None and name == "mac-ax-watcher" and not capture.event_driven:
+            out.append(Check(name, "ok", "not required; event-driven capture is disabled"))
+            continue
         override = os.environ.get(env_var)
         if override:
             p = Path(override).expanduser()
@@ -222,13 +246,13 @@ def check_helpers() -> list[Check]:
         found = next((c for c in candidates if _is_executable_file(c)), None)
         if found is not None:
             out.append(Check(name, "ok", str(found)))
-        elif any(candidate.with_suffix(".swift").is_file() for candidate in candidates):
+        elif any(source.is_file() for source in _helper_sources(name)):
             if shutil.which("swiftc"):
                 out.append(
                     Check(
                         name,
                         "warn",
-                        "bundled Swift source found — compiles on first capture/start",
+                        "current Swift source found — compile it with the installer",
                     )
                 )
             else:
@@ -251,21 +275,37 @@ def check_helpers() -> list[Check]:
     return out
 
 
-def check_ax_trust() -> Check:
-    """macOS Accessibility trust for THIS process (capture.source='daemon' mode).
+def check_ax_trust(capture: config_mod.CaptureConfig | None = None) -> Check:
+    """macOS Accessibility trust for the configured native capture helpers.
 
     Off-macOS, or when the probe itself errors, the answer is unknowable →
     ``warn`` (unknown), never a hard fail."""
+    capture = capture or config_mod.CaptureConfig()
+    if capture.source == "ingest":
+        return Check("AX trust", "ok", "not applicable; trusted ingest producer owns capture")
     if platform.system() != "Darwin":
         return Check("AX trust", "warn", "unknown (not macOS)")
     try:
-        from .capture.ax_capture import ax_trusted
+        from .capture.ax_capture import _binary_ax_trusted
 
-        trusted = ax_trusted()
+        required = [_HELPERS[0]]
+        if capture.event_driven:
+            required.append(_HELPERS[1])
+        helper_paths = [_configured_helper_path(name, env_var) for name, env_var in required]
+        if any(path is None for path in helper_paths):
+            return Check(
+                "AX trust",
+                "fail",
+                "current bundled AX helper is missing — rerun the Persome installer",
+            )
+        trusted = all(_binary_ax_trusted(path) for path in helper_paths if path is not None)
     except Exception as exc:  # noqa: BLE001 — a TCC probe must never crash doctor
         return Check("AX trust", "warn", f"unknown (probe failed: {exc.__class__.__name__})")
     if trusted:
-        return Check("AX trust", "ok", "Accessibility granted to this process")
+        principals = (
+            "capture helper and event watcher" if capture.event_driven else "capture helper"
+        )
+        return Check("AX trust", "ok", f"Accessibility granted to the bundled {principals}")
     return Check(
         "AX trust",
         "fail",
@@ -276,6 +316,12 @@ def check_ax_trust() -> Check:
 
 def check_screen_recording(capture: config_mod.CaptureConfig) -> Check:
     """Check the TCC permission required by OCR and screenshot capture."""
+    if capture.source == "ingest":
+        return Check(
+            "Screen Recording",
+            "ok",
+            "not applicable; trusted ingest producer owns screen capture",
+        )
     if platform.system() != "Darwin":
         return Check("Screen Recording", "warn", "unknown (not macOS)")
     required = capture.enable_ocr_fallback or capture.include_screenshot
@@ -319,12 +365,24 @@ def check_ocr(capture: config_mod.CaptureConfig) -> Check:
 def check_root_writable() -> Check:
     """The data root exists (created on demand) and accepts writes."""
     root = paths.root()
-    probe = root / ".doctor-write-probe"
+    descriptor: int | None = None
+    probe: str | None = None
     try:
-        paths.atomic_write_private_text(probe, "ok")
-        probe.unlink()
+        root = paths.ensure_private_dir(root)
+        descriptor, probe = tempfile.mkstemp(prefix=".doctor-write-probe.", dir=root)
+        # Unlink before writing so SIGKILL or a crash cannot leave a probe file.
+        os.unlink(probe)
+        probe = None
+        os.write(descriptor, b"ok")
+        os.fsync(descriptor)
     except (OSError, RuntimeError) as exc:
         return Check("data root writable", "fail", f"{root}: {exc}")
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        if probe is not None:
+            with contextlib.suppress(OSError):
+                os.unlink(probe)
     return Check("data root writable", "ok", str(root))
 
 
@@ -348,17 +406,8 @@ def check_port(host: str, port: int) -> Check:
 
 
 def _running_daemon_pid() -> int | None:
-    try:
-        pid = int(paths.pid_file().read_text().strip())
-    except (FileNotFoundError, ValueError, OSError):
-        return None
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return None
-    except PermissionError:
-        return pid
-    return pid
+    process = runtime_pid.resolve_recorded_process()
+    return process.pid if process is not None else None
 
 
 def run_checks(host: str, port: int) -> list[Check]:
@@ -374,8 +423,8 @@ def run_checks(host: str, port: int) -> list[Check]:
         check_api_key(profile),
         check_screenshot_key(),
         check_base_url(profile),
-        *check_helpers(),
-        check_ax_trust(),
+        *check_helpers(cfg.capture),
+        check_ax_trust(cfg.capture),
         check_screen_recording(cfg.capture),
         check_ocr(cfg.capture),
         check_root_writable(),

--- a/src/persome/launchagent.py
+++ b/src/persome/launchagent.py
@@ -18,14 +18,17 @@ This module is the single source of truth for the label, plist location, and
 
 from __future__ import annotations
 
+import contextlib
 import os
 import plistlib
+import re
 import signal
 import subprocess
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
-from . import paths
+from . import paths, runtime_pid
 
 #: launchd job label.
 LABEL = "com.persome.runtime"
@@ -88,20 +91,132 @@ def write_plist(binary: str) -> Path:
     target = plist_path()
     target.parent.mkdir(parents=True, exist_ok=True)
     paths.ensure_private_dir(paths.logs_dir())
-    with target.open("wb") as fh:
-        plistlib.dump(build_plist(binary), fh)
+    payload = plistlib.dumps(build_plist(binary), fmt=plistlib.FMT_XML).decode("utf-8")
+    paths.atomic_write_private_text(target, payload)
     return target
+
+
+def configured_binary_matches(binary: str) -> bool:
+    """Whether the owner-only plist already describes this exact Runtime binary."""
+    target = plist_path()
+    try:
+        paths.ensure_private_file(target)
+        with target.open("rb") as handle:
+            payload = plistlib.load(handle)
+    except (FileNotFoundError, OSError, RuntimeError, plistlib.InvalidFileException):
+        return False
+    return payload.get("ProgramArguments") == [binary, "start", "--foreground"]
+
+
+def configured_runtime_binary() -> str | None:
+    """Return a valid configured daemon binary from the owner-only plist."""
+
+    target = plist_path()
+    try:
+        paths.ensure_private_file(target)
+        with target.open("rb") as handle:
+            payload = plistlib.load(handle)
+    except (FileNotFoundError, OSError, RuntimeError, plistlib.InvalidFileException):
+        return None
+    arguments = payload.get("ProgramArguments")
+    if not isinstance(arguments, list) or arguments[1:] != ["start", "--foreground"]:
+        return None
+    binary = arguments[0] if arguments else None
+    if not isinstance(binary, str) or not Path(binary).is_absolute():
+        return None
+    candidate = Path(binary)
+    if candidate.is_symlink() or not candidate.is_file() or not os.access(candidate, os.X_OK):
+        return None
+    return binary
+
+
+@dataclass(frozen=True)
+class LoadedJob:
+    """Minimal launchd state needed to bind a job to its daemon process."""
+
+    pid: int
+    program: str
+
+
+def loaded_job() -> LoadedJob | None:
+    """Return launchd's cached program and live PID for the Runtime job."""
+
+    try:
+        result = subprocess.run(
+            ["launchctl", "print", gui_domain_target()],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    pid_match = re.search(r"(?m)^\s*pid\s*=\s*(\d+)\s*$", result.stdout)
+    program_match = re.search(r"(?m)^\s*program\s*=\s*(.+?)\s*$", result.stdout)
+    if pid_match is None or program_match is None:
+        return None
+    pid = int(pid_match.group(1))
+    if pid <= 1:
+        return None
+    program = program_match.group(1).strip().strip('"')
+    if not program:
+        return None
+    return LoadedJob(pid=pid, program=program)
+
+
+def owns_recorded_runtime(binary: str) -> bool:
+    """Whether launchd, the plist, and the generation receipt name one daemon."""
+
+    job = loaded_job()
+    process = runtime_pid.resolve_recorded_process()
+    return bool(
+        job is not None
+        and job.program == binary
+        and configured_binary_matches(binary)
+        and process is not None
+        and process.pid == job.pid
+    )
+
+
+def _wait_for_owned_runtime(binary: str, timeout: float = 15.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if owns_recorded_runtime(binary):
+            return True
+        time.sleep(0.2)
+    return owns_recorded_runtime(binary)
+
+
+def owner_intended() -> bool:
+    """Whether a prior successful install recorded launchd lifecycle intent."""
+
+    marker = paths.launchagent_owner_file()
+    try:
+        paths.ensure_private_file(marker)
+        return marker.read_text(encoding="utf-8").strip() == "enabled"
+    except (FileNotFoundError, OSError, RuntimeError):
+        return False
+
+
+def _record_owner_intent() -> None:
+    paths.atomic_write_private_text(paths.launchagent_owner_file(), "enabled\n")
 
 
 def is_loaded() -> bool:
     """True iff launchd currently has the job registered (loaded), regardless
     of whether the process is up at this instant."""
-    result = subprocess.run(
-        ["launchctl", "print", gui_domain_target()],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["launchctl", "print", gui_domain_target()],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
     return result.returncode == 0
 
 
@@ -113,6 +228,23 @@ def bootstrap() -> subprocess.CompletedProcess[str]:
         capture_output=True,
         text=True,
         check=False,
+        timeout=30,
+    )
+
+
+def kickstart(*, kill: bool) -> subprocess.CompletedProcess[str]:
+    """Ask launchd to start, or atomically replace, its owned daemon."""
+
+    command = ["launchctl", "kickstart"]
+    if kill:
+        command.append("-k")
+    command.append(gui_domain_target())
+    return subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
     )
 
 
@@ -123,6 +255,7 @@ def bootout() -> subprocess.CompletedProcess[str]:
         capture_output=True,
         text=True,
         check=False,
+        timeout=30,
     )
 
 
@@ -142,26 +275,16 @@ def _terminate_stray_daemon(timeout: float = 2.0) -> None:
        process may still be shutting down; waiting here avoids a port race with
        the daemon we're about to bootstrap.
 
-    A stale/dead pid is ignored (``start`` already tolerates it via the
-    liveness check in ``cli._read_pid``). Best-effort — never raises."""
-    try:
-        pid = int(paths.pid_file().read_text().strip())
-    except (FileNotFoundError, ValueError):
+    A stale/dead pid is ignored. Ambiguous live state fails closed so takeover
+    can never create a second writer."""
+    process = runtime_pid.signal_recorded_process(signal.SIGTERM)
+    if process is None:
+        problem = runtime_pid.unresolved_runtime_reason()
+        if problem is not None:
+            raise RuntimeError(f"cannot take over Runtime lifecycle: {problem}")
         return
-    try:
-        os.kill(pid, 0)  # probe liveness; ProcessLookupError ⇒ already gone
-        os.kill(pid, signal.SIGTERM)
-    except ProcessLookupError:
-        return
-    except OSError:
-        return
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        try:
-            os.kill(pid, 0)
-        except ProcessLookupError:
-            return
-        time.sleep(0.1)
+    if not runtime_pid.wait_for_exit(process, timeout):
+        raise RuntimeError(f"Persome daemon pid {process.pid} did not stop during takeover")
 
 
 def _bootout_legacy_labels() -> None:
@@ -176,6 +299,7 @@ def _bootout_legacy_labels() -> None:
             capture_output=True,
             text=True,
             check=False,
+            timeout=10,
         )
         legacy_plist = plist_path().parent / f"{label}.plist"
         try:
@@ -192,18 +316,51 @@ def install(binary: str) -> Path:
     pre-launchd orphan, or the just-booted-out one still exiting) is terminated
     first so the fresh ``start`` won't bail with "Already running"."""
     _bootout_legacy_labels()
-    if is_loaded():
-        bootout()
+    loaded = is_loaded()
+    if loaded and configured_binary_matches(binary) and owns_recorded_runtime(binary):
+        # The stable install path is unchanged across a venv swap. Keep a
+        # generation that the updater has already fully proved.
+        _record_owner_intent()
+        return plist_path()
+    if loaded:
+        try:
+            result = bootout()
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise RuntimeError(f"could not stop the existing Persome LaunchAgent: {exc}") from exc
+        if result.returncode != 0:
+            detail = result.stderr.strip() or result.stdout.strip() or "launchctl bootout failed"
+            raise RuntimeError(f"could not stop the existing Persome LaunchAgent: {detail}")
     _terminate_stray_daemon()
     target = write_plist(binary)
-    bootstrap()
+    try:
+        result = bootstrap()
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise RuntimeError(f"could not start the Persome LaunchAgent: {exc}") from exc
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "launchctl bootstrap failed"
+        raise RuntimeError(f"could not start the Persome LaunchAgent: {detail}")
+    if not _wait_for_owned_runtime(binary):
+        with contextlib.suppress(OSError):
+            bootout()
+        raise RuntimeError(
+            "Persome LaunchAgent loaded but did not produce a matching daemon generation"
+        )
+    _record_owner_intent()
     return target
 
 
 def uninstall() -> None:
     """Boot the agent out (if loaded) and remove the plist file."""
     if is_loaded():
-        bootout()
+        try:
+            result = bootout()
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise RuntimeError(f"could not stop the Persome LaunchAgent: {exc}") from exc
+        if result.returncode != 0:
+            detail = result.stderr.strip() or result.stdout.strip() or "launchctl bootout failed"
+            raise RuntimeError(f"could not stop the Persome LaunchAgent: {detail}")
     target = plist_path()
     if target.exists():
         target.unlink()
+    with contextlib.suppress(FileNotFoundError):
+        paths.launchagent_owner_file().unlink()

--- a/src/persome/ocr_setup.py
+++ b/src/persome/ocr_setup.py
@@ -9,13 +9,22 @@ from . import paths
 VALID_TIERS = ("tiny", "small", "medium")
 
 
-def save_ocr_config(*, enabled: bool, tier: str, config_path: Path) -> None:
+def save_ocr_config(
+    *,
+    enabled: bool,
+    tier: str,
+    config_path: Path,
+    policy: str | None = None,
+) -> None:
     """Update only the OCR fields while preserving the rest of config.toml."""
     import tomlkit
     from tomlkit.items import Table
 
     if tier not in VALID_TIERS:
         raise ValueError(f"unsupported OCR tier: {tier}")
+    intended_policy = policy or ("enabled" if enabled else "disabled")
+    if intended_policy not in {"auto", "enabled", "disabled"}:
+        raise ValueError(f"unsupported OCR policy: {intended_policy}")
     if config_path.is_symlink():
         raise RuntimeError(f"config file must not be a symlink: {config_path}")
 
@@ -29,6 +38,7 @@ def save_ocr_config(*, enabled: bool, tier: str, config_path: Path) -> None:
         capture = tomlkit.table()
         document["capture"] = capture
     capture["enable_ocr_fallback"] = enabled
+    capture["ocr_policy"] = intended_policy
     capture["ocr_tier"] = tier
     capture["ocr_structured"] = True
 

--- a/src/persome/onboarding.py
+++ b/src/persome/onboarding.py
@@ -50,10 +50,10 @@ on run argv
 end run
 """
 
-_INFO_SCRIPT = """
+_NOTIFICATION_SCRIPT = """
 on run argv
-    display dialog (item 2 of argv) with title (item 1 of argv) buttons {"Done"} default button "Done" with icon note
-    return "Done"
+    display notification (item 2 of argv) with title (item 1 of argv)
+    return "Notified"
 end run
 """
 
@@ -67,6 +67,8 @@ class OnboardingCancelled(OnboardingError):
 
 
 class PermissionUI(Protocol):
+    def status(self, message: str) -> None: ...
+
     def confirm(self, *, title: str, message: str, action: str) -> bool: ...
 
     def wait_for_permission(self, *, title: str, message: str) -> PermissionAction: ...
@@ -78,7 +80,7 @@ class OnboardingUI:
     def __init__(self, *, gui: bool = True) -> None:
         self.gui = gui and sys.platform == "darwin" and shutil.which("osascript") is not None
 
-    def _osascript(self, script: str, *args: str) -> str | None:
+    def _osascript(self, script: str, *args: str, timeout: float | None = None) -> str | None:
         if not self.gui:
             return None
         try:
@@ -87,8 +89,9 @@ class OnboardingUI:
                 check=False,
                 capture_output=True,
                 text=True,
+                timeout=timeout,
             )
-        except OSError:
+        except (OSError, subprocess.TimeoutExpired):
             return None
         if result.returncode != 0:
             return None
@@ -107,6 +110,10 @@ class OnboardingUI:
         if result is not None:
             return result == action
         return self._terminal_confirm(title, message, action)
+
+    @staticmethod
+    def status(message: str) -> None:
+        print(message, flush=True)
 
     def wait_for_permission(self, *, title: str, message: str) -> PermissionAction:
         result = self._osascript(_WAIT_SCRIPT, title, message)
@@ -128,8 +135,10 @@ class OnboardingUI:
         return "cancel"
 
     def success(self, message: str) -> None:
-        if self._osascript(_INFO_SCRIPT, "Persome is ready", message) is None:
-            print(f"\nPersome is ready\n{message}")
+        # Completion must never hold the CLI open behind a modal dialog. Keep
+        # the terminal authoritative and use a best-effort notification only.
+        print(f"\nPersome is ready\n{message}", flush=True)
+        self._osascript(_NOTIFICATION_SCRIPT, "Persome is ready", message, timeout=5)
 
 
 def _open_privacy_settings(pane: str) -> None:
@@ -161,7 +170,9 @@ def _ensure_permission(
     explanation: str,
 ) -> bool:
     """Request one permission and do not return until its live probe passes."""
+    ui.status(f"Checking {label} permission...")
     if check():
+        ui.status(f"✓ {label} already granted")
         return True
     if not ui.confirm(
         title=f"Persome needs {label}",
@@ -170,6 +181,7 @@ def _ensure_permission(
     ):
         raise OnboardingCancelled(f"{label} request was cancelled")
 
+    ui.status(f"Requesting {label} from macOS...")
     request()
     while not check():
         action = ui.wait_for_permission(
@@ -184,6 +196,7 @@ def _ensure_permission(
             raise OnboardingCancelled(f"{label} was not granted")
         if action == "open_settings":
             open_settings()
+    ui.status(f"✓ {label} granted")
     return True
 
 
@@ -210,6 +223,7 @@ def ensure_local_ocr(*, tier: str, ui: PermissionUI) -> bool:
     from .config import load
     from .ocr_setup import VALID_TIERS, save_ocr_config
 
+    ui.status(f"Checking bundled local OCR ({tier})...")
     if tier not in VALID_TIERS:
         raise OnboardingError(f"unsupported OCR tier {tier!r}: choose {', '.join(VALID_TIERS)}")
     if ocr_local.disabled_by_environment():
@@ -232,6 +246,9 @@ def ensure_local_ocr(*, tier: str, ui: PermissionUI) -> bool:
         ),
     )
 
+    ui.status(
+        "Initializing the isolated OCR worker (the first model load can take up to two minutes)..."
+    )
     if not ocr_local.warm(tier):
         raise OnboardingError("the isolated local OCR worker could not initialize")
 
@@ -241,6 +258,7 @@ def ensure_local_ocr(*, tier: str, ui: PermissionUI) -> bool:
     health = ocr_health.inspect(load().capture)
     if not health.ready:
         raise OnboardingError(f"local OCR verification failed: {health.state}: {health.detail}")
+    ui.status("✓ Local OCR worker ready")
     return changed
 
 
@@ -304,13 +322,17 @@ def _latest_capture() -> Path | None:
     return max(captures, key=lambda path: path.stat().st_mtime, default=None)
 
 
-def ensure_runtime(*, restart: bool, timeout: float = 45.0) -> RuntimeProof:
+def ensure_runtime(
+    *, restart: bool, timeout: float = 45.0, ui: PermissionUI | None = None
+) -> RuntimeProof:
     """Leave the daemon running and prove HTTP health plus one fresh capture."""
     from .config import load
 
     cfg = load()
     pid = _running_daemon_pid()
     if restart and pid is not None:
+        if ui is not None:
+            ui.status("Restarting Persome to apply the OCR configuration...")
         _run_cli("stop", "--timeout", "20", timeout=25)
         deadline = time.monotonic() + 25
         while _running_daemon_pid() is not None and time.monotonic() < deadline:
@@ -318,11 +340,15 @@ def ensure_runtime(*, restart: bool, timeout: float = 45.0) -> RuntimeProof:
         pid = _running_daemon_pid()
 
     if pid is None:
+        if ui is not None:
+            ui.status("Starting the Persome Runtime...")
         result = _run_cli("start", timeout=30)
         if result.returncode != 0 and _running_daemon_pid() is None:
             detail = result.stderr.strip() or result.stdout.strip() or "unknown start failure"
             raise OnboardingError(f"Persome could not start: {detail}")
 
+    if ui is not None:
+        ui.status("Checking the local Runtime health endpoint...")
     deadline = time.monotonic() + timeout
     payload: dict[str, str] | None = None
     while time.monotonic() < deadline:
@@ -338,6 +364,11 @@ def ensure_runtime(*, restart: bool, timeout: float = 45.0) -> RuntimeProof:
             f"the daemon is degraded (status={payload.get('status')}, ocr={payload.get('ocr')})"
         )
 
+    if ui is not None:
+        ui.status(
+            "Writing one fresh capture to verify the complete path "
+            "(this can take up to three minutes)..."
+        )
     started_at = time.time()
     capture = _run_cli("capture-once", timeout=180)
     if capture.returncode != 0:
@@ -370,6 +401,9 @@ def ensure_runtime(*, restart: bool, timeout: float = 45.0) -> RuntimeProof:
     if not record.get("timestamp") or not has_context:
         raise OnboardingError("fresh capture record contains no usable screen context")
 
+    if ui is not None:
+        ui.status("✓ Runtime healthy and fresh capture verified")
+
     return RuntimeProof(
         pid=pid,
         health=payload["status"],
@@ -385,7 +419,7 @@ def onboard(*, tier: str = "tiny", gui: bool = True) -> RuntimeProof:
     ui = OnboardingUI(gui=gui)
     ensure_accessibility(ui)
     ocr_changed = ensure_local_ocr(tier=tier, ui=ui)
-    proof = ensure_runtime(restart=ocr_changed)
+    proof = ensure_runtime(restart=ocr_changed, ui=ui)
     ui.success(
         "Accessibility and local OCR are ready. Persome is running, its local health endpoint "
         "is OK, and a fresh capture was written successfully."

--- a/src/persome/onboarding.py
+++ b/src/persome/onboarding.py
@@ -1,15 +1,16 @@
 """Interactive macOS permission onboarding and runtime proof.
 
 The installer delegates here so it cannot claim success after merely printing
-privacy instructions.  Each sensitive request gets a separate, plain-language
-native dialog.  Completion requires live Accessibility and Screen Recording
-grants, a working isolated OCR worker, a healthy daemon, and a fresh capture.
+privacy instructions. Each sensitive request gets a separate, plain-language
+native dialog. Standard daemon mode requires live Accessibility and Screen
+Recording grants, a working isolated OCR worker, a healthy final owner, and a
+fresh capture; supported alternate policies return explicit mode-aware receipts.
 """
 
 from __future__ import annotations
 
 import json
-import os
+import platform
 import shutil
 import subprocess
 import sys
@@ -22,12 +23,14 @@ from typing import Literal, Protocol
 from . import paths
 
 PermissionAction = Literal["cancel", "open_settings", "check_again"]
+RuntimeOwner = Literal["any", "launchagent", "background"]
 
 _CONFIRM_SCRIPT = """
 on run argv
     set dialogTitle to item 1 of argv
     set dialogMessage to item 2 of argv
     set actionLabel to item 3 of argv
+    tell current application to activate
     try
         set chosen to button returned of (display dialog dialogMessage with title dialogTitle buttons {"Cancel", actionLabel} default button actionLabel cancel button "Cancel" with icon note)
         return chosen
@@ -41,6 +44,7 @@ _WAIT_SCRIPT = """
 on run argv
     set dialogTitle to item 1 of argv
     set dialogMessage to item 2 of argv
+    tell current application to activate
     try
         set chosen to button returned of (display dialog dialogMessage with title dialogTitle buttons {"Cancel", "Open Settings", "Check Again"} default button "Check Again" cancel button "Cancel" with icon caution)
         return chosen
@@ -106,7 +110,7 @@ class OnboardingUI:
         return reply in {"", "y", "yes"}
 
     def confirm(self, *, title: str, message: str, action: str) -> bool:
-        result = self._osascript(_CONFIRM_SCRIPT, title, message, action)
+        result = self._osascript(_CONFIRM_SCRIPT, title, message, action, timeout=300)
         if result is not None:
             return result == action
         return self._terminal_confirm(title, message, action)
@@ -116,7 +120,7 @@ class OnboardingUI:
         print(message, flush=True)
 
     def wait_for_permission(self, *, title: str, message: str) -> PermissionAction:
-        result = self._osascript(_WAIT_SCRIPT, title, message)
+        result = self._osascript(_WAIT_SCRIPT, title, message, timeout=300)
         if result == "Open Settings":
             return "open_settings"
         if result == "Check Again":
@@ -168,12 +172,14 @@ def _ensure_permission(
     open_settings: Callable[[], None],
     ui: PermissionUI,
     explanation: str,
+    settings_label: str | None = None,
+    entry_name: str = "Persome",
 ) -> bool:
-    """Request one permission and do not return until its live probe passes."""
+    """Request one permission and return whether it was newly granted."""
     ui.status(f"Checking {label} permission...")
     if check():
         ui.status(f"✓ {label} already granted")
-        return True
+        return False
     if not ui.confirm(
         title=f"Persome needs {label}",
         message=explanation,
@@ -183,11 +189,12 @@ def _ensure_permission(
 
     ui.status(f"Requesting {label} from macOS...")
     request()
+    pane_label = settings_label or label
     while not check():
         action = ui.wait_for_permission(
             title=f"Finish {label} setup",
             message=(
-                f"Enable the terminal or Persome entry under Privacy & Security -> {label}. "
+                f"Enable {entry_name} under Privacy & Security -> {pane_label}. "
                 "Return here and choose Check Again. Persome will not continue until macOS "
                 "reports that the permission is granted."
             ),
@@ -200,66 +207,179 @@ def _ensure_permission(
     return True
 
 
-def ensure_accessibility(ui: PermissionUI) -> None:
+def ensure_accessibility(ui: PermissionUI, *, event_driven: bool = True) -> bool:
     from .capture import ax_capture, watcher
 
-    _ensure_permission(
-        label="Accessibility",
-        check=ax_capture.ax_trusted,
+    helper_changed = _ensure_permission(
+        label="Capture Helper Accessibility",
+        check=lambda: ax_capture.ax_trusted(refresh=True, include_watcher=False),
+        request=lambda: ax_capture.request_accessibility_permission(include_watcher=False),
+        open_settings=open_accessibility_settings,
+        ui=ui,
+        explanation=(
+            "Persome's bundled capture helper reads the focused app's visible text and "
+            "structure. It cannot type, click, or control your Mac. macOS will show one "
+            "permission request for this helper next."
+        ),
+        settings_label="Accessibility",
+        entry_name="mac-ax-helper",
+    )
+    if not event_driven:
+        return helper_changed
+
+    def watcher_trusted() -> bool:
+        binary = watcher._resolve_watcher_path()
+        return bool(binary is not None and ax_capture._binary_ax_trusted(binary))
+
+    watcher_changed = _ensure_permission(
+        label="Event Watcher Accessibility",
+        check=watcher_trusted,
         request=watcher.request_accessibility_permission,
         open_settings=open_accessibility_settings,
         ui=ui,
         explanation=(
-            "Persome uses macOS Accessibility to read the focused app's visible text and "
-            "structure. It does not use this permission to type, click, or control your Mac. "
-            "macOS will show its own permission request next."
+            "Persome's bundled event watcher notices window and typing-context changes so "
+            "capture can react without polling constantly. It cannot type, click, or control "
+            "your Mac. macOS will show a separate request for this watcher next."
         ),
+        settings_label="Accessibility",
+        entry_name="mac-ax-watcher",
     )
+    return helper_changed or watcher_changed
 
 
-def ensure_local_ocr(*, tier: str, ui: PermissionUI) -> bool:
-    """Grant Screen Recording, warm OCR, persist it, and return whether config changed."""
+@dataclass(frozen=True)
+class OCRPolicyProof:
+    require_worker: bool
+    config_changed: bool
+    permission_changed: bool
+    tier: str
+    state: str
+
+
+def ensure_local_ocr(
+    *,
+    tier: str | None,
+    ui: PermissionUI,
+    preserve_policy: bool = False,
+    screenshot_permission_required: bool = True,
+    capture_source: str = "daemon",
+) -> OCRPolicyProof:
+    """Verify the effective OCR policy without silently changing it on updates."""
     from .capture import ocr_health, ocr_local, screen_recording
     from .config import load
     from .ocr_setup import VALID_TIERS, save_ocr_config
 
-    ui.status(f"Checking bundled local OCR ({tier})...")
-    if tier not in VALID_TIERS:
-        raise OnboardingError(f"unsupported OCR tier {tier!r}: choose {', '.join(VALID_TIERS)}")
-    if ocr_local.disabled_by_environment():
-        raise OnboardingError("OCR is disabled by PERSOME_DISABLE_OCR")
-    if not ocr_local.runtime_available():
-        raise OnboardingError("the local Paddle OCR runtime is unavailable on this architecture")
-    if not ocr_local.models_available(tier):
-        raise OnboardingError(f"bundled PP-OCRv6 {tier} model weights are missing")
-
-    _ensure_permission(
-        label="Screen Recording",
-        check=screen_recording.has_screen_recording,
-        request=screen_recording.request_screen_recording,
-        open_settings=open_screen_recording_settings,
-        ui=ui,
-        explanation=(
-            "Persome uses Screen Recording only to run bundled PP-OCRv6 on this Mac when an "
-            "app's Accessibility text is incomplete. Pixels are not sent to an LLM or uploaded. "
-            "macOS will show its own permission request next."
-        ),
-    )
-
-    ui.status(
-        "Initializing the isolated OCR worker (the first model load can take up to two minutes)..."
-    )
-    if not ocr_local.warm(tier):
-        raise OnboardingError("the isolated local OCR worker could not initialize")
-
     before = load().capture
-    changed = not before.enable_ocr_fallback or before.ocr_tier != tier
-    save_ocr_config(enabled=True, tier=tier, config_path=paths.config_file())
+    effective_tier = (
+        before.ocr_tier
+        if preserve_policy or (tier is None and before.enable_ocr_fallback)
+        else tier or before.ocr_tier or "tiny"
+    )
+    ui.status(f"Checking bundled local OCR ({effective_tier})...")
+
+    require_worker = True
+    fallback_state: str | None = None
+    fallback_message: str | None = None
+    explicit_opt_out = before.ocr_policy == "disabled" and tier is None
+    if (preserve_policy or explicit_opt_out) and not before.enable_ocr_fallback:
+        require_worker = False
+        fallback_state = "disabled"
+        fallback_message = "disabled"
+    elif preserve_policy and ocr_local.disabled_by_environment():
+        require_worker = False
+        fallback_state = "disabled_by_environment"
+        fallback_message = "disabled_by_environment"
+    runtime_available = ocr_local.runtime_available() if require_worker else False
+    intel_without_runtime = platform.machine().lower() in {"x86_64", "amd64"}
+    if require_worker and not runtime_available and intel_without_runtime:
+        require_worker = False
+        fallback_state = "runtime_unavailable" if before.enable_ocr_fallback else "disabled"
+        fallback_message = "runtime_unavailable"
+
+    if require_worker and effective_tier not in VALID_TIERS:
+        raise OnboardingError(
+            f"unsupported OCR tier {effective_tier!r}: choose {', '.join(VALID_TIERS)}"
+        )
+    if require_worker and ocr_local.disabled_by_environment():
+        raise OnboardingError("OCR is disabled by PERSOME_DISABLE_OCR")
+    if require_worker and not runtime_available:
+        raise OnboardingError("the local Paddle OCR runtime is unavailable on this architecture")
+    if require_worker and not ocr_local.models_available(effective_tier):
+        raise OnboardingError(f"bundled PP-OCRv6 {effective_tier} model weights are missing")
+
+    permission_changed = False
+    require_screen_recording = bool(
+        capture_source == "daemon" and (screenshot_permission_required or require_worker)
+    )
+    if require_screen_recording:
+        permission_changed = _ensure_permission(
+            label="Screen Recording",
+            check=screen_recording.has_screen_recording,
+            request=screen_recording.request_screen_recording,
+            open_settings=open_screen_recording_settings,
+            ui=ui,
+            explanation=(
+                "Persome uses Screen Recording for locally encrypted screenshots and, when "
+                "enabled, bundled PP-OCRv6 when an app's Accessibility text is incomplete. "
+                "Pixels are not sent to an LLM or uploaded. macOS will show its own permission "
+                "request next."
+            ),
+            entry_name="the Persome Runtime",
+        )
+    elif capture_source == "ingest":
+        ui.status("✓ Screen pixels are owned by the trusted ingest producer")
+    else:
+        ui.status("✓ Screen pixel capture is disabled by policy")
+
+    if not require_worker:
+        messages = {
+            "disabled": "✓ Preserving the configured OCR opt-out",
+            "disabled_by_environment": "✓ Preserving the PERSOME_DISABLE_OCR safety policy",
+            "runtime_unavailable": "✓ Local OCR is unavailable on this architecture",
+        }
+        assert fallback_state is not None
+        if preserve_policy and not before.enable_ocr_fallback and before.ocr_policy == "auto":
+            # Older releases had no explicit-intent field. An update must not
+            # later let ordinary repeated onboarding reinterpret the preserved
+            # disabled policy as a fresh auto-enable request.
+            save_ocr_config(
+                enabled=False,
+                tier=effective_tier,
+                config_path=paths.config_file(),
+                policy="disabled",
+            )
+        ui.status(
+            f"{messages[fallback_message or fallback_state]}; "
+            "Accessibility capture remains available"
+        )
+        return OCRPolicyProof(
+            False,
+            False,
+            permission_changed,
+            effective_tier,
+            fallback_state,
+        )
+
+    changed = not before.enable_ocr_fallback or before.ocr_tier != effective_tier
+    if not preserve_policy:
+        save_ocr_config(
+            enabled=True,
+            tier=effective_tier,
+            config_path=paths.config_file(),
+            policy="enabled",
+        )
     health = ocr_health.inspect(load().capture)
     if not health.ready:
         raise OnboardingError(f"local OCR verification failed: {health.state}: {health.detail}")
-    ui.status("✓ Local OCR worker ready")
-    return changed
+    ui.status("✓ Local OCR prerequisites ready")
+    return OCRPolicyProof(
+        True,
+        changed and not preserve_policy,
+        permission_changed,
+        effective_tier,
+        health.state,
+    )
 
 
 @dataclass(frozen=True)
@@ -267,21 +387,100 @@ class RuntimeProof:
     pid: int
     health: str
     ocr: str
-    capture_path: Path
+    capture_path: Path | None
+    mode: str = "daemon"
+    receipt: str = "fresh-capture"
+    generation: str = ""
+    accessibility: str = "not_applicable"
+    screen_recording: str = "not_applicable"
+    owner: str = "background"
 
 
 def _running_daemon_pid() -> int | None:
+    from . import runtime_pid
+
+    process = runtime_pid.resolve_recorded_process()
+    return process.pid if process is not None else None
+
+
+def _launchagent_is_loaded() -> bool:
+    from . import launchagent
+
+    return launchagent.is_loaded()
+
+
+def _select_runtime_owner(expected_owner: RuntimeOwner, *, ui: PermissionUI | None) -> str:
+    """Resolve lifecycle intent and restore launchd ownership when required."""
+    from . import launchagent
+
+    if expected_owner not in {"any", "launchagent", "background"}:
+        raise OnboardingError(
+            "invalid Runtime owner expectation; use any, launchagent, or background"
+        )
+    loaded = _launchagent_is_loaded()
+    owner = (
+        "launchagent"
+        if expected_owner == "any" and (loaded or launchagent.owner_intended())
+        else "background"
+        if expected_owner == "any"
+        else expected_owner
+    )
+    if owner == "background" and loaded:
+        raise OnboardingError(
+            "the Persome LaunchAgent is loaded, so a background-owned Runtime cannot be proved"
+        )
+    if owner == "launchagent":
+        binary = launchagent.configured_runtime_binary()
+        if binary is None:
+            raise OnboardingError(
+                "launchd ownership is expected, but its configured Persome binary is missing; "
+                "rerun the installer"
+            )
+        if not loaded or not launchagent.owns_recorded_runtime(binary):
+            if ui is not None:
+                ui.status("Restoring launchd ownership of the Persome Runtime...")
+            try:
+                launchagent.install(binary)
+            except RuntimeError as exc:
+                raise OnboardingError(
+                    f"could not restore launchd Runtime ownership: {exc}"
+                ) from exc
+        if not _launchagent_is_loaded():
+            raise OnboardingError("launchd did not retain the Persome Runtime job")
+    return owner
+
+
+def _prove_runtime_owner(pid: int, expected_owner: str) -> str:
+    """Bind the final generation to its required lifecycle owner."""
+    from . import launchagent
+
+    if _running_daemon_pid() != pid:
+        raise OnboardingError("the final Runtime generation no longer matches its process")
+    loaded = _launchagent_is_loaded()
+    if expected_owner == "launchagent":
+        binary = launchagent.configured_runtime_binary()
+        if binary is None or not loaded or not launchagent.owns_recorded_runtime(binary):
+            raise OnboardingError(
+                "the healthy Runtime is not owned by the configured Persome LaunchAgent"
+            )
+        return "launchagent"
+    if loaded:
+        raise OnboardingError(
+            "launchd owns the healthy Runtime, but background ownership was required"
+        )
+    return "background"
+
+
+def _kickstart_launchagent(*, kill: bool) -> None:
+    from . import launchagent
+
     try:
-        pid = int(paths.pid_file().read_text(encoding="utf-8").strip())
-    except (FileNotFoundError, OSError, ValueError):
-        return None
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return None
-    except PermissionError:
-        return pid
-    return pid
+        result = launchagent.kickstart(kill=kill)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise OnboardingError(f"could not restart the launchd-owned Runtime: {exc}") from exc
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "launchctl kickstart failed"
+        raise OnboardingError(f"could not restart the launchd-owned Runtime: {detail}")
 
 
 def _cli_prefix() -> list[str]:
@@ -291,137 +490,752 @@ def _cli_prefix() -> list[str]:
 
 
 def _run_cli(*args: str, timeout: float = 180.0) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        [*_cli_prefix(), *args],
-        check=False,
-        capture_output=True,
-        text=True,
-        timeout=timeout,
-    )
+    try:
+        return subprocess.run(
+            [*_cli_prefix(), *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        command = " ".join(("persome", *args))
+        raise OnboardingError(f"`{command}` timed out after {timeout:.0f} seconds") from exc
+
+
+def _local_api_url(host: str, port: int, path: str) -> str:
+    from .security.auth import LocalAPIConfigurationError, loopback_http_url
+
+    try:
+        return loopback_http_url(host, port, path)
+    except LocalAPIConfigurationError as exc:
+        raise OnboardingError(str(exc)) from exc
+
+
+def _local_api_headers() -> dict[str, str]:
+    from .security.auth import LocalAPIConfigurationError, auth_headers
+
+    try:
+        return auth_headers()
+    except LocalAPIConfigurationError as exc:
+        raise OnboardingError(str(exc)) from exc
 
 
 def _health_payload(host: str, port: int) -> dict[str, str] | None:
-    try:
-        import httpx
+    import httpx
 
-        response = httpx.get(f"http://{host}:{port}/health", timeout=2.0)
+    url = _local_api_url(host, port, "/health")
+    try:
+        response = httpx.get(url, timeout=2.0)
         response.raise_for_status()
         data = response.json().get("data")
-    except Exception:  # noqa: BLE001 - the bounded poll reports a useful final error
+    except (httpx.RequestError, httpx.HTTPStatusError, ValueError):
         return None
     if not isinstance(data, dict):
         return None
     return {str(key): str(value) for key, value in data.items()}
 
 
-def _latest_capture() -> Path | None:
-    directory = paths.capture_buffer_dir()
-    if not directory.exists():
+def _runtime_permissions(host: str, port: int) -> dict[str, str] | None:
+    """Read live probes for the Runtime and its configured native helpers."""
+    import httpx
+
+    try:
+        response = httpx.get(
+            _local_api_url(host, port, "/permissions"),
+            headers=_local_api_headers(),
+            timeout=2.0,
+        )
+        response.raise_for_status()
+        data = response.json().get("data")
+    except httpx.HTTPStatusError as exc:
+        status = exc.response.status_code
+        if status in {401, 403}:
+            raise OnboardingError(
+                "the running Runtime rejected PERSOME_LOCAL_API_TOKEN; clear any stale shell "
+                "override and rerun onboarding"
+            ) from exc
+        if status == 404:
+            raise OnboardingError(
+                "the running Runtime does not expose the permission proof endpoint; restart "
+                "it with the current Persome version"
+            ) from exc
+        if status == 503:
+            return None
+        raise OnboardingError(f"permission proof failed with HTTP {status}") from exc
+    except (httpx.RequestError, ValueError):
         return None
-    captures = [path for path in directory.iterdir() if path.suffix == ".json"]
-    return max(captures, key=lambda path: path.stat().st_mtime, default=None)
+    if not isinstance(data, dict):
+        return None
+    return {str(key): str(value) for key, value in data.items()}
+
+
+@dataclass(frozen=True)
+class CaptureRequestProof:
+    path: Path | None
+    mode: str
+    receipt: str
+
+
+def _request_runtime_capture(host: str, port: int) -> CaptureRequestProof | None:
+    """Ask the daemon-owned runner for a fresh capture without a second writer."""
+    import httpx
+
+    try:
+        response = httpx.post(
+            _local_api_url(host, port, "/_onboarding/capture"),
+            headers=_local_api_headers(),
+            timeout=45.0,
+        )
+        if response.status_code == 503:
+            return None
+        response.raise_for_status()
+        data = response.json().get("data")
+    except httpx.HTTPStatusError as exc:
+        status = exc.response.status_code
+        if status in {401, 403}:
+            raise OnboardingError(
+                "the running Runtime rejected PERSOME_LOCAL_API_TOKEN; clear any stale shell "
+                "override and rerun onboarding"
+            ) from exc
+        if status == 404:
+            raise OnboardingError(
+                "the running Runtime does not expose the fresh-capture proof endpoint; "
+                "restart it with the current Persome version"
+            ) from exc
+        if status == 409:
+            return CaptureRequestProof(None, "privacy", "privacy-paused")
+        if status == 423:
+            return CaptureRequestProof(None, "privacy", "privacy-locked")
+        raise OnboardingError(
+            f"the Runtime rejected the fresh-capture proof (HTTP {status})"
+        ) from exc
+    except (httpx.RequestError, ValueError) as exc:
+        raise OnboardingError(f"the fresh-capture request failed: {exc}") from exc
+    if not isinstance(data, dict):
+        raise OnboardingError("the Runtime returned an invalid fresh-capture receipt")
+    mode = data.get("mode")
+    receipt = data.get("receipt")
+    capture_id = data.get("id")
+    if mode == "ingest" and receipt == "ingest-ready" and capture_id is None:
+        return CaptureRequestProof(None, mode, receipt)
+    if mode != "daemon" or receipt != "fresh-capture" or not isinstance(capture_id, str):
+        raise OnboardingError("the Runtime returned an invalid fresh-capture receipt")
+    if not capture_id or Path(capture_id).name != capture_id:
+        raise OnboardingError("the Runtime returned an unsafe fresh-capture id")
+    return CaptureRequestProof(
+        paths.capture_buffer_dir() / f"{capture_id}.json",
+        mode,
+        receipt,
+    )
+
+
+def _runtime_state(
+    pid: int,
+    *,
+    minimum_updated_at: float | None = None,
+) -> dict[str, object] | None:
+    """Read and validate the current daemon generation's owner-only state."""
+    from . import runtime_pid
+
+    generation = runtime_pid.read_runtime_generation()
+    if generation is None or generation.pid != pid:
+        return None
+    if minimum_updated_at is not None and generation.updated_at < minimum_updated_at - 1:
+        return None
+    state_path = paths.runtime_state_file()
+    if state_path.is_symlink():
+        return None
+    try:
+        payload = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if (
+        payload.get("schema_version") != 1
+        or payload.get("pid") != pid
+        or payload.get("generation") != generation.generation
+        or payload.get("started_at") != generation.started_at
+        or payload.get("capture_mode") not in {"daemon", "ingest"}
+        or payload.get("ocr_worker") not in {"not_started", "warming", "ready", "failed"}
+        or payload.get("phase") not in {"starting", "ready"}
+        or payload.get("ocr")
+        not in {
+            "ready",
+            "disabled",
+            "disabled_by_environment",
+            "runtime_unavailable",
+            "models_missing",
+            "permission_required",
+        }
+        or not isinstance(payload.get("ocr_enabled"), bool)
+        or not isinstance(payload.get("ocr_tier"), str)
+        or not isinstance(payload.get("permissions"), dict)
+    ):
+        return None
+    return payload
+
+
+def _capture_path_from_id(capture_id: object) -> Path | None:
+    if not isinstance(capture_id, str) or not capture_id or Path(capture_id).name != capture_id:
+        return None
+    return paths.capture_buffer_dir() / f"{capture_id}.json"
+
+
+def _capture_has_real_context(path: Path, *, wait_for_ocr: float = 10.0) -> bool:
+    """Require actual AX/text/pixels or completed OCR, never a queued OCR flag."""
+    deadline = time.monotonic() + max(0.0, wait_for_ocr)
+    while True:
+        try:
+            record = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            raise OnboardingError(f"fresh capture record is unreadable: {exc}") from exc
+        if not isinstance(record, dict):
+            raise OnboardingError("fresh capture record is not a JSON object")
+        if not record.get("timestamp"):
+            raise OnboardingError("fresh capture record has no timestamp")
+
+        focused = record.get("focused_element")
+        screenshot = record.get("screenshot")
+        ax_tree = record.get("ax_tree")
+        if (
+            bool(str(record.get("visible_text") or "").strip())
+            or (isinstance(focused, dict) and any(focused.get(key) for key in ("role", "value")))
+            or (isinstance(ax_tree, dict) and bool(ax_tree.get("apps")))
+            or (isinstance(screenshot, dict) and bool(screenshot.get("image_base64")))
+        ):
+            return True
+
+        if record.get("ocr_submitted"):
+            try:
+                from .store import fts
+
+                with fts.cursor() as conn:
+                    if fts.get_ocr_result_for_capture(conn, path.stem):
+                        return True
+            except Exception as exc:  # noqa: BLE001
+                raise OnboardingError(f"fresh capture OCR receipt is unreadable: {exc}") from exc
+
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(0.2)
 
 
 def ensure_runtime(
-    *, restart: bool, timeout: float = 45.0, ui: PermissionUI | None = None
+    *,
+    restart: bool,
+    timeout: float = 150.0,
+    ui: PermissionUI | None = None,
+    require_ocr: bool = True,
+    require_screen_recording: bool | None = None,
+    preserve_policy: bool = False,
+    expected_ocr_state: str = "ready",
+    expected_ocr_tier: str | None = None,
+    expected_ocr_enabled: bool | None = None,
+    expected_owner: RuntimeOwner = "any",
 ) -> RuntimeProof:
-    """Leave the daemon running and prove HTTP health plus one fresh capture."""
+    """Leave the daemon running and prove its effective mode without policy drift."""
+    from .capture import scheduler
     from .config import load
 
     cfg = load()
+    http_enabled = bool(cfg.mcp.auto_start and cfg.mcp.transport in {"sse", "streamable-http"})
+    if cfg.capture.source == "ingest" and not http_enabled:
+        raise OnboardingError(
+            "capture.source='ingest' requires mcp.auto_start=true with the streamable-http "
+            "transport so the authenticated /captures/ingest endpoint exists"
+        )
+    screen_recording_required = (
+        require_ocr if require_screen_recording is None else require_screen_recording
+    )
+    privacy_gate = scheduler.capture_gate_reason(cfg.capture)
+    if privacy_gate and not preserve_policy:
+        action = "run `persome resume`" if privacy_gate == "paused" else "unlock the screen"
+        raise OnboardingError(
+            f"capture proof is blocked because capture is {privacy_gate}; {action}, then retry"
+        )
+
+    selected_owner = _select_runtime_owner(expected_owner, ui=ui)
+    proof_started_at = time.time()
     pid = _running_daemon_pid()
+    launchagent_loaded = _launchagent_is_loaded()
+    if pid is not None and not restart:
+        if not http_enabled:
+            restart = True
+        else:
+            current_health = _health_payload(cfg.mcp.host, cfg.mcp.port)
+            policy_mismatch = bool(
+                current_health is not None
+                and (
+                    (
+                        expected_ocr_state != "ready"
+                        and current_health.get("ocr") != expected_ocr_state
+                    )
+                    or (
+                        expected_ocr_tier is not None
+                        and current_health.get("ocr_tier") != expected_ocr_tier
+                    )
+                    or (
+                        expected_ocr_enabled is not None
+                        and current_health.get("ocr_enabled") != str(expected_ocr_enabled)
+                    )
+                )
+            )
+            if (
+                current_health is None
+                or policy_mismatch
+                or (
+                    require_ocr
+                    and (
+                        "ocr_worker" not in current_health
+                        or current_health.get("ocr_worker") == "failed"
+                    )
+                )
+            ):
+                restart = True
+        if restart and ui is not None:
+            ui.status("Restarting the Runtime to establish a fresh readiness generation...")
     if restart and pid is not None:
         if ui is not None:
-            ui.status("Restarting Persome to apply the OCR configuration...")
-        _run_cli("stop", "--timeout", "20", timeout=25)
-        deadline = time.monotonic() + 25
-        while _running_daemon_pid() is not None and time.monotonic() < deadline:
-            time.sleep(0.2)
-        pid = _running_daemon_pid()
+            ui.status("Restarting Persome to apply and verify the OCR configuration...")
+        previous_pid = pid
+        if launchagent_loaded:
+            _kickstart_launchagent(kill=True)
+            deadline = time.monotonic() + 30
+            next_restart_progress_at = time.monotonic() + 10
+            replacement_pid: int | None = None
+            while time.monotonic() < deadline:
+                candidate = _running_daemon_pid()
+                if candidate is not None and candidate != previous_pid:
+                    replacement_pid = candidate
+                    break
+                now = time.monotonic()
+                if ui is not None and now >= next_restart_progress_at:
+                    ui.status("Still waiting for launchd to publish the replacement Runtime...")
+                    next_restart_progress_at = now + 10
+                time.sleep(0.2)
+            if replacement_pid is None:
+                raise OnboardingError(
+                    "launchd did not publish a new, identity-verifiable Runtime generation"
+                )
+            pid = replacement_pid
+        else:
+            result = _run_cli("stop", "--timeout", "20", timeout=25)
+            if result.returncode != 0 and _running_daemon_pid() is not None:
+                detail = result.stderr.strip() or result.stdout.strip() or "unknown stop failure"
+                raise OnboardingError(f"the previous Runtime could not be stopped: {detail}")
+            deadline = time.monotonic() + 25
+            while _running_daemon_pid() is not None and time.monotonic() < deadline:
+                time.sleep(0.2)
+            pid = _running_daemon_pid()
+            if pid is not None:
+                detail = result.stderr.strip() or result.stdout.strip()
+                suffix = f": {detail}" if detail else ""
+                raise OnboardingError(
+                    f"the previous Runtime process (pid {pid}) did not stop{suffix}"
+                )
 
     if pid is None:
         if ui is not None:
             ui.status("Starting the Persome Runtime...")
-        result = _run_cli("start", timeout=30)
-        if result.returncode != 0 and _running_daemon_pid() is None:
+        if launchagent_loaded:
+            _kickstart_launchagent(kill=False)
+            result = subprocess.CompletedProcess([], 0, "", "")
+        else:
+            result = _run_cli("start", timeout=30)
+        start_deadline = time.monotonic() + min(timeout, 30)
+        next_start_progress_at = time.monotonic() + 10
+        while pid is None and time.monotonic() < start_deadline:
+            pid = _running_daemon_pid()
+            if pid is None:
+                now = time.monotonic()
+                if ui is not None and now >= next_start_progress_at:
+                    ui.status("Still waiting for the Runtime process to publish its identity...")
+                    next_start_progress_at = now + 10
+                time.sleep(0.2)
+        if pid is None:
             detail = result.stderr.strip() or result.stdout.strip() or "unknown start failure"
             raise OnboardingError(f"Persome could not start: {detail}")
 
     if ui is not None:
-        ui.status("Checking the local Runtime health endpoint...")
+        worker_note = " and its isolated OCR worker" if require_ocr else ""
+        ui.status(f"Waiting for the Runtime{worker_note} to become ready...")
     deadline = time.monotonic() + timeout
     payload: dict[str, str] | None = None
+    permissions: dict[str, str] | None = None
+    state: dict[str, object] | None = None
+    worker: str | None = None
+    ocr_state: str | None = None
+    ready = False
+    next_progress_at = time.monotonic() + 10
     while time.monotonic() < deadline:
-        pid = _running_daemon_pid()
-        payload = _health_payload(cfg.mcp.host, cfg.mcp.port)
-        if pid is not None and payload is not None:
+        current_pid = _running_daemon_pid()
+        if current_pid != pid:
+            raise OnboardingError("the Runtime process changed while onboarding was verifying it")
+
+        if http_enabled:
+            payload = _health_payload(cfg.mcp.host, cfg.mcp.port)
+            permissions = (
+                _runtime_permissions(cfg.mcp.host, cfg.mcp.port) if payload is not None else None
+            )
+            worker = payload.get("ocr_worker") if payload is not None else None
+            ocr_state = payload.get("ocr") if payload is not None else None
+            status_ready = bool(
+                payload is not None
+                and payload.get("status") in ({"ok"} if require_ocr else {"ok", "degraded"})
+            )
+        else:
+            state = _runtime_state(pid, minimum_updated_at=proof_started_at)
+            permissions_payload = state.get("permissions") if state is not None else None
+            permissions = (
+                {str(key): str(value) for key, value in permissions_payload.items()}
+                if isinstance(permissions_payload, dict)
+                else None
+            )
+            worker = str(state.get("ocr_worker")) if state is not None else None
+            ocr_state = str(state.get("ocr")) if state is not None else None
+            status_ready = state is not None and state.get("phase") == "ready"
+
+        if require_ocr and worker == "failed":
+            raise OnboardingError("the daemon's isolated OCR worker failed to initialize")
+        if cfg.capture.source == "daemon" and permissions is not None:
+            required_permissions = [("Accessibility", "accessibility")]
+            if screen_recording_required:
+                required_permissions.append(("Screen Recording", "screen_recording"))
+            missing_permissions = [
+                label for label, key in required_permissions if permissions.get(key) != "granted"
+            ]
+            if missing_permissions:
+                raise OnboardingError(
+                    "the running Runtime does not have "
+                    f"{' and '.join(missing_permissions)} permission; enable it in "
+                    "System Settings -> Privacy & Security, then rerun `persome onboard`"
+                )
+        permission_ready = cfg.capture.source != "daemon" or bool(
+            permissions is not None
+            and permissions.get("accessibility") == "granted"
+            and (not screen_recording_required or permissions.get("screen_recording") == "granted")
+        )
+        reported_tier = (
+            payload.get("ocr_tier")
+            if payload is not None
+            else str(state.get("ocr_tier"))
+            if state is not None
+            else None
+        )
+        reported_enabled = (
+            payload.get("ocr_enabled")
+            if payload is not None
+            else str(state.get("ocr_enabled"))
+            if state is not None
+            else None
+        )
+        policy_ready = bool(
+            ocr_state == expected_ocr_state
+            and (expected_ocr_tier is None or reported_tier == expected_ocr_tier)
+            and (expected_ocr_enabled is None or reported_enabled == str(expected_ocr_enabled))
+        )
+        ready = bool(
+            status_ready
+            and policy_ready
+            and (not require_ocr or (ocr_state == "ready" and worker == "ready"))
+            and permission_ready
+        )
+        if ready:
             break
+        now = time.monotonic()
+        if ui is not None and now >= next_progress_at:
+            runtime_status = (
+                payload.get("status", "starting")
+                if payload is not None
+                else str(state.get("phase", "starting"))
+                if state is not None
+                else "starting"
+            )
+            worker_status = worker or ("not required" if not require_ocr else "starting")
+            if cfg.capture.source == "daemon":
+                accessibility_status = (
+                    permissions.get("accessibility", "checking")
+                    if permissions is not None
+                    else "checking"
+                )
+                screen_status = (
+                    permissions.get("screen_recording", "checking")
+                    if permissions is not None and screen_recording_required
+                    else "not required"
+                    if not screen_recording_required
+                    else "checking"
+                )
+                permission_note = (
+                    f", Accessibility: {accessibility_status}, Screen Recording: {screen_status}"
+                )
+            else:
+                permission_note = ", capture permissions: owned by trusted ingest"
+            ui.status(
+                "Still waiting for Runtime readiness "
+                f"(runtime: {runtime_status}, OCR worker: {worker_status}"
+                f"{permission_note})..."
+            )
+            next_progress_at = now + 10
         time.sleep(0.25)
-    if pid is None or payload is None:
-        raise OnboardingError("the daemon did not become healthy before the timeout")
-    if payload.get("status") != "ok" or payload.get("ocr") != "ready":
+    if not ready:
+        runtime_status = (
+            payload.get("status", "unreachable")
+            if payload is not None
+            else str(state.get("phase", "unreachable"))
+            if state is not None
+            else "unreachable"
+        )
         raise OnboardingError(
-            f"the daemon is degraded (status={payload.get('status')}, ocr={payload.get('ocr')})"
+            "the daemon did not become fully ready before the timeout "
+            f"(status={runtime_status}, "
+            f"ocr={ocr_state or 'unknown'}, "
+            f"worker={worker or 'unknown'}, "
+            "accessibility="
+            f"{permissions.get('accessibility', 'unknown') if permissions else 'unknown'}, "
+            "screen_recording="
+            f"{permissions.get('screen_recording', 'unknown') if permissions else 'unknown'})"
         )
 
-    if ui is not None:
-        ui.status(
-            "Writing one fresh capture to verify the complete path "
-            "(this can take up to three minutes)..."
+    generation = ""
+    current_state = _runtime_state(pid)
+    if current_state is not None:
+        generation = str(current_state["generation"])
+
+    capture_path: Path | None = None
+    capture_mode = cfg.capture.source
+    receipt = "fresh-capture"
+    capture_started_at = time.time()
+    if http_enabled:
+        if ui is not None:
+            ui.status("Requesting a mode-aware capture proof from the running Runtime...")
+        requested: CaptureRequestProof | None = None
+        capture_deadline = time.monotonic() + 10
+        while requested is None and time.monotonic() < capture_deadline:
+            requested = _request_runtime_capture(cfg.mcp.host, cfg.mcp.port)
+            if requested is None:
+                time.sleep(0.25)
+        if requested is None:
+            raise OnboardingError("the daemon's live capture runner was not ready")
+        capture_path = requested.path
+        capture_mode = requested.mode
+        receipt = requested.receipt
+    else:
+        if ui is not None:
+            ui.status("Waiting for this daemon generation's owner-only capture receipt...")
+        capture_deadline = time.monotonic() + min(timeout, 30)
+        next_capture_progress_at = time.monotonic() + 10
+        while time.monotonic() < capture_deadline:
+            state = _runtime_state(pid, minimum_updated_at=proof_started_at)
+            if state is None:
+                time.sleep(0.2)
+                continue
+            generation = str(state["generation"])
+            reason = str(state.get("last_capture_reason") or "")
+            if reason in {"paused", "locked"}:
+                receipt = f"privacy-{reason}"
+                break
+            if cfg.capture.source == "ingest" and reason == "ingest-ready":
+                receipt = "ingest-ready"
+                break
+            capture_path = _capture_path_from_id(state.get("last_capture_id"))
+            if capture_path is not None:
+                receipt = "fresh-capture"
+                break
+            now = time.monotonic()
+            if ui is not None and now >= next_capture_progress_at:
+                ui.status("Still waiting for this Runtime generation's capture receipt...")
+                next_capture_progress_at = now + 10
+            time.sleep(0.2)
+        else:
+            raise OnboardingError("this Runtime generation did not publish a capture receipt")
+
+    if receipt in {"privacy-paused", "privacy-locked"}:
+        live_gate = receipt.removeprefix("privacy-")
+        if not preserve_policy:
+            action = "run `persome resume`" if live_gate == "paused" else "unlock the screen"
+            raise OnboardingError(
+                f"capture became {live_gate} while proof was running; {action}, then retry"
+            )
+        if _running_daemon_pid() != pid:
+            raise OnboardingError("the Runtime process changed after the privacy receipt")
+        if ui is not None:
+            ui.status(f"✓ Runtime ready; capture remains {live_gate} by owner policy")
+        owner = _prove_runtime_owner(pid, selected_owner)
+        return RuntimeProof(
+            pid=pid,
+            health=payload.get("status", "ok") if payload else "ok",
+            ocr=payload.get("ocr", expected_ocr_state) if payload else expected_ocr_state,
+            capture_path=None,
+            mode=cfg.capture.source,
+            receipt=receipt,
+            generation=generation,
+            accessibility=(
+                permissions.get("accessibility", "not_applicable")
+                if permissions
+                else "not_applicable"
+            ),
+            screen_recording=(
+                permissions.get("screen_recording", "not_applicable")
+                if permissions
+                else "not_applicable"
+            ),
+            owner=owner,
         )
-    started_at = time.time()
-    capture = _run_cli("capture-once", timeout=180)
-    if capture.returncode != 0:
-        detail = capture.stderr.strip() or capture.stdout.strip() or "capture failed"
-        raise OnboardingError(f"fresh capture verification failed: {detail}")
-    capture_path = _latest_capture()
-    if capture_path is None or capture_path.stat().st_mtime < started_at - 1:
-        raise OnboardingError("fresh capture verification did not create a capture record")
 
-    payload = _health_payload(cfg.mcp.host, cfg.mcp.port)
-    pid = _running_daemon_pid()
-    if pid is None or payload is None or payload.get("status") != "ok":
-        raise OnboardingError("the daemon lost health after the capture smoke test")
+    if capture_path is not None:
+        try:
+            capture_mtime = capture_path.stat().st_mtime
+        except OSError as exc:
+            raise OnboardingError(f"fresh capture receipt is missing: {capture_path}") from exc
+        if capture_mtime < min(proof_started_at, capture_started_at) - 1:
+            raise OnboardingError("fresh capture verification returned a stale capture record")
+        if not _capture_has_real_context(capture_path):
+            raise OnboardingError(
+                "fresh capture contains no AX text, focused element, screenshot, or completed "
+                "OCR; focus a normal unlocked window and retry"
+            )
+    elif receipt != "ingest-ready":
+        raise OnboardingError("the Runtime did not return a valid mode-aware capture receipt")
 
-    # Verify the record is readable JSON before treating it as onboarding proof.
-    try:
-        record = json.loads(capture_path.read_text(encoding="utf-8"))
-    except (OSError, ValueError) as exc:
-        raise OnboardingError(f"fresh capture record is unreadable: {exc}") from exc
-    if not isinstance(record, dict):
-        raise OnboardingError("fresh capture record is not a JSON object")
-    meta = record.get("window_meta")
-    has_context = bool(
-        (isinstance(meta, dict) and (meta.get("app_name") or meta.get("title")))
-        or record.get("visible_text")
-        or record.get("focused_element")
-        or record.get("ax_tree")
-        or record.get("ocr_submitted")
-    )
-    if not record.get("timestamp") or not has_context:
-        raise OnboardingError("fresh capture record contains no usable screen context")
+    if _running_daemon_pid() != pid:
+        raise OnboardingError("the Runtime process changed after the capture proof")
+    if http_enabled:
+        final_payload = _health_payload(cfg.mcp.host, cfg.mcp.port)
+        if final_payload is None or (
+            require_ocr
+            and (final_payload.get("status") != "ok" or final_payload.get("ocr_worker") != "ready")
+        ):
+            raise OnboardingError("the daemon lost health after the capture smoke test")
+        if (
+            final_payload.get("ocr") != expected_ocr_state
+            or (
+                expected_ocr_tier is not None and final_payload.get("ocr_tier") != expected_ocr_tier
+            )
+            or (
+                expected_ocr_enabled is not None
+                and final_payload.get("ocr_enabled") != str(expected_ocr_enabled)
+            )
+        ):
+            raise OnboardingError("the daemon's OCR policy changed after the capture smoke test")
+        final_permissions = _runtime_permissions(cfg.mcp.host, cfg.mcp.port)
+        if cfg.capture.source == "daemon" and (
+            final_permissions is None
+            or final_permissions.get("accessibility") != "granted"
+            or (
+                screen_recording_required and final_permissions.get("screen_recording") != "granted"
+            )
+        ):
+            raise OnboardingError("the daemon lost a required macOS permission after capture")
+        if final_permissions is not None:
+            permissions = final_permissions
+        payload = final_payload
+    else:
+        final_state = _runtime_state(pid)
+        if final_state is None:
+            raise OnboardingError("the Runtime generation receipt disappeared after capture proof")
+        if require_ocr and final_state.get("ocr_worker") != "ready":
+            raise OnboardingError("the daemon's OCR worker lost readiness after capture proof")
+        if (
+            final_state.get("ocr") != expected_ocr_state
+            or (expected_ocr_tier is not None and final_state.get("ocr_tier") != expected_ocr_tier)
+            or (
+                expected_ocr_enabled is not None
+                and final_state.get("ocr_enabled") is not expected_ocr_enabled
+            )
+        ):
+            raise OnboardingError("the daemon's OCR policy changed after capture proof")
+        final_permissions = final_state.get("permissions")
+        if cfg.capture.source == "daemon" and (
+            not isinstance(final_permissions, dict)
+            or final_permissions.get("accessibility") != "granted"
+            or (
+                screen_recording_required and final_permissions.get("screen_recording") != "granted"
+            )
+        ):
+            raise OnboardingError("the daemon lost a required macOS permission after capture")
 
+    owner = _prove_runtime_owner(pid, selected_owner)
     if ui is not None:
-        ui.status("✓ Runtime healthy and fresh capture verified")
+        if receipt == "ingest-ready":
+            ui.status("✓ Runtime healthy and trusted ingest runner ready")
+        else:
+            ui.status("✓ Runtime healthy and fresh capture verified")
 
     return RuntimeProof(
         pid=pid,
-        health=payload["status"],
-        ocr=payload.get("ocr", "unknown"),
+        health=payload.get("status", "ok") if payload else "ok",
+        ocr=payload.get("ocr", expected_ocr_state) if payload else expected_ocr_state,
         capture_path=capture_path,
+        mode=capture_mode,
+        receipt=receipt,
+        generation=generation,
+        accessibility=(
+            permissions.get("accessibility", "not_applicable") if permissions else "not_applicable"
+        ),
+        screen_recording=(
+            permissions.get("screen_recording", "not_applicable")
+            if permissions
+            else "not_applicable"
+        ),
+        owner=owner,
     )
 
 
-def onboard(*, tier: str = "tiny", gui: bool = True) -> RuntimeProof:
+def onboard(
+    *,
+    tier: str | None = None,
+    gui: bool = True,
+    preserve_policy: bool = False,
+    expected_owner: RuntimeOwner = "any",
+) -> RuntimeProof:
     """Run the complete permission, OCR, daemon, and capture onboarding gate."""
     if sys.platform != "darwin":
         raise OnboardingError("live Persome onboarding requires macOS")
+    from .config import load
+    from .ocr_setup import VALID_TIERS
+
+    if tier is not None and tier not in VALID_TIERS:
+        raise OnboardingError(f"unsupported OCR tier {tier!r}: choose {', '.join(VALID_TIERS)}")
+
     ui = OnboardingUI(gui=gui)
-    ensure_accessibility(ui)
-    ocr_changed = ensure_local_ocr(tier=tier, ui=ui)
-    proof = ensure_runtime(restart=ocr_changed, ui=ui)
-    ui.success(
-        "Accessibility and local OCR are ready. Persome is running, its local health endpoint "
-        "is OK, and a fresh capture was written successfully."
+    cfg = load()
+    accessibility_changed = False
+    if cfg.capture.source == "daemon":
+        accessibility_changed = ensure_accessibility(ui, event_driven=cfg.capture.event_driven)
+    else:
+        ui.status("✓ Accessibility and screen pixels are owned by the trusted ingest producer")
+    ocr = ensure_local_ocr(
+        tier=tier,
+        ui=ui,
+        preserve_policy=preserve_policy,
+        screenshot_permission_required=(
+            cfg.capture.source == "daemon" and cfg.capture.include_screenshot
+        ),
+        capture_source=cfg.capture.source,
     )
+    effective_cfg = load()
+    require_screen_recording = bool(
+        effective_cfg.capture.source == "daemon"
+        and (effective_cfg.capture.include_screenshot or ocr.require_worker)
+    )
+    proof = ensure_runtime(
+        restart=(accessibility_changed or ocr.config_changed or ocr.permission_changed),
+        ui=ui,
+        require_ocr=ocr.require_worker,
+        require_screen_recording=require_screen_recording,
+        preserve_policy=preserve_policy,
+        expected_ocr_state=ocr.state,
+        expected_ocr_tier=ocr.tier,
+        expected_ocr_enabled=effective_cfg.capture.enable_ocr_fallback,
+        expected_owner=expected_owner,
+    )
+    if proof.receipt == "fresh-capture":
+        completion = "a fresh capture with real context was verified"
+    elif proof.receipt == "ingest-ready":
+        completion = "the authenticated ingest runner is ready"
+    else:
+        completion = f"capture remains {proof.receipt.removeprefix('privacy-')} by owner policy"
+    ui.success(f"Persome generation {proof.generation or proof.pid} is ready; {completion}.")
     return proof

--- a/src/persome/paths.py
+++ b/src/persome/paths.py
@@ -33,6 +33,11 @@ def logs_dir() -> Path:
     return root() / "logs"
 
 
+def native_helpers_dir() -> Path:
+    """Stable machine-local AX binaries whose TCC identity survives reinstalls."""
+    return root() / "native"
+
+
 def exports_dir() -> Path:
     """Generated, user-shareable artifacts such as model snapshots."""
     return root() / "exports"
@@ -66,6 +71,21 @@ def index_db() -> Path:
 
 def pid_file() -> Path:
     return root() / ".pid"
+
+
+def runtime_state_file() -> Path:
+    """Owner-only daemon generation/readiness state for non-HTTP verification."""
+    return root() / ".runtime-state.json"
+
+
+def daemon_lock_file() -> Path:
+    """Lifetime single-writer lock inherited by the foreground/background daemon."""
+    return root() / ".daemon.lock"
+
+
+def launchagent_owner_file() -> Path:
+    """Durable intent marker for launchd-owned Runtime lifecycle."""
+    return root() / ".launchagent-owner"
 
 
 def paused_flag() -> Path:

--- a/src/persome/runtime_pid.py
+++ b/src/persome/runtime_pid.py
@@ -1,0 +1,588 @@
+"""Safe identity checks for the daemon PID recorded under ``PERSOME_ROOT``.
+
+A PID by itself is not a process identity: after the daemon exits, macOS can
+reuse that number for an unrelated process.  Lifecycle code must therefore
+resolve the pid file to a verified :class:`ProcessIdentity` before sending a
+signal, and re-check that identity immediately before the signal is delivered.
+
+Current releases write the legacy, numeric-only pid file.  That format is
+accepted conservatively during upgrades only when the process:
+
+* is owned by the current user;
+* has an exact Persome daemon command shape; and
+* started no later than the pid file was written (so an obviously reused PID is
+  rejected).
+
+The versioned JSON format additionally pins owner, process start time, and
+command.  ``write_current_process`` is provided for a future daemon migration;
+readers support both formats now so lifecycle modules can migrate first.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import json
+import math
+import os
+import re
+import shlex
+import signal
+import stat
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from . import paths
+
+PID_FILE_VERSION = 1
+_MAX_PID_FILE_BYTES = 4096
+_START_RE = re.compile(
+    r"^\s*(?P<uid>\d+)\s+"
+    r"(?P<start>[A-Za-z]{3}\s+[A-Za-z]{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}\s+\d{4})"
+    r"\s+(?P<command>.+?)\s*$"
+)
+_MONTHS = {
+    "Jan": 1,
+    "Feb": 2,
+    "Mar": 3,
+    "Apr": 4,
+    "May": 5,
+    "Jun": 6,
+    "Jul": 7,
+    "Aug": 8,
+    "Sep": 9,
+    "Oct": 10,
+    "Nov": 11,
+    "Dec": 12,
+}
+_DAEMON_OPTIONS = {"--foreground", "-f", "--capture-only"}
+
+
+@dataclass(frozen=True)
+class ProcessIdentity:
+    """A process identity stable across PID reuse for the available ps data."""
+
+    pid: int
+    uid: int
+    started_at: float
+    command: str
+    generation: str | None = None
+    runtime_started_at: float | None = None
+    executable: str = ""
+
+
+@dataclass(frozen=True)
+class PIDFileRecord:
+    """Parsed pid-file state.
+
+    ``legacy`` records contain only a PID plus the trusted pid-file mtime.
+    Versioned records carry the complete expected process identity.
+    """
+
+    pid: int
+    file_mtime: float
+    legacy: bool
+    uid: int | None = None
+    started_at: float | None = None
+    command: str | None = None
+    generation: str | None = None
+
+
+@dataclass(frozen=True)
+class RuntimeGeneration:
+    """Identity fields published by the daemon's owner-only readiness state."""
+
+    pid: int
+    generation: str
+    started_at: float
+    updated_at: float
+
+
+def _normalise_command(command: str) -> str:
+    return " ".join(command.split())
+
+
+def _valid_generation(value: object) -> str | None:
+    if not isinstance(value, str) or re.fullmatch(r"[0-9a-f]{32}", value) is None:
+        return None
+    return value
+
+
+def _valid_pid(value: object) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 1:
+        return None
+    return value
+
+
+def _read_private_regular_file(path: Path) -> tuple[str, float] | None:
+    """Read a small owner-owned regular file without following a symlink."""
+
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    flags |= getattr(os, "O_NONBLOCK", 0)
+    try:
+        fd = os.open(path, flags)
+    except OSError:
+        return None
+    try:
+        metadata = os.fstat(fd)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != os.getuid()
+            or metadata.st_nlink != 1
+        ):
+            return None
+        payload = os.read(fd, _MAX_PID_FILE_BYTES + 1)
+        if len(payload) > _MAX_PID_FILE_BYTES:
+            return None
+        try:
+            return payload.decode("utf-8"), metadata.st_mtime
+        except UnicodeDecodeError:
+            return None
+    finally:
+        os.close(fd)
+
+
+def read_pid_file(path: Path | None = None) -> PIDFileRecord | None:
+    """Parse a legacy numeric or versioned runtime pid file.
+
+    Invalid files, unsafe PIDs (including PID 0 and PID 1), symlinks, and
+    incomplete versioned identities are rejected.
+    """
+
+    loaded = _read_private_regular_file(path or paths.pid_file())
+    if loaded is None:
+        return None
+    raw, mtime = loaded
+    stripped = raw.strip()
+    try:
+        legacy_pid = int(stripped)
+    except ValueError:
+        legacy_pid = None
+    if legacy_pid is not None:
+        pid = _valid_pid(legacy_pid)
+        if pid is None:
+            return None
+        return PIDFileRecord(pid=pid, file_mtime=mtime, legacy=True)
+
+    try:
+        payload = json.loads(stripped)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(payload, dict) or payload.get("version") != PID_FILE_VERSION:
+        return None
+    pid = _valid_pid(payload.get("pid"))
+    uid = payload.get("uid")
+    started_at = payload.get("started_at")
+    command = payload.get("command")
+    generation = _valid_generation(payload.get("generation"))
+    if (
+        pid is None
+        or isinstance(uid, bool)
+        or not isinstance(uid, int)
+        or uid < 0
+        or isinstance(started_at, bool)
+        or not isinstance(started_at, (int, float))
+        or not math.isfinite(started_at)
+        or started_at <= 0
+        or not isinstance(command, str)
+        or not command.strip()
+        or generation is None
+    ):
+        return None
+    return PIDFileRecord(
+        pid=pid,
+        file_mtime=mtime,
+        legacy=False,
+        uid=uid,
+        started_at=float(started_at),
+        command=_normalise_command(command),
+        generation=generation,
+    )
+
+
+def read_runtime_generation(path: Path | None = None) -> RuntimeGeneration | None:
+    """Read the daemon generation from the owner-only runtime state sidecar."""
+
+    loaded = _read_private_regular_file(path or paths.runtime_state_file())
+    if loaded is None:
+        return None
+    raw, _mtime = loaded
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(payload, dict) or payload.get("schema_version") != 1:
+        return None
+    pid = _valid_pid(payload.get("pid"))
+    generation = _valid_generation(payload.get("generation"))
+    started_at = payload.get("started_at")
+    updated_at = payload.get("updated_at")
+    if (
+        pid is None
+        or generation is None
+        or isinstance(started_at, bool)
+        or not isinstance(started_at, (int, float))
+        or not math.isfinite(started_at)
+        or started_at <= 0
+        or isinstance(updated_at, bool)
+        or not isinstance(updated_at, (int, float))
+        or not math.isfinite(updated_at)
+        or updated_at < started_at
+    ):
+        return None
+    return RuntimeGeneration(
+        pid=pid,
+        generation=generation,
+        started_at=float(started_at),
+        updated_at=float(updated_at),
+    )
+
+
+def _parse_started_at(value: str) -> float | None:
+    """Parse macOS/BSD ``ps -o lstart=`` without depending on process locale."""
+
+    parts = value.split()
+    if len(parts) != 5 or parts[1] not in _MONTHS:
+        return None
+    try:
+        hour, minute, second = (int(part) for part in parts[3].split(":"))
+        local = datetime(
+            int(parts[4]),
+            _MONTHS[parts[1]],
+            int(parts[2]),
+            hour,
+            minute,
+            second,
+        )
+        return local.astimezone().timestamp()
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+def inspect_process(pid: int) -> ProcessIdentity | None:
+    """Return owner, start time, and full command for ``pid`` via macOS ``ps``."""
+
+    if _valid_pid(pid) is None:
+        return None
+    try:
+        result = subprocess.run(
+            ["ps", "-ww", "-p", str(pid), "-o", "uid=", "-o", "lstart=", "-o", "command="],
+            capture_output=True,
+            text=True,
+            check=False,
+            env={**os.environ, "LC_ALL": "C"},
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    matched = _START_RE.match(result.stdout)
+    if matched is None:
+        return None
+    started_at = _parse_started_at(matched.group("start"))
+    if started_at is None:
+        return None
+    return ProcessIdentity(
+        pid=pid,
+        uid=int(matched.group("uid")),
+        started_at=started_at,
+        command=_normalise_command(matched.group("command")),
+        executable=_process_executable(pid) or "",
+    )
+
+
+def _process_executable(pid: int) -> str | None:
+    """Return the kernel-reported executable path without parsing argv text.
+
+    ``ps command`` cannot quote a frozen executable such as ``Persome Backend``
+    reliably.  macOS libproc gives us the executable boundary independently of
+    spaces; the ``/proc`` fallback keeps unit/dev use portable.
+    """
+
+    if sys.platform == "darwin":
+        try:
+            libproc = ctypes.CDLL("/usr/lib/libproc.dylib", use_errno=True)
+            proc_pidpath = libproc.proc_pidpath
+            proc_pidpath.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_uint32]
+            proc_pidpath.restype = ctypes.c_int
+            buffer = ctypes.create_string_buffer(4096)
+            length = int(proc_pidpath(pid, buffer, len(buffer)))
+            if length > 0:
+                return os.fsdecode(buffer.raw[:length])
+        except (AttributeError, OSError, ValueError):
+            return None
+        return None
+    try:
+        return os.readlink(f"/proc/{pid}/exe")
+    except OSError:
+        return None
+
+
+def _valid_daemon_arguments(arguments: list[str]) -> bool:
+    return (
+        bool(arguments)
+        and arguments[0] == "start"
+        and all(option in _DAEMON_OPTIONS for option in arguments[1:])
+    )
+
+
+def _is_python_executable(argument: str) -> bool:
+    return Path(argument).name.lower().startswith("python")
+
+
+def is_runtime_command(command: str, *, executable: str = "") -> bool:
+    """Return whether ``command`` has an exact supported daemon argv shape."""
+
+    try:
+        arguments = shlex.split(command)
+    except ValueError:
+        return False
+    if Path(executable).name == "Persome Backend":
+        for index, argument in enumerate(arguments):
+            if argument == executable or Path(argument).name == "Persome Backend":
+                return _valid_daemon_arguments(arguments[index + 1 :])
+    for index, argument in enumerate(arguments):
+        if Path(argument).name == "persome":
+            if index > 1 or (index == 1 and not _is_python_executable(arguments[0])):
+                continue
+            remainder = arguments[index + 1 :]
+        elif (
+            argument == "-m"
+            and index == 1
+            and _is_python_executable(arguments[0])
+            and index + 1 < len(arguments)
+            and arguments[index + 1]
+            in {
+                "persome",
+                "persome.cli",
+            }
+        ):
+            remainder = arguments[index + 2 :]
+        else:
+            continue
+        return _valid_daemon_arguments(remainder)
+
+    # PyInstaller ships a bare executable named ``Persome Backend``. macOS
+    # renders its argv in ``ps`` without quoting the space, so shlex necessarily
+    # sees two tokens. Trust the kernel-reported executable boundary, then parse
+    # and validate only the remaining arguments.
+    if Path(executable).name == "Persome Backend":
+        normalised = _normalise_command(command)
+        prefixes = (executable, str(Path(executable).resolve()))
+        for prefix in prefixes:
+            if normalised == prefix:
+                return False
+            if normalised.startswith(f"{prefix} "):
+                try:
+                    return _valid_daemon_arguments(shlex.split(normalised[len(prefix) :].strip()))
+                except ValueError:
+                    return False
+        marker = "Persome Backend "
+        marker_index = normalised.rfind(marker)
+        if marker_index >= 0:
+            try:
+                return _valid_daemon_arguments(
+                    shlex.split(normalised[marker_index + len(marker) :])
+                )
+            except ValueError:
+                return False
+    return False
+
+
+def is_runtime_process(process: ProcessIdentity) -> bool:
+    """Whether a kernel-inspected process has an exact Persome daemon shape."""
+
+    return is_runtime_command(process.command, executable=process.executable)
+
+
+def _matches_record(record: PIDFileRecord, process: ProcessIdentity) -> bool:
+    if process.pid != record.pid or process.uid != os.getuid():
+        return False
+    if not is_runtime_process(process):
+        return False
+    if record.legacy:
+        # The daemon writes its pid file after the process starts.  If the
+        # process is newer than the legacy file, the PID has been reused.
+        return process.started_at <= record.file_mtime
+    return (
+        process.uid == record.uid
+        and process.started_at == record.started_at
+        and process.command == record.command
+    )
+
+
+def resolve_recorded_process(path: Path | None = None) -> ProcessIdentity | None:
+    """Resolve the pid file to a verified, currently live Persome process."""
+
+    record = read_pid_file(path)
+    if record is None:
+        return None
+    process = inspect_process(record.pid)
+    if process is None or not _matches_record(record, process):
+        return None
+    state_path = paths.runtime_state_file()
+    try:
+        state_path.lstat()
+    except FileNotFoundError:
+        state = None
+    except OSError:
+        return None
+    else:
+        state = read_runtime_generation(state_path)
+        # Once the new daemon sidecar exists, never downgrade to the weaker
+        # legacy check because a malformed/stale sidecar is itself suspicious.
+        if (
+            state is None
+            or state.pid != process.pid
+            or process.started_at > state.started_at
+            or (record.generation is not None and record.generation != state.generation)
+        ):
+            return None
+    if state is None and record.generation is not None:
+        # Versioned pid records are generation-bound and require the matching
+        # readiness sidecar.  Numeric first-upgrade records remain compatible.
+        return None
+    if state is not None:
+        return ProcessIdentity(
+            pid=process.pid,
+            uid=process.uid,
+            started_at=process.started_at,
+            command=process.command,
+            generation=state.generation,
+            runtime_started_at=state.started_at,
+            executable=process.executable,
+        )
+    return process
+
+
+def unresolved_runtime_reason(path: Path | None = None) -> str | None:
+    """Explain recorded state that is unsafe to treat as a stopped Runtime.
+
+    A dead PID or a PID reused by an unrelated process is safely stale and
+    returns ``None``. An unreadable/malformed pid file, or a live Persome-shaped
+    process whose generation sidecar cannot be verified, must stop lifecycle
+    takeover rather than letting a second daemon start.
+    """
+
+    target = path or paths.pid_file()
+    try:
+        target.lstat()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        return f"cannot inspect Runtime PID state at {target}: {exc}"
+    record = read_pid_file(target)
+    if record is None:
+        return f"Runtime PID state at {target} is invalid or unsafe"
+    process = inspect_process(record.pid)
+    if process is None or not is_runtime_process(process):
+        return None
+    if resolve_recorded_process(target) is not None:
+        return None
+    return (
+        f"live Persome Runtime pid {process.pid} has an invalid or stale generation receipt; "
+        "refusing to start a second daemon"
+    )
+
+
+def same_process_is_running(process: ProcessIdentity) -> bool:
+    """Return whether ``process`` still owns its PID with the same identity."""
+
+    current = inspect_process(process.pid)
+    return not (
+        current is None
+        or current.pid != process.pid
+        or current.uid != process.uid
+        or current.started_at != process.started_at
+        or current.command != process.command
+        or (
+            bool(current.executable)
+            and bool(process.executable)
+            and current.executable != process.executable
+        )
+        or current.uid != os.getuid()
+        or not is_runtime_process(current)
+    )
+
+
+def _same_runtime_generation(process: ProcessIdentity) -> bool:
+    """Revalidate the optional daemon-owned generation sidecar."""
+
+    if process.generation is None:
+        return True
+    state = read_runtime_generation()
+    return (
+        state is not None
+        and state.pid == process.pid
+        and state.generation == process.generation
+        and state.started_at == process.runtime_started_at
+    )
+
+
+def signal_process(process: ProcessIdentity, sig: signal.Signals | int) -> bool:
+    """Signal ``process`` only after immediately revalidating its full identity."""
+
+    if not same_process_is_running(process) or not _same_runtime_generation(process):
+        return False
+    try:
+        os.kill(process.pid, sig)
+    except OSError:
+        return False
+    return True
+
+
+def signal_recorded_process(
+    sig: signal.Signals | int, path: Path | None = None
+) -> ProcessIdentity | None:
+    """Resolve and safely signal the runtime recorded by ``path``.
+
+    Returns the pinned identity when a signal was sent, otherwise ``None``.
+    """
+
+    process = resolve_recorded_process(path)
+    if process is None or not signal_process(process, sig):
+        return None
+    return process
+
+
+def wait_for_exit(process: ProcessIdentity, timeout: float, *, interval: float = 0.1) -> bool:
+    """Wait until this exact process exits; PID reuse counts as an exit."""
+
+    deadline = time.monotonic() + max(0.0, timeout)
+    while time.monotonic() < deadline:
+        if not same_process_is_running(process):
+            return True
+        time.sleep(interval)
+    return not same_process_is_running(process)
+
+
+def write_current_process(*, generation: str, path: Path | None = None) -> ProcessIdentity:
+    """Write a versioned identity for the current Persome daemon process.
+
+    The daemon still writes a numeric pid file today.  This API lets it migrate
+    atomically later without requiring lifecycle readers to change again.
+    """
+
+    valid_generation = _valid_generation(generation)
+    if valid_generation is None:
+        raise ValueError("generation must be 32 lowercase hexadecimal characters")
+    process = inspect_process(os.getpid())
+    if process is None or process.uid != os.getuid() or not is_runtime_process(process):
+        raise RuntimeError("current process is not an identifiable Persome daemon")
+    payload = json.dumps(
+        {
+            "version": PID_FILE_VERSION,
+            "pid": process.pid,
+            "uid": process.uid,
+            "started_at": process.started_at,
+            "command": process.command,
+            "generation": valid_generation,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    paths.atomic_write_private_text(path or paths.pid_file(), payload)
+    return process

--- a/src/persome/store/fts.py
+++ b/src/persome/store/fts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+import time
 from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -35,6 +36,31 @@ _CAPTURES_FTS_OBJECTS = (
     "captures_fts_docsize",
     "captures_fts_config",
 )
+
+
+def _ensure_wal_mode(conn: sqlite3.Connection, *, timeout: float = 10.0) -> None:
+    """Enable WAL without failing a concurrent connection startup spuriously."""
+    deadline = time.monotonic() + timeout
+    delay = 0.01
+    while True:
+        try:
+            current = conn.execute("PRAGMA journal_mode").fetchone()
+            if current is not None and str(current[0]).lower() == "wal":
+                return
+            enabled = conn.execute("PRAGMA journal_mode=WAL").fetchone()
+            if enabled is not None and str(enabled[0]).lower() == "wal":
+                return
+            error = sqlite3.OperationalError("SQLite did not enable WAL journal mode")
+        except sqlite3.OperationalError as exc:
+            if not any(label in str(exc).lower() for label in ("locked", "busy")):
+                raise
+            error = exc
+        if time.monotonic() >= deadline:
+            raise error
+        time.sleep(delay)
+        delay = min(delay * 2, 0.25)
+
+
 # These indexes are projections. Their canonical sources are Markdown/evo_nodes
 # for entries and captures for screen-context search.
 DERIVED_FTS_SCHEMA_OBJECTS = _ENTRIES_FTS_OBJECTS + _CAPTURES_FTS_OBJECTS
@@ -346,7 +372,7 @@ def connect(db_path: Path | None = None) -> sqlite3.Connection:
     # Personal text must not survive ordinary DELETE operations in free pages.
     # Explicit wipe paths additionally VACUUM + truncate WAL below.
     conn.execute("PRAGMA secure_delete=ON")
-    conn.execute("PRAGMA journal_mode=WAL")
+    _ensure_wal_mode(conn)
     conn.execute("PRAGMA synchronous=NORMAL")
     # Make the auto-checkpoint pages explicit (this is also the SQLite default).
     # Auto-checkpoint resets the WAL pointer but never shrinks the file —

--- a/src/persome/updater.py
+++ b/src/persome/updater.py
@@ -185,13 +185,35 @@ def run_installer(source: UpdateSource) -> None:
     # accident.
     env["PERSOME_ROOT"] = str(paths.root())
     env["PERSOME_INSTALL_HOME"] = str(paths.root())
-    result = subprocess.run(
+    # The running CLI points SSL_CERT_FILE into its current virtualenv. The
+    # transactional installer moves that directory aside, so forwarding the
+    # path produces a stale-certificate warning and can break downloads.
+    env.pop("SSL_CERT_FILE", None)
+    process = subprocess.Popen(
         ["/bin/bash", str(source.path / "install.sh"), "--update"],
         cwd=source.path,
-        check=False,
         env=env,
+        start_new_session=True,
     )
-    if result.returncode != 0:
+    try:
+        returncode = process.wait()
+    except KeyboardInterrupt as exc:
+        # The installer owns an on-disk transaction. Forward cancellation to
+        # its process group, then wait for its EXIT trap to restore the old
+        # virtualenv before the outer updater tries to restart the Runtime.
+        if process.poll() is None:
+            with contextlib.suppress(ProcessLookupError):
+                os.killpg(process.pid, signal.SIGINT)
+        try:
+            process.wait(timeout=30)
+        except (KeyboardInterrupt, subprocess.TimeoutExpired):
+            with contextlib.suppress(ProcessLookupError):
+                os.killpg(process.pid, signal.SIGKILL)
+            process.wait()
+        raise UpdateError(
+            "update cancelled; the previous Persome installation was restored"
+        ) from exc
+    if returncode != 0:
         raise UpdateError(
             "the installer did not complete; the existing Persome data and secrets were preserved"
         )

--- a/src/persome/updater.py
+++ b/src/persome/updater.py
@@ -10,18 +10,26 @@ stay identical to a manual update.
 from __future__ import annotations
 
 import contextlib
+import ctypes
+import fcntl
+import json
 import os
 import shutil
 import signal
 import subprocess
+import sys
 import tempfile
 import time
 import tomllib
+import urllib.error
+import urllib.request
+import uuid
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 
-from . import paths
+from . import config as config_mod
+from . import launchagent, paths, runtime_pid
 
 OFFICIAL_REPOSITORY = "https://github.com/Intuition-Lab/personal-model.git"
 DEFAULT_BRANCH = "main"
@@ -31,11 +39,213 @@ class UpdateError(RuntimeError):
     """The Runtime could not be updated safely."""
 
 
+class UpdateCancelled(UpdateError):
+    """The user cancelled an update after its rollback completed."""
+
+    def __init__(self, message: str, *, signum: int = signal.SIGINT) -> None:
+        super().__init__(message)
+        self.signum = int(signum)
+        self.exit_code = 128 + self.signum
+
+
+class UpdateSignal(BaseException):
+    """A termination signal received while an update transaction is active."""
+
+    def __init__(self, signum: int) -> None:
+        super().__init__(signum)
+        self.signum = int(signum)
+        self.exit_code = 128 + self.signum
+
+
 @dataclass(frozen=True)
 class UpdateSource:
     path: Path
     revision: str
     official: bool
+
+
+_CANCELLATION_SIGNALS = (signal.SIGINT, signal.SIGTERM, signal.SIGHUP)
+_LEGACY_HANDOFF_ENV = "PERSOME_UPDATE_INFER_LAUNCHAGENT_FROM_PLIST"
+_LEGACY_LOCK_WAIT_SECONDS = 300.0
+_LEGACY_KEEPER_MAX_SECONDS = 300.0
+_TRANSACTION_MARKER = ".persome-update-transaction"
+_ACTIVE_UPDATE_LOCK_FD: int | None = None
+
+
+@dataclass(frozen=True)
+class UpdateTransaction:
+    launchagent_was_loaded: bool
+    phase: str
+    transaction_id: str
+
+
+@dataclass(frozen=True)
+class LegacyUpdateTransaction:
+    """Recovery metadata written by the pre-candidate updater."""
+
+    launchagent_was_loaded: bool
+    phase: str
+
+
+@contextlib.contextmanager
+def catch_update_signals() -> Iterator[None]:
+    """Translate terminal/process cancellation into a recoverable exception."""
+
+    previous: dict[signal.Signals, signal.Handlers] = {}
+
+    def _raise(signum: int, _frame: object) -> None:
+        raise UpdateSignal(signum)
+
+    for signum in _CANCELLATION_SIGNALS:
+        previous[signum] = signal.getsignal(signum)
+        signal.signal(signum, _raise)
+    try:
+        yield
+    finally:
+        for signum, handler in previous.items():
+            signal.signal(signum, handler)
+
+
+@contextlib.contextmanager
+def ignore_update_signals() -> Iterator[None]:
+    """Keep atomic rollback/recovery alive through repeated cancellation."""
+
+    previous: dict[signal.Signals, signal.Handlers] = {}
+    for signum in _CANCELLATION_SIGNALS:
+        previous[signum] = signal.getsignal(signum)
+        signal.signal(signum, signal.SIG_IGN)
+    try:
+        yield
+    finally:
+        for signum, handler in previous.items():
+            signal.signal(signum, handler)
+
+
+def claim_legacy_foreground() -> bool:
+    """Retained API for older CLI callers; signal ownership stays unchanged.
+
+    A delegated updater may itself be a session leader, so trying to move it
+    into the terminal foreground is neither reliable nor necessary.  The new
+    installer never changes the active venv, and the inherited update-lock
+    keeper prevents the previous updater from racing the completed handoff.
+    """
+
+    return False
+
+
+def _update_lock_path() -> Path:
+    return paths.root() / ".update.lock"
+
+
+def _update_backup_dir() -> Path:
+    """Legacy pre-candidate backup path, checked only to fail closed."""
+
+    return paths.root() / "venv.previous.update"
+
+
+def _update_replacement_dir() -> Path:
+    return paths.root() / "venv.replacement.update"
+
+
+def _update_state_file() -> Path:
+    return paths.root() / ".update-state.json"
+
+
+def _venv_dir() -> Path:
+    return paths.root() / "venv"
+
+
+def _runtime_binary() -> Path:
+    return _venv_dir() / "bin" / "persome"
+
+
+def _runtime_python() -> Path:
+    return _venv_dir() / "bin" / "python"
+
+
+_LOCK_KEEPER_CODE = r"""
+import os
+import sys
+import time
+
+parent = int(sys.argv[1])
+deadline = time.monotonic() + float(sys.argv[2])
+while time.monotonic() < deadline:
+    try:
+        os.kill(parent, 0)
+    except ProcessLookupError:
+        break
+    except PermissionError:
+        pass
+    time.sleep(0.1)
+"""
+
+
+def _spawn_legacy_lock_keeper(lock_fd: int, parent_pid: int) -> subprocess.Popen[bytes]:
+    """Keep the inherited flock until the delegating updater actually exits."""
+
+    return subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            _LOCK_KEEPER_CODE,
+            str(parent_pid),
+            str(_LEGACY_KEEPER_MAX_SECONDS),
+        ],
+        pass_fds=(lock_fd,),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+
+@contextlib.contextmanager
+def update_lock() -> Iterator[None]:
+    """Hold the one root-scoped update lock.
+
+    Normal callers fail fast. A delegated previous-release updater has already
+    touched lifecycle state before reaching this code, so it waits for the
+    active transaction and leaves an inherited-fd lock keeper alive until its
+    delegating parent exits (with a bounded failsafe).
+    """
+
+    global _ACTIVE_UPDATE_LOCK_FD
+    previous_lock_fd = _ACTIVE_UPDATE_LOCK_FD
+    lock_acquired = False
+    legacy_parent_pid = os.getppid()
+    try:
+        handle = paths.open_private_lock_file(_update_lock_path())
+    except (OSError, RuntimeError) as exc:
+        raise UpdateError(f"could not open the Runtime update lock: {exc}") from exc
+    try:
+        legacy_handoff = os.environ.get(_LEGACY_HANDOFF_ENV) == "1"
+        deadline = time.monotonic() + _LEGACY_LOCK_WAIT_SECONDS
+        while True:
+            try:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                lock_acquired = True
+                break
+            except BlockingIOError as exc:
+                if not legacy_handoff:
+                    raise UpdateError("another Persome update is already in progress") from exc
+                if time.monotonic() >= deadline:
+                    raise UpdateError(
+                        "timed out waiting for the in-progress Persome update to finish"
+                    ) from exc
+                time.sleep(0.2)
+        _ACTIVE_UPDATE_LOCK_FD = handle.fileno()
+        yield
+    finally:
+        keeper: subprocess.Popen[bytes] | None = None
+        if lock_acquired and os.environ.get(_LEGACY_HANDOFF_ENV) == "1":
+            with contextlib.suppress(OSError):
+                keeper = _spawn_legacy_lock_keeper(handle.fileno(), legacy_parent_pid)
+        _ACTIVE_UPDATE_LOCK_FD = previous_lock_fd
+        if lock_acquired and keeper is None:
+            with contextlib.suppress(OSError):
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        handle.close()
 
 
 def _validate_source(path: Path) -> Path:
@@ -73,13 +283,16 @@ def _revision(path: Path) -> str:
     git = shutil.which("git")
     if git is None:
         return "local source"
-    result = subprocess.run(
-        [git, "-C", str(path), "rev-parse", "HEAD"],
-        check=False,
-        capture_output=True,
-        text=True,
-        timeout=15,
-    )
+    try:
+        result = subprocess.run(
+            [git, "-C", str(path), "rev-parse", "HEAD"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return "local source"
     revision = result.stdout.strip()
     return revision if result.returncode == 0 and revision else "local source"
 
@@ -99,24 +312,31 @@ def acquire_source(source: Path | None = None) -> Iterator[UpdateSource]:
         root = Path(temporary) / "personal-model"
         env = os.environ.copy()
         env["GIT_TERMINAL_PROMPT"] = "0"
-        result = subprocess.run(
-            [
-                git,
-                "clone",
-                "--depth",
-                "1",
-                "--single-branch",
-                "--branch",
-                DEFAULT_BRANCH,
-                OFFICIAL_REPOSITORY,
-                str(root),
-            ],
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=180,
-            env=env,
-        )
+        try:
+            result = subprocess.run(
+                [
+                    git,
+                    "clone",
+                    "--depth",
+                    "1",
+                    "--single-branch",
+                    "--branch",
+                    DEFAULT_BRANCH,
+                    OFFICIAL_REPOSITORY,
+                    str(root),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=180,
+                env=env,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise UpdateError(
+                f"downloading official {DEFAULT_BRANCH} timed out after 180 seconds"
+            ) from exc
+        except OSError as exc:
+            raise UpdateError(f"could not run git to download the Runtime: {exc}") from exc
         if result.returncode != 0:
             detail = result.stderr.strip() or result.stdout.strip() or "git clone failed"
             raise UpdateError(f"could not download official {DEFAULT_BRANCH}: {detail}")
@@ -127,140 +347,789 @@ def acquire_source(source: Path | None = None) -> Iterator[UpdateSource]:
         yield UpdateSource(validated, revision, True)
 
 
+def _running_daemon_process() -> runtime_pid.ProcessIdentity | None:
+    """Return only a PID-file process whose complete Runtime identity matches."""
+
+    return runtime_pid.resolve_recorded_process()
+
+
 def _running_daemon_pid() -> int | None:
-    try:
-        pid = int(paths.pid_file().read_text(encoding="utf-8").strip())
-    except (FileNotFoundError, OSError, ValueError):
-        return None
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return None
-    except PermissionError:
-        return pid
-    return pid
+    process = _running_daemon_process()
+    return process.pid if process is not None else None
 
 
 def launchagent_is_loaded() -> bool:
     """Whether launchd currently owns the Runtime lifecycle."""
-    from . import launchagent
 
-    return launchagent.is_loaded()
-
-
-def stop_runtime(*, launchagent_was_loaded: bool, timeout: float = 20.0) -> None:
-    """Stop launchd ownership and any current daemon before replacing code."""
-    from . import launchagent
-
-    if launchagent_was_loaded:
-        result = launchagent.bootout()
-        if result.returncode != 0:
-            detail = result.stderr.strip() or result.stdout.strip() or "launchctl bootout failed"
-            raise UpdateError(f"could not stop the Persome LaunchAgent: {detail}")
-
-    pid = _running_daemon_pid()
-    if pid is None:
-        return
     try:
-        os.kill(pid, signal.SIGTERM)
-    except ProcessLookupError:
-        return
+        result = subprocess.run(
+            ["launchctl", "print", launchagent.gui_domain_target()],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise UpdateError("checking the Persome LaunchAgent timed out after 10 seconds") from exc
     except OSError as exc:
-        raise UpdateError(f"could not stop Persome daemon pid {pid}: {exc}") from exc
+        raise UpdateError(f"could not inspect the Persome LaunchAgent: {exc}") from exc
+    return result.returncode == 0
 
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if _running_daemon_pid() is None:
+
+def launchagent_should_be_restored() -> bool:
+    """Return the intended owner, including a previous-updater handoff."""
+    if launchagent_is_loaded():
+        return True
+    if launchagent.owner_intended():
+        return True
+    if os.environ.get("PERSOME_UPDATE_INFER_LAUNCHAGENT_FROM_PLIST") != "1":
+        return False
+    # A released updater booted launchd out before invoking the new installer,
+    # so the loaded state is no longer observable. Its retained, owner-only
+    # plist is the compatibility receipt; accept the normal shim as well as a
+    # direct venv binary. Future installs use the explicit owner marker above.
+    return launchagent.configured_runtime_binary() is not None
+
+
+def _bootout_launchagent() -> None:
+    try:
+        result = subprocess.run(
+            ["launchctl", "bootout", launchagent.gui_domain_target()],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise UpdateError("stopping the Persome LaunchAgent timed out after 20 seconds") from exc
+    except OSError as exc:
+        raise UpdateError(f"could not stop the Persome LaunchAgent: {exc}") from exc
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "launchctl bootout failed"
+        raise UpdateError(f"could not stop the Persome LaunchAgent: {detail}")
+
+
+def stop_runtime(
+    *, launchagent_was_loaded: bool, timeout: float = 20.0, force: bool = False
+) -> None:
+    """Stop launchd ownership and any current daemon before replacing code."""
+    process = _running_daemon_process()
+    if launchagent_was_loaded and launchagent_is_loaded():
+        _bootout_launchagent()
+    if process is None:
+        process = _running_daemon_process()
+    if process is None:
+        problem = runtime_pid.unresolved_runtime_reason()
+        if problem is not None:
+            raise UpdateError(f"could not safely stop Persome: {problem}")
+        return
+    if not runtime_pid.same_process_is_running(process):
+        return
+    if not runtime_pid.signal_process(process, signal.SIGTERM):
+        if not runtime_pid.same_process_is_running(process):
             return
-        time.sleep(0.2)
-    raise UpdateError(f"Persome daemon pid {pid} did not stop within {timeout:.0f}s")
+        raise UpdateError(f"could not safely stop Persome daemon pid {process.pid}")
+    if runtime_pid.wait_for_exit(process, timeout):
+        return
+    if (
+        force
+        and runtime_pid.signal_process(process, signal.SIGKILL)
+        and runtime_pid.wait_for_exit(process, 5)
+    ):
+        return
+    raise UpdateError(f"Persome daemon pid {process.pid} did not stop within {timeout:.0f}s")
+
+
+def _child_environment(*, include_source: Path | None = None) -> dict[str, str]:
+    env = os.environ.copy()
+    env["PERSOME_ROOT"] = str(paths.root())
+    env["PERSOME_INSTALL_HOME"] = str(paths.root())
+    env["PYTHONNOUSERSITE"] = "1"
+    for variable in (
+        "SSL_CERT_FILE",
+        "PYTHONHOME",
+        "PYTHONPATH",
+        "VIRTUAL_ENV",
+        "__PYVENV_LAUNCHER__",
+    ):
+        env.pop(variable, None)
+    old_bin = str(_venv_dir() / "bin")
+    env["PATH"] = os.pathsep.join(
+        component for component in env.get("PATH", "").split(os.pathsep) if component != old_bin
+    )
+    if include_source is not None:
+        env["PYTHONPATH"] = str(include_source / "src")
+    return env
 
 
 def run_installer(source: UpdateSource) -> None:
-    """Install the validated source through the locked update-mode installer."""
-    env = os.environ.copy()
-    # ``PERSOME_ROOT`` is the Runtime's canonical path override, while the
-    # installer historically calls the same location ``PERSOME_INSTALL_HOME``.
-    # Pin both so a custom-root install can never be updated into ~/.persome by
-    # accident.
-    env["PERSOME_ROOT"] = str(paths.root())
-    env["PERSOME_INSTALL_HOME"] = str(paths.root())
-    # The running CLI points SSL_CERT_FILE into its current virtualenv. The
-    # transactional installer moves that directory aside, so forwarding the
-    # path produces a stale-certificate warning and can break downloads.
-    env.pop("SSL_CERT_FILE", None)
-    process = subprocess.Popen(
-        ["/bin/bash", str(source.path / "install.sh"), "--update"],
-        cwd=source.path,
-        env=env,
-        start_new_session=True,
-    )
+    """Build a marked candidate venv without changing the active installation."""
+
+    state = _read_update_state()
+    if not isinstance(state, UpdateTransaction) or state.phase != "preparing":
+        raise UpdateError("the update installer requires an active preparing transaction")
+    lock_fd = _ACTIVE_UPDATE_LOCK_FD
+    if lock_fd is None:
+        raise UpdateError("the update installer requires the exclusive Runtime update lock")
+    env = _child_environment()
+    env["PERSOME_UPDATE_DEFER_COMMIT"] = "1"
+    env["PERSOME_UPDATE_REPLACEMENT"] = str(_update_replacement_dir())
+    env["PERSOME_UPDATE_TRANSACTION_ID"] = state.transaction_id
+    env["PERSOME_UPDATE_LOCK_FD"] = str(lock_fd)
     try:
-        returncode = process.wait()
-    except KeyboardInterrupt as exc:
-        # The installer owns an on-disk transaction. Forward cancellation to
-        # its process group, then wait for its EXIT trap to restore the old
-        # virtualenv before the outer updater tries to restart the Runtime.
-        if process.poll() is None:
-            with contextlib.suppress(ProcessLookupError):
-                os.killpg(process.pid, signal.SIGINT)
+        process = subprocess.Popen(
+            ["/bin/bash", str(source.path / "install.sh"), "--update"],
+            cwd=source.path,
+            env=env,
+            pass_fds=(lock_fd,),
+            start_new_session=True,
+        )
+    except OSError as exc:
+        raise UpdateError(f"could not start the transactional installer: {exc}") from exc
+    try:
         try:
-            process.wait(timeout=30)
-        except (KeyboardInterrupt, subprocess.TimeoutExpired):
-            with contextlib.suppress(ProcessLookupError):
-                os.killpg(process.pid, signal.SIGKILL)
-            process.wait()
-        raise UpdateError(
-            "update cancelled; the previous Persome installation was restored"
-        ) from exc
+            returncode = process.wait()
+        except (KeyboardInterrupt, UpdateSignal) as exc:
+            signum = signal.SIGINT if isinstance(exc, KeyboardInterrupt) else exc.signum
+            if process.poll() is None:
+                with contextlib.suppress(ProcessLookupError, PermissionError):
+                    os.killpg(process.pid, signum)
+            with ignore_update_signals():
+                rollback_deadline = time.monotonic() + 30
+                while process.poll() is None:
+                    remaining = rollback_deadline - time.monotonic()
+                    if remaining <= 0:
+                        with contextlib.suppress(ProcessLookupError, PermissionError):
+                            os.killpg(process.pid, signal.SIGKILL)
+                        process.wait()
+                        break
+                    try:
+                        process.wait(timeout=remaining)
+                    except (KeyboardInterrupt, UpdateSignal):
+                        continue
+                    except subprocess.TimeoutExpired:
+                        continue
+            # Cancellation wins even if the child happened to exit 0 between
+            # signal delivery and poll(). The active venv was never touched.
+            raise UpdateCancelled(
+                "update cancelled; the previous installation remains active",
+                signum=signum,
+            ) from exc
+    except OSError as exc:
+        raise UpdateError(f"waiting for the transactional installer failed: {exc}") from exc
     if returncode != 0:
         raise UpdateError(
             "the installer did not complete; the existing Persome data and secrets were preserved"
         )
+    if not transaction_prepared():
+        raise UpdateError("the installer exited without a complete, marked candidate venv")
+
+
+def _write_update_state(*, launchagent_was_loaded: bool, phase: str, transaction_id: str) -> None:
+    if phase not in {"preparing", "prepared", "activated", "committing"}:
+        raise ValueError(f"invalid update phase: {phase}")
+    if len(transaction_id) != 32 or any(
+        character not in "0123456789abcdef" for character in transaction_id
+    ):
+        raise ValueError("invalid update transaction ID")
+    paths.atomic_write_private_text(
+        _update_state_file(),
+        json.dumps(
+            {
+                "schema_version": 2,
+                "launchagent_was_loaded": launchagent_was_loaded,
+                "phase": phase,
+                "transaction_id": transaction_id,
+            },
+            sort_keys=True,
+        ),
+    )
+    _fsync_root()
+
+
+def _read_update_state() -> UpdateTransaction | LegacyUpdateTransaction | None:
+    state_file = _update_state_file()
+    try:
+        paths.ensure_private_file(state_file)
+        payload = json.loads(state_file.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except (OSError, RuntimeError, json.JSONDecodeError) as exc:
+        raise UpdateError(f"could not safely read unfinished update state: {exc}") from exc
+    if not isinstance(payload, dict) or not isinstance(payload.get("launchagent_was_loaded"), bool):
+        raise UpdateError(f"unfinished update state is invalid: {state_file}")
+    if payload.get("schema_version") == 1 and payload.get("phase") in {
+        "preparing",
+        "prepared",
+        "committing",
+    }:
+        return LegacyUpdateTransaction(
+            bool(payload["launchagent_was_loaded"]), str(payload["phase"])
+        )
+    if (
+        payload.get("schema_version") != 2
+        or payload.get("phase") not in {"preparing", "prepared", "activated", "committing"}
+        or not isinstance(payload.get("transaction_id"), str)
+        or len(payload["transaction_id"]) != 32
+        or any(character not in "0123456789abcdef" for character in payload["transaction_id"])
+    ):
+        raise UpdateError(f"unfinished update state is invalid: {state_file}")
+    return UpdateTransaction(
+        bool(payload["launchagent_was_loaded"]),
+        str(payload["phase"]),
+        str(payload["transaction_id"]),
+    )
+
+
+def begin_update_transaction(launchagent_was_loaded: bool) -> str:
+    if (
+        _read_update_state() is not None
+        or os.path.lexists(_update_replacement_dir())
+        or os.path.lexists(_update_backup_dir())
+    ):
+        raise UpdateError("an unfinished update must be recovered before starting another")
+    transaction_id = uuid.uuid4().hex
+    _write_update_state(
+        launchagent_was_loaded=launchagent_was_loaded,
+        phase="preparing",
+        transaction_id=transaction_id,
+    )
+    return transaction_id
+
+
+def mark_update_phase(launchagent_was_loaded: bool, phase: str) -> None:
+    state = _read_update_state()
+    if (
+        not isinstance(state, UpdateTransaction)
+        or state.launchagent_was_loaded != launchagent_was_loaded
+    ):
+        raise UpdateError("the update transaction owner metadata changed unexpectedly")
+    _write_update_state(
+        launchagent_was_loaded=launchagent_was_loaded,
+        phase=phase,
+        transaction_id=state.transaction_id,
+    )
+
+
+def clear_update_state() -> None:
+    state = _read_update_state()
+    if isinstance(state, UpdateTransaction):
+        active_marker = _marker_transaction(_venv_dir())
+        if active_marker not in {None, state.transaction_id}:
+            raise UpdateError("the active Runtime marker does not match update state")
+    if (
+        isinstance(state, UpdateTransaction)
+        and _marker_transaction(_venv_dir()) == state.transaction_id
+    ):
+        marker = _venv_dir() / _TRANSACTION_MARKER
+        marker.unlink()
+        _fsync_directory(_venv_dir())
+    with contextlib.suppress(FileNotFoundError):
+        _update_state_file().unlink()
+    _fsync_root()
+
+
+def _fsync_root() -> None:
+    """Durably order transaction metadata and virtualenv directory renames."""
+
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(paths.root(), flags)
+        try:
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+    except OSError as exc:
+        raise UpdateError(f"could not persist the update transaction directory: {exc}") from exc
+
+
+def _fsync_directory(directory: Path) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(directory, flags)
+        try:
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+    except OSError as exc:
+        raise UpdateError(f"could not persist update metadata in {directory}: {exc}") from exc
+
+
+def _marker_transaction(directory: Path) -> str | None:
+    marker = directory / _TRANSACTION_MARKER
+    try:
+        stat_result = marker.lstat()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise UpdateError(f"could not inspect candidate transaction marker: {exc}") from exc
+    if (
+        marker.is_symlink()
+        or not marker.is_file()
+        or stat_result.st_uid != os.getuid()
+        or stat_result.st_mode & 0o077
+        or stat_result.st_nlink != 1
+    ):
+        raise UpdateError(f"candidate transaction marker is unsafe: {marker}")
+    try:
+        value = marker.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        raise UpdateError(f"could not read candidate transaction marker: {exc}") from exc
+    if len(value) != 32 or any(character not in "0123456789abcdef" for character in value):
+        raise UpdateError(f"candidate transaction marker is invalid: {marker}")
+    return value
+
+
+def cleanup_transaction_artifacts() -> None:
+    for candidate in paths.root().glob("venv.previous.committed.*"):
+        if candidate.is_dir() and not candidate.is_symlink():
+            with contextlib.suppress(OSError):
+                shutil.rmtree(candidate)
+
+
+def ensure_no_pending_update() -> None:
+    if (
+        _read_update_state() is not None
+        or os.path.lexists(_update_replacement_dir())
+        or os.path.lexists(_update_backup_dir())
+    ):
+        raise UpdateError("an unfinished update remains after automatic recovery")
+    cleanup_transaction_artifacts()
+
+
+def transaction_prepared() -> bool:
+    state = _read_update_state()
+    candidate = _update_replacement_dir()
+    return bool(
+        isinstance(state, UpdateTransaction)
+        and state.phase == "preparing"
+        and candidate.is_dir()
+        and not candidate.is_symlink()
+        and _marker_transaction(candidate) == state.transaction_id
+    )
+
+
+def _atomic_exchange(first: Path, second: Path) -> None:
+    """Exchange two same-filesystem directories in one kernel operation."""
+
+    if first.parent != second.parent:
+        raise UpdateError("update directories must share one parent for atomic exchange")
+    encoded_first = os.fsencode(first)
+    encoded_second = os.fsencode(second)
+    library = ctypes.CDLL(None, use_errno=True)
+    result: int
+    if sys.platform == "darwin":
+        rename = library.renameatx_np
+        rename.argtypes = [
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_uint,
+        ]
+        rename.restype = ctypes.c_int
+        result = rename(-2, encoded_first, -2, encoded_second, 0x00000002)
+    elif sys.platform.startswith("linux"):
+        rename = library.renameat2
+        rename.argtypes = [
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_uint,
+        ]
+        rename.restype = ctypes.c_int
+        result = rename(-100, encoded_first, -100, encoded_second, 0x00000002)
+    else:  # pragma: no cover - Persome is macOS-only; Linux supports CI.
+        raise UpdateError(f"atomic virtualenv exchange is unavailable on {sys.platform}")
+    if result != 0:
+        error_number = ctypes.get_errno()
+        raise UpdateError(
+            "could not atomically exchange the active and candidate Runtime: "
+            f"{os.strerror(error_number)}"
+        )
+    _fsync_root()
+
+
+def _validate_safe_venv(directory: Path, *, label: str) -> None:
+    if directory.is_symlink() or not directory.is_dir():
+        raise UpdateError(f"{label} is not a safe virtualenv directory: {directory}")
+
+
+def _validate_relocatable_candidate(directory: Path) -> None:
+    """Reject a console script that would execute the old directory after exchange."""
+    executable = directory / "bin" / "persome"
+    if executable.is_symlink() or not executable.is_file() or not os.access(executable, os.X_OK):
+        raise UpdateError(f"candidate Runtime executable is missing or unsafe: {executable}")
+    try:
+        script = executable.read_bytes()
+    except OSError as exc:
+        raise UpdateError(f"could not inspect candidate Runtime executable: {exc}") from exc
+    if os.fsencode(directory) in script:
+        raise UpdateError(
+            "candidate Runtime is not relocatable; its console script contains the inactive "
+            "virtualenv path"
+        )
+
+
+def activate_prepared_install() -> None:
+    """Atomically activate the complete candidate before starting its daemon."""
+
+    state = _read_update_state()
+    if not isinstance(state, UpdateTransaction) or state.phase != "prepared":
+        raise UpdateError("the candidate Runtime is not in prepared state")
+    active = _venv_dir()
+    candidate = _update_replacement_dir()
+    _validate_safe_venv(active, label="active Runtime")
+    _validate_safe_venv(candidate, label="candidate Runtime")
+    _validate_relocatable_candidate(candidate)
+    if _marker_transaction(candidate) != state.transaction_id:
+        raise UpdateError("the candidate Runtime does not belong to this update transaction")
+    if _marker_transaction(active) is not None:
+        raise UpdateError("the active Runtime unexpectedly contains an update marker")
+    _atomic_exchange(active, candidate)
+    _write_update_state(
+        launchagent_was_loaded=state.launchagent_was_loaded,
+        phase="activated",
+        transaction_id=state.transaction_id,
+    )
+
+
+def _wait_for_runtime_process(timeout: float = 20.0) -> runtime_pid.ProcessIdentity:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        process = _running_daemon_process()
+        if process is not None:
+            return process
+        time.sleep(0.2)
+    raise UpdateError(
+        f"the Runtime process did not become identity-verifiable within {timeout:.0f}s"
+    )
 
 
 def restore_launchagent(was_loaded: bool) -> None:
-    """Restore launchd ownership with the newly installed Runtime binary."""
+    """Restore launchd ownership; the caller performs the final Runtime proof."""
     if not was_loaded:
         return
-    binary = paths.root() / "venv" / "bin" / "persome"
+    binary = _runtime_binary()
     if not binary.is_file() or not os.access(binary, os.X_OK):
         raise UpdateError(f"updated Persome executable is missing: {binary}")
-    result = subprocess.run(
-        [str(binary), "launchagent", "install", "--binary", str(binary)],
-        check=False,
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
+    try:
+        result = subprocess.run(
+            [str(binary), "launchagent", "install", "--binary", str(binary)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=_child_environment(),
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise UpdateError("restoring the Persome LaunchAgent timed out after 30 seconds") from exc
+    except OSError as exc:
+        raise UpdateError(f"could not run LaunchAgent restoration: {exc}") from exc
     if result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or "launchagent install failed"
         raise UpdateError(f"update succeeded but LaunchAgent restoration failed: {detail}")
     deadline = time.monotonic() + 15
     while time.monotonic() < deadline:
-        if launchagent_is_loaded() and _running_daemon_pid() is not None:
+        if launchagent_is_loaded() and launchagent.owns_recorded_runtime(str(binary)):
             return
         time.sleep(0.25)
     raise UpdateError("updated LaunchAgent did not become loaded and running within 15s")
 
 
-def recover_runtime(launchagent_was_loaded: bool) -> None:
-    """Best-effort recovery when an update fails after the old daemon stopped."""
-    if _running_daemon_pid() is not None:
-        return
-    if launchagent_was_loaded:
-        restore_launchagent(True)
-        return
-    binary = paths.root() / "venv" / "bin" / "persome"
+def _start_background_runtime() -> None:
+    binary = _runtime_binary()
     if not binary.is_file() or not os.access(binary, os.X_OK):
         raise UpdateError(f"no runnable Persome executable remains at {binary}")
-    result = subprocess.run(
-        [str(binary), "start"],
-        check=False,
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
+    try:
+        result = subprocess.run(
+            [str(binary), "start"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=_child_environment(),
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise UpdateError("starting the Persome Runtime timed out after 30 seconds") from exc
+    except OSError as exc:
+        raise UpdateError(f"could not start the Persome Runtime: {exc}") from exc
     if result.returncode != 0 and _running_daemon_pid() is None:
-        detail = result.stderr.strip() or result.stdout.strip() or "runtime restart failed"
-        raise UpdateError(f"could not restart the previous Runtime: {detail}")
+        detail = result.stderr.strip() or result.stdout.strip() or "runtime start failed"
+        raise UpdateError(f"could not start the Persome Runtime: {detail}")
+    _wait_for_runtime_process()
+
+
+def activate_runtime(launchagent_was_loaded: bool) -> None:
+    """Start the prepared replacement under the user's prior ownership mode."""
+
+    activate_prepared_install()
+    if launchagent_was_loaded:
+        restore_launchagent(True)
+    else:
+        _start_background_runtime()
+
+
+def prove_runtime(launchagent_was_loaded: bool) -> None:
+    """Run onboarding proof against the final owner without changing capture policy."""
+
+    binary = _runtime_binary()
+    if not binary.is_file() or not os.access(binary, os.X_OK):
+        raise UpdateError(f"Runtime proof executable is missing: {binary}")
+    command = [
+        str(binary),
+        "onboard",
+        "--preserve-policy",
+        "--expect-owner",
+        "launchagent" if launchagent_was_loaded else "background",
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            timeout=240,
+            env=_child_environment(),
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise UpdateError("final Runtime onboarding proof timed out after 240 seconds") from exc
+    except OSError as exc:
+        raise UpdateError(f"could not run the final Runtime onboarding proof: {exc}") from exc
+    if result.returncode != 0:
+        raise UpdateError("the final Runtime owner failed onboarding health/capture proof")
+
+
+def commit_prepared_install() -> Path:
+    """Commit the activated Runtime and return its old-venv cleanup path."""
+
+    state = _read_update_state()
+    previous = _update_replacement_dir()
+    if not isinstance(state, UpdateTransaction) or state.phase != "committing":
+        raise UpdateError("the activated Runtime is not ready to commit")
+    _validate_safe_venv(_venv_dir(), label="activated Runtime")
+    _validate_safe_venv(previous, label="retained previous Runtime")
+    if _marker_transaction(_venv_dir()) != state.transaction_id:
+        raise UpdateError("the activated Runtime does not belong to this update transaction")
+    if _marker_transaction(previous) is not None:
+        raise UpdateError("the retained previous Runtime has an unexpected update marker")
+    cleanup = paths.root() / f"venv.previous.committed.{uuid.uuid4().hex}"
+    try:
+        os.replace(previous, cleanup)
+        _fsync_root()
+    except OSError as exc:
+        raise UpdateError(f"could not commit the prepared Runtime update: {exc}") from exc
+    return cleanup
+
+
+def cleanup_committed_install(cleanup: Path) -> None:
+    """Best-effort cleanup after the atomic commit point."""
+
+    if cleanup.parent != paths.root() or not cleanup.name.startswith("venv.previous.committed."):
+        return
+    with contextlib.suppress(OSError):
+        shutil.rmtree(cleanup)
+
+
+def rollback_prepared_install() -> bool:
+    """Restore old code if exchanged, or discard an unactivated candidate."""
+
+    state = _read_update_state()
+    candidate = _update_replacement_dir()
+    if state is None:
+        if os.path.lexists(candidate):
+            raise UpdateError("a candidate Runtime exists without update transaction metadata")
+        return False
+    if not isinstance(state, UpdateTransaction):
+        raise UpdateError("legacy update artifacts require legacy recovery")
+    active = _venv_dir()
+    _validate_safe_venv(active, label="active Runtime")
+    active_marker = _marker_transaction(active)
+    if active_marker is not None and active_marker != state.transaction_id:
+        raise UpdateError("the active Runtime belongs to a different update transaction")
+    if not os.path.lexists(candidate):
+        if active_marker == state.transaction_id and state.phase != "committing":
+            raise UpdateError("the previous Runtime is missing; rollback cannot continue safely")
+        return False
+    _validate_safe_venv(candidate, label="candidate Runtime")
+    candidate_marker = _marker_transaction(candidate)
+    if active_marker == state.transaction_id:
+        if candidate_marker is not None:
+            raise UpdateError("both Runtime directories contain update transaction markers")
+        _atomic_exchange(active, candidate)
+    elif candidate_marker not in {None, state.transaction_id}:
+        raise UpdateError("the candidate Runtime belongs to a different update transaction")
+
+    # Active is now definitively the old venv. Rename the failed/partial new
+    # candidate before slow cleanup so the reserved transaction path is clear.
+    failed = paths.root() / f"venv.failed.update.{uuid.uuid4().hex}"
+    try:
+        os.replace(candidate, failed)
+        _fsync_root()
+    except OSError as exc:
+        raise UpdateError(f"could not quarantine the failed Runtime candidate: {exc}") from exc
+    with contextlib.suppress(OSError):
+        shutil.rmtree(failed)
+    return True
+
+
+def _wait_for_legacy_runtime_proof(timeout: float = 30.0) -> None:
+    """Backward-compatible proof for a restored pre-preserve-policy Runtime."""
+
+    process = _wait_for_runtime_process()
+    cfg = config_mod.load()
+    http_enabled = bool(cfg.mcp.auto_start and cfg.mcp.transport in {"sse", "streamable-http"})
+    if not http_enabled:
+        # HTTP is intentionally disabled. Pinning the full PID/start/command
+        # identity across a short stability window proves the old owner stayed up.
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            if not runtime_pid.same_process_is_running(process):
+                raise UpdateError("the restored Runtime exited during its stability proof")
+            time.sleep(0.1)
+        return
+    deadline = time.monotonic() + timeout
+    from .security.auth import LocalAPIConfigurationError, loopback_http_url
+
+    try:
+        endpoint = loopback_http_url(cfg.mcp.host, cfg.mcp.port, "/health")
+    except LocalAPIConfigurationError as exc:
+        raise UpdateError(f"could not build the restored Runtime health URL: {exc}") from exc
+    while time.monotonic() < deadline:
+        if not runtime_pid.same_process_is_running(process):
+            raise UpdateError("the restored Runtime exited before its health proof")
+        try:
+            with urllib.request.urlopen(endpoint, timeout=2) as response:  # noqa: S310
+                payload = json.loads(response.read())
+        except (OSError, ValueError, urllib.error.URLError):
+            time.sleep(0.25)
+            continue
+        data = payload.get("data") if isinstance(payload, dict) else None
+        if isinstance(data, dict) and data.get("status") in {"ok", "degraded"}:
+            return
+        time.sleep(0.25)
+    raise UpdateError("the restored Runtime did not pass its legacy health proof within 30 seconds")
+
+
+def _clear_replacement_runtime_state() -> None:
+    """Remove generation state only after the replacement process is stopped."""
+
+    for target in (paths.pid_file(), paths.runtime_state_file()):
+        with contextlib.suppress(FileNotFoundError):
+            target.unlink()
+
+
+def recover_runtime(launchagent_was_loaded: bool) -> None:
+    """Restore prior lifecycle ownership and prove a legacy Runtime safely."""
+
+    if launchagent_was_loaded:
+        restore_launchagent(True)
+    elif _running_daemon_pid() is None:
+        _start_background_runtime()
+    _wait_for_legacy_runtime_proof()
+
+
+def rollback_and_recover(launchagent_was_loaded: bool) -> None:
+    """Stop any replacement, restore old code/ownership, and run preserve proof."""
+
+    currently_loaded = launchagent_is_loaded()
+    stop_runtime(launchagent_was_loaded=currently_loaded, force=True)
+    rollback_prepared_install()
+    _clear_replacement_runtime_state()
+    recover_runtime(launchagent_was_loaded)
+    clear_update_state()
+
+
+def _discard_directory(directory: Path, *, prefix: str) -> None:
+    """Clear a reserved transaction path before its best-effort slow removal."""
+
+    quarantined = paths.root() / f"{prefix}.{uuid.uuid4().hex}"
+    try:
+        os.replace(directory, quarantined)
+        _fsync_root()
+    except OSError as exc:
+        raise UpdateError(f"could not quarantine update artifact {directory}: {exc}") from exc
+    with contextlib.suppress(OSError):
+        shutil.rmtree(quarantined)
+
+
+def _recover_legacy_pending_update(state: LegacyUpdateTransaction) -> None:
+    """Recover schema-v1 two-rename transactions from an installed release."""
+
+    backup = _update_backup_dir()
+    backup_exists = os.path.lexists(backup)
+    active = _venv_dir()
+    if state.phase == "committing" and not backup_exists:
+        # The previous updater had already passed proof and renamed its backup
+        # away. Preserve that committed installation and re-establish ownership.
+        currently_loaded = launchagent_is_loaded()
+        if currently_loaded != state.launchagent_was_loaded or _running_daemon_pid() is None:
+            stop_runtime(launchagent_was_loaded=currently_loaded, force=True)
+            if state.launchagent_was_loaded:
+                restore_launchagent(True)
+            else:
+                _start_background_runtime()
+        _wait_for_legacy_runtime_proof()
+        clear_update_state()
+        cleanup_transaction_artifacts()
+        return
+
+    currently_loaded = launchagent_is_loaded()
+    stop_runtime(launchagent_was_loaded=currently_loaded, force=True)
+    if backup_exists:
+        _validate_safe_venv(backup, label="legacy previous Runtime")
+        if os.path.lexists(active):
+            _validate_safe_venv(active, label="legacy replacement Runtime")
+            _atomic_exchange(active, backup)
+            _discard_directory(backup, prefix="venv.failed.legacy-update")
+        else:
+            try:
+                os.replace(backup, active)
+                _fsync_root()
+            except OSError as exc:
+                raise UpdateError(f"could not restore the legacy previous Runtime: {exc}") from exc
+    elif not active.is_dir() or active.is_symlink():
+        raise UpdateError("the interrupted legacy update left no recoverable Runtime venv")
+    _clear_replacement_runtime_state()
+    recover_runtime(state.launchagent_was_loaded)
+    clear_update_state()
+
+
+def recover_pending_update() -> None:
+    """Repair an interrupted deterministic transaction under the update lock."""
+
+    state = _read_update_state()
+    candidate_exists = os.path.lexists(_update_replacement_dir())
+    legacy_backup_exists = os.path.lexists(_update_backup_dir())
+    if state is None and not candidate_exists and not legacy_backup_exists:
+        cleanup_transaction_artifacts()
+        return
+    if state is None:
+        raise UpdateError("an update artifact exists without lifecycle recovery metadata")
+    if isinstance(state, LegacyUpdateTransaction):
+        _recover_legacy_pending_update(state)
+        return
+    if legacy_backup_exists:
+        raise UpdateError(
+            "a legacy update backup remains; move it aside only after verifying the active Runtime"
+        )
+    active_marker = _marker_transaction(_venv_dir())
+    if state.phase == "committing" and active_marker == state.transaction_id:
+        # Proof completed before the committing phase was written. Finish the
+        # old-venv rename if needed, then re-prove the intended final owner.
+        if candidate_exists:
+            commit_prepared_install()
+        currently_loaded = launchagent_is_loaded()
+        if currently_loaded != state.launchagent_was_loaded or _running_daemon_pid() is None:
+            stop_runtime(launchagent_was_loaded=currently_loaded, force=True)
+            if state.launchagent_was_loaded:
+                restore_launchagent(True)
+            else:
+                _start_background_runtime()
+        else:
+            _wait_for_runtime_process()
+        prove_runtime(state.launchagent_was_loaded)
+        clear_update_state()
+        cleanup_transaction_artifacts()
+        return
+    rollback_and_recover(state.launchagent_was_loaded)
+    cleanup_transaction_artifacts()

--- a/tests/test_api_origin_guard.py
+++ b/tests/test_api_origin_guard.py
@@ -76,7 +76,9 @@ def test_ipv6_loopback_host_passes() -> None:
 
 def test_health_allowed_despite_malicious_origin() -> None:
     """``/health`` is always allowed — a hostile Origin can't trip liveness."""
-    client = TestClient(build_api_app(auth_enabled=False))
+    # Pin the default (OCR-disabled) config so this origin-guard test does not
+    # depend on a developer's on-disk config or another in-process API app.
+    client = TestClient(build_api_app(Config(), auth_enabled=False))
     response = client.get(
         "/health",
         headers={"origin": "https://evil.com", "host": "attacker.com"},

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
 from fastapi.testclient import TestClient
 
 from persome import __version__
@@ -15,14 +16,24 @@ def test_health_returns_ok(monkeypatch) -> None:
     monkeypatch.setattr(
         routes.ocr_health,
         "inspect",
-        lambda capture: SimpleNamespace(enabled=True, ready=True, state="ready"),
+        lambda capture: SimpleNamespace(enabled=True, ready=True, state="ready", tier="tiny"),
     )
+    monkeypatch.setattr(routes.ocr_health, "worker_state", lambda: "ready")
     client = TestClient(build_api_app(auth_enabled=False))
     response = client.get("/health")
 
     assert response.status_code == 200
     body = response.json()
-    assert body == {"success": True, "data": {"status": "ok", "ocr": "ready"}}
+    assert body == {
+        "success": True,
+        "data": {
+            "status": "ok",
+            "ocr": "ready",
+            "ocr_worker": "ready",
+            "ocr_enabled": True,
+            "ocr_tier": "tiny",
+        },
+    }
 
 
 def test_health_reports_enabled_ocr_degradation(monkeypatch) -> None:
@@ -33,8 +44,10 @@ def test_health_reports_enabled_ocr_degradation(monkeypatch) -> None:
             enabled=True,
             ready=False,
             state="permission_required",
+            tier="tiny",
         ),
     )
+    monkeypatch.setattr(routes.ocr_health, "worker_state", lambda: "not_started")
     client = TestClient(build_api_app(auth_enabled=False))
 
     response = client.get("/health")
@@ -43,7 +56,104 @@ def test_health_reports_enabled_ocr_degradation(monkeypatch) -> None:
     assert response.json()["data"] == {
         "status": "degraded",
         "ocr": "permission_required",
+        "ocr_worker": "not_started",
+        "ocr_enabled": True,
+        "ocr_tier": "tiny",
     }
+
+
+def test_health_reports_failed_daemon_ocr_worker(monkeypatch) -> None:
+    monkeypatch.setattr(
+        routes.ocr_health,
+        "inspect",
+        lambda capture: SimpleNamespace(enabled=True, ready=True, state="ready", tier="tiny"),
+    )
+    monkeypatch.setattr(routes.ocr_health, "worker_state", lambda: "failed")
+    client = TestClient(build_api_app(auth_enabled=False))
+
+    assert client.get("/health").json()["data"] == {
+        "status": "degraded",
+        "ocr": "ready",
+        "ocr_worker": "failed",
+        "ocr_enabled": True,
+        "ocr_tier": "tiny",
+    }
+
+
+def test_health_reports_warming_daemon_ocr_worker_as_degraded(monkeypatch) -> None:
+    monkeypatch.setattr(
+        routes.ocr_health,
+        "inspect",
+        lambda capture: SimpleNamespace(enabled=True, ready=True, state="ready", tier="tiny"),
+    )
+    monkeypatch.setattr(routes.ocr_health, "worker_state", lambda: "warming")
+    client = TestClient(build_api_app(auth_enabled=False))
+
+    assert client.get("/health").json()["data"] == {
+        "status": "degraded",
+        "ocr": "ready",
+        "ocr_worker": "warming",
+        "ocr_enabled": True,
+        "ocr_tier": "tiny",
+    }
+
+
+def test_onboarding_capture_returns_exact_daemon_receipt(tmp_path, monkeypatch) -> None:
+    capture = tmp_path / "fresh.json"
+    monkeypatch.setattr(routes.scheduler, "active_runner_state", lambda cfg: "ready")
+    monkeypatch.setattr(routes.scheduler, "capture_now", lambda: capture)
+    client = TestClient(build_api_app(auth_enabled=False))
+
+    response = client.post("/_onboarding/capture")
+
+    assert response.status_code == 200
+    assert response.json()["data"] == {
+        "id": "fresh",
+        "mode": "daemon",
+        "receipt": "fresh-capture",
+    }
+
+
+def test_onboarding_capture_reports_runner_not_ready(monkeypatch) -> None:
+    monkeypatch.setattr(routes.scheduler, "active_runner_state", lambda cfg: "not-ready")
+    monkeypatch.setattr(routes.scheduler, "capture_now", lambda: None)
+    client = TestClient(build_api_app(auth_enabled=False))
+
+    response = client.post("/_onboarding/capture")
+
+    assert response.status_code == 503
+
+
+def test_onboarding_capture_reports_ingest_readiness_without_fake_record(monkeypatch) -> None:
+    monkeypatch.setattr(routes.scheduler, "active_runner_state", lambda cfg: "ingest-ready")
+    monkeypatch.setattr(
+        routes.scheduler,
+        "capture_now",
+        lambda: pytest.fail("ingest readiness must not synthesize a capture"),
+    )
+    client = TestClient(build_api_app(auth_enabled=False))
+
+    response = client.post("/_onboarding/capture")
+
+    assert response.status_code == 200
+    assert response.json()["data"] == {
+        "id": None,
+        "mode": "ingest",
+        "receipt": "ingest-ready",
+    }
+
+
+@pytest.mark.parametrize(("state", "status"), [("paused", 409), ("locked", 423)])
+def test_onboarding_capture_preserves_privacy_gate(state, status, monkeypatch) -> None:
+    monkeypatch.setattr(routes.scheduler, "active_runner_state", lambda cfg: state)
+    monkeypatch.setattr(
+        routes.scheduler,
+        "capture_now",
+        lambda: pytest.fail("privacy-gated onboarding must not capture"),
+    )
+    client = TestClient(build_api_app(auth_enabled=False))
+
+    assert client.post("/_onboarding/capture").status_code == status
 
 
 def test_openapi_reports_runtime_version() -> None:

--- a/tests/test_ax_capture.py
+++ b/tests/test_ax_capture.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -154,6 +155,80 @@ def test_create_provider_darwin_with_helper_is_macax(
     provider = create_provider(depth=4, timeout=2, raw=True)
     assert isinstance(provider, MacAXHelperProvider)
     assert provider.available is True
+
+
+def test_ax_trust_checks_only_helper_when_event_watcher_is_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    helper = tmp_path / "mac-ax-helper"
+    helper.write_text("", encoding="utf-8")
+    helper.chmod(0o700)
+    monkeypatch.setattr(ax_capture.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(ax_capture, "_resolve_helper_path", lambda: helper)
+    monkeypatch.setattr(ax_capture, "_binary_ax_trusted", lambda binary: binary == helper)
+    ax_capture._ax_trust_cache.clear()
+
+    assert ax_capture.ax_trusted(refresh=True, include_watcher=False) is True
+
+
+def test_accessibility_request_targets_only_configured_principals(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    helper = tmp_path / "mac-ax-helper"
+    helper.write_text("", encoding="utf-8")
+    helper.chmod(0o700)
+    commands: list[list[str]] = []
+    monkeypatch.setattr(ax_capture.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(ax_capture, "_resolve_helper_path", lambda: helper)
+
+    def run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(ax_capture.subprocess, "run", run)
+
+    assert ax_capture.request_accessibility_permission(include_watcher=False) is True
+    assert commands == [[str(helper), "--request-accessibility"]]
+
+
+def test_stable_native_binary_is_reused_across_reinstall_sources(
+    ac_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    first_source = tmp_path / "first" / "mac-ax-helper.swift"
+    second_source = tmp_path / "second" / "mac-ax-helper.swift"
+    first_source.parent.mkdir()
+    second_source.parent.mkdir()
+    first_source.write_text("print(1)\n", encoding="utf-8")
+    second_source.write_text("print(1)\n", encoding="utf-8")
+    builds: list[Path] = []
+
+    def compile_once(source: Path, binary: Path) -> None:
+        builds.append(source)
+        binary.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        binary.chmod(0o700)
+
+    monkeypatch.setattr(ax_capture, "_maybe_compile", compile_once)
+
+    first = ax_capture._stable_native_binary(first_source, "mac-ax-helper")
+    second = ax_capture._stable_native_binary(second_source, "mac-ax-helper")
+
+    assert first is not None
+    assert first.parent.parent == ac_root / "native"
+    assert second == first
+    assert builds == [first_source]
+    old_bytes = first.read_bytes()
+
+    second_source.write_text("print(2)\n", encoding="utf-8")
+    upgraded = ax_capture._stable_native_binary(second_source, "mac-ax-helper")
+    assert upgraded is not None and upgraded != first
+    assert builds == [first_source, second_source]
+
+    # A cancelled update can resolve the old source again without rebuilding
+    # or changing the old code identity that already owns the TCC grant.
+    rolled_back = ax_capture._stable_native_binary(first_source, "mac-ax-helper")
+    assert rolled_back == first
+    assert rolled_back.read_bytes() == old_bytes
+    assert builds == [first_source, second_source]
 
 
 # --- real macOS hardware smoke (keeps the `macos` marker live) ------------------

--- a/tests/test_captures_fts.py
+++ b/tests/test_captures_fts.py
@@ -2,9 +2,37 @@
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 from persome.store import fts
+
+
+def test_wal_initialization_retries_transient_connection_lock(monkeypatch) -> None:
+    class Result:
+        def __init__(self, value: str) -> None:
+            self.value = value
+
+        def fetchone(self) -> tuple[str]:
+            return (self.value,)
+
+    class Connection:
+        attempts = 0
+
+        def execute(self, statement: str) -> Result:
+            if statement == "PRAGMA journal_mode":
+                return Result("delete")
+            self.attempts += 1
+            if self.attempts < 3:
+                raise sqlite3.OperationalError("database is locked")
+            return Result("wal")
+
+    connection = Connection()
+    monkeypatch.setattr(fts.time, "sleep", lambda delay: None)
+
+    fts._ensure_wal_mode(connection)  # type: ignore[arg-type]
+
+    assert connection.attempts == 3
 
 
 def _seed(conn, *, id, ts, app, title, value, text, url=""):

--- a/tests/test_cli_lifecycle.py
+++ b/tests/test_cli_lifecycle.py
@@ -37,3 +37,53 @@ def test_start_short_circuits_before_initialization_when_already_running(
 
     assert result.exit_code == 1
     assert "Already running (pid 4242)" in result.output
+
+
+def test_daemon_lifetime_lock_excludes_a_second_start(ac_root) -> None:
+    first = cli._acquire_daemon_lock()
+    try:
+        with pytest.raises(RuntimeError, match="already starting or running"):
+            cli._acquire_daemon_lock()
+    finally:
+        first.close()
+
+    replacement = cli._acquire_daemon_lock()
+    replacement.close()
+
+
+def test_start_lock_failure_never_initializes_or_forks(
+    ac_root, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(cli, "_read_pid", lambda: None)
+    monkeypatch.setattr(cli, "_fail_if_runtime_state_is_ambiguous", lambda: None)
+    monkeypatch.setattr(
+        cli,
+        "_acquire_daemon_lock",
+        lambda: (_ for _ in ()).throw(RuntimeError("another Runtime is starting")),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_init",
+        lambda **kwargs: pytest.fail("losing start must not initialize the Runtime"),
+    )
+
+    result = CliRunner().invoke(cli.app, ["start"])
+
+    assert result.exit_code == 1
+    assert "another Runtime is starting" in result.output
+
+
+def test_non_starting_client_skips_integrity_during_pid_publication_window(
+    ac_root, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    lock = cli._acquire_daemon_lock()
+    monkeypatch.setattr(cli, "_read_pid", lambda: None)
+    monkeypatch.setattr(
+        cli.integrity,
+        "check_and_recover",
+        lambda: pytest.fail("active startup window must not mutate SQLite"),
+    )
+    try:
+        assert cli._init() is not None
+    finally:
+        lock.close()

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -248,6 +248,10 @@ def test_status_renders_new_fields(ac_root: Path) -> None:
     assert "Last Capture" in result.output
     assert "OCR" in result.output
     assert "Screen Recording" in result.output
+    assert "Capture Source" in result.output
+    assert "Runtime Owner" in result.output
+    assert "Generation" in result.output
+    assert "Accessibility" in result.output
 
 
 def test_status_shows_version(ac_root: Path) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from persome import config
 
 
@@ -52,6 +54,24 @@ actionable_retention_days = 3
     assert capture.encrypt_screenshots is False
     assert capture.extended_retention_enabled is False
     assert capture.actionable_retention_days == 3
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("source", "typo", "capture.source"),
+        ("ocr_policy", "sometimes", "capture.ocr_policy"),
+        ("ocr_tier", "huge", "capture.ocr_tier"),
+    ],
+)
+def test_invalid_capture_policy_fails_closed(
+    tmp_path: Path, field: str, value: str, message: str
+) -> None:
+    path = tmp_path / "config.toml"
+    path.write_text(f'[capture]\n{field} = "{value}"\n', encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match=message):
+        config.load(path)
 
 
 def test_legacy_top_level_capture_privacy_settings_still_load(tmp_path: Path) -> None:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import errno
+import json
+import os
 from dataclasses import replace
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -319,16 +321,21 @@ class TestRunLifecycle:
         stub_registry = [
             replace(td, create=lambda c, sm: _never()) for td in _build_task_registry()
         ]
-        monkeypatch.setattr("persome.daemon._build_task_registry", lambda: stub_registry)
+        monkeypatch.setattr(
+            "persome.daemon._build_task_registry", lambda _receipt=None: stub_registry
+        )
 
         async def driver() -> None:
             task = asyncio.create_task(_run(self._no_task_cfg(), capture_only=True))
             # Let _run reach the point where the pid file exists.
             for _ in range(50):
                 await asyncio.sleep(0.01)
-                if paths.pid_file().exists():
+                if paths.pid_file().exists() and paths.runtime_state_file().exists():
                     break
             assert paths.pid_file().exists()
+            state = json.loads(paths.runtime_state_file().read_text(encoding="utf-8"))
+            assert state["pid"] == os.getpid()
+            assert len(state["generation"]) == 32
             # Simulate SIGTERM by signalling the daemon's stop path: the
             # handler just sets an Event, so we cancel the run task which
             # exercises the same shutdown / cleanup branch deterministically.
@@ -351,12 +358,15 @@ class TestRunLifecycle:
         stub_registry = [
             replace(td, create=lambda c, sm: returns()) for td in _build_task_registry()
         ]
-        monkeypatch.setattr("persome.daemon._build_task_registry", lambda: stub_registry)
+        monkeypatch.setattr(
+            "persome.daemon._build_task_registry", lambda _receipt=None: stub_registry
+        )
 
         await _run(self._no_task_cfg(), capture_only=True)
 
         # Health invariant: a cleanly stopped daemon leaves no pid file behind.
         assert not paths.pid_file().exists()
+        assert not paths.runtime_state_file().exists()
 
     async def test_force_end_failure_does_not_crash_shutdown(
         self, ac_root: Path, monkeypatch: pytest.MonkeyPatch
@@ -367,7 +377,9 @@ class TestRunLifecycle:
         stub_registry = [
             replace(td, create=lambda c, sm: returns()) for td in _build_task_registry()
         ]
-        monkeypatch.setattr("persome.daemon._build_task_registry", lambda: stub_registry)
+        monkeypatch.setattr(
+            "persome.daemon._build_task_registry", lambda _receipt=None: stub_registry
+        )
 
         # SessionManager.force_end blowing up during shutdown must be swallowed
         # (it runs inside ``with suppress(Exception)``), so the pid file is
@@ -383,6 +395,37 @@ class TestRunLifecycle:
         boom_manager.force_end.assert_called_once()
         assert not paths.pid_file().exists()
 
+    async def test_runtime_start_never_requests_screen_recording(
+        self, ac_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def returns() -> None:
+            return
+
+        stub_registry = [
+            replace(td, create=lambda c, sm: returns()) for td in _build_task_registry()
+        ]
+        monkeypatch.setattr(
+            "persome.daemon._build_task_registry", lambda _receipt=None: stub_registry
+        )
+        monkeypatch.setattr(
+            "persome.capture.screen_recording.request_screen_recording",
+            lambda: pytest.fail("ordinary Runtime startup must never prompt for TCC access"),
+        )
+        cfg = self._no_task_cfg()
+
+        await _run(cfg, capture_only=True)
+
+    async def test_ingest_without_http_transport_refuses_to_start(self, ac_root: Path) -> None:
+        from persome import paths
+
+        cfg = self._no_task_cfg()
+        cfg.capture.source = "ingest"
+
+        with pytest.raises(RuntimeError, match="requires the authenticated HTTP"):
+            await _run(cfg, capture_only=True)
+
+        assert not paths.pid_file().exists()
+
 
 def test_shutdown_timeout_constant_is_sane() -> None:
     # Guard against an accidental 0/negative that would make shutdown not wait.
@@ -396,6 +439,7 @@ def test_hard_exit_persists_session_before_process_exit(
 
     manager = MagicMock()
     paths.pid_file().write_text("123")
+    paths.runtime_state_file().write_text("{}")
     exit_mock = MagicMock()
     monkeypatch.setattr("persome.daemon.os._exit", exit_mock)
 
@@ -403,4 +447,5 @@ def test_hard_exit_persists_session_before_process_exit(
 
     manager.force_end.assert_called_once_with(reason="daemon-shutdown")
     assert not paths.pid_file().exists()
+    assert not paths.runtime_state_file().exists()
     exit_mock.assert_called_once_with(0)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -205,6 +205,7 @@ def test_helpers_missing_fail_with_install_hint(
     monkeypatch.delenv("PERSOME_AX_HELPER", raising=False)
     monkeypatch.delenv("PERSOME_AX_WATCHER", raising=False)
     monkeypatch.setattr(doctor, "_helper_candidates", lambda name: [tmp_path / name])
+    monkeypatch.setattr(doctor, "_helper_sources", lambda name: [])
     checks = doctor.check_helpers()
     assert all(c.status == "fail" for c in checks)
     assert "reinstall" in checks[0].detail
@@ -218,12 +219,13 @@ def test_helpers_bundled_source_warns_without_compiling(
     for name in ("mac-ax-helper", "mac-ax-watcher"):
         (tmp_path / f"{name}.swift").write_text("// synthetic")
     monkeypatch.setattr(doctor, "_helper_candidates", lambda name: [tmp_path / name])
+    monkeypatch.setattr(doctor, "_helper_sources", lambda name: [tmp_path / f"{name}.swift"])
     monkeypatch.setattr(doctor.shutil, "which", lambda name: "/usr/bin/swiftc")
 
     checks = doctor.check_helpers()
 
     assert all(c.status == "warn" for c in checks)
-    assert all("first capture" in c.detail for c in checks)
+    assert all("installer" in c.detail for c in checks)
     assert not any((tmp_path / name).exists() for name in ("mac-ax-helper", "mac-ax-watcher"))
 
 
@@ -235,12 +237,44 @@ def test_helpers_bundled_source_without_swiftc_fails(
     for name in ("mac-ax-helper", "mac-ax-watcher"):
         (tmp_path / f"{name}.swift").write_text("// synthetic")
     monkeypatch.setattr(doctor, "_helper_candidates", lambda name: [tmp_path / name])
+    monkeypatch.setattr(doctor, "_helper_sources", lambda name: [tmp_path / f"{name}.swift"])
     monkeypatch.setattr(doctor.shutil, "which", lambda name: None)
 
     checks = doctor.check_helpers()
 
     assert all(c.status == "fail" for c in checks)
     assert all("Command Line Tools" in c.detail for c in checks)
+
+
+def test_doctor_ignores_historical_helper_cache_and_never_compiles(
+    ac_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from persome.capture import ax_capture
+
+    for name in ("mac-ax-helper", "mac-ax-watcher"):
+        _make_exec(ac_root / "native" / "historical-digest" / name)
+        (tmp_path / f"{name}.swift").write_text("// current source", encoding="utf-8")
+    monkeypatch.setattr(
+        doctor,
+        "_helper_sources",
+        lambda name: [tmp_path / f"{name}.swift"],
+    )
+    monkeypatch.setattr(doctor.shutil, "which", lambda name: "/usr/bin/swiftc")
+    monkeypatch.setattr(doctor.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(
+        ax_capture,
+        "_maybe_compile",
+        lambda *args, **kwargs: pytest.fail("doctor must never compile or write helpers"),
+    )
+
+    checks = doctor.check_helpers(CaptureConfig())
+    trust = doctor.check_ax_trust(CaptureConfig())
+
+    assert all(check.status == "warn" for check in checks)
+    assert trust.status == "fail"
+    assert not any(
+        path.parent.name != "historical-digest" for path in (ac_root / "native").glob("*/*")
+    )
 
 
 # ── AX trust ──────────────────────────────────────────────────────────────────
@@ -250,7 +284,12 @@ def test_ax_trust_granted_ok(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(doctor.platform, "system", lambda: "Darwin")
     import persome.capture.ax_capture as ax_capture
 
-    monkeypatch.setattr(ax_capture, "ax_trusted", lambda: True)
+    monkeypatch.setattr(
+        doctor,
+        "_configured_helper_path",
+        lambda name, env_var: Path("/synthetic") / name,
+    )
+    monkeypatch.setattr(ax_capture, "_binary_ax_trusted", lambda path: True)
     assert doctor.check_ax_trust().status == "ok"
 
 
@@ -258,7 +297,12 @@ def test_ax_trust_denied_fails(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(doctor.platform, "system", lambda: "Darwin")
     import persome.capture.ax_capture as ax_capture
 
-    monkeypatch.setattr(ax_capture, "ax_trusted", lambda: False)
+    monkeypatch.setattr(
+        doctor,
+        "_configured_helper_path",
+        lambda name, env_var: Path("/synthetic") / name,
+    )
+    monkeypatch.setattr(ax_capture, "_binary_ax_trusted", lambda path: False)
     c = doctor.check_ax_trust()
     assert c.status == "fail"
     assert "Accessibility" in c.detail
@@ -268,10 +312,15 @@ def test_ax_trust_probe_error_warns_unknown(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setattr(doctor.platform, "system", lambda: "Darwin")
     import persome.capture.ax_capture as ax_capture
 
-    def boom() -> bool:
+    def boom(path: Path) -> bool:
         raise RuntimeError("no TCC")
 
-    monkeypatch.setattr(ax_capture, "ax_trusted", boom)
+    monkeypatch.setattr(
+        doctor,
+        "_configured_helper_path",
+        lambda name, env_var: Path("/synthetic") / name,
+    )
+    monkeypatch.setattr(ax_capture, "_binary_ax_trusted", boom)
     c = doctor.check_ax_trust()
     assert c.status == "warn"
     assert "unknown" in c.detail
@@ -282,6 +331,28 @@ def test_ax_trust_non_macos_warns_unknown(monkeypatch: pytest.MonkeyPatch) -> No
     c = doctor.check_ax_trust()
     assert c.status == "warn"
     assert "unknown" in c.detail
+
+
+def test_ingest_mode_skips_daemon_tcc_and_helper_probes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    capture = CaptureConfig(source="ingest")
+    import persome.capture.ax_capture as ax_capture
+
+    monkeypatch.setattr(
+        ax_capture,
+        "_binary_ax_trusted",
+        lambda path: pytest.fail("ingest must not probe daemon Accessibility"),
+    )
+    monkeypatch.setattr(
+        screen_recording,
+        "has_screen_recording",
+        lambda: pytest.fail("ingest must not probe daemon Screen Recording"),
+    )
+
+    assert doctor.check_ax_trust(capture).status == "ok"
+    assert doctor.check_screen_recording(capture).status == "ok"
+    assert all(check.status == "ok" for check in doctor.check_helpers(capture))
 
 
 # ── Screen Recording + local OCR ─────────────────────────────────────────────
@@ -358,8 +429,23 @@ def test_root_unwritable_fails(ac_root: Path, monkeypatch: pytest.MonkeyPatch) -
     def boom(*a: object, **kw: object) -> None:
         raise OSError(13, "Permission denied")
 
-    monkeypatch.setattr(paths, "atomic_write_private_text", boom)
+    monkeypatch.setattr(doctor.tempfile, "mkstemp", boom)
     assert doctor.check_root_writable().status == "fail"
+
+
+def test_root_initialization_failure_is_reported(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def boom(*a: object, **kw: object) -> None:
+        raise RuntimeError("unsafe data root")
+
+    monkeypatch.setattr(doctor.paths, "ensure_private_dir", boom)
+
+    check = doctor.check_root_writable()
+
+    assert check.status == "fail"
+    assert str(paths.root()) in check.detail
+    assert "unsafe data root" in check.detail
 
 
 def test_root_writable_probe_does_not_follow_symlink(ac_root: Path) -> None:
@@ -372,6 +458,11 @@ def test_root_writable_probe_does_not_follow_symlink(ac_root: Path) -> None:
     assert doctor.check_root_writable().status == "ok"
     assert victim.read_text(encoding="utf-8") == "ORIGINAL"
     assert victim.stat().st_mode & 0o777 == 0o644
+
+
+def test_root_writable_probe_is_unlinked_before_write(ac_root: Path) -> None:
+    assert doctor.check_root_writable().status == "ok"
+    assert not list(paths.root().glob(".doctor-write-probe.*"))
 
 
 # ── port ──────────────────────────────────────────────────────────────────────
@@ -406,11 +497,12 @@ def test_port_taken_by_our_daemon_ok(ac_root: Path, monkeypatch: pytest.MonkeyPa
     assert "12345" in c.detail
 
 
-def test_running_daemon_pid_reads_pid_file(ac_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_running_daemon_pid_rejects_unverified_pid_file(ac_root: Path) -> None:
     import os
 
-    paths.pid_file().write_text(str(os.getpid()))  # our own pid is always alive
-    assert doctor._running_daemon_pid() == os.getpid()
+    # A live PID is not enough: it must resolve to this user's Persome daemon.
+    paths.pid_file().write_text(str(os.getpid()))
+    assert doctor._running_daemon_pid() is None
     paths.pid_file().write_text("not-a-pid")
     assert doctor._running_daemon_pid() is None
 

--- a/tests/test_launchagent.py
+++ b/tests/test_launchagent.py
@@ -7,15 +7,25 @@ path and ``subprocess.run`` are redirected/monkeypatched.
 
 from __future__ import annotations
 
+import json
+import os
 import plistlib
 import signal
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
 from typer.testing import CliRunner
 
-from persome import cli, launchagent, paths
+from persome import cli, launchagent, paths, runtime_pid
+
+
+@pytest.fixture(autouse=True)
+def ready_fake_launchagent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install unit tests never wait on the user's real launchd namespace."""
+
+    monkeypatch.setattr(launchagent, "_wait_for_owned_runtime", lambda binary, timeout=15: True)
 
 
 def test_label_matches_runtime_contract() -> None:
@@ -32,6 +42,41 @@ def test_gui_domain_target_shape() -> None:
     target = launchagent.gui_domain_target()
     assert target.startswith("gui/")
     assert target.endswith(f"/{launchagent.LABEL}")
+
+
+def test_loaded_job_parses_launchd_cached_program_and_pid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = """
+    program = /Applications/Persome.app/Contents/MacOS/Persome Backend
+    state = running
+    pid = 4242
+    """
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda args, **kwargs: subprocess.CompletedProcess(args, 0, output, ""),
+    )
+
+    assert launchagent.loaded_job() == launchagent.LoadedJob(
+        4242,
+        "/Applications/Persome.app/Contents/MacOS/Persome Backend",
+    )
+
+
+def test_loaded_job_requires_a_live_pid(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda args, **kwargs: subprocess.CompletedProcess(
+            args,
+            0,
+            "program = /tmp/persome\nstate = waiting\n",
+            "",
+        ),
+    )
+
+    assert launchagent.loaded_job() is None
 
 
 def test_build_plist_core_fields(ac_root: Path) -> None:
@@ -122,6 +167,87 @@ def test_install_reloads_when_already_loaded(
     assert verbs == ["bootout"] * len(launchagent.LEGACY_LABELS) + ["bootout", "bootstrap"]
 
 
+def test_install_keeps_already_loaded_matching_generation(
+    ac_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "LaunchAgents" / "com.persome.runtime.plist"
+    monkeypatch.setattr(launchagent, "plist_path", lambda: target)
+    monkeypatch.setattr(launchagent, "is_loaded", lambda: True)
+    launchagent.write_plist("/usr/local/bin/persome")
+    monkeypatch.setattr(launchagent, "owns_recorded_runtime", lambda binary: True)
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda args, **kwargs: calls.append(args) or subprocess.CompletedProcess(args, 0, "", ""),
+    )
+
+    assert launchagent.install("/usr/local/bin/persome") == target
+    assert calls == []
+
+
+def test_install_restarts_loaded_job_when_no_owned_generation_exists(
+    ac_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "LaunchAgents" / "com.persome.runtime.plist"
+    monkeypatch.setattr(launchagent, "plist_path", lambda: target)
+    launchagent.write_plist("/usr/local/bin/persome")
+    monkeypatch.setattr(launchagent, "is_loaded", lambda: True)
+    monkeypatch.setattr(launchagent, "owns_recorded_runtime", lambda binary: False)
+    monkeypatch.setattr(launchagent, "_terminate_stray_daemon", lambda: None)
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda args, **kwargs: calls.append(args) or subprocess.CompletedProcess(args, 0, "", ""),
+    )
+
+    launchagent.install("/usr/local/bin/persome")
+
+    assert [command[1] for command in calls] == ["bootout", "bootstrap"]
+
+
+def test_install_fails_when_launchctl_bootstrap_fails(
+    ac_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "LaunchAgents" / "com.persome.runtime.plist"
+    monkeypatch.setattr(launchagent, "plist_path", lambda: target)
+    monkeypatch.setattr(launchagent, "is_loaded", lambda: False)
+    monkeypatch.setattr(launchagent, "_terminate_stray_daemon", lambda: None)
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda args, **kwargs: subprocess.CompletedProcess(args, 5, "", "denied"),
+    )
+
+    with pytest.raises(RuntimeError, match="denied"):
+        launchagent.install("/usr/local/bin/persome")
+
+    assert not paths.launchagent_owner_file().exists()
+
+
+def test_install_fails_when_loaded_job_never_owns_the_daemon_generation(
+    ac_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "LaunchAgents" / "com.persome.runtime.plist"
+    monkeypatch.setattr(launchagent, "plist_path", lambda: target)
+    monkeypatch.setattr(launchagent, "is_loaded", lambda: False)
+    monkeypatch.setattr(launchagent, "_terminate_stray_daemon", lambda: None)
+    monkeypatch.setattr(launchagent, "_wait_for_owned_runtime", lambda binary, timeout=15: False)
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda args, **kwargs: calls.append(args) or subprocess.CompletedProcess(args, 0, "", ""),
+    )
+
+    with pytest.raises(RuntimeError, match="matching daemon generation"):
+        launchagent.install("/usr/local/bin/persome")
+
+    assert [command[1] for command in calls] == ["bootstrap", "bootout"]
+    assert not paths.launchagent_owner_file().exists()
+
+
 def test_uninstall_boots_out_and_removes_plist(
     ac_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -187,44 +313,62 @@ def test_cli_uninstall_invokes_module(ac_root: Path, monkeypatch: pytest.MonkeyP
 def test_terminate_stray_ignores_missing_pidfile(
     ac_root: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    sent: list[tuple[int, int]] = []
-    monkeypatch.setattr(launchagent.os, "kill", lambda pid, sig: sent.append((pid, sig)))
+    waited: list[runtime_pid.ProcessIdentity] = []
+    monkeypatch.setattr(runtime_pid, "signal_recorded_process", lambda _sig: None)
+    monkeypatch.setattr(
+        runtime_pid, "wait_for_exit", lambda process, _timeout: waited.append(process)
+    )
     launchagent._terminate_stray_daemon()
-    assert sent == []  # no pid file → nothing to signal
+    assert waited == []  # no verified process → nothing to wait for
 
 
 def test_terminate_stray_ignores_dead_pid(ac_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    paths.pid_file().parent.mkdir(parents=True, exist_ok=True)
-    paths.pid_file().write_text("999999")
-    probed: list[int] = []
-
-    def fake_kill(pid: int, sig: int) -> None:
-        probed.append(sig)
-        raise ProcessLookupError  # already gone
-
-    monkeypatch.setattr(launchagent.os, "kill", fake_kill)
+    waited: list[runtime_pid.ProcessIdentity] = []
+    monkeypatch.setattr(runtime_pid, "signal_recorded_process", lambda _sig: None)
+    monkeypatch.setattr(
+        runtime_pid, "wait_for_exit", lambda process, _timeout: waited.append(process)
+    )
     launchagent._terminate_stray_daemon()
-    assert probed == [0]  # only the liveness probe; never reached SIGTERM
+    assert waited == []
 
 
 def test_terminate_stray_sigterms_live_pid(ac_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    paths.pid_file().parent.mkdir(parents=True, exist_ok=True)
-    paths.pid_file().write_text("4242")
+    process = runtime_pid.ProcessIdentity(
+        pid=4242,
+        uid=os.getuid(),
+        started_at=time.time() - 10,
+        command="/tmp/example/.persome/venv/bin/persome start --foreground",
+    )
     sent: list[int] = []
-    state = {"alive": True}
+    waited: list[tuple[runtime_pid.ProcessIdentity, float]] = []
 
-    def fake_kill(pid: int, sig: int) -> None:
-        if sig == 0:  # liveness probe
-            if not state["alive"]:
-                raise ProcessLookupError
-            return
+    def fake_signal(sig: int) -> runtime_pid.ProcessIdentity:
         sent.append(sig)
-        state["alive"] = False  # dies after SIGTERM
+        return process
 
-    monkeypatch.setattr(launchagent.os, "kill", fake_kill)
-    monkeypatch.setattr(launchagent.time, "sleep", lambda _: None)
-    launchagent._terminate_stray_daemon()
+    monkeypatch.setattr(runtime_pid, "signal_recorded_process", fake_signal)
+    monkeypatch.setattr(
+        runtime_pid,
+        "wait_for_exit",
+        lambda identity, timeout: waited.append((identity, timeout)) or True,
+    )
+    launchagent._terminate_stray_daemon(timeout=3.0)
     assert sent == [signal.SIGTERM]
+    assert waited == [(process, 3.0)]
+
+
+def test_terminate_stray_rejects_ambiguous_live_runtime(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(runtime_pid, "signal_recorded_process", lambda _sig: None)
+    monkeypatch.setattr(
+        runtime_pid,
+        "unresolved_runtime_reason",
+        lambda: "live Persome Runtime pid 4242 has an invalid generation receipt",
+    )
+
+    with pytest.raises(RuntimeError, match="refusing|invalid generation"):
+        launchagent._terminate_stray_daemon()
 
 
 def test_install_terminates_stray_before_bootstrap(
@@ -245,3 +389,277 @@ def test_install_terminates_stray_before_bootstrap(
     # Stray daemon is killed BEFORE the fresh job is bootstrapped (the legacy
     # label sweep records its bootout verbs first).
     assert order == ["bootout"] * len(launchagent.LEGACY_LABELS) + ["terminate", "bootstrap"]
+
+
+# ── Runtime PID identity: never signal a stale or unrelated PID ──────────
+
+
+def _identity(
+    pid: int = 4242,
+    *,
+    uid: int | None = None,
+    started_at: float | None = None,
+    command: str = "/tmp/example/.persome/venv/bin/persome start --foreground",
+) -> runtime_pid.ProcessIdentity:
+    return runtime_pid.ProcessIdentity(
+        pid=pid,
+        uid=os.getuid() if uid is None else uid,
+        started_at=time.time() - 10 if started_at is None else started_at,
+        command=command,
+    )
+
+
+@pytest.mark.parametrize("raw", ["0", "-1", "1"])
+def test_runtime_pid_rejects_unsafe_pid_values(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch, raw: str
+) -> None:
+    paths.pid_file().write_text(raw)
+    inspected: list[int] = []
+    signalled: list[tuple[int, int]] = []
+    monkeypatch.setattr(runtime_pid, "inspect_process", lambda pid: inspected.append(pid))
+    monkeypatch.setattr(runtime_pid.os, "kill", lambda pid, sig: signalled.append((pid, sig)))
+
+    assert runtime_pid.resolve_recorded_process() is None
+    assert runtime_pid.signal_recorded_process(signal.SIGTERM) is None
+    assert inspected == []
+    assert signalled == []
+
+
+def test_runtime_pid_rejects_unrelated_same_user_process(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths.pid_file().write_text("4242")
+    unrelated = _identity(command="/usr/bin/python3 /tmp/report-worker.py")
+    monkeypatch.setattr(runtime_pid, "inspect_process", lambda _pid: unrelated)
+    signalled: list[tuple[int, int]] = []
+    monkeypatch.setattr(runtime_pid.os, "kill", lambda pid, sig: signalled.append((pid, sig)))
+
+    assert runtime_pid.signal_recorded_process(signal.SIGTERM) is None
+    assert signalled == []
+
+
+def test_runtime_pid_rejects_process_owned_by_another_user(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths.pid_file().write_text("4242")
+    monkeypatch.setattr(runtime_pid, "inspect_process", lambda _pid: _identity(uid=os.getuid() + 1))
+    monkeypatch.setattr(
+        runtime_pid.os,
+        "kill",
+        lambda _pid, _sig: pytest.fail("must not signal another user's process"),
+    )
+
+    assert runtime_pid.signal_recorded_process(signal.SIGTERM) is None
+
+
+def test_legacy_runtime_pid_rejects_pid_reused_after_pidfile(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths.pid_file().write_text("4242")
+    os.utime(paths.pid_file(), (1_000.0, 1_000.0))
+    reused = _identity(started_at=1_001.0)
+    monkeypatch.setattr(runtime_pid, "inspect_process", lambda _pid: reused)
+    monkeypatch.setattr(
+        runtime_pid.os,
+        "kill",
+        lambda _pid, _sig: pytest.fail("must not signal a process newer than the pid file"),
+    )
+
+    assert runtime_pid.signal_recorded_process(signal.SIGTERM) is None
+
+
+def test_versioned_runtime_pid_rejects_reused_identity(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    expected = _identity(started_at=1_000.0)
+    paths.pid_file().write_text(
+        json.dumps(
+            {
+                "version": runtime_pid.PID_FILE_VERSION,
+                "pid": expected.pid,
+                "uid": expected.uid,
+                "started_at": expected.started_at,
+                "command": expected.command,
+                "generation": "a" * 32,
+            }
+        )
+    )
+    monkeypatch.setattr(runtime_pid, "inspect_process", lambda _pid: _identity(started_at=2_000.0))
+    monkeypatch.setattr(
+        runtime_pid.os,
+        "kill",
+        lambda _pid, _sig: pytest.fail("must not signal a reused versioned PID"),
+    )
+
+    assert runtime_pid.signal_recorded_process(signal.SIGTERM) is None
+
+
+def test_runtime_pid_revalidates_identity_immediately_before_signal(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths.pid_file().write_text("4242")
+    first = _identity()
+    reused = _identity(started_at=first.started_at + 1)
+    inspections = iter([first, reused])
+    monkeypatch.setattr(runtime_pid, "inspect_process", lambda _pid: next(inspections))
+    monkeypatch.setattr(
+        runtime_pid.os,
+        "kill",
+        lambda _pid, _sig: pytest.fail("must not signal after identity changes"),
+    )
+
+    assert runtime_pid.signal_recorded_process(signal.SIGTERM) is None
+
+
+def test_runtime_pid_signals_verified_legacy_daemon(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths.pid_file().write_text("4242")
+    process = _identity()
+    monkeypatch.setattr(runtime_pid, "inspect_process", lambda _pid: process)
+    signalled: list[tuple[int, int]] = []
+    monkeypatch.setattr(runtime_pid.os, "kill", lambda pid, sig: signalled.append((pid, sig)))
+
+    resolved = runtime_pid.signal_recorded_process(signal.SIGTERM)
+
+    assert resolved == process
+    assert signalled == [(4242, signal.SIGTERM)]
+
+
+def test_wait_for_exit_treats_pid_reuse_as_original_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    original = _identity()
+    monkeypatch.setattr(
+        runtime_pid,
+        "inspect_process",
+        lambda _pid: _identity(started_at=original.started_at + 1),
+    )
+
+    assert runtime_pid.wait_for_exit(original, timeout=1.0) is True
+
+
+def test_versioned_pid_file_roundtrips_current_identity(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    current = _identity(pid=os.getpid())
+    monkeypatch.setattr(runtime_pid, "inspect_process", lambda _pid: current)
+
+    assert runtime_pid.write_current_process(generation="a" * 32) == current
+    record = runtime_pid.read_pid_file()
+    assert record is not None
+    assert record.legacy is False
+    assert record.pid == current.pid
+    assert record.uid == current.uid
+    assert record.started_at == current.started_at
+    assert record.command == current.command
+    assert record.generation == "a" * 32
+
+
+def test_runtime_generation_is_pinned_across_signal_revalidation(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths.pid_file().write_text("4242")
+    process = _identity()
+    now = time.time()
+    paths.runtime_state_file().write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "pid": process.pid,
+                "generation": "a" * 32,
+                "started_at": now - 5,
+                "updated_at": now,
+            }
+        )
+    )
+    monkeypatch.setattr(runtime_pid, "inspect_process", lambda _pid: process)
+    states = iter(
+        [
+            runtime_pid.RuntimeGeneration(process.pid, "a" * 32, now - 5, now),
+            runtime_pid.RuntimeGeneration(process.pid, "b" * 32, now - 4, now),
+        ]
+    )
+    monkeypatch.setattr(runtime_pid, "read_runtime_generation", lambda _path=None: next(states))
+    monkeypatch.setattr(
+        runtime_pid.os,
+        "kill",
+        lambda _pid, _sig: pytest.fail("must not signal a different daemon generation"),
+    )
+
+    assert runtime_pid.signal_recorded_process(signal.SIGTERM) is None
+
+
+def test_runtime_pid_rejects_malformed_generation_sidecar(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths.pid_file().write_text("4242")
+    paths.runtime_state_file().write_text("{}")
+    monkeypatch.setattr(runtime_pid, "inspect_process", lambda _pid: _identity())
+
+    assert runtime_pid.resolve_recorded_process() is None
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "/Applications/Persome.app/Contents/MacOS/Persome Backend start --foreground",
+        "'/Applications/Persome.app/Contents/MacOS/Persome Backend' start --foreground",
+    ],
+)
+def test_runtime_pid_accepts_frozen_desktop_backend_command(command: str) -> None:
+    process = _identity(
+        command=command,
+    )
+    process = runtime_pid.ProcessIdentity(
+        **{
+            **process.__dict__,
+            "executable": "/Applications/Persome.app/Contents/MacOS/Persome Backend",
+        }
+    )
+
+    assert runtime_pid.is_runtime_process(process) is True
+
+
+def test_runtime_pid_rejects_frozen_backend_non_daemon_command() -> None:
+    process = runtime_pid.ProcessIdentity(
+        pid=4242,
+        uid=os.getuid(),
+        started_at=time.time() - 10,
+        command="/Applications/Persome.app/Contents/MacOS/Persome Backend mcp",
+        executable="/Applications/Persome.app/Contents/MacOS/Persome Backend",
+    )
+
+    assert runtime_pid.is_runtime_process(process) is False
+
+
+def test_unresolved_runtime_reason_fails_closed_for_live_daemon_with_bad_sidecar(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths.pid_file().write_text("4242")
+    paths.runtime_state_file().write_text("{}")
+    monkeypatch.setattr(runtime_pid, "inspect_process", lambda _pid: _identity())
+
+    reason = runtime_pid.unresolved_runtime_reason()
+
+    assert reason is not None
+    assert "invalid or stale generation" in reason
+
+
+def test_inspect_process_parses_macos_ps_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    ps_output = (
+        "  501 Sun Jul 12 12:24:49 2026     "
+        "/tmp/example/.persome/venv/bin/python "
+        "/tmp/example/.persome/venv/bin/persome start --foreground\n"
+    )
+    monkeypatch.setattr(
+        runtime_pid.subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0, ps_output, ""),
+    )
+
+    identity = runtime_pid.inspect_process(4242)
+
+    assert identity is not None
+    assert identity.pid == 4242
+    assert identity.uid == 501
+    assert identity.command.endswith("persome start --foreground")
+    assert runtime_pid.is_runtime_command(identity.command)

--- a/tests/test_llm_setup.py
+++ b/tests/test_llm_setup.py
@@ -10,7 +10,7 @@ from typer.testing import CliRunner
 from persome import config, paths
 from persome.cli import app
 from persome.llm_setup import ProbeResult, probe_profile, save_profile
-from persome.providers import LLM_API_KEY_ENV, make_profile
+from persome.providers import LLM_API_KEY_ENV, make_profile, provider_spec
 
 
 def _profile(api_key: str = "synthetic-secret"):  # type: ignore[no-untyped-def]
@@ -240,6 +240,42 @@ def test_rerun_keeps_advanced_route_without_reasking_for_routing(
     assert "Advanced setup" not in rerun.output
     assert "API endpoint" not in rerun.output
     assert "Model id" not in rerun.output
+
+
+def test_declining_current_provider_does_not_auto_select_it_again(
+    ac_root: Path, monkeypatch
+) -> None:  # type: ignore[no-untyped-def]
+    paths.config_file().write_text(
+        """
+[models.default]
+provider = "anthropic"
+protocol = "anthropic"
+model = "claude-sonnet-4-5"
+base_url = "https://api.anthropic.com"
+api_key_env = "PERSOME_LLM_API_KEY"
+""",
+        encoding="utf-8",
+    )
+    paths.env_file().write_text(f"{LLM_API_KEY_ENV}=anthropic-secret\n", encoding="utf-8")
+    paths.env_file().chmod(0o600)
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-secret")
+    monkeypatch.setattr("persome.cli._interactive_terminal", lambda: True)
+    anthropic = provider_spec("anthropic")
+    assert anthropic is not None
+    monkeypatch.setattr("persome.providers.detected_providers", lambda: [anthropic])
+
+    result = CliRunner().invoke(
+        app,
+        ["llm", "setup", "--skip-check"],
+        input="n\n2\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Found an existing Anthropic API key" not in result.output
+    assert "Choose the LLM provider Persome should use" in result.output
+    selected = config.load().model_for("default")
+    assert selected.provider == "openai"
+    assert paths.env_file().read_text() == f"{LLM_API_KEY_ENV}=openai-secret\n"
 
 
 def test_provider_list_hides_routing_details_by_default(ac_root: Path) -> None:

--- a/tests/test_llm_setup.py
+++ b/tests/test_llm_setup.py
@@ -278,6 +278,38 @@ api_key_env = "PERSOME_LLM_API_KEY"
     assert paths.env_file().read_text() == f"{LLM_API_KEY_ENV}=openai-secret\n"
 
 
+def test_declining_regional_provider_never_auto_switches_to_shared_key_variant(
+    ac_root: Path, monkeypatch
+) -> None:  # type: ignore[no-untyped-def]
+    paths.config_file().write_text(
+        """
+[models.default]
+provider = "qwen-cn"
+protocol = "openai"
+model = "qwen-plus"
+base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+api_key_env = "PERSOME_LLM_API_KEY"
+""",
+        encoding="utf-8",
+    )
+    paths.env_file().write_text(f"{LLM_API_KEY_ENV}=qwen-secret\n", encoding="utf-8")
+    paths.env_file().chmod(0o600)
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "qwen-secret")
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-secret")
+    monkeypatch.setattr("persome.cli._interactive_terminal", lambda: True)
+
+    result = CliRunner().invoke(
+        app,
+        ["llm", "setup", "--skip-check"],
+        input="n\n2\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Found an existing Qwen (US) API key" not in result.output
+    assert "Choose the LLM provider Persome should use" in result.output
+    assert config.load().model_for("default").provider == "openai"
+
+
 def test_provider_list_hides_routing_details_by_default(ac_root: Path) -> None:
     runner = CliRunner()
 

--- a/tests/test_local_api_auth.py
+++ b/tests/test_local_api_auth.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from persome.api import build_api_app
+from persome.api import routes as routes_mod
 from persome.config import Config
 from persome.mcp.server import build_server, endpoint_url
 from persome.security.auth import (
@@ -88,20 +89,25 @@ def test_health_is_public_but_missing_token_closes_protected_rest(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv(LOCAL_API_TOKEN_ENV, raising=False)
-    client = TestClient(build_api_app(), headers={"host": "127.0.0.1:8742"})
+    cfg = Config()
+    routes_mod.set_config(cfg)
+    client = TestClient(build_api_app(cfg), headers={"host": "127.0.0.1:8742"})
 
     health = client.get("/health")
     protected = client.get("/openapi.json")
+    onboarding_capture = client.post("/_onboarding/capture")
 
     assert health.status_code == 200
     assert health.json()["data"]["status"] == "ok"
     assert "ocr" in health.json()["data"]
     assert protected.status_code == 503
+    assert onboarding_capture.status_code == 503
     assert protected.headers["connection"] == "close"
     assert protected.json() == {
         "success": False,
         "error": "local API authentication is not configured",
     }
+    routes_mod.set_config(None)
 
 
 def test_unauthorized_rejection_closes_unread_request_body(

--- a/tests/test_ocr_onboarding.py
+++ b/tests/test_ocr_onboarding.py
@@ -55,6 +55,31 @@ def test_health_reports_disabled_without_hiding_runtime_state(
     assert health.models_available is True
 
 
+def test_screen_recording_probe_fails_closed_when_coregraphics_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(screen_recording.sys, "platform", "darwin")
+    monkeypatch.setattr(screen_recording, "_resolved", True)
+    monkeypatch.setattr(screen_recording, "_cg", None)
+
+    assert screen_recording.has_screen_recording() is False
+    assert screen_recording.request_screen_recording() is False
+
+
+def test_screen_recording_probe_fails_closed_when_preflight_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class BrokenCoreGraphics:
+        @staticmethod
+        def CGPreflightScreenCaptureAccess() -> bool:
+            raise OSError("probe failed")
+
+    monkeypatch.setattr(screen_recording.sys, "platform", "darwin")
+    monkeypatch.setattr(screen_recording, "_coregraphics", lambda: BrokenCoreGraphics())
+
+    assert screen_recording.has_screen_recording() is False
+
+
 def test_save_ocr_config_preserves_other_capture_fields(tmp_path: Path) -> None:
     path = tmp_path / "config.toml"
     path.write_text("[capture]\ninterval_minutes = 7\n", encoding="utf-8")

--- a/tests/test_ocr_subprocess.py
+++ b/tests/test_ocr_subprocess.py
@@ -119,8 +119,10 @@ class TestCrashContainment:
         client = ocr_subprocess.OCRWorkerClient(spawn=_spawn, timeout=10)
         try:
             assert client.recognize_detailed(_JPEG, "tiny") is None  # crash → fail open
+            assert client.state() == "failed"
             # respawn: fresh worker handles the next request normally
             assert client.recognize_detailed(_JPEG, "tiny") == (["ok:tiny"], [[1, 2, 3, 4]], [0.9])
+            assert client.state() == "ready"
         finally:
             client.shutdown()
 
@@ -152,9 +154,11 @@ class TestWarm:
         client = ocr_subprocess.OCRWorkerClient(spawn=_spawner(_ECHO), timeout=10)
         try:
             assert client.warm("tiny") is True
+            assert client.state() == "ready"
             assert client._proc is not None and client._proc.poll() is None
         finally:
             client.shutdown()
+        assert client.state() == "not_started"
 
     def test_cold_start_has_a_separate_timeout(self) -> None:
         client = ocr_subprocess.OCRWorkerClient(timeout=20, startup_timeout=120)
@@ -207,6 +211,21 @@ class TestRouting:
         monkeypatch.delenv("PERSOME_OCR_IN_PROCESS", raising=False)
         monkeypatch.setenv("PERSOME_OCR_WORKER", "1")
         assert ocr_local._use_isolation() is False
+
+
+def test_worker_state_listener_receives_runtime_transitions() -> None:
+    seen: list[str] = []
+    client = ocr_subprocess.OCRWorkerClient(spawn=lambda: pytest.fail("no worker needed"))
+    ocr_subprocess.set_state_listener(seen.append)
+    seen.clear()  # discard the singleton's current-state registration receipt
+    try:
+        client._set_state("warming")
+        client._set_state("ready")
+        client._set_state("failed")
+    finally:
+        ocr_subprocess.set_state_listener(None)
+
+    assert seen == ["warming", "ready", "failed"]
 
 
 @pytest.mark.integration

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -4,13 +4,26 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
+import httpx
 import pytest
 from typer.testing import CliRunner
 
-from persome import config, onboarding, paths
-from persome.capture import ocr_health, ocr_local, screen_recording
+from persome import config, launchagent, onboarding, paths
+from persome.capture import ax_capture, ocr_health, ocr_local, scheduler, screen_recording, watcher
 from persome.cli import app
+
+
+@pytest.fixture(autouse=True)
+def no_real_launchagent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unit onboarding must never depend on or mutate the user's launchd job."""
+
+    monkeypatch.setattr(onboarding, "_launchagent_is_loaded", lambda: False)
+    monkeypatch.setattr(launchagent, "owner_intended", lambda: False)
+    monkeypatch.setattr(launchagent, "configured_runtime_binary", lambda: "/fake/persome")
+    monkeypatch.setattr(launchagent, "owns_recorded_runtime", lambda binary: True)
+    monkeypatch.setattr(scheduler, "capture_gate_reason", lambda capture: None)
 
 
 class ScriptedUI:
@@ -79,19 +92,110 @@ def test_permission_flow_cancellation_is_a_hard_stop() -> None:
         )
 
 
-def test_local_ocr_is_saved_only_after_permission_and_worker_proof(
+def test_accessibility_requests_each_actual_native_principal_separately(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    watcher_binary = tmp_path / "mac-ax-watcher"
+    state = {"helper": False, "watcher": False}
+    ui = ScriptedUI()
+    monkeypatch.setattr(
+        ax_capture,
+        "ax_trusted",
+        lambda **kwargs: state["helper"],
+    )
+    monkeypatch.setattr(
+        ax_capture,
+        "request_accessibility_permission",
+        lambda **kwargs: state.__setitem__("helper", True) or True,
+    )
+    monkeypatch.setattr(watcher, "_resolve_watcher_path", lambda: watcher_binary)
+    monkeypatch.setattr(
+        ax_capture,
+        "_binary_ax_trusted",
+        lambda binary: state["watcher"] if binary == watcher_binary else False,
+    )
+    monkeypatch.setattr(
+        watcher,
+        "request_accessibility_permission",
+        lambda: state.__setitem__("watcher", True) or True,
+    )
+
+    assert onboarding.ensure_accessibility(ui, event_driven=True) is True
+    assert ui.confirmed == [
+        "Request Capture Helper Accessibility",
+        "Request Event Watcher Accessibility",
+    ]
+
+
+def test_accessibility_skips_watcher_when_event_driven_capture_is_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(ax_capture, "ax_trusted", lambda **kwargs: True)
+    monkeypatch.setattr(
+        watcher,
+        "_resolve_watcher_path",
+        lambda: pytest.fail("disabled watcher must not become a permission principal"),
+    )
+
+    assert onboarding.ensure_accessibility(ScriptedUI(), event_driven=False) is False
+
+
+def test_permission_dialog_timeout_falls_back_to_visible_terminal_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(onboarding.sys, "platform", "darwin")
+    monkeypatch.setattr(onboarding.shutil, "which", lambda name: "/usr/bin/osascript")
+    seen: dict[str, object] = {}
+
+    def timeout(command: list[str], **kwargs: object) -> None:
+        seen.update(command=command, kwargs=kwargs)
+        raise subprocess.TimeoutExpired(command, kwargs["timeout"])
+
+    monkeypatch.setattr(onboarding.subprocess, "run", timeout)
+    monkeypatch.setattr(onboarding.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda prompt: "n")
+
+    accepted = onboarding.OnboardingUI().confirm(
+        title="Permission", message="Explain it.", action="Request Accessibility"
+    )
+
+    assert accepted is False
+    assert seen["kwargs"]["timeout"] == 300  # type: ignore[index]
+
+
+def test_non_tty_missing_permission_fails_fast(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(onboarding.sys.stdin, "isatty", lambda: False)
+    ui = onboarding.OnboardingUI(gui=False)
+
+    with pytest.raises(onboarding.OnboardingCancelled, match="was cancelled"):
+        onboarding._ensure_permission(
+            label="Accessibility",
+            check=lambda: False,
+            request=lambda: False,
+            open_settings=lambda: None,
+            ui=ui,
+            explanation="Synthetic explanation.",
+        )
+
+
+def test_local_ocr_prerequisites_are_saved_before_daemon_worker_proof(
     ac_root: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(ocr_local, "disabled_by_environment", lambda: False)
     monkeypatch.setattr(ocr_local, "runtime_available", lambda: True)
     monkeypatch.setattr(ocr_local, "models_available", lambda tier: tier == "tiny")
-    monkeypatch.setattr(ocr_local, "warm", lambda tier: tier == "tiny")
+    monkeypatch.setattr(
+        ocr_local,
+        "warm",
+        lambda tier: pytest.fail("onboarding must warm only the daemon-owned worker"),
+    )
     monkeypatch.setattr(screen_recording, "has_screen_recording", lambda: True)
     monkeypatch.setattr(ocr_health.sys, "platform", "darwin")
 
     changed = onboarding.ensure_local_ocr(tier="tiny", ui=ScriptedUI())
 
-    assert changed is True
+    assert changed.config_changed is True
+    assert changed.require_worker is True
     assert config.load().capture.enable_ocr_fallback is True
     assert config.load().capture.ocr_tier == "tiny"
 
@@ -102,24 +206,30 @@ def test_runtime_proof_requires_health_and_fresh_readable_capture(
     capture_path = paths.capture_buffer_dir() / "fresh.json"
     capture_path.parent.mkdir(parents=True, exist_ok=True)
     capture_path.write_text(
-        '{"timestamp":"2026-07-12T00:00:00+00:00","window_meta":{"app_name":"Terminal"}}',
+        '{"timestamp":"2026-07-12T00:00:00+00:00","visible_text":"ready"}',
         encoding="utf-8",
     )
-    calls: list[tuple[str, ...]] = []
-
     monkeypatch.setattr(onboarding, "_running_daemon_pid", lambda: 4242)
     monkeypatch.setattr(
         onboarding,
         "_health_payload",
-        lambda host, port: {"status": "ok", "ocr": "ready"},
+        lambda host, port: {"status": "ok", "ocr": "ready", "ocr_worker": "ready"},
     )
-    monkeypatch.setattr(onboarding, "_latest_capture", lambda: capture_path)
-
-    def fake_cli(*args: str, timeout: float = 180.0) -> subprocess.CompletedProcess[str]:
-        calls.append(args)
-        return subprocess.CompletedProcess(args, 0, "", "")
-
-    monkeypatch.setattr(onboarding, "_run_cli", fake_cli)
+    monkeypatch.setattr(
+        onboarding,
+        "_runtime_permissions",
+        lambda host, port: {"accessibility": "granted", "screen_recording": "granted"},
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "_request_runtime_capture",
+        lambda host, port: onboarding.CaptureRequestProof(capture_path, "daemon", "fresh-capture"),
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "_run_cli",
+        lambda *args, **kwargs: pytest.fail("fresh capture must use the daemon"),
+    )
 
     proof = onboarding.ensure_runtime(restart=False)
 
@@ -127,7 +237,6 @@ def test_runtime_proof_requires_health_and_fresh_readable_capture(
     assert proof.health == "ok"
     assert proof.ocr == "ready"
     assert proof.capture_path == capture_path
-    assert calls == [("capture-once",)]
 
 
 def test_runtime_proof_rejects_degraded_ocr(ac_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -135,11 +244,258 @@ def test_runtime_proof_rejects_degraded_ocr(ac_root: Path, monkeypatch: pytest.M
     monkeypatch.setattr(
         onboarding,
         "_health_payload",
-        lambda host, port: {"status": "degraded", "ocr": "permission_required"},
+        lambda host, port: {
+            "status": "degraded",
+            "ocr": "permission_required",
+            "ocr_worker": "ready",
+        },
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "_runtime_permissions",
+        lambda host, port: {"accessibility": "granted", "screen_recording": "granted"},
     )
 
-    with pytest.raises(onboarding.OnboardingError, match="degraded"):
+    with pytest.raises(onboarding.OnboardingError, match="status=degraded"):
         onboarding.ensure_runtime(restart=False, timeout=0.01)
+
+
+@pytest.mark.parametrize(
+    ("permissions", "missing"),
+    [
+        ({"accessibility": "denied", "screen_recording": "granted"}, "Accessibility"),
+        ({"accessibility": "granted", "screen_recording": "denied"}, "Screen Recording"),
+        (
+            {"accessibility": "denied", "screen_recording": "denied"},
+            "Accessibility and Screen Recording",
+        ),
+    ],
+)
+def test_runtime_proof_rejects_daemon_permission_mismatch(
+    ac_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    permissions: dict[str, str],
+    missing: str,
+) -> None:
+    monkeypatch.setattr(onboarding, "_running_daemon_pid", lambda: 4242)
+    monkeypatch.setattr(
+        onboarding,
+        "_health_payload",
+        lambda host, port: {"status": "ok", "ocr": "ready", "ocr_worker": "ready"},
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "_runtime_permissions",
+        lambda host, port: permissions,
+    )
+
+    with pytest.raises(onboarding.OnboardingError, match=f"does not have {missing}"):
+        onboarding.ensure_runtime(restart=False)
+
+
+def test_failed_stop_cannot_pass_with_old_daemon(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(onboarding, "_running_daemon_pid", lambda: 4242)
+    monkeypatch.setattr(
+        onboarding,
+        "_run_cli",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args, 1, "", "stop failed"),
+    )
+    monkeypatch.setattr(onboarding.time, "sleep", lambda seconds: None)
+
+    with pytest.raises(onboarding.OnboardingError, match="could not be stopped: stop failed"):
+        onboarding.ensure_runtime(restart=True, timeout=0.01)
+
+
+def test_unreachable_existing_daemon_is_restarted(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    capture_path = paths.capture_buffer_dir() / "fresh.json"
+    capture_path.parent.mkdir(parents=True, exist_ok=True)
+    capture_path.write_text(
+        '{"timestamp":"2026-07-12T00:00:00+00:00","visible_text":"ready"}',
+        encoding="utf-8",
+    )
+    state = {"pid": 4242, "health_calls": 0}
+    calls: list[tuple[str, ...]] = []
+
+    monkeypatch.setattr(onboarding, "_running_daemon_pid", lambda: state["pid"])
+
+    def health(host: str, port: int) -> dict[str, str] | None:
+        state["health_calls"] += 1
+        if state["health_calls"] == 1:
+            return None
+        return {"status": "ok", "ocr": "ready", "ocr_worker": "ready"}
+
+    def cli(*args: str, timeout: float = 180.0) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        if args[0] == "stop":
+            state["pid"] = None
+        elif args[0] == "start":
+            state["pid"] = 7777
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr(onboarding, "_health_payload", health)
+    monkeypatch.setattr(onboarding, "_run_cli", cli)
+    monkeypatch.setattr(
+        onboarding,
+        "_runtime_permissions",
+        lambda host, port: {"accessibility": "granted", "screen_recording": "granted"},
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "_request_runtime_capture",
+        lambda host, port: onboarding.CaptureRequestProof(capture_path, "daemon", "fresh-capture"),
+    )
+
+    proof = onboarding.ensure_runtime(restart=False)
+
+    assert proof.pid == 7777
+    assert calls == [("stop", "--timeout", "20"), ("start",)]
+
+
+def test_runtime_waits_for_daemon_worker_warming_to_finish(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    capture_path = paths.capture_buffer_dir() / "fresh.json"
+    capture_path.parent.mkdir(parents=True, exist_ok=True)
+    capture_path.write_text(
+        '{"timestamp":"2026-07-12T00:00:00+00:00","visible_text":"ready"}',
+        encoding="utf-8",
+    )
+    states = iter(["warming", "warming", "ready", "ready"])
+    monkeypatch.setattr(onboarding, "_running_daemon_pid", lambda: 4242)
+    monkeypatch.setattr(
+        onboarding,
+        "_health_payload",
+        lambda host, port: {
+            "status": "ok",
+            "ocr": "ready",
+            "ocr_worker": next(states),
+        },
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "_runtime_permissions",
+        lambda host, port: {"accessibility": "granted", "screen_recording": "granted"},
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "_request_runtime_capture",
+        lambda host, port: onboarding.CaptureRequestProof(capture_path, "daemon", "fresh-capture"),
+    )
+    monkeypatch.setattr(onboarding.time, "sleep", lambda seconds: None)
+
+    assert onboarding.ensure_runtime(restart=False).pid == 4242
+
+
+def test_daemon_worker_failure_is_a_hard_stop(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(onboarding, "_running_daemon_pid", lambda: 4242)
+    monkeypatch.setattr(
+        onboarding,
+        "_run_cli",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args, 0, "", ""),
+    )
+    states = iter(["warming", "failed"])
+    monkeypatch.setattr(
+        onboarding,
+        "_health_payload",
+        lambda host, port: {
+            "status": "degraded",
+            "ocr": "ready",
+            "ocr_worker": next(states),
+        },
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "_runtime_permissions",
+        lambda host, port: {"accessibility": "granted", "screen_recording": "granted"},
+    )
+
+    with pytest.raises(onboarding.OnboardingError, match="worker failed"):
+        onboarding.ensure_runtime(restart=False)
+
+
+def test_cli_timeout_is_reported_as_onboarding_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        onboarding.subprocess,
+        "run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            subprocess.TimeoutExpired(args[0], kwargs["timeout"])
+        ),
+    )
+
+    with pytest.raises(onboarding.OnboardingError, match="persome start.*30 seconds"):
+        onboarding._run_cli("start", timeout=30)
+
+
+def test_runtime_capture_receipt_validation(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PERSOME_LOCAL_API_TOKEN", "x" * 32)
+
+    class Response:
+        status_code = 200
+
+        @staticmethod
+        def raise_for_status() -> None:
+            return None
+
+        @staticmethod
+        def json() -> dict:
+            return {
+                "data": {
+                    "id": "../escape",
+                    "mode": "daemon",
+                    "receipt": "fresh-capture",
+                }
+            }
+
+    monkeypatch.setattr(httpx, "post", lambda *args, **kwargs: Response())
+
+    with pytest.raises(onboarding.OnboardingError, match="unsafe.*id"):
+        onboarding._request_runtime_capture("127.0.0.1", 8742)
+
+
+def test_runtime_capture_runner_not_ready_is_retryable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PERSOME_LOCAL_API_TOKEN", "x" * 32)
+
+    class Response:
+        status_code = 503
+
+    monkeypatch.setattr(httpx, "post", lambda *args, **kwargs: Response())
+
+    assert onboarding._request_runtime_capture("127.0.0.1", 8742) is None
+
+
+def test_daemon_onboarding_capture_forces_a_fresh_record_past_dedup(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output = {
+        "timestamp": "2026-07-12T00:00:00+00:00",
+        "window_meta": {"app_name": "Terminal", "title": "Onboarding"},
+        "visible_text": "  ready",
+    }
+    written: list[Path] = []
+    monkeypatch.setattr(scheduler, "_build_capture", lambda cfg, provider, trigger: output)
+
+    def write(_out: dict) -> Path:
+        path = paths.capture_buffer_dir() / f"fresh-{len(written)}.json"
+        written.append(path)
+        return path
+
+    monkeypatch.setattr(scheduler, "_write_capture", write)
+    runner = scheduler._CaptureRunner(config.load().capture, provider=object())
+    scheduler._set_active_runner(runner)
+    try:
+        first = scheduler.capture_now()
+        second = scheduler.capture_now()
+    finally:
+        scheduler._set_active_runner(None)
+
+    assert first != second
+    assert len(written) == 2
 
 
 def test_complete_onboarding_orders_permissions_before_runtime_proof(
@@ -154,22 +510,99 @@ def test_complete_onboarding_orders_permissions_before_runtime_proof(
     monkeypatch.setattr(
         onboarding,
         "ensure_accessibility",
-        lambda active_ui: calls.append("accessibility"),
+        lambda active_ui, *, event_driven: calls.append("accessibility"),
     )
     monkeypatch.setattr(
         onboarding,
         "ensure_local_ocr",
-        lambda tier, ui: calls.append("ocr") or True,
+        lambda tier, ui, preserve_policy, screenshot_permission_required, capture_source: (
+            calls.append("ocr")
+            or onboarding.OCRPolicyProof(True, True, False, tier or "tiny", "ready")
+        ),
     )
     monkeypatch.setattr(
         onboarding,
         "ensure_runtime",
-        lambda restart, ui: calls.append(f"runtime:{restart}") or proof,
+        lambda **kwargs: calls.append(f"runtime:{kwargs['restart']}") or proof,
     )
 
     assert onboarding.onboard() == proof
     assert calls == ["accessibility", "ocr", "runtime:True"]
     assert ui.success_messages
+
+
+def test_invalid_ocr_tier_fails_before_any_permission_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(onboarding.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        onboarding,
+        "ensure_accessibility",
+        lambda *args, **kwargs: pytest.fail("invalid input must not request TCC access"),
+    )
+
+    with pytest.raises(onboarding.OnboardingError, match="unsupported OCR tier"):
+        onboarding.onboard(tier="huge")
+
+
+def test_loaded_but_unowned_launchagent_is_repaired(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owned = {"value": False}
+    installs: list[str] = []
+    monkeypatch.setattr(onboarding, "_launchagent_is_loaded", lambda: True)
+    monkeypatch.setattr(launchagent, "owner_intended", lambda: True)
+    monkeypatch.setattr(launchagent, "configured_runtime_binary", lambda: "/stable/persome")
+    monkeypatch.setattr(
+        launchagent,
+        "owns_recorded_runtime",
+        lambda binary: owned["value"],
+    )
+
+    def install(binary: str) -> Path:
+        installs.append(binary)
+        owned["value"] = True
+        return Path("/tmp/persome.plist")
+
+    monkeypatch.setattr(launchagent, "install", install)
+
+    assert onboarding._select_runtime_owner("any", ui=ScriptedUI()) == "launchagent"
+    assert installs == ["/stable/persome"]
+
+
+def test_runtime_readiness_emits_progress_heartbeat(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = config.Config()
+    ui = ScriptedUI()
+    clock = {"value": 0.0}
+
+    def monotonic() -> float:
+        clock["value"] += 5
+        return clock["value"]
+
+    monkeypatch.setattr(config, "load", lambda *args, **kwargs: cfg)
+    monkeypatch.setattr(scheduler, "capture_gate_reason", lambda capture: None)
+    monkeypatch.setattr(onboarding, "_running_daemon_pid", lambda: 4242)
+    monkeypatch.setattr(
+        onboarding,
+        "_health_payload",
+        lambda host, port: {"status": "starting", "ocr": "ready", "ocr_worker": "warming"},
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "_runtime_permissions",
+        lambda host, port: None,
+    )
+    monkeypatch.setattr(onboarding.time, "monotonic", monotonic)
+    monkeypatch.setattr(onboarding.time, "sleep", lambda seconds: None)
+
+    with pytest.raises(onboarding.OnboardingError, match="did not become fully ready"):
+        onboarding.ensure_runtime(restart=False, timeout=40, ui=ui)
+
+    assert any("Still waiting for Runtime readiness" in line for line in ui.status_messages)
+    assert any("Accessibility: checking" in line for line in ui.status_messages)
+    assert any("Screen Recording: checking" in line for line in ui.status_messages)
 
 
 def test_success_is_printed_and_uses_a_nonblocking_notification(
@@ -196,11 +629,13 @@ def test_cli_onboard_reports_each_completed_gate(
     monkeypatch.setattr(
         onboarding,
         "onboard",
-        lambda tier, gui: onboarding.RuntimeProof(
+        lambda tier, gui, preserve_policy, expected_owner: onboarding.RuntimeProof(
             pid=4242,
             health="ok",
             ocr="ready",
             capture_path=capture_path,
+            accessibility="granted",
+            screen_recording="granted",
         ),
     )
 
@@ -208,9 +643,62 @@ def test_cli_onboard_reports_each_completed_gate(
 
     assert result.exit_code == 0, result.output
     assert "Accessibility granted" in result.output
-    assert "Local OCR and Screen Recording ready" in result.output
+    assert "Screen Recording granted" in result.output
+    assert "Isolated local OCR worker ready" in result.output
     assert "Persome running and healthy" in result.output
     assert "Fresh capture verified" in result.output
+
+
+def test_onboard_help_describes_mode_aware_runtime_proof() -> None:
+    result = CliRunner().invoke(app, ["onboard", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "Runtime ownership" in result.output
+    assert "live readiness" in result.output
+
+
+def test_plain_cli_onboard_forwards_no_tier_override(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seen: dict[str, object] = {}
+
+    def run(**kwargs: object) -> onboarding.RuntimeProof:
+        seen.update(kwargs)
+        return onboarding.RuntimeProof(4242, "ok", "disabled", None, receipt="privacy-paused")
+
+    monkeypatch.setattr(onboarding, "onboard", run)
+
+    result = CliRunner().invoke(app, ["onboard"])
+
+    assert result.exit_code == 0, result.output
+    assert seen["tier"] is None
+    assert seen["expected_owner"] == "any"
+
+
+@pytest.mark.parametrize(
+    ("error_type", "expected"),
+    [
+        (onboarding.OnboardingCancelled, "Onboarding stopped"),
+        (onboarding.OnboardingError, "Onboarding failed"),
+    ],
+)
+def test_cli_onboard_errors_are_visible_and_actionable(
+    ac_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    error_type: type[Exception],
+    expected: str,
+) -> None:
+    monkeypatch.setattr(
+        onboarding,
+        "onboard",
+        lambda **kwargs: (_ for _ in ()).throw(error_type("synthetic reason")),
+    )
+
+    result = CliRunner().invoke(app, ["onboard"])
+
+    assert result.exit_code == 1
+    assert expected in result.output
+    assert "synthetic reason" in result.output
 
 
 def test_installer_runs_strict_onboarding_gate() -> None:
@@ -218,7 +706,785 @@ def test_installer_runs_strict_onboarding_gate() -> None:
 
     assert "run_onboarding()" in script
     assert 'persome" onboard --tier tiny' in script
+    assert 'venv "${VENV_DIR}" --python "${python_target}" --relocatable' in script
     assert script.index("run_onboarding\n") < script.index(
         "print_summary\n", script.index("main()")
     )
     assert 'die "onboarding is incomplete' in script
+
+
+def test_preserve_policy_keeps_explicit_ocr_disable(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = config.Config()
+    cfg.capture.enable_ocr_fallback = False
+    cfg.capture.ocr_tier = "medium"
+    monkeypatch.setattr(config, "load", lambda *args, **kwargs: cfg)
+    monkeypatch.setattr(
+        ocr_local,
+        "runtime_available",
+        lambda: pytest.fail("disabled policy must not start or inspect Paddle"),
+    )
+    monkeypatch.setattr(screen_recording, "has_screen_recording", lambda: True)
+
+    proof = onboarding.ensure_local_ocr(
+        tier="tiny",
+        ui=ScriptedUI(),
+        preserve_policy=True,
+    )
+
+    assert proof == onboarding.OCRPolicyProof(False, False, False, "medium", "disabled")
+    assert cfg.capture.enable_ocr_fallback is False
+    assert cfg.capture.ocr_tier == "medium"
+
+
+def test_preserve_policy_keeps_existing_ocr_tier(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = config.Config()
+    cfg.capture.enable_ocr_fallback = True
+    cfg.capture.ocr_tier = "small"
+    monkeypatch.setattr(config, "load", lambda *args, **kwargs: cfg)
+    monkeypatch.setattr(ocr_local, "disabled_by_environment", lambda: False)
+    monkeypatch.setattr(ocr_local, "runtime_available", lambda: True)
+    monkeypatch.setattr(ocr_local, "models_available", lambda tier: tier == "small")
+    monkeypatch.setattr(screen_recording, "has_screen_recording", lambda: True)
+    monkeypatch.setattr(
+        ocr_health,
+        "inspect",
+        lambda capture: SimpleNamespace(ready=True, state="ready", detail="ready"),
+    )
+
+    proof = onboarding.ensure_local_ocr(
+        tier="tiny",
+        ui=ScriptedUI(),
+        preserve_policy=True,
+    )
+
+    assert proof.tier == "small"
+    assert proof.config_changed is False
+    assert cfg.capture.ocr_tier == "small"
+
+
+def test_fresh_intel_onboarding_uses_supported_ax_only_mode(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = config.Config()
+    monkeypatch.setattr(config, "load", lambda *args, **kwargs: cfg)
+    monkeypatch.setattr(onboarding.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(ocr_local, "runtime_available", lambda: False)
+    monkeypatch.setattr(screen_recording, "has_screen_recording", lambda: True)
+
+    proof = onboarding.ensure_local_ocr(tier="tiny", ui=ScriptedUI())
+
+    assert proof.require_worker is False
+    # The daemon reports its effective disabled policy; the UX separately
+    # explains that Intel has no bundled OCR runtime.
+    assert proof.state == "disabled"
+
+
+def test_plain_repeated_onboarding_preserves_explicit_ocr_opt_out(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = config.Config()
+    cfg.capture.enable_ocr_fallback = False
+    cfg.capture.ocr_policy = "disabled"
+    cfg.capture.ocr_tier = "small"
+    cfg.capture.include_screenshot = False
+    monkeypatch.setattr(config, "load", lambda *args, **kwargs: cfg)
+    monkeypatch.setattr(
+        ocr_local,
+        "runtime_available",
+        lambda: pytest.fail("saved opt-out must not inspect Paddle"),
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "_ensure_permission",
+        lambda **kwargs: pytest.fail("pixel opt-out must not request Screen Recording"),
+    )
+
+    proof = onboarding.ensure_local_ocr(
+        tier=None,
+        ui=ScriptedUI(),
+        preserve_policy=False,
+        screenshot_permission_required=False,
+    )
+
+    assert proof.require_worker is False
+    assert proof.config_changed is False
+    assert proof.state == "disabled"
+    assert proof.tier == "small"
+    assert cfg.capture.enable_ocr_fallback is False
+
+
+def test_ingest_onboarding_skips_daemon_tcc_requests(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = config.Config()
+    cfg.capture.source = "ingest"
+    monkeypatch.setattr(config, "load", lambda *args, **kwargs: cfg)
+    monkeypatch.setattr(onboarding.sys, "platform", "darwin")
+    ui = ScriptedUI()
+    monkeypatch.setattr(onboarding, "OnboardingUI", lambda gui: ui)
+    monkeypatch.setattr(
+        onboarding,
+        "ensure_accessibility",
+        lambda active_ui: pytest.fail("ingest mode does not own Accessibility"),
+    )
+    seen: dict[str, object] = {}
+
+    def ocr_policy(**kwargs: object) -> onboarding.OCRPolicyProof:
+        seen.update(kwargs)
+        return onboarding.OCRPolicyProof(False, False, False, "tiny", "disabled")
+
+    proof = onboarding.RuntimeProof(
+        4242,
+        "ok",
+        "disabled",
+        None,
+        mode="ingest",
+        receipt="ingest-ready",
+        generation="a" * 32,
+    )
+    monkeypatch.setattr(onboarding, "ensure_local_ocr", ocr_policy)
+    monkeypatch.setattr(onboarding, "ensure_runtime", lambda **kwargs: proof)
+
+    assert onboarding.onboard(preserve_policy=True) == proof
+    assert seen["screenshot_permission_required"] is False
+    assert seen["capture_source"] == "ingest"
+    assert any("trusted ingest producer" in message for message in ui.status_messages)
+
+
+@pytest.mark.parametrize("gate", ["paused", "locked"])
+def test_strict_capture_proof_fails_immediately_for_privacy_gate(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch, gate: str
+) -> None:
+    cfg = config.Config()
+    monkeypatch.setattr(config, "load", lambda *args, **kwargs: cfg)
+    monkeypatch.setattr(scheduler, "capture_gate_reason", lambda capture: gate)
+    monkeypatch.setattr(
+        onboarding,
+        "_running_daemon_pid",
+        lambda: pytest.fail("privacy failure must happen before lifecycle mutation"),
+    )
+
+    with pytest.raises(onboarding.OnboardingError, match=gate):
+        onboarding.ensure_runtime(restart=False, preserve_policy=False)
+
+
+def test_update_preserves_paused_capture_without_forcing_a_frame(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = config.Config()
+    monkeypatch.setattr(config, "load", lambda *args, **kwargs: cfg)
+    monkeypatch.setattr(scheduler, "capture_gate_reason", lambda capture: "paused")
+    monkeypatch.setattr(onboarding, "_running_daemon_pid", lambda: 4242)
+    monkeypatch.setattr(
+        onboarding,
+        "_health_payload",
+        lambda host, port: {"status": "ok", "ocr": "disabled", "ocr_worker": "not_started"},
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "_runtime_permissions",
+        lambda host, port: {"accessibility": "granted", "screen_recording": "denied"},
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "_runtime_state",
+        lambda pid, **kwargs: {
+            "generation": "a" * 32,
+            "phase": "ready",
+            "permissions": {"accessibility": "granted", "screen_recording": "denied"},
+            "ocr": "disabled",
+            "ocr_enabled": False,
+            "ocr_tier": "tiny",
+        },
+    )
+    requests: list[tuple[object, ...]] = []
+
+    def paused_receipt(*args: object) -> onboarding.CaptureRequestProof:
+        requests.append(args)
+        return onboarding.CaptureRequestProof(None, "privacy", "privacy-paused")
+
+    monkeypatch.setattr(onboarding, "_request_runtime_capture", paused_receipt)
+
+    proof = onboarding.ensure_runtime(
+        restart=False,
+        require_ocr=False,
+        preserve_policy=True,
+        expected_ocr_state="disabled",
+    )
+
+    assert proof.capture_path is None
+    assert proof.receipt == "privacy-paused"
+    assert requests
+
+
+def test_preserve_policy_accepts_screen_lock_that_happens_during_proof(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = config.Config()
+    monkeypatch.setattr(config, "load", lambda *args, **kwargs: cfg)
+    monkeypatch.setattr(onboarding, "_running_daemon_pid", lambda: 4242)
+    monkeypatch.setattr(
+        onboarding,
+        "_health_payload",
+        lambda host, port: {"status": "ok", "ocr": "disabled", "ocr_worker": "not_started"},
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "_runtime_permissions",
+        lambda host, port: {"accessibility": "granted", "screen_recording": "denied"},
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "_request_runtime_capture",
+        lambda host, port: onboarding.CaptureRequestProof(None, "privacy", "privacy-locked"),
+    )
+
+    proof = onboarding.ensure_runtime(
+        restart=False,
+        require_ocr=False,
+        preserve_policy=True,
+        expected_ocr_state="disabled",
+    )
+
+    assert proof.receipt == "privacy-locked"
+
+
+def test_preserve_policy_accepts_live_ingest_readiness_after_unlock(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = config.Config()
+    cfg.capture.source = "ingest"
+    monkeypatch.setattr(config, "load", lambda *args, **kwargs: cfg)
+    monkeypatch.setattr(scheduler, "capture_gate_reason", lambda capture: "locked")
+    monkeypatch.setattr(onboarding, "_running_daemon_pid", lambda: 4242)
+    monkeypatch.setattr(
+        onboarding,
+        "_health_payload",
+        lambda host, port: {"status": "ok", "ocr": "disabled", "ocr_worker": "not_started"},
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "_runtime_permissions",
+        lambda host, port: {
+            "accessibility": "not_applicable",
+            "screen_recording": "not_applicable",
+        },
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "_request_runtime_capture",
+        lambda host, port: onboarding.CaptureRequestProof(None, "ingest", "ingest-ready"),
+    )
+
+    proof = onboarding.ensure_runtime(
+        restart=False,
+        require_ocr=False,
+        preserve_policy=True,
+        expected_ocr_state="disabled",
+    )
+
+    assert proof.receipt == "ingest-ready"
+
+
+def test_strict_proof_reports_privacy_gate_race_actionably(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = config.Config()
+    monkeypatch.setattr(config, "load", lambda *args, **kwargs: cfg)
+    monkeypatch.setattr(onboarding, "_running_daemon_pid", lambda: 4242)
+    monkeypatch.setattr(
+        onboarding,
+        "_health_payload",
+        lambda host, port: {"status": "ok", "ocr": "disabled", "ocr_worker": "not_started"},
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "_runtime_permissions",
+        lambda host, port: {"accessibility": "granted", "screen_recording": "denied"},
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "_request_runtime_capture",
+        lambda host, port: onboarding.CaptureRequestProof(None, "privacy", "privacy-locked"),
+    )
+
+    with pytest.raises(onboarding.OnboardingError, match="became locked.*unlock the screen"):
+        onboarding.ensure_runtime(
+            restart=False,
+            require_ocr=False,
+            preserve_policy=False,
+            expected_ocr_state="disabled",
+        )
+
+
+def test_non_http_runtime_uses_generation_state_and_startup_capture(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = config.Config()
+    cfg.mcp.auto_start = False
+    cfg.capture.enable_ocr_fallback = True
+    monkeypatch.setattr(config, "load", lambda *args, **kwargs: cfg)
+    monkeypatch.setattr(scheduler, "capture_gate_reason", lambda capture: None)
+    capture_path = paths.capture_buffer_dir() / "fresh.json"
+    capture_path.write_text(
+        '{"timestamp":"2026-07-12T00:00:00+00:00","visible_text":"ready"}',
+        encoding="utf-8",
+    )
+    live = {"pid": None}
+    monkeypatch.setattr(onboarding, "_running_daemon_pid", lambda: live["pid"])
+
+    def run_cli(*args: str, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert args == ("start",)
+        live["pid"] = 4242
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr(onboarding, "_run_cli", run_cli)
+    monkeypatch.setattr(
+        onboarding,
+        "_health_payload",
+        lambda *args: pytest.fail("HTTP is intentionally disabled"),
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "_runtime_state",
+        lambda pid, **kwargs: {
+            "generation": "b" * 32,
+            "phase": "ready",
+            "permissions": {"accessibility": "granted", "screen_recording": "granted"},
+            "ocr_worker": "ready",
+            "ocr": "ready",
+            "ocr_enabled": True,
+            "ocr_tier": "tiny",
+            "last_capture_id": "fresh",
+            "last_capture_reason": "heartbeat",
+        },
+    )
+
+    proof = onboarding.ensure_runtime(restart=False, require_ocr=True)
+
+    assert proof.pid == 4242
+    assert proof.generation == "b" * 32
+    assert proof.capture_path == capture_path
+
+
+def test_ingest_runtime_returns_runner_readiness_without_fake_capture(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = config.Config()
+    cfg.capture.source = "ingest"
+    monkeypatch.setattr(config, "load", lambda *args, **kwargs: cfg)
+    monkeypatch.setattr(onboarding, "_running_daemon_pid", lambda: 4242)
+    monkeypatch.setattr(
+        onboarding,
+        "_health_payload",
+        lambda host, port: {"status": "ok", "ocr": "disabled", "ocr_worker": "not_started"},
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "_runtime_permissions",
+        lambda host, port: {
+            "accessibility": "not_applicable",
+            "screen_recording": "not_applicable",
+        },
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "_request_runtime_capture",
+        lambda host, port: onboarding.CaptureRequestProof(None, "ingest", "ingest-ready"),
+    )
+    monkeypatch.setattr(onboarding, "_runtime_state", lambda *args, **kwargs: None)
+
+    proof = onboarding.ensure_runtime(
+        restart=False,
+        require_ocr=False,
+        preserve_policy=True,
+        expected_ocr_state="disabled",
+    )
+
+    assert proof.mode == "ingest"
+    assert proof.receipt == "ingest-ready"
+    assert proof.capture_path is None
+
+
+def test_permission_auth_failure_is_actionable_without_polling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PERSOME_LOCAL_API_TOKEN", "x" * 32)
+    response = httpx.Response(
+        401,
+        request=httpx.Request("GET", "http://127.0.0.1:8742/permissions"),
+    )
+    monkeypatch.setattr(httpx, "get", lambda *args, **kwargs: response)
+
+    with pytest.raises(onboarding.OnboardingError, match="stale shell override"):
+        onboarding._runtime_permissions("127.0.0.1", 8742)
+
+
+def test_onboarding_loopback_url_supports_ipv6() -> None:
+    assert onboarding._local_api_url("::1", 8742, "/health") == "http://[::1]:8742/health"
+
+
+def test_new_screen_recording_grant_restarts_existing_daemon(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = config.Config()
+    monkeypatch.setattr(config, "load", lambda *args, **kwargs: cfg)
+    monkeypatch.setattr(onboarding.sys, "platform", "darwin")
+    monkeypatch.setattr(onboarding, "OnboardingUI", lambda gui: ScriptedUI())
+    monkeypatch.setattr(onboarding, "ensure_accessibility", lambda ui, *, event_driven: False)
+    monkeypatch.setattr(
+        onboarding,
+        "ensure_local_ocr",
+        lambda **kwargs: onboarding.OCRPolicyProof(
+            True,
+            False,
+            True,
+            "tiny",
+            "ready",
+        ),
+    )
+    seen: dict[str, object] = {}
+    proof = onboarding.RuntimeProof(4242, "ok", "ready", ac_root / "fresh.json")
+
+    def runtime(**kwargs: object) -> onboarding.RuntimeProof:
+        seen.update(kwargs)
+        return proof
+
+    monkeypatch.setattr(onboarding, "ensure_runtime", runtime)
+
+    assert onboarding.onboard() == proof
+    assert seen["restart"] is True
+
+
+def test_launchagent_restart_accepts_direct_old_to_new_pid_handoff(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    capture_path = paths.capture_buffer_dir() / "fresh.json"
+    capture_path.write_text(
+        '{"timestamp":"2026-07-12T00:00:00+00:00","visible_text":"ready"}',
+        encoding="utf-8",
+    )
+    first = {"value": True}
+
+    def pid() -> int:
+        if first["value"]:
+            first["value"] = False
+            return 100
+        return 200
+
+    monkeypatch.setattr(onboarding, "_running_daemon_pid", pid)
+    monkeypatch.setattr(onboarding, "_launchagent_is_loaded", lambda: True)
+    kicks: list[bool] = []
+    monkeypatch.setattr(
+        onboarding,
+        "_kickstart_launchagent",
+        lambda *, kill: kicks.append(kill),
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "_run_cli",
+        lambda *args, **kwargs: pytest.fail("launchd owns this lifecycle"),
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "_health_payload",
+        lambda host, port: {
+            "status": "ok",
+            "ocr": "ready",
+            "ocr_worker": "ready",
+            "ocr_enabled": "True",
+            "ocr_tier": "tiny",
+        },
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "_runtime_permissions",
+        lambda host, port: {"accessibility": "granted", "screen_recording": "granted"},
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "_request_runtime_capture",
+        lambda host, port: onboarding.CaptureRequestProof(capture_path, "daemon", "fresh-capture"),
+    )
+    monkeypatch.setattr(onboarding, "_runtime_state", lambda *args, **kwargs: None)
+
+    proof = onboarding.ensure_runtime(
+        restart=True,
+        expected_ocr_state="ready",
+        expected_ocr_tier="tiny",
+        expected_ocr_enabled=True,
+    )
+
+    assert proof.pid == 200
+    assert kicks == [True]
+
+
+def test_launchagent_non_http_existing_runtime_restarts_for_fresh_generation(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = config.Config()
+    cfg.mcp.auto_start = False
+    cfg.capture.enable_ocr_fallback = True
+    monkeypatch.setattr(config, "load", lambda *args, **kwargs: cfg)
+    monkeypatch.setattr(scheduler, "capture_gate_reason", lambda capture: None)
+    capture_path = paths.capture_buffer_dir() / "fresh.json"
+    capture_path.write_text(
+        '{"timestamp":"2026-07-12T00:00:00+00:00","visible_text":"ready"}',
+        encoding="utf-8",
+    )
+    pids = iter([100, 200])
+    current = {"pid": 200}
+
+    def pid() -> int:
+        return next(pids, current["pid"])
+
+    monkeypatch.setattr(onboarding, "_running_daemon_pid", pid)
+    monkeypatch.setattr(onboarding, "_launchagent_is_loaded", lambda: True)
+    kicks: list[bool] = []
+    monkeypatch.setattr(
+        onboarding,
+        "_kickstart_launchagent",
+        lambda *, kill: kicks.append(kill),
+    )
+    state = {
+        "generation": "c" * 32,
+        "phase": "ready",
+        "permissions": {"accessibility": "granted", "screen_recording": "granted"},
+        "ocr_worker": "ready",
+        "ocr": "ready",
+        "ocr_enabled": True,
+        "ocr_tier": "tiny",
+        "last_capture_id": "fresh",
+        "last_capture_reason": "startup",
+    }
+    monkeypatch.setattr(onboarding, "_runtime_state", lambda *args, **kwargs: state)
+
+    proof = onboarding.ensure_runtime(
+        restart=False,
+        expected_ocr_state="ready",
+        expected_ocr_tier="tiny",
+        expected_ocr_enabled=True,
+    )
+
+    assert proof.pid == 200
+    assert proof.generation == "c" * 32
+    assert kicks == [True]
+
+
+def test_ingest_without_http_transport_is_rejected_before_lifecycle_mutation(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = config.Config()
+    cfg.capture.source = "ingest"
+    cfg.mcp.auto_start = False
+    monkeypatch.setattr(config, "load", lambda *args, **kwargs: cfg)
+    monkeypatch.setattr(
+        onboarding,
+        "_running_daemon_pid",
+        lambda: pytest.fail("invalid configuration must fail before starting a daemon"),
+    )
+
+    with pytest.raises(onboarding.OnboardingError, match="requires mcp.auto_start=true"):
+        onboarding.ensure_runtime(restart=False, require_ocr=False)
+
+
+def test_pixel_and_ocr_opt_out_does_not_probe_screen_recording(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = config.Config()
+    cfg.capture.enable_ocr_fallback = False
+    cfg.capture.include_screenshot = False
+    monkeypatch.setattr(config, "load", lambda *args, **kwargs: cfg)
+    monkeypatch.setattr(
+        screen_recording,
+        "has_screen_recording",
+        lambda: pytest.fail("pixel opt-out must not probe Screen Recording"),
+    )
+    monkeypatch.setattr(
+        ocr_local,
+        "runtime_available",
+        lambda: pytest.fail("OCR opt-out must not inspect Paddle"),
+    )
+
+    proof = onboarding.ensure_local_ocr(
+        tier="tiny",
+        ui=ScriptedUI(),
+        preserve_policy=True,
+        screenshot_permission_required=False,
+        capture_source="daemon",
+    )
+
+    assert proof.state == "disabled"
+    assert proof.permission_changed is False
+
+
+def test_screenshot_policy_still_proves_screen_recording_when_ocr_is_disabled(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = config.Config()
+    cfg.capture.enable_ocr_fallback = False
+    cfg.capture.include_screenshot = True
+    monkeypatch.setattr(config, "load", lambda *args, **kwargs: cfg)
+    checked: list[str] = []
+    monkeypatch.setattr(
+        screen_recording,
+        "has_screen_recording",
+        lambda: checked.append("screen") or True,
+    )
+
+    proof = onboarding.ensure_local_ocr(
+        tier="tiny",
+        ui=ScriptedUI(),
+        preserve_policy=True,
+        screenshot_permission_required=True,
+        capture_source="daemon",
+    )
+
+    assert proof.state == "disabled"
+    assert checked == ["screen"]
+
+
+def test_preserve_policy_restarts_daemon_using_a_different_ocr_policy(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = config.Config()
+    cfg.capture.enable_ocr_fallback = False
+    cfg.capture.include_screenshot = False
+    monkeypatch.setattr(config, "load", lambda *args, **kwargs: cfg)
+    monkeypatch.setattr(scheduler, "capture_gate_reason", lambda capture: None)
+    capture_path = paths.capture_buffer_dir() / "fresh.json"
+    capture_path.write_text(
+        '{"timestamp":"2026-07-12T00:00:00+00:00","visible_text":"ready"}',
+        encoding="utf-8",
+    )
+    live = {"pid": 100}
+    commands: list[str] = []
+
+    def run_cli(command: str, *args: str, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        live["pid"] = None if command == "stop" else 200
+        return subprocess.CompletedProcess([command], 0, "", "")
+
+    monkeypatch.setattr(onboarding, "_running_daemon_pid", lambda: live["pid"])
+    monkeypatch.setattr(onboarding, "_run_cli", run_cli)
+
+    def health(host: str, port: int) -> dict[str, str]:
+        if live["pid"] == 100:
+            return {
+                "status": "ok",
+                "ocr": "ready",
+                "ocr_worker": "ready",
+                "ocr_enabled": "True",
+                "ocr_tier": "small",
+            }
+        return {
+            "status": "ok",
+            "ocr": "disabled",
+            "ocr_worker": "not_started",
+            "ocr_enabled": "False",
+            "ocr_tier": "tiny",
+        }
+
+    monkeypatch.setattr(onboarding, "_health_payload", health)
+    monkeypatch.setattr(
+        onboarding,
+        "_runtime_permissions",
+        lambda host, port: {"accessibility": "granted", "screen_recording": "denied"},
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "_request_runtime_capture",
+        lambda host, port: onboarding.CaptureRequestProof(capture_path, "daemon", "fresh-capture"),
+    )
+    monkeypatch.setattr(onboarding, "_runtime_state", lambda *args, **kwargs: None)
+
+    proof = onboarding.ensure_runtime(
+        restart=False,
+        require_ocr=False,
+        require_screen_recording=False,
+        preserve_policy=True,
+        expected_ocr_state="disabled",
+        expected_ocr_tier="tiny",
+        expected_ocr_enabled=False,
+    )
+
+    assert proof.pid == 200
+    assert commands == ["stop", "start"]
+
+
+def test_non_http_proof_rechecks_worker_after_capture(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = config.Config()
+    cfg.mcp.auto_start = False
+    cfg.capture.enable_ocr_fallback = True
+    monkeypatch.setattr(config, "load", lambda *args, **kwargs: cfg)
+    monkeypatch.setattr(scheduler, "capture_gate_reason", lambda capture: None)
+    capture_path = paths.capture_buffer_dir() / "fresh.json"
+    capture_path.write_text(
+        '{"timestamp":"2026-07-12T00:00:00+00:00","visible_text":"ready"}',
+        encoding="utf-8",
+    )
+    live = {"pid": None}
+    state = {
+        "generation": "d" * 32,
+        "phase": "ready",
+        "permissions": {"accessibility": "granted", "screen_recording": "granted"},
+        "ocr_worker": "ready",
+        "ocr": "ready",
+        "ocr_enabled": True,
+        "ocr_tier": "tiny",
+        "last_capture_id": "fresh",
+        "last_capture_reason": "startup",
+    }
+    monkeypatch.setattr(onboarding, "_running_daemon_pid", lambda: live["pid"])
+    monkeypatch.setattr(
+        onboarding,
+        "_run_cli",
+        lambda *args, **kwargs: (
+            live.__setitem__("pid", 4242) or subprocess.CompletedProcess(args, 0, "", "")
+        ),
+    )
+    monkeypatch.setattr(onboarding, "_runtime_state", lambda *args, **kwargs: state)
+
+    def verify_context(path: Path, **kwargs: object) -> bool:
+        state["ocr_worker"] = "failed"
+        return True
+
+    monkeypatch.setattr(onboarding, "_capture_has_real_context", verify_context)
+
+    with pytest.raises(onboarding.OnboardingError, match="lost readiness"):
+        onboarding.ensure_runtime(
+            restart=False,
+            expected_ocr_state="ready",
+            expected_ocr_tier="tiny",
+            expected_ocr_enabled=True,
+        )
+
+
+def test_cli_reports_degraded_ax_only_runtime_truthfully(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    capture_path = ac_root / "capture-buffer" / "fresh.json"
+    monkeypatch.setattr(
+        onboarding,
+        "onboard",
+        lambda tier, gui, preserve_policy, expected_owner: onboarding.RuntimeProof(
+            4242,
+            "degraded",
+            "runtime_unavailable",
+            capture_path,
+            accessibility="granted",
+            screen_recording="granted",
+        ),
+    )
+
+    result = CliRunner().invoke(app, ["onboard"])
+
+    assert result.exit_code == 0, result.output
+    assert "degraded optional features" in result.output
+    assert "running and healthy" not in result.output

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -23,7 +23,11 @@ class ScriptedUI:
         self.confirm_result = confirm
         self.actions = list(actions or [])
         self.confirmed: list[str] = []
+        self.status_messages: list[str] = []
         self.success_messages: list[str] = []
+
+    def status(self, message: str) -> None:
+        self.status_messages.append(message)
 
     def confirm(self, *, title: str, message: str, action: str) -> bool:
         self.confirmed.append(action)
@@ -54,6 +58,11 @@ def test_permission_flow_explains_requests_and_waits_for_live_grant() -> None:
     assert ui.confirmed == ["Request Accessibility"]
     assert requested == [True]
     assert opened == [True]
+    assert ui.status_messages == [
+        "Checking Accessibility permission...",
+        "Requesting Accessibility from macOS...",
+        "✓ Accessibility granted",
+    ]
 
 
 def test_permission_flow_cancellation_is_a_hard_stop() -> None:
@@ -155,12 +164,29 @@ def test_complete_onboarding_orders_permissions_before_runtime_proof(
     monkeypatch.setattr(
         onboarding,
         "ensure_runtime",
-        lambda restart: calls.append(f"runtime:{restart}") or proof,
+        lambda restart, ui: calls.append(f"runtime:{restart}") or proof,
     )
 
     assert onboarding.onboard() == proof
     assert calls == ["accessibility", "ocr", "runtime:True"]
     assert ui.success_messages
+
+
+def test_success_is_printed_and_uses_a_nonblocking_notification(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ui = onboarding.OnboardingUI(gui=True)
+    calls: list[tuple[str, dict[str, object]]] = []
+    monkeypatch.setattr(
+        ui,
+        "_osascript",
+        lambda script, *args, **kwargs: calls.append((script, kwargs)) or "Notified",
+    )
+
+    ui.success("Everything passed.")
+
+    assert "Persome is ready" in capsys.readouterr().out
+    assert calls == [(onboarding._NOTIFICATION_SCRIPT, {"timeout": 5})]
 
 
 def test_cli_onboard_reports_each_completed_gate(

--- a/tests/test_permissions_api.py
+++ b/tests/test_permissions_api.py
@@ -21,7 +21,7 @@ def _make_client() -> TestClient:
 
 
 def test_permissions_reports_granted(monkeypatch) -> None:
-    monkeypatch.setattr(ax_capture, "ax_trusted", lambda: True)
+    monkeypatch.setattr(ax_capture, "ax_trusted", lambda **kwargs: True)
     monkeypatch.setattr(screen_recording, "has_screen_recording", lambda: True)
     resp = _make_client().get("/permissions")
     assert resp.status_code == 200
@@ -32,7 +32,7 @@ def test_permissions_reports_granted(monkeypatch) -> None:
 
 
 def test_permissions_reports_denied(monkeypatch) -> None:
-    monkeypatch.setattr(ax_capture, "ax_trusted", lambda: False)
+    monkeypatch.setattr(ax_capture, "ax_trusted", lambda **kwargs: False)
     monkeypatch.setattr(screen_recording, "has_screen_recording", lambda: False)
     resp = _make_client().get("/permissions")
     assert resp.status_code == 200

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 import contextlib
+import fcntl
+import json
+import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 from typer.testing import CliRunner
 
-from persome import cli, launchagent, paths, updater
+from persome import cli, paths, updater
 
 
 def _source_tree(root: Path) -> Path:
@@ -22,6 +26,21 @@ def _source_tree(root: Path) -> Path:
     (root / "build-constraints.txt").write_text("", encoding="utf-8")
     (root / "install.sh").write_text("#!/bin/bash\n", encoding="utf-8")
     return root
+
+
+def _begin_transaction(*, launchagent: bool = False) -> str:
+    return updater.begin_update_transaction(launchagent)
+
+
+def _write_candidate_marker(directory: Path, transaction_id: str) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    executable = directory / "bin" / "persome"
+    executable.parent.mkdir(parents=True, exist_ok=True)
+    executable.write_text("#!/bin/sh\nprintf 'candidate runtime\\n'\n", encoding="utf-8")
+    executable.chmod(0o700)
+    marker = directory / ".persome-update-transaction"
+    marker.write_text(transaction_id + "\n", encoding="utf-8")
+    marker.chmod(0o600)
 
 
 def test_local_source_is_validated_without_mutating_it(
@@ -89,21 +108,47 @@ def test_official_source_is_a_fresh_shallow_main_clone(
 def test_stop_runtime_terminates_daemon_after_disabling_launchagent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    pids = iter([4242, 4242, None])
-    signals: list[tuple[int, int]] = []
-    bootout = subprocess.CompletedProcess(["launchctl"], 0, "", "")
-    monkeypatch.setattr(launchagent, "is_loaded", lambda: True)
-    monkeypatch.setattr(launchagent, "bootout", lambda: bootout)
-    monkeypatch.setattr(updater, "_running_daemon_pid", lambda: next(pids))
-    monkeypatch.setattr(updater.os, "kill", lambda pid, sig: signals.append((pid, sig)))
-    monkeypatch.setattr(updater.time, "sleep", lambda seconds: None)
+    process = updater.runtime_pid.ProcessIdentity(4242, os.getuid(), 1.0, "persome start")
+    calls: list[object] = []
+    monkeypatch.setattr(updater, "_running_daemon_process", lambda: process)
+    monkeypatch.setattr(updater, "launchagent_is_loaded", lambda: True)
+    monkeypatch.setattr(updater, "_bootout_launchagent", lambda: calls.append("bootout"))
+    monkeypatch.setattr(
+        updater.runtime_pid,
+        "same_process_is_running",
+        lambda value: value is process,
+    )
+    monkeypatch.setattr(
+        updater.runtime_pid,
+        "signal_process",
+        lambda value, sig: calls.append((value.pid, sig)) or True,
+    )
+    monkeypatch.setattr(updater.runtime_pid, "wait_for_exit", lambda value, timeout: True)
 
     updater.stop_runtime(launchagent_was_loaded=True)
-    assert signals == [(4242, updater.signal.SIGTERM)]
+    assert calls == ["bootout", (4242, updater.signal.SIGTERM)]
+
+
+def test_stop_runtime_rejects_live_daemon_with_unverifiable_generation(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths.pid_file().write_text("4242")
+    paths.runtime_state_file().write_text("{}")
+    process = updater.runtime_pid.ProcessIdentity(
+        4242,
+        os.getuid(),
+        1.0,
+        "/tmp/persome start --foreground",
+    )
+    monkeypatch.setattr(updater.runtime_pid, "inspect_process", lambda _pid: process)
+    monkeypatch.setattr(updater, "launchagent_is_loaded", lambda: False)
+
+    with pytest.raises(updater.UpdateError, match="invalid or stale generation"):
+        updater.stop_runtime(launchagent_was_loaded=False)
 
 
 def test_installer_uses_update_mode_without_shell_interpolation(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ac_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     source = updater.UpdateSource(_source_tree(tmp_path / "source"), "c" * 40, False)
     seen: dict[str, object] = {}
@@ -117,22 +162,101 @@ def test_installer_uses_update_mode_without_shell_interpolation(
             return 0
 
     monkeypatch.setattr(updater.subprocess, "Popen", Process)
+    monkeypatch.setattr(updater, "transaction_prepared", lambda: True)
+    transaction_id = _begin_transaction()
+    monkeypatch.setattr(updater, "_ACTIVE_UPDATE_LOCK_FD", 91)
 
     updater.run_installer(source)
 
     assert seen["command"] == ["/bin/bash", str(source.path / "install.sh"), "--update"]
     assert seen["kwargs"]["cwd"] == source.path  # type: ignore[index]
     assert seen["kwargs"]["start_new_session"] is True  # type: ignore[index]
+    assert seen["kwargs"]["pass_fds"] == (91,)  # type: ignore[index]
     env = seen["kwargs"]["env"]  # type: ignore[index]
     assert env["PERSOME_ROOT"] == str(paths.root())
     assert env["PERSOME_INSTALL_HOME"] == str(paths.root())
     assert "SSL_CERT_FILE" not in env
+    assert "PYTHONPATH" not in env
+    assert env["PERSOME_UPDATE_DEFER_COMMIT"] == "1"
+    assert env["PERSOME_UPDATE_REPLACEMENT"] == str(paths.root() / "venv.replacement.update")
+    assert env["PERSOME_UPDATE_TRANSACTION_ID"] == transaction_id
+    assert env["PERSOME_UPDATE_LOCK_FD"] == "91"
+
+
+def test_installer_candidate_preparation_never_touches_active_venv(
+    ac_root: Path, tmp_path: Path
+) -> None:
+    source_root = _source_tree(tmp_path / "source")
+    (source_root / "install.sh").write_text(
+        "#!/bin/bash\n"
+        "set -euo pipefail\n"
+        'mkdir -p "$PERSOME_UPDATE_REPLACEMENT/bin"\n'
+        'printf "%s\\n" "$PERSOME_UPDATE_TRANSACTION_ID" '
+        '> "$PERSOME_UPDATE_REPLACEMENT/.persome-update-transaction"\n'
+        'chmod 0600 "$PERSOME_UPDATE_REPLACEMENT/.persome-update-transaction"\n',
+        encoding="utf-8",
+    )
+    source = updater.UpdateSource(source_root, "c" * 40, False)
+    active = paths.root() / "venv"
+    active.mkdir()
+    (active / "old").write_text("old", encoding="utf-8")
+
+    with updater.update_lock():
+        transaction_id = _begin_transaction()
+        updater.run_installer(source)
+
+    candidate = paths.root() / "venv.replacement.update"
+    assert (active / "old").read_text(encoding="utf-8") == "old"
+    assert updater._marker_transaction(candidate) == transaction_id
 
 
 def test_interrupted_installer_waits_for_transaction_rollback(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ac_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     source = updater.UpdateSource(_source_tree(tmp_path / "source"), "c" * 40, False)
+    signals: list[tuple[int, int]] = []
+    binary = paths.root() / "venv" / "bin" / "persome"
+    binary.parent.mkdir(parents=True)
+    binary.write_text("", encoding="utf-8")
+    binary.chmod(0o755)
+
+    class Process:
+        pid = 4242
+
+        def __init__(self, command: list[str], **kwargs: object) -> None:
+            self.waits = 0
+            self.done = False
+
+        def wait(self, timeout: float | None = None) -> int:
+            self.waits += 1
+            if self.waits == 1:
+                raise KeyboardInterrupt
+            assert timeout is not None and 0 < timeout <= 30
+            self.done = True
+            return 130
+
+        def poll(self) -> int | None:
+            return 130 if self.done else None
+
+    monkeypatch.setattr(updater.subprocess, "Popen", Process)
+    monkeypatch.setattr(updater.os, "killpg", lambda pid, sig: signals.append((pid, sig)))
+    _begin_transaction()
+    monkeypatch.setattr(updater, "_ACTIVE_UPDATE_LOCK_FD", 91)
+
+    with pytest.raises(updater.UpdateCancelled, match="previous installation remains active"):
+        updater.run_installer(source)
+
+    assert signals == [(4242, updater.signal.SIGINT)]
+
+
+def test_second_interrupt_does_not_kill_transaction_rollback(
+    ac_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = updater.UpdateSource(_source_tree(tmp_path / "source"), "c" * 40, False)
+    binary = paths.root() / "venv" / "bin" / "persome"
+    binary.parent.mkdir(parents=True)
+    binary.write_text("", encoding="utf-8")
+    binary.chmod(0o755)
     signals: list[tuple[int, int]] = []
 
     class Process:
@@ -140,24 +264,55 @@ def test_interrupted_installer_waits_for_transaction_rollback(
 
         def __init__(self, command: list[str], **kwargs: object) -> None:
             self.waits = 0
+            self.done = False
 
         def wait(self, timeout: float | None = None) -> int:
             self.waits += 1
-            if self.waits == 1:
+            if self.waits <= 2:
                 raise KeyboardInterrupt
-            assert timeout == 30
+            self.done = True
             return 130
 
-        def poll(self) -> None:
-            return None
+        def poll(self) -> int | None:
+            return 130 if self.done else None
 
     monkeypatch.setattr(updater.subprocess, "Popen", Process)
     monkeypatch.setattr(updater.os, "killpg", lambda pid, sig: signals.append((pid, sig)))
+    _begin_transaction()
+    monkeypatch.setattr(updater, "_ACTIVE_UPDATE_LOCK_FD", 91)
 
-    with pytest.raises(updater.UpdateError, match="cancelled.*restored"):
+    with pytest.raises(updater.UpdateCancelled, match="previous installation remains active"):
         updater.run_installer(source)
 
     assert signals == [(4242, updater.signal.SIGINT)]
+
+
+def test_interrupt_after_installer_exits_zero_still_cancels(
+    ac_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = updater.UpdateSource(_source_tree(tmp_path / "source"), "c" * 40, False)
+
+    class Process:
+        pid = 4242
+
+        def __init__(self, command: list[str], **kwargs: object) -> None:
+            pass
+
+        def wait(self, timeout: float | None = None) -> int:
+            raise KeyboardInterrupt
+
+        def poll(self) -> int:
+            return 0
+
+    monkeypatch.setattr(updater.subprocess, "Popen", Process)
+    _begin_transaction()
+    monkeypatch.setattr(updater, "_ACTIVE_UPDATE_LOCK_FD", 91)
+
+    with pytest.raises(updater.UpdateCancelled) as raised:
+        updater.run_installer(source)
+
+    assert raised.value.exit_code == 130
+    assert not (paths.root() / "venv").exists()
 
 
 def test_failed_update_recovers_background_runtime(
@@ -167,19 +322,14 @@ def test_failed_update_recovers_background_runtime(
     binary.parent.mkdir(parents=True)
     binary.write_text("", encoding="utf-8")
     binary.chmod(0o755)
-    calls: list[list[str]] = []
+    calls: list[object] = []
     monkeypatch.setattr(updater, "_running_daemon_pid", lambda: None)
-    monkeypatch.setattr(
-        updater.subprocess,
-        "run",
-        lambda command, **kwargs: (
-            calls.append(command) or subprocess.CompletedProcess(command, 0, "", "")
-        ),
-    )
+    monkeypatch.setattr(updater, "_start_background_runtime", lambda: calls.append("start"))
+    monkeypatch.setattr(updater, "_wait_for_legacy_runtime_proof", lambda: calls.append("proof"))
 
     updater.recover_runtime(False)
 
-    assert calls == [[str(binary), "start"]]
+    assert calls == ["start", "proof"]
 
 
 def test_launchagent_restore_uses_new_binary_and_waits_for_running_state(
@@ -198,7 +348,7 @@ def test_launchagent_restore_uses_new_binary_and_waits_for_running_state(
         ),
     )
     monkeypatch.setattr(updater, "launchagent_is_loaded", lambda: True)
-    monkeypatch.setattr(updater, "_running_daemon_pid", lambda: 4242)
+    monkeypatch.setattr(updater.launchagent, "owns_recorded_runtime", lambda binary: True)
 
     updater.restore_launchagent(True)
 
@@ -208,7 +358,7 @@ def test_launchagent_restore_uses_new_binary_and_waits_for_running_state(
 
 
 def test_cli_update_runs_download_stop_install_and_restore(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ac_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     source = updater.UpdateSource(_source_tree(tmp_path / "source"), "d" * 40, True)
     calls: list[object] = []
@@ -219,32 +369,71 @@ def test_cli_update_runs_download_stop_install_and_restore(
         yield source
 
     monkeypatch.setattr(updater, "acquire_source", fake_acquire)
-    monkeypatch.setattr(updater, "launchagent_is_loaded", lambda: True)
+    monkeypatch.setattr(updater, "recover_pending_update", lambda: calls.append("recover-pending"))
+    monkeypatch.setattr(updater, "ensure_no_pending_update", lambda: calls.append("ensure-clean"))
+    monkeypatch.setattr(updater, "launchagent_should_be_restored", lambda: True)
+    monkeypatch.setattr(
+        updater,
+        "begin_update_transaction",
+        lambda loaded: calls.append(("begin", loaded)),
+    )
     monkeypatch.setattr(
         updater,
         "stop_runtime",
-        lambda launchagent_was_loaded: calls.append(("stop", launchagent_was_loaded)),
+        lambda *, launchagent_was_loaded, force=False: calls.append(
+            ("stop", launchagent_was_loaded, force)
+        ),
     )
     monkeypatch.setattr(updater, "run_installer", lambda value: calls.append(("install", value)))
     monkeypatch.setattr(
-        updater, "restore_launchagent", lambda value: calls.append(("restore", value))
+        updater,
+        "mark_update_phase",
+        lambda loaded, phase: calls.append(("phase", loaded, phase)),
+    )
+    monkeypatch.setattr(
+        updater, "activate_runtime", lambda loaded: calls.append(("activate", loaded))
+    )
+    monkeypatch.setattr(updater, "prove_runtime", lambda loaded: calls.append(("prove", loaded)))
+    cleanup = ac_root / "committed"
+    monkeypatch.setattr(
+        updater,
+        "commit_prepared_install",
+        lambda: calls.append("commit") or cleanup,
+    )
+    monkeypatch.setattr(updater, "clear_update_state", lambda: calls.append("clear"))
+    monkeypatch.setattr(
+        updater,
+        "cleanup_committed_install",
+        lambda path: calls.append(("cleanup", path)),
     )
 
     result = CliRunner().invoke(cli.app, ["update"])
 
     assert result.exit_code == 0, result.output
     assert calls == [
+        "recover-pending",
+        "ensure-clean",
         ("acquire", None),
-        ("stop", True),
+        ("begin", True),
+        ("stop", True, False),
         ("install", source),
-        ("restore", True),
+        ("phase", True, "prepared"),
+        ("activate", True),
+        ("prove", True),
+        ("phase", True, "committing"),
+        "commit",
+        "clear",
+        ("cleanup", cleanup),
     ]
     assert "Persome update complete" in result.output
     assert "personal data were" in result.output
     assert "preserved" in result.output
+    assert "Checking for an interrupted update" in result.output
+    assert "Downloading the latest official main revision" in result.output
 
 
 def test_cli_download_failure_does_not_change_runtime(
+    ac_root: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls: list[str] = []
@@ -255,8 +444,9 @@ def test_cli_download_failure_does_not_change_runtime(
         yield  # pragma: no cover
 
     monkeypatch.setattr(updater, "acquire_source", failed_acquire)
+    monkeypatch.setattr(updater, "recover_pending_update", lambda: None)
+    monkeypatch.setattr(updater, "ensure_no_pending_update", lambda: None)
     monkeypatch.setattr(updater, "stop_runtime", lambda **kwargs: calls.append("stop"))
-    monkeypatch.setattr(updater, "recover_runtime", lambda was_loaded: calls.append("recover"))
 
     result = CliRunner().invoke(cli.app, ["update"])
 
@@ -265,8 +455,51 @@ def test_cli_download_failure_does_not_change_runtime(
     assert calls == []
 
 
+def test_cli_cancel_before_transaction_reports_runtime_unchanged(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    @contextlib.contextmanager
+    def cancelled_acquire(path: Path | None = None):
+        raise updater.UpdateSignal(updater.signal.SIGINT)
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(updater, "acquire_source", cancelled_acquire)
+    monkeypatch.setattr(updater, "recover_pending_update", lambda: None)
+    monkeypatch.setattr(updater, "ensure_no_pending_update", lambda: None)
+
+    result = CliRunner().invoke(cli.app, ["update"])
+
+    assert result.exit_code == 130
+    assert "before the Runtime was changed" in result.output
+    assert "was restored" not in result.output
+
+
+def test_pending_recovery_ignores_repeated_terminal_interrupt(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[str] = []
+
+    def recover() -> None:
+        calls.append("recover-start")
+        os.kill(os.getpid(), updater.signal.SIGINT)
+        calls.append("recover-finished")
+
+    monkeypatch.setattr(updater, "recover_pending_update", recover)
+    monkeypatch.setattr(
+        updater,
+        "ensure_no_pending_update",
+        lambda: (_ for _ in ()).throw(updater.UpdateError("stop after recovery")),
+    )
+
+    result = CliRunner().invoke(cli.app, ["update"])
+
+    assert result.exit_code == 1
+    assert calls == ["recover-start", "recover-finished"]
+    assert "stop after recovery" in result.output
+
+
 def test_cli_install_failure_attempts_runtime_recovery(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ac_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     source = updater.UpdateSource(_source_tree(tmp_path / "source"), "e" * 40, True)
     calls: list[object] = []
@@ -276,7 +509,10 @@ def test_cli_install_failure_attempts_runtime_recovery(
         yield source
 
     monkeypatch.setattr(updater, "acquire_source", fake_acquire)
-    monkeypatch.setattr(updater, "launchagent_is_loaded", lambda: True)
+    monkeypatch.setattr(updater, "recover_pending_update", lambda: None)
+    monkeypatch.setattr(updater, "ensure_no_pending_update", lambda: None)
+    monkeypatch.setattr(updater, "launchagent_should_be_restored", lambda: True)
+    monkeypatch.setattr(updater, "begin_update_transaction", lambda loaded: None)
     monkeypatch.setattr(updater, "stop_runtime", lambda **kwargs: calls.append("stop"))
     monkeypatch.setattr(
         updater,
@@ -284,14 +520,177 @@ def test_cli_install_failure_attempts_runtime_recovery(
         lambda value: (_ for _ in ()).throw(updater.UpdateError("install failed")),
     )
     monkeypatch.setattr(
-        updater, "recover_runtime", lambda was_loaded: calls.append(("recover", was_loaded))
+        updater,
+        "rollback_and_recover",
+        lambda loaded: calls.append(("rollback", loaded)),
     )
 
     result = CliRunner().invoke(cli.app, ["update"])
 
     assert result.exit_code == 1
     assert "install failed" in result.output
-    assert calls == ["stop", ("recover", True)]
+    assert calls == ["stop", ("rollback", True)]
+
+
+def test_cli_interrupt_during_stop_recovers_runtime(
+    ac_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = updater.UpdateSource(_source_tree(tmp_path / "source"), "f" * 40, True)
+    calls: list[object] = []
+
+    @contextlib.contextmanager
+    def fake_acquire(path: Path | None = None):
+        yield source
+
+    monkeypatch.setattr(updater, "acquire_source", fake_acquire)
+    monkeypatch.setattr(updater, "recover_pending_update", lambda: None)
+    monkeypatch.setattr(updater, "ensure_no_pending_update", lambda: None)
+    monkeypatch.setattr(updater, "launchagent_should_be_restored", lambda: False)
+    monkeypatch.setattr(updater, "begin_update_transaction", lambda loaded: None)
+    monkeypatch.setattr(
+        updater,
+        "stop_runtime",
+        lambda **kwargs: (_ for _ in ()).throw(KeyboardInterrupt()),
+    )
+    monkeypatch.setattr(
+        updater,
+        "rollback_and_recover",
+        lambda loaded: calls.append(("rollback", loaded)),
+    )
+
+    result = CliRunner().invoke(cli.app, ["update"])
+
+    assert result.exit_code == 130
+    assert calls == [("rollback", False)]
+    assert "Update cancelled" in result.output
+
+
+@pytest.mark.parametrize(
+    ("installer_arg", "launchagent_marker"),
+    [("--no-client-config", "0"), ("--update", "0")],
+)
+def test_existing_install_delegates_to_transactional_update(
+    tmp_path: Path, installer_arg: str, launchagent_marker: str
+) -> None:
+    root = tmp_path / "existing root"
+    python = root / "venv" / "bin" / "python"
+    python.parent.mkdir(parents=True)
+    record = tmp_path / "delegated.txt"
+    python.write_text(
+        "#!/bin/bash\n"
+        'printf "%s\\n" "$@" > "$PERSOME_DELEGATION_RECORD"\n'
+        'printf "%s\\n" "$PERSOME_ROOT" "$PYTHONPATH" >> "$PERSOME_DELEGATION_RECORD"\n'
+        'printf "marker=%s\\n" "${PERSOME_UPDATE_INFER_LAUNCHAGENT_FROM_PLIST:-0}" '
+        '>> "$PERSOME_DELEGATION_RECORD"\n',
+        encoding="utf-8",
+    )
+    python.chmod(0o755)
+    repo = Path(__file__).resolve().parents[1]
+    env = {
+        **os.environ,
+        "PERSOME_INSTALL_HOME": str(root),
+        "PERSOME_DELEGATION_RECORD": str(record),
+    }
+
+    result = subprocess.run(
+        ["/bin/bash", str(repo / "install.sh"), installer_arg],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "bootstrapping the current source-tree updater" in result.stdout
+    assert record.read_text(encoding="utf-8").splitlines() == [
+        "-m",
+        "persome",
+        "update",
+        "--source",
+        str(repo),
+        str(root),
+        str(repo / "src"),
+        f"marker={launchagent_marker}",
+    ]
+
+
+def test_previous_updater_parent_enables_legacy_handoff_only_for_compatibility(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "existing"
+    python = root / "venv" / "bin" / "python"
+    python.parent.mkdir(parents=True)
+    record = tmp_path / "delegated.txt"
+    python.write_text(
+        "#!/bin/bash\n"
+        'printf "%s" "${PERSOME_UPDATE_INFER_LAUNCHAGENT_FROM_PLIST:-0}" '
+        '> "$PERSOME_DELEGATION_RECORD"\n',
+        encoding="utf-8",
+    )
+    python.chmod(0o755)
+    wrapper = tmp_path / "persome"
+    wrapper.write_text('#!/bin/bash\n/bin/bash "$2" --update\n', encoding="utf-8")
+    wrapper.chmod(0o755)
+    repo = Path(__file__).resolve().parents[1]
+
+    result = subprocess.run(
+        [str(wrapper), "update", str(repo / "install.sh")],
+        cwd=repo,
+        env={
+            **os.environ,
+            "PERSOME_INSTALL_HOME": str(root),
+            "PERSOME_DELEGATION_RECORD": str(record),
+        },
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert record.read_text(encoding="utf-8") == "1"
+
+
+@pytest.mark.parametrize(("signal_name", "returncode"), [("INT", 130), ("TERM", 143), ("HUP", 129)])
+def test_update_signal_restores_old_venv_with_real_bash(
+    tmp_path: Path, signal_name: str, returncode: int
+) -> None:
+    install_script = (Path(__file__).resolve().parents[1] / "install.sh").read_text(
+        encoding="utf-8"
+    )
+    transaction_code = install_script.split("# The fallback bootstrap downloads", maxsplit=1)[0]
+    root = tmp_path / signal_name.lower()
+    active = root / "venv"
+    backup = root / "venv.previous.test"
+    active.mkdir(parents=True)
+    backup.mkdir(parents=True)
+    (active / "new-marker").write_text("new", encoding="utf-8")
+    (backup / "old-marker").write_text("old", encoding="utf-8")
+    env_file = root / "env"
+    env_file.write_text("PERSOME_LLM_API_KEY=preserved\n", encoding="utf-8")
+    harness = (
+        transaction_code
+        + "\n"
+        + 'INSTALL_HOME="$1"\n'
+        + 'VENV_DIR="${INSTALL_HOME}/venv"\n'
+        + 'OLD_VENV_BACKUP="${INSTALL_HOME}/venv.previous.test"\n'
+        + "INSTALL_TRANSACTION_ACTIVE=1\n"
+        + "UPDATE_MODE=0\n"
+        + f"kill -{signal_name} $$\n"
+    )
+
+    result = subprocess.run(
+        ["/bin/bash", "-c", harness, "rollback-test", str(root)],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+    assert result.returncode == returncode
+    assert (active / "old-marker").read_text(encoding="utf-8") == "old"
+    assert not (active / "new-marker").exists()
+    assert not backup.exists()
+    assert env_file.read_text(encoding="utf-8") == "PERSOME_LLM_API_KEY=preserved\n"
 
 
 def test_update_mode_skips_setup_prompts_but_keeps_runtime_proof() -> None:
@@ -300,12 +699,581 @@ def test_update_mode_skips_setup_prompts_but_keeps_runtime_proof() -> None:
     assert "--update" in script
     assert "UPDATE_MODE=1" in script
     assert "update mode: preserving the existing LLM profile and credentials" in script
-    assert "non-interactive update: verifying existing permissions and Runtime health" in script
-    assert "onboard --tier tiny --no-gui" in script
-    assert script.index("run_onboarding\n") < script.rindex("commit_install\n")
+    assert "PERSOME_UPDATE_DEFER_COMMIT" in script
+    assert "PERSOME_UPDATE_TRANSACTION_ID" in script
+    assert "PERSOME_UPDATE_LOCK_FD" in script
+    assert "venv.replacement.update" in script
+    assert "final Runtime proof and commit are owned by persome update" in script
+    assert script.index("defer_install_commit\n") < script.index("run_onboarding\n")
     assert "restoring the previous virtualenv" in script
-    move_failed = script.index('mv "${VENV_DIR}" "${failed_venv}"')
-    restore_previous = script.index('mv "${OLD_VENV_BACKUP}" "${VENV_DIR}"')
-    remove_failed = script.index('rm -rf "${failed_venv}"')
-    assert move_failed < restore_previous < remove_failed
+    assert "discarding the inactive update candidate" in script
+    assert script.index("defer_install_commit\n") < script.index("install_shim\n")
     assert "trap - EXIT INT TERM HUP" in script
+
+
+@pytest.mark.parametrize(
+    "missing_variable",
+    ["PERSOME_UPDATE_TRANSACTION_ID", "PERSOME_UPDATE_LOCK_FD"],
+)
+def test_internal_deferred_install_flags_cannot_bypass_transaction_validation(
+    tmp_path: Path, missing_variable: str
+) -> None:
+    root = tmp_path / "root"
+    python = root / "venv" / "bin" / "python"
+    python.parent.mkdir(parents=True)
+    python.symlink_to(sys.executable)
+    state = root / ".update-state.json"
+    transaction_id = "a" * 32
+    state.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "launchagent_was_loaded": False,
+                "phase": "preparing",
+                "transaction_id": transaction_id,
+            }
+        ),
+        encoding="utf-8",
+    )
+    state.chmod(0o600)
+    lock = root / ".update.lock"
+    lock.touch(mode=0o600)
+    descriptor = os.open(lock, os.O_RDWR)
+    fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    env = {
+        **os.environ,
+        "PERSOME_INSTALL_HOME": str(root),
+        "PERSOME_UPDATE_DEFER_COMMIT": "1",
+        "PERSOME_UPDATE_REPLACEMENT": str(root / "venv.replacement.update"),
+        "PERSOME_UPDATE_TRANSACTION_ID": transaction_id,
+        "PERSOME_UPDATE_LOCK_FD": str(descriptor),
+    }
+    env.pop(missing_variable)
+    repo = Path(__file__).resolve().parents[1]
+    try:
+        result = subprocess.run(
+            ["/bin/bash", str(repo / "install.sh"), "--update"],
+            cwd=repo,
+            env=env,
+            pass_fds=(descriptor,),
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    finally:
+        os.close(descriptor)
+
+    assert result.returncode == 1
+    assert "deferred update" in result.stderr
+
+
+def test_internal_deferred_install_rejects_mismatched_state_nonce(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    python = root / "venv" / "bin" / "python"
+    python.parent.mkdir(parents=True)
+    python.symlink_to(sys.executable)
+    state = root / ".update-state.json"
+    state.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "launchagent_was_loaded": False,
+                "phase": "preparing",
+                "transaction_id": "a" * 32,
+            }
+        ),
+        encoding="utf-8",
+    )
+    state.chmod(0o600)
+    lock = root / ".update.lock"
+    lock.touch(mode=0o600)
+    descriptor = os.open(lock, os.O_RDWR)
+    fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    repo = Path(__file__).resolve().parents[1]
+    try:
+        result = subprocess.run(
+            ["/bin/bash", str(repo / "install.sh"), "--update"],
+            cwd=repo,
+            env={
+                **os.environ,
+                "PERSOME_INSTALL_HOME": str(root),
+                "PERSOME_UPDATE_DEFER_COMMIT": "1",
+                "PERSOME_UPDATE_REPLACEMENT": str(root / "venv.replacement.update"),
+                "PERSOME_UPDATE_TRANSACTION_ID": "b" * 32,
+                "PERSOME_UPDATE_LOCK_FD": str(descriptor),
+            },
+            pass_fds=(descriptor,),
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    finally:
+        os.close(descriptor)
+
+    assert result.returncode == 1
+    assert "transaction validation failed" in result.stderr
+
+
+def test_internal_deferred_install_rejects_an_unlocked_descriptor(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    python = root / "venv" / "bin" / "python"
+    python.parent.mkdir(parents=True)
+    python.symlink_to(sys.executable)
+    transaction_id = "a" * 32
+    state = root / ".update-state.json"
+    state.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "launchagent_was_loaded": False,
+                "phase": "preparing",
+                "transaction_id": transaction_id,
+            }
+        ),
+        encoding="utf-8",
+    )
+    state.chmod(0o600)
+    lock = root / ".update.lock"
+    lock.touch(mode=0o600)
+    descriptor = os.open(lock, os.O_RDWR)
+    repo = Path(__file__).resolve().parents[1]
+    try:
+        result = subprocess.run(
+            ["/bin/bash", str(repo / "install.sh"), "--update"],
+            cwd=repo,
+            env={
+                **os.environ,
+                "PERSOME_INSTALL_HOME": str(root),
+                "PERSOME_UPDATE_DEFER_COMMIT": "1",
+                "PERSOME_UPDATE_REPLACEMENT": str(root / "venv.replacement.update"),
+                "PERSOME_UPDATE_TRANSACTION_ID": transaction_id,
+                "PERSOME_UPDATE_LOCK_FD": str(descriptor),
+            },
+            pass_fds=(descriptor,),
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    finally:
+        os.close(descriptor)
+
+    assert result.returncode == 1
+    assert "transaction validation failed" in result.stderr
+
+
+def test_internal_deferred_install_accepts_matching_nonce_and_inherited_lock(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "root"
+    python = root / "venv" / "bin" / "python"
+    python.parent.mkdir(parents=True)
+    python.symlink_to(sys.executable)
+    transaction_id = "a" * 32
+    state = root / ".update-state.json"
+    state.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "launchagent_was_loaded": False,
+                "phase": "preparing",
+                "transaction_id": transaction_id,
+            }
+        ),
+        encoding="utf-8",
+    )
+    state.chmod(0o600)
+    lock = root / ".update.lock"
+    lock.touch(mode=0o600)
+    descriptor = os.open(lock, os.O_RDWR)
+    fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    uname = fake_bin / "uname"
+    uname.write_text("#!/bin/bash\nprintf 'Linux\\n'\n", encoding="utf-8")
+    uname.chmod(0o755)
+    repo = Path(__file__).resolve().parents[1]
+    try:
+        result = subprocess.run(
+            ["/bin/bash", str(repo / "install.sh"), "--update"],
+            cwd=repo,
+            env={
+                **os.environ,
+                "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+                "PERSOME_INSTALL_HOME": str(root),
+                "PERSOME_UPDATE_DEFER_COMMIT": "1",
+                "PERSOME_UPDATE_REPLACEMENT": str(root / "venv.replacement.update"),
+                "PERSOME_UPDATE_TRANSACTION_ID": transaction_id,
+                "PERSOME_UPDATE_LOCK_FD": str(descriptor),
+            },
+            pass_fds=(descriptor,),
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    finally:
+        os.close(descriptor)
+
+    assert result.returncode == 1
+    assert "supports macOS only" in result.stderr
+    assert "transaction validation failed" not in result.stderr
+
+
+def test_update_lock_rejects_a_concurrent_updater(ac_root: Path) -> None:
+    with (
+        updater.update_lock(),
+        pytest.raises(updater.UpdateError, match="already in progress"),
+        updater.update_lock(),
+    ):
+        pass
+
+
+def test_final_proof_executes_installed_binary_with_clean_environment(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    binary = paths.root() / "venv" / "bin" / "persome"
+    binary.parent.mkdir(parents=True)
+    binary.write_text("#!/bin/bash\n", encoding="utf-8")
+    binary.chmod(0o755)
+    monkeypatch.setenv("PYTHONPATH", "/tmp/source-tree")
+    monkeypatch.setenv("SSL_CERT_FILE", "/tmp/old-venv/cert.pem")
+    seen: dict[str, object] = {}
+
+    def run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        seen.update(command=command, kwargs=kwargs)
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(updater.subprocess, "run", run)
+
+    updater.prove_runtime(True)
+
+    assert seen["command"] == [
+        str(binary),
+        "onboard",
+        "--preserve-policy",
+        "--expect-owner",
+        "launchagent",
+    ]
+    env = seen["kwargs"]["env"]  # type: ignore[index]
+    assert "PYTHONPATH" not in env
+    assert "SSL_CERT_FILE" not in env
+
+
+def test_legacy_updater_handoff_recovers_launchagent_ownership(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(updater, "launchagent_is_loaded", lambda: False)
+    monkeypatch.setattr(updater.launchagent, "owner_intended", lambda: False)
+    monkeypatch.setattr(
+        updater.launchagent,
+        "configured_runtime_binary",
+        lambda: "/tmp/example/persome",
+    )
+    monkeypatch.setenv("PERSOME_UPDATE_INFER_LAUNCHAGENT_FROM_PLIST", "1")
+
+    assert updater.launchagent_should_be_restored() is True
+
+    monkeypatch.delenv("PERSOME_UPDATE_INFER_LAUNCHAGENT_FROM_PLIST")
+    assert updater.launchagent_should_be_restored() is False
+
+
+def test_legacy_handoff_accepts_the_normal_executable_shim_plist(
+    ac_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    binary = tmp_path / "bin" / "persome"
+    binary.parent.mkdir()
+    binary.write_text("#!/bin/bash\n", encoding="utf-8")
+    binary.chmod(0o755)
+    plist = tmp_path / "com.persome.runtime.plist"
+    monkeypatch.setattr(updater.launchagent, "plist_path", lambda: plist)
+    updater.launchagent.write_plist(str(binary))
+    monkeypatch.setattr(updater, "launchagent_is_loaded", lambda: False)
+    monkeypatch.setattr(updater.launchagent, "owner_intended", lambda: False)
+    monkeypatch.setenv("PERSOME_UPDATE_INFER_LAUNCHAGENT_FROM_PLIST", "1")
+
+    assert updater.launchagent_should_be_restored() is True
+
+
+def test_legacy_foreground_handoff_does_not_attempt_impossible_process_group_move(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PERSOME_UPDATE_INFER_LAUNCHAGENT_FROM_PLIST", "1")
+    monkeypatch.setattr(
+        updater.os,
+        "setpgid",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("must not move process group")),
+    )
+
+    assert updater.claim_legacy_foreground() is False
+
+
+def test_legacy_lock_keeper_tracks_parent_lifetime_instead_of_fixed_sleep(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: dict[str, object] = {}
+
+    class Process:
+        def __init__(self, command: list[str], **kwargs: object) -> None:
+            seen.update(command=command, kwargs=kwargs)
+
+    monkeypatch.setattr(updater.subprocess, "Popen", Process)
+
+    updater._spawn_legacy_lock_keeper(17, 4242)
+
+    command = seen["command"]
+    assert command[0] == sys.executable
+    assert command[1] == "-c"
+    assert "os.kill(parent, 0)" in command[2]
+    assert command[3] == "4242"
+    assert seen["kwargs"]["pass_fds"] == (17,)  # type: ignore[index]
+
+
+def test_rollback_prepared_install_atomically_restores_old_venv(ac_root: Path) -> None:
+    active = paths.root() / "venv"
+    candidate = paths.root() / "venv.replacement.update"
+    active.mkdir()
+    _begin_transaction()
+    candidate.mkdir()
+    (active / "old").write_text("old", encoding="utf-8")
+    (candidate / "partial-new").write_text("new", encoding="utf-8")
+    assert updater.rollback_prepared_install() is True
+
+    assert (active / "old").read_text(encoding="utf-8") == "old"
+    assert not (active / "partial-new").exists()
+    assert not candidate.exists()
+    assert not list(paths.root().glob("venv.failed.update.*"))
+
+
+def test_activation_uses_atomic_exchange_and_rollback_infers_it_from_marker(
+    ac_root: Path,
+) -> None:
+    active = paths.root() / "venv"
+    candidate = paths.root() / "venv.replacement.update"
+    active.mkdir()
+    (active / "old").write_text("old", encoding="utf-8")
+    transaction_id = _begin_transaction()
+    _write_candidate_marker(candidate, transaction_id)
+    (candidate / "new").write_text("new", encoding="utf-8")
+    updater.mark_update_phase(False, "prepared")
+
+    updater.activate_prepared_install()
+
+    assert (active / "new").read_text(encoding="utf-8") == "new"
+    assert (candidate / "old").read_text(encoding="utf-8") == "old"
+    assert updater._read_update_state().phase == "activated"  # type: ignore[union-attr]
+
+    assert updater.rollback_prepared_install() is True
+    assert (active / "old").read_text(encoding="utf-8") == "old"
+    assert not (active / "new").exists()
+    assert not candidate.exists()
+
+
+def test_committed_candidate_console_script_survives_directory_exchange(
+    ac_root: Path,
+) -> None:
+    active = paths.root() / "venv"
+    candidate = paths.root() / "venv.replacement.update"
+    active.mkdir()
+    (active / "old").write_text("old", encoding="utf-8")
+    transaction_id = _begin_transaction()
+    _write_candidate_marker(candidate, transaction_id)
+    updater.mark_update_phase(False, "prepared")
+
+    updater.activate_prepared_install()
+    updater.mark_update_phase(False, "committing")
+    cleanup = updater.commit_prepared_install()
+    updater.clear_update_state()
+    updater.cleanup_committed_install(cleanup)
+
+    result = subprocess.run(
+        [str(active / "bin" / "persome")],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert result.stdout == "candidate runtime\n"
+    assert not candidate.exists()
+
+
+def test_activation_rejects_candidate_with_absolute_inactive_shebang(
+    ac_root: Path,
+) -> None:
+    active = paths.root() / "venv"
+    candidate = paths.root() / "venv.replacement.update"
+    active.mkdir()
+    (active / "old").write_text("old", encoding="utf-8")
+    transaction_id = _begin_transaction()
+    _write_candidate_marker(candidate, transaction_id)
+    executable = candidate / "bin" / "persome"
+    executable.write_text(
+        f"#!{candidate}/bin/python\nprint('wrong interpreter')\n",
+        encoding="utf-8",
+    )
+    executable.chmod(0o700)
+    updater.mark_update_phase(False, "prepared")
+
+    with pytest.raises(updater.UpdateError, match="not relocatable"):
+        updater.activate_prepared_install()
+
+    assert (active / "old").is_file()
+    assert candidate.is_dir()
+
+
+def test_crash_after_exchange_before_phase_write_is_rollbackable_from_marker(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    active = paths.root() / "venv"
+    candidate = paths.root() / "venv.replacement.update"
+    active.mkdir()
+    (active / "old").write_text("old", encoding="utf-8")
+    transaction_id = _begin_transaction()
+    _write_candidate_marker(candidate, transaction_id)
+    (candidate / "new").write_text("new", encoding="utf-8")
+    updater.mark_update_phase(False, "prepared")
+    original_write = updater._write_update_state
+    monkeypatch.setattr(
+        updater,
+        "_write_update_state",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("simulated crash")),
+    )
+
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        updater.activate_prepared_install()
+
+    monkeypatch.setattr(updater, "_write_update_state", original_write)
+    assert updater._read_update_state().phase == "prepared"  # type: ignore[union-attr]
+    assert updater._marker_transaction(active) == transaction_id
+    assert updater.rollback_prepared_install() is True
+    assert (active / "old").exists()
+
+
+def test_commit_never_creates_a_missing_active_venv_window(ac_root: Path) -> None:
+    active = paths.root() / "venv"
+    candidate = paths.root() / "venv.replacement.update"
+    active.mkdir()
+    (active / "old").write_text("old", encoding="utf-8")
+    transaction_id = _begin_transaction()
+    _write_candidate_marker(candidate, transaction_id)
+    (candidate / "new").write_text("new", encoding="utf-8")
+    updater.mark_update_phase(False, "prepared")
+    updater.activate_prepared_install()
+    updater.mark_update_phase(False, "committing")
+
+    cleanup = updater.commit_prepared_install()
+
+    assert (active / "new").exists()
+    assert cleanup.is_dir()
+    assert (cleanup / "old").exists()
+    assert not candidate.exists()
+    updater.clear_update_state()
+    assert not (active / ".persome-update-transaction").exists()
+
+
+def test_committed_interruption_reproves_final_runtime_before_clearing_state(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    active = paths.root() / "venv"
+    transaction_id = "a" * 32
+    _write_candidate_marker(active, transaction_id)
+    updater._write_update_state(
+        launchagent_was_loaded=False,
+        phase="committing",
+        transaction_id=transaction_id,
+    )
+    calls: list[str] = []
+    monkeypatch.setattr(updater, "launchagent_is_loaded", lambda: False)
+    monkeypatch.setattr(updater, "_running_daemon_pid", lambda: 4242)
+    monkeypatch.setattr(updater, "_wait_for_runtime_process", lambda: calls.append("process"))
+    monkeypatch.setattr(updater, "prove_runtime", lambda loaded: calls.append(f"proof:{loaded}"))
+    monkeypatch.setattr(updater, "cleanup_transaction_artifacts", lambda: calls.append("cleanup"))
+
+    updater.recover_pending_update()
+
+    assert calls == ["process", "proof:False", "cleanup"]
+    assert not updater._update_state_file().exists()
+
+
+def test_legacy_two_rename_transaction_is_recovered_with_atomic_exchange(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    active = paths.root() / "venv"
+    backup = paths.root() / "venv.previous.update"
+    active.mkdir()
+    backup.mkdir()
+    (active / "new").write_text("new", encoding="utf-8")
+    (backup / "old").write_text("old", encoding="utf-8")
+    paths.atomic_write_private_text(
+        updater._update_state_file(),
+        json.dumps(
+            {
+                "schema_version": 1,
+                "launchagent_was_loaded": False,
+                "phase": "prepared",
+            }
+        ),
+    )
+    calls: list[str] = []
+    monkeypatch.setattr(updater, "launchagent_is_loaded", lambda: False)
+    monkeypatch.setattr(updater, "stop_runtime", lambda **_kwargs: calls.append("stop"))
+    monkeypatch.setattr(updater, "_clear_replacement_runtime_state", lambda: None)
+    monkeypatch.setattr(
+        updater, "recover_runtime", lambda loaded: calls.append(f"recover:{loaded}")
+    )
+
+    updater.recover_pending_update()
+
+    assert (active / "old").exists()
+    assert not (active / "new").exists()
+    assert not backup.exists()
+    assert calls == ["stop", "recover:False"]
+    assert not updater._update_state_file().exists()
+
+
+def test_legacy_crash_during_missing_active_window_restores_backup(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    backup = paths.root() / "venv.previous.update"
+    backup.mkdir()
+    (backup / "old").write_text("old", encoding="utf-8")
+    paths.atomic_write_private_text(
+        updater._update_state_file(),
+        json.dumps(
+            {
+                "schema_version": 1,
+                "launchagent_was_loaded": True,
+                "phase": "preparing",
+            }
+        ),
+    )
+    monkeypatch.setattr(updater, "launchagent_is_loaded", lambda: False)
+    monkeypatch.setattr(updater, "stop_runtime", lambda **_kwargs: None)
+    monkeypatch.setattr(updater, "_clear_replacement_runtime_state", lambda: None)
+    monkeypatch.setattr(updater, "recover_runtime", lambda _loaded: None)
+
+    updater.recover_pending_update()
+
+    assert (paths.root() / "venv" / "old").exists()
+    assert not backup.exists()
+    assert not updater._update_state_file().exists()
+
+
+@pytest.mark.parametrize(
+    "signum", [updater.signal.SIGINT, updater.signal.SIGTERM, updater.signal.SIGHUP]
+)
+def test_outer_update_signals_become_recoverable_cancellation(
+    signum: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    installed: dict[int, object] = {}
+
+    def install_handler(signal_number: int, handler: object) -> None:
+        installed[signal_number] = handler
+
+    monkeypatch.setattr(updater.signal, "getsignal", lambda _signum: updater.signal.SIG_DFL)
+    monkeypatch.setattr(updater.signal, "signal", install_handler)
+    with pytest.raises(updater.UpdateSignal) as raised, updater.catch_update_signals():
+        handler = installed[signum]
+        assert callable(handler)
+        handler(signum, None)
+
+    assert raised.value.signum == signum
+    assert raised.value.exit_code == 128 + signum

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -107,21 +107,57 @@ def test_installer_uses_update_mode_without_shell_interpolation(
 ) -> None:
     source = updater.UpdateSource(_source_tree(tmp_path / "source"), "c" * 40, False)
     seen: dict[str, object] = {}
+    monkeypatch.setenv("SSL_CERT_FILE", str(paths.root() / "venv" / "cert.pem"))
 
-    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        seen.update(command=command, kwargs=kwargs)
-        return subprocess.CompletedProcess(command, 0)
+    class Process:
+        def __init__(self, command: list[str], **kwargs: object) -> None:
+            seen.update(command=command, kwargs=kwargs)
 
-    monkeypatch.setattr(updater.subprocess, "run", fake_run)
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+    monkeypatch.setattr(updater.subprocess, "Popen", Process)
 
     updater.run_installer(source)
 
     assert seen["command"] == ["/bin/bash", str(source.path / "install.sh"), "--update"]
     assert seen["kwargs"]["cwd"] == source.path  # type: ignore[index]
-    assert seen["kwargs"]["check"] is False  # type: ignore[index]
+    assert seen["kwargs"]["start_new_session"] is True  # type: ignore[index]
     env = seen["kwargs"]["env"]  # type: ignore[index]
     assert env["PERSOME_ROOT"] == str(paths.root())
     assert env["PERSOME_INSTALL_HOME"] == str(paths.root())
+    assert "SSL_CERT_FILE" not in env
+
+
+def test_interrupted_installer_waits_for_transaction_rollback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = updater.UpdateSource(_source_tree(tmp_path / "source"), "c" * 40, False)
+    signals: list[tuple[int, int]] = []
+
+    class Process:
+        pid = 4242
+
+        def __init__(self, command: list[str], **kwargs: object) -> None:
+            self.waits = 0
+
+        def wait(self, timeout: float | None = None) -> int:
+            self.waits += 1
+            if self.waits == 1:
+                raise KeyboardInterrupt
+            assert timeout == 30
+            return 130
+
+        def poll(self) -> None:
+            return None
+
+    monkeypatch.setattr(updater.subprocess, "Popen", Process)
+    monkeypatch.setattr(updater.os, "killpg", lambda pid, sig: signals.append((pid, sig)))
+
+    with pytest.raises(updater.UpdateError, match="cancelled.*restored"):
+        updater.run_installer(source)
+
+    assert signals == [(4242, updater.signal.SIGINT)]
 
 
 def test_failed_update_recovers_background_runtime(
@@ -268,3 +304,8 @@ def test_update_mode_skips_setup_prompts_but_keeps_runtime_proof() -> None:
     assert "onboard --tier tiny --no-gui" in script
     assert script.index("run_onboarding\n") < script.rindex("commit_install\n")
     assert "restoring the previous virtualenv" in script
+    move_failed = script.index('mv "${VENV_DIR}" "${failed_venv}"')
+    restore_previous = script.index('mv "${OLD_VENV_BACKUP}" "${VENV_DIR}"')
+    remove_failed = script.index('rm -rf "${failed_venv}"')
+    assert move_failed < restore_previous < remove_failed
+    assert "trap - EXIT INT TERM HUP" in script

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -228,3 +228,13 @@ def test_request_accessibility_uses_one_shot_native_watcher(
 
     assert watcher.request_accessibility_permission() is True
     assert seen == [[str(binary), "--request-accessibility"]]
+
+
+def test_normal_watcher_start_uses_pure_accessibility_check() -> None:
+    source = (Path(__file__).resolve().parents[1] / "resources" / "mac-ax-watcher.swift").read_text(
+        encoding="utf-8"
+    )
+    normal_start = source.split("// Normal Runtime starts are pure checks.", 1)[1]
+
+    assert "let trusted = AXIsProcessTrusted()" in normal_start
+    assert "AXIsProcessTrustedWithOptions" not in normal_start


### PR DESCRIPTION
## What changed

- make onboarding request Accessibility and Screen Recording step by step, against the exact native helper identities that run capture
- persist OCR opt-in or opt-out and avoid surprise permission prompts during ordinary daemon starts
- require daemon ownership, generation, health, worker, permission, and fresh-capture proof before onboarding succeeds
- make repeated starts, LaunchAgent takeover, stale PID reuse, locked or paused privacy states, and ingest-only mode deterministic
- build updates in an inactive relocatable environment, atomically exchange it with the active runtime, and restore the old runtime after cancellation or failure
- require explicit provider selection after declining an existing LLM provider instead of silently reusing Anthropic
- document the permission, update, recovery, and validation contracts

## Validation

- 1,685 unit tests passed; 15 deselected
- macOS marked tests: 2 passed
- integration tests: 2 passed, 11 skipped
- isolated real install: fresh install, three consecutive successful updates, five consecutive onboard runs, and direct install.sh update
- cancellation injected after replacement preparation: old runtime and shim remained usable; no candidate or transaction residue
- live branches exercised: locked, paused, ingest-ready, OCR enabled with worker ready, OCR disabled with opt-out preserved
- both Swift helpers compiled as arm64 Mach-O and passed Accessibility probes
- Ruff, format, secret, PII, language, documentation-link, OpenAPI, DB-schema, shell syntax, wheel-content, and diff checks passed

Two independent code reviews were completed and all findings were fixed before push.
