### PR TITLE
fix(llm): support completion token limits for OpenAI providers

### DIFF
--- a/src/persome/llm_setup.py
+++ b/src/persome/llm_setup.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from . import env_file, paths
-from .providers import LLM_API_KEY_ENV, ResolvedLLMProfile
+from .providers import LLM_API_KEY_ENV, ResolvedLLMProfile, openai_token_limit_kwargs
 
 _PROBE_TOOL_NAME = "persome_setup_check"
 _PROBE_TOOL_DESCRIPTION = "Confirm that this model can call Persome memory tools."
@@ -64,7 +64,7 @@ def probe_profile(profile: ResolvedLLMProfile, *, timeout: float = 20.0) -> Prob
             client.chat.completions.create(
                 model=profile.wire_model,
                 messages=[{"role": "user", "content": "Reply with exactly: ok"}],
-                max_tokens=8,
+                **openai_token_limit_kwargs(profile, 8),
             )
     except Exception as exc:  # noqa: BLE001
         return ProbeResult(
@@ -124,9 +124,9 @@ def probe_profile(profile: ResolvedLLMProfile, *, timeout: float = 20.0) -> Prob
                 tool_response = client.chat.completions.create(
                     model=profile.wire_model,
                     messages=[{"role": "user", "content": prompt}],
-                    max_tokens=128,
                     tools=[tool],
                     tool_choice=tool_choice,
+                    **openai_token_limit_kwargs(profile, 128),
                 )
             except Exception as exc:  # noqa: BLE001
                 tool_error = _safe_error(exc, profile.api_key)

--- a/src/persome/providers.py
+++ b/src/persome/providers.py
@@ -271,6 +271,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
 )
 
 _BY_ID = {provider.id: provider for provider in PROVIDERS}
+_COMPLETION_TOKEN_LIMIT_PROVIDERS = frozenset({"openai", "azure-openai"})
 
 
 @dataclass(frozen=True)
@@ -317,6 +318,16 @@ class ResolvedLLMProfile:
         if not self.key_required:
             return "persome-local"
         raise RuntimeError(f"{self.api_key_env} is not set for {self.provider_label}")
+
+
+def openai_token_limit_kwargs(profile: ResolvedLLMProfile, limit: int) -> dict[str, int]:
+    """Map Persome's provider-neutral output limit to the provider's wire parameter."""
+    parameter = (
+        "max_completion_tokens"
+        if profile.provider in _COMPLETION_TOKEN_LIMIT_PROVIDERS
+        else "max_tokens"
+    )
+    return {parameter: limit}
 
 
 def provider_spec(provider: str) -> ProviderSpec | None:

--- a/src/persome/writer/llm.py
+++ b/src/persome/writer/llm.py
@@ -18,7 +18,7 @@ from typing import Any, cast
 
 from ..config import Config, ModelConfig
 from ..logger import get
-from ..providers import ResolvedLLMProfile, resolve_profile
+from ..providers import ResolvedLLMProfile, openai_token_limit_kwargs, resolve_profile
 
 logger = get("persome.writer")
 
@@ -318,8 +318,10 @@ def call_llm(
         openai_kwargs: dict[str, Any] = {
             "model": profile.wire_model,
             "messages": _to_openai_messages(messages),
-            "max_tokens": model_cfg.max_tokens or _DEFAULT_MAX_TOKENS,
         }
+        openai_kwargs.update(
+            openai_token_limit_kwargs(profile, model_cfg.max_tokens or _DEFAULT_MAX_TOKENS)
+        )
         if tools:
             openai_kwargs["tools"] = _to_openai_tools(tools)
         # ``extra`` contains Anthropic-specific controls in existing callers.
@@ -427,7 +429,7 @@ def ping_stage(cfg: Config, stage: str, *, timeout: float = 5.0) -> PingResult:
             client.chat.completions.create(
                 model=profile.wire_model,
                 messages=[{"role": "user", "content": "Reply with 'ok'."}],
-                max_tokens=4,
+                **openai_token_limit_kwargs(profile, 4),
             )
     except Exception as exc:  # noqa: BLE001
         label = type(exc).__name__

--- a/tests/test_openai_protocol_http.py
+++ b/tests/test_openai_protocol_http.py
@@ -8,6 +8,8 @@ from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 
+import pytest
+
 from persome.config import Config, ModelConfig
 from persome.llm_setup import probe_profile
 from persome.providers import make_profile
@@ -85,14 +87,15 @@ def _server() -> Iterator[tuple[str, list[dict[str, Any]]]]:
         thread.join(timeout=2)
 
 
-def test_writer_uses_real_openai_sdk_over_configured_endpoint(monkeypatch) -> None:
+@pytest.mark.parametrize("provider", ["custom-openai", "deepseek"])
+def test_compatible_writer_keeps_legacy_token_limit_parameter(monkeypatch, provider) -> None:
     monkeypatch.delenv("PERSOME_LLM_MOCK", raising=False)
     monkeypatch.setenv("PERSOME_LLM_API_KEY", "wire-secret")
     with _server() as (base_url, requests):
         cfg = Config(
             models={
                 "default": ModelConfig(
-                    provider="custom-openai",
+                    provider=provider,
                     protocol="openai",
                     model="test-model",
                     base_url=base_url,
@@ -110,6 +113,35 @@ def test_writer_uses_real_openai_sdk_over_configured_endpoint(monkeypatch) -> No
     assert extract_text(response) == "ok"
     assert requests[0]["path"] == "/v1/chat/completions"
     assert requests[0]["authorization"] == "Bearer wire-secret"
+    assert requests[0]["body"]["max_tokens"] == 8192
+    assert "max_completion_tokens" not in requests[0]["body"]
+
+
+def test_openai_writer_uses_completion_token_limit_parameter(monkeypatch) -> None:
+    monkeypatch.delenv("PERSOME_LLM_MOCK", raising=False)
+    monkeypatch.setenv("PERSOME_LLM_API_KEY", "wire-secret")
+    with _server() as (base_url, requests):
+        cfg = Config(
+            models={
+                "default": ModelConfig(
+                    provider="openai",
+                    protocol="openai",
+                    model="gpt-5.4",
+                    base_url=base_url,
+                    api_key_env="PERSOME_LLM_API_KEY",
+                )
+            }
+        )
+
+        response = call_llm(
+            cfg,
+            "timeline",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+
+    assert extract_text(response) == "ok"
+    assert requests[0]["body"]["max_completion_tokens"] == 8192
+    assert "max_tokens" not in requests[0]["body"]
 
 
 def test_onboarding_probe_uses_real_openai_sdk(monkeypatch) -> None:
@@ -130,3 +162,23 @@ def test_onboarding_probe_uses_real_openai_sdk(monkeypatch) -> None:
     assert result.tool_call_ok is True
     assert len(requests) == 2
     assert requests[1]["body"]["tool_choice"]["function"]["name"] == "persome_setup_check"
+
+
+def test_azure_onboarding_probe_uses_completion_token_limit_parameter(monkeypatch) -> None:
+    monkeypatch.setenv("PERSOME_LLM_API_KEY", "wire-secret")
+    with _server() as (base_url, requests):
+        profile = make_profile(
+            "azure-openai",
+            model="gpt-5.4",
+            base_url=base_url,
+            api_key_env="PERSOME_LLM_API_KEY",
+            api_key="wire-secret",
+            protocol="openai",
+        )
+
+        result = probe_profile(profile)
+
+    assert result.completion_ok is True
+    assert result.tool_call_ok is True
+    assert [request["body"]["max_completion_tokens"] for request in requests] == [8, 128]
+    assert all("max_tokens" not in request["body"] for request in requests)

--- a/tests/test_writer_llm_ping.py
+++ b/tests/test_writer_llm_ping.py
@@ -176,6 +176,8 @@ def test_ping_stage_openai_compatible_uses_selected_endpoint(
     assert result.ok is True
     assert captured_client["base_url"] == "https://gateway.example/v1"
     assert captured_call["model"] == "gpt-4.1-mini"
+    assert captured_call["max_completion_tokens"] == 4
+    assert "max_tokens" not in captured_call
 
 
 def test_ping_stage_reports_missing_selected_credential(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What

- Map the provider-neutral output token limit to `max_completion_tokens` for OpenAI and Azure OpenAI.
- Keep `max_tokens` for other OpenAI-compatible providers.
- Apply the mapping consistently to onboarding probes, runtime generation, and health checks.
- Add HTTP-level regression coverage for OpenAI, Azure OpenAI, Custom OpenAI, and DeepSeek routes.

## Why

Azure OpenAI GPT-5.4 rejects `max_tokens` and requires `max_completion_tokens`. Persome previously hardcoded `max_tokens` across all Chat Completions requests, so `persome llm setup` failed before saving a valid profile.

## Verification

- Related LLM suite: 36 passed.
- Offline suite excluding one confirmed pre-existing local FTS5 baseline failure: 1699 passed.
- Ruff and format checks passed.
- Secret, PII, language, and documentation-link scans passed.
- Live Azure OpenAI GPT-5.4 verification passed for completion, tool calling, profile save, and `persome llm status --check`.

## Known baseline issue

`test_malformed_derived_captures_fts_is_rebuilt_without_quarantine` fails unchanged before and after this patch on the local macOS SQLite runtime; it is unrelated to the LLM request path.