### PR TITLE
fix(llm): support completion token limits for OpenAI providers

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -95,6 +95,12 @@ Ollama, LM Studio, and vLLM. Presets describe endpoint defaults, not a blanket
 capability guarantee for every model. Use `custom-openai` or
 `custom-anthropic` for another compatible gateway.
 
+OpenAI and Azure OpenAI requests prefer the current `max_completion_tokens`
+output limit, while other compatible providers prefer `max_tokens`. If the
+selected endpoint explicitly rejects its preferred parameter, Persome retries
+once when it returns a recognized parameter-rejection error, then remembers the
+accepted choice for the process lifetime.
+
 During onboarding, Persome can discover common provider-specific variables such
 as keys exported by provider CLIs or existing shell profiles. They are import
 sources only; the saved Runtime profile always references `PERSOME_LLM_API_KEY`.

--- a/src/persome/llm_setup.py
+++ b/src/persome/llm_setup.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from . import env_file, paths
-from .providers import LLM_API_KEY_ENV, ResolvedLLMProfile
+from .providers import LLM_API_KEY_ENV, ResolvedLLMProfile, openai_token_limit_kwargs
 
 _PROBE_TOOL_NAME = "persome_setup_check"
 _PROBE_TOOL_DESCRIPTION = "Confirm that this model can call Persome memory tools."
@@ -64,7 +64,7 @@ def probe_profile(profile: ResolvedLLMProfile, *, timeout: float = 20.0) -> Prob
             client.chat.completions.create(
                 model=profile.wire_model,
                 messages=[{"role": "user", "content": "Reply with exactly: ok"}],
-                max_tokens=8,
+                **openai_token_limit_kwargs(profile, 8),
             )
     except Exception as exc:  # noqa: BLE001
         return ProbeResult(
@@ -124,9 +124,9 @@ def probe_profile(profile: ResolvedLLMProfile, *, timeout: float = 20.0) -> Prob
                 tool_response = client.chat.completions.create(
                     model=profile.wire_model,
                     messages=[{"role": "user", "content": prompt}],
-                    max_tokens=128,
                     tools=[tool],
                     tool_choice=tool_choice,
+                    **openai_token_limit_kwargs(profile, 128),
                 )
             except Exception as exc:  # noqa: BLE001
                 tool_error = _safe_error(exc, profile.api_key)

--- a/src/persome/llm_setup.py
+++ b/src/persome/llm_setup.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from . import env_file, paths
-from .providers import LLM_API_KEY_ENV, ResolvedLLMProfile, openai_token_limit_kwargs
+from .providers import LLM_API_KEY_ENV, ResolvedLLMProfile, create_openai_chat_completion
 
 _PROBE_TOOL_NAME = "persome_setup_check"
 _PROBE_TOOL_DESCRIPTION = "Confirm that this model can call Persome memory tools."
@@ -61,10 +61,12 @@ def probe_profile(profile: ResolvedLLMProfile, *, timeout: float = 20.0) -> Prob
                 base_url=profile.base_url,
                 timeout=timeout,
             )
-            client.chat.completions.create(
+            create_openai_chat_completion(
+                profile,
+                client.chat.completions.create,
+                limit=8,
                 model=profile.wire_model,
                 messages=[{"role": "user", "content": "Reply with exactly: ok"}],
-                **openai_token_limit_kwargs(profile, 8),
             )
     except Exception as exc:  # noqa: BLE001
         return ProbeResult(
@@ -121,12 +123,18 @@ def probe_profile(profile: ResolvedLLMProfile, *, timeout: float = 20.0) -> Prob
         ]
         for tool_choice in choices:
             try:
-                tool_response = client.chat.completions.create(
+                tool_response = create_openai_chat_completion(
+                    profile,
+                    client.chat.completions.create,
+                    # Completion limits include hidden reasoning tokens on
+                    # current OpenAI models. Leave enough room for the forced
+                    # tool call instead of misclassifying budget exhaustion as
+                    # missing tool support.
+                    limit=512,
                     model=profile.wire_model,
                     messages=[{"role": "user", "content": prompt}],
                     tools=[tool],
                     tool_choice=tool_choice,
-                    **openai_token_limit_kwargs(profile, 128),
                 )
             except Exception as exc:  # noqa: BLE001
                 tool_error = _safe_error(exc, profile.api_key)

--- a/src/persome/providers.py
+++ b/src/persome/providers.py
@@ -271,6 +271,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
 )
 
 _BY_ID = {provider.id: provider for provider in PROVIDERS}
+_COMPLETION_TOKEN_LIMIT_PROVIDERS = frozenset({"openai", "azure-openai"})
 
 
 @dataclass(frozen=True)
@@ -317,6 +318,16 @@ class ResolvedLLMProfile:
         if not self.key_required:
             return "persome-local"
         raise RuntimeError(f"{self.api_key_env} is not set for {self.provider_label}")
+
+
+def openai_token_limit_kwargs(profile: ResolvedLLMProfile, limit: int) -> dict[str, int]:
+    """Map Persome's provider-neutral output limit to the provider's wire parameter."""
+    parameter = (
+        "max_completion_tokens"
+        if profile.provider in _COMPLETION_TOKEN_LIMIT_PROVIDERS
+        else "max_tokens"
+    )
+    return {parameter: limit}
 
 
 def provider_spec(provider: str) -> ProviderSpec | None:

--- a/src/persome/providers.py
+++ b/src/persome/providers.py
@@ -9,7 +9,9 @@ are not listed here.
 from __future__ import annotations
 
 import os
+from collections.abc import Callable
 from dataclasses import dataclass, field
+from threading import Lock
 from typing import Any, Literal
 
 LLMProtocol = Literal["anthropic", "openai"]
@@ -272,6 +274,8 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
 
 _BY_ID = {provider.id: provider for provider in PROVIDERS}
 _COMPLETION_TOKEN_LIMIT_PROVIDERS = frozenset({"openai", "azure-openai"})
+_TOKEN_LIMIT_PARAMETER_BY_ROUTE: dict[tuple[str, str, str], str] = {}
+_TOKEN_LIMIT_CACHE_LOCK = Lock()
 
 
 @dataclass(frozen=True)
@@ -322,12 +326,73 @@ class ResolvedLLMProfile:
 
 def openai_token_limit_kwargs(profile: ResolvedLLMProfile, limit: int) -> dict[str, int]:
     """Map Persome's provider-neutral output limit to the provider's wire parameter."""
-    parameter = (
-        "max_completion_tokens"
-        if profile.provider in _COMPLETION_TOKEN_LIMIT_PROVIDERS
-        else "max_tokens"
-    )
+    cache_key = (profile.provider.lower(), profile.base_url.rstrip("/"), profile.wire_model)
+    with _TOKEN_LIMIT_CACHE_LOCK:
+        parameter = _TOKEN_LIMIT_PARAMETER_BY_ROUTE.get(cache_key)
+    if parameter is None:
+        parameter = (
+            "max_completion_tokens"
+            if profile.provider.lower() in _COMPLETION_TOKEN_LIMIT_PROVIDERS
+            else "max_tokens"
+        )
     return {parameter: limit}
+
+
+def _completion_token_limit_is_unsupported(exc: Exception, parameter: str) -> bool:
+    """Return whether a 400 response explicitly rejects the attempted parameter."""
+    if getattr(exc, "status_code", None) != 400:
+        return False
+
+    body = getattr(exc, "body", None)
+    if isinstance(body, dict) and isinstance(body.get("error"), dict):
+        body = body["error"]
+    code = getattr(exc, "code", None)
+    rejected_parameter = getattr(exc, "param", None)
+    message = ""
+    if isinstance(body, dict):
+        code = code or body.get("code")
+        rejected_parameter = rejected_parameter or body.get("param")
+        message = str(body.get("message", ""))
+    if code == "unsupported_parameter" and rejected_parameter == parameter:
+        return True
+
+    # Older Azure deployments return neither code nor param, but use this
+    # exact error shape for an unknown request argument.
+    if code is not None or rejected_parameter is not None:
+        return False
+    normalized = " ".join(message.lower().split())
+    return normalized == f"unrecognized request argument supplied: {parameter}"
+
+
+def create_openai_chat_completion(
+    profile: ResolvedLLMProfile,
+    create: Callable[..., Any],
+    *,
+    limit: int,
+    **kwargs: Any,
+) -> Any:
+    """Create a chat completion with a narrow token-limit compatibility fallback.
+
+    Official OpenAI profiles prefer ``max_completion_tokens`` and compatible
+    gateways prefer ``max_tokens``. Either can point at a model with the opposite
+    requirement, so retry once only when the endpoint explicitly rejects the
+    attempted parameter. Cache the accepted choice per route for this process.
+    """
+    token_limit = openai_token_limit_kwargs(profile, limit)
+    parameter = next(iter(token_limit))
+    try:
+        return create(**kwargs, **token_limit)
+    except Exception as exc:
+        if not _completion_token_limit_is_unsupported(exc, parameter):
+            raise
+        alternate = (
+            "max_tokens" if parameter == "max_completion_tokens" else "max_completion_tokens"
+        )
+        response = create(**kwargs, **{alternate: limit})
+        cache_key = (profile.provider.lower(), profile.base_url.rstrip("/"), profile.wire_model)
+        with _TOKEN_LIMIT_CACHE_LOCK:
+            _TOKEN_LIMIT_PARAMETER_BY_ROUTE[cache_key] = alternate
+        return response
 
 
 def provider_spec(provider: str) -> ProviderSpec | None:
@@ -421,7 +486,7 @@ def resolve_profile(model_cfg: Any) -> ResolvedLLMProfile:
         return legacy
 
     model = str(getattr(model_cfg, "model", "") or "")
-    provider = str(getattr(model_cfg, "provider", "") or "") or infer_provider(model)
+    provider = (str(getattr(model_cfg, "provider", "") or "") or infer_provider(model)).lower()
     spec = provider_spec(provider)
     if spec is None:
         spec = _BY_ID["custom-openai"]
@@ -465,6 +530,7 @@ def make_profile(
     protocol: LLMProtocol | None = None,
 ) -> ResolvedLLMProfile:
     """Build a profile from onboarding inputs before they are persisted."""
+    provider = provider.lower()
     spec = provider_spec(provider) or _BY_ID["custom-openai"]
     return ResolvedLLMProfile(
         provider=provider,

--- a/src/persome/writer/llm.py
+++ b/src/persome/writer/llm.py
@@ -18,7 +18,7 @@ from typing import Any, cast
 
 from ..config import Config, ModelConfig
 from ..logger import get
-from ..providers import ResolvedLLMProfile, resolve_profile
+from ..providers import ResolvedLLMProfile, openai_token_limit_kwargs, resolve_profile
 
 logger = get("persome.writer")
 
@@ -318,8 +318,10 @@ def call_llm(
         openai_kwargs: dict[str, Any] = {
             "model": profile.wire_model,
             "messages": _to_openai_messages(messages),
-            "max_tokens": model_cfg.max_tokens or _DEFAULT_MAX_TOKENS,
         }
+        openai_kwargs.update(
+            openai_token_limit_kwargs(profile, model_cfg.max_tokens or _DEFAULT_MAX_TOKENS)
+        )
         if tools:
             openai_kwargs["tools"] = _to_openai_tools(tools)
         # ``extra`` contains Anthropic-specific controls in existing callers.
@@ -427,7 +429,7 @@ def ping_stage(cfg: Config, stage: str, *, timeout: float = 5.0) -> PingResult:
             client.chat.completions.create(
                 model=profile.wire_model,
                 messages=[{"role": "user", "content": "Reply with 'ok'."}],
-                max_tokens=4,
+                **openai_token_limit_kwargs(profile, 4),
             )
     except Exception as exc:  # noqa: BLE001
         label = type(exc).__name__

--- a/src/persome/writer/llm.py
+++ b/src/persome/writer/llm.py
@@ -18,7 +18,7 @@ from typing import Any, cast
 
 from ..config import Config, ModelConfig
 from ..logger import get
-from ..providers import ResolvedLLMProfile, openai_token_limit_kwargs, resolve_profile
+from ..providers import ResolvedLLMProfile, create_openai_chat_completion, resolve_profile
 
 logger = get("persome.writer")
 
@@ -319,14 +319,16 @@ def call_llm(
             "model": profile.wire_model,
             "messages": _to_openai_messages(messages),
         }
-        openai_kwargs.update(
-            openai_token_limit_kwargs(profile, model_cfg.max_tokens or _DEFAULT_MAX_TOKENS)
-        )
         if tools:
             openai_kwargs["tools"] = _to_openai_tools(tools)
         # ``extra`` contains Anthropic-specific controls in existing callers.
         # Do not leak those unsupported fields into compatible gateways.
-        resp = _openai_client(profile).chat.completions.create(**openai_kwargs)
+        resp = create_openai_chat_completion(
+            profile,
+            _openai_client(profile).chat.completions.create,
+            limit=model_cfg.max_tokens or _DEFAULT_MAX_TOKENS,
+            **openai_kwargs,
+        )
     if json_mode and resp.choices and resp.choices[0].message.content:
         resp.choices[0].message.content = _unfence_json(resp.choices[0].message.content)
     return resp
@@ -426,10 +428,12 @@ def ping_stage(cfg: Config, stage: str, *, timeout: float = 5.0) -> PingResult:
                 base_url=profile.base_url,
                 timeout=timeout,
             )
-            client.chat.completions.create(
+            create_openai_chat_completion(
+                profile,
+                client.chat.completions.create,
+                limit=4,
                 model=profile.wire_model,
                 messages=[{"role": "user", "content": "Reply with 'ok'."}],
-                **openai_token_limit_kwargs(profile, 4),
             )
     except Exception as exc:  # noqa: BLE001
         label = type(exc).__name__

--- a/tests/test_openai_protocol_http.py
+++ b/tests/test_openai_protocol_http.py
@@ -8,6 +8,8 @@ from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 
+import pytest
+
 from persome.config import Config, ModelConfig
 from persome.llm_setup import probe_profile
 from persome.providers import make_profile
@@ -85,14 +87,15 @@ def _server() -> Iterator[tuple[str, list[dict[str, Any]]]]:
         thread.join(timeout=2)
 
 
-def test_writer_uses_real_openai_sdk_over_configured_endpoint(monkeypatch) -> None:
+@pytest.mark.parametrize("provider", ["custom-openai", "deepseek"])
+def test_compatible_writer_keeps_legacy_token_limit_parameter(monkeypatch, provider) -> None:
     monkeypatch.delenv("PERSOME_LLM_MOCK", raising=False)
     monkeypatch.setenv("PERSOME_LLM_API_KEY", "wire-secret")
     with _server() as (base_url, requests):
         cfg = Config(
             models={
                 "default": ModelConfig(
-                    provider="custom-openai",
+                    provider=provider,
                     protocol="openai",
                     model="test-model",
                     base_url=base_url,
@@ -110,6 +113,35 @@ def test_writer_uses_real_openai_sdk_over_configured_endpoint(monkeypatch) -> No
     assert extract_text(response) == "ok"
     assert requests[0]["path"] == "/v1/chat/completions"
     assert requests[0]["authorization"] == "Bearer wire-secret"
+    assert requests[0]["body"]["max_tokens"] == 8192
+    assert "max_completion_tokens" not in requests[0]["body"]
+
+
+def test_openai_writer_uses_completion_token_limit_parameter(monkeypatch) -> None:
+    monkeypatch.delenv("PERSOME_LLM_MOCK", raising=False)
+    monkeypatch.setenv("PERSOME_LLM_API_KEY", "wire-secret")
+    with _server() as (base_url, requests):
+        cfg = Config(
+            models={
+                "default": ModelConfig(
+                    provider="openai",
+                    protocol="openai",
+                    model="gpt-5.4",
+                    base_url=base_url,
+                    api_key_env="PERSOME_LLM_API_KEY",
+                )
+            }
+        )
+
+        response = call_llm(
+            cfg,
+            "timeline",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+
+    assert extract_text(response) == "ok"
+    assert requests[0]["body"]["max_completion_tokens"] == 8192
+    assert "max_tokens" not in requests[0]["body"]
 
 
 def test_onboarding_probe_uses_real_openai_sdk(monkeypatch) -> None:
@@ -130,3 +162,23 @@ def test_onboarding_probe_uses_real_openai_sdk(monkeypatch) -> None:
     assert result.tool_call_ok is True
     assert len(requests) == 2
     assert requests[1]["body"]["tool_choice"]["function"]["name"] == "persome_setup_check"
+
+
+def test_azure_onboarding_probe_uses_completion_token_limit_parameter(monkeypatch) -> None:
+    monkeypatch.setenv("PERSOME_LLM_API_KEY", "wire-secret")
+    with _server() as (base_url, requests):
+        profile = make_profile(
+            "azure-openai",
+            model="gpt-5.4",
+            base_url=base_url,
+            api_key_env="PERSOME_LLM_API_KEY",
+            api_key="wire-secret",
+            protocol="openai",
+        )
+
+        result = probe_profile(profile)
+
+    assert result.completion_ok is True
+    assert result.tool_call_ok is True
+    assert [request["body"]["max_completion_tokens"] for request in requests] == [8, 128]
+    assert all("max_tokens" not in request["body"] for request in requests)

--- a/tests/test_openai_protocol_http.py
+++ b/tests/test_openai_protocol_http.py
@@ -18,6 +18,7 @@ from persome.writer.llm import call_llm, extract_text
 
 class _Handler(BaseHTTPRequestHandler):
     requests: list[dict[str, Any]] = []
+    token_limit_error: str | None = None
 
     def log_message(self, format: str, *args: Any) -> None:
         return None
@@ -32,7 +33,54 @@ class _Handler(BaseHTTPRequestHandler):
                 "body": body,
             }
         )
+        if self.token_limit_error == "reject_completion" and "max_completion_tokens" in body:
+            self._json_error(
+                "Unrecognized request argument supplied: max_completion_tokens",
+            )
+            return
+        if self.token_limit_error == "reject_legacy" and "max_tokens" in body:
+            self._json_error(
+                "Unsupported parameter: 'max_tokens' is not supported with this model.",
+                param="max_tokens",
+                code="unsupported_parameter",
+            )
+            return
+        if self.token_limit_error == "unrelated":
+            self._json_error(
+                "The requested model was not found.", param="model", code="model_not_found"
+            )
+            return
+        if self.token_limit_error == "conflicting_unrecognized":
+            self._json_error(
+                "Unrecognized request argument supplied: max_completion_tokens",
+                param="model",
+                code="invalid_request_error",
+            )
+            return
+        if self.token_limit_error == "verbose_unrecognized":
+            self._json_error(
+                "Request failed: Unrecognized request argument supplied: max_completion_tokens",
+            )
+            return
         self._json_completion(body)
+
+    def _json_error(
+        self, message: str, *, param: str | None = None, code: str | None = None
+    ) -> None:
+        payload = {
+            "error": {
+                "message": message,
+                "type": "invalid_request_error",
+                "param": param,
+                "code": code,
+            }
+        }
+        raw = json.dumps(payload).encode()
+        self.send_response(400)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
 
     def _json_completion(self, body: dict[str, Any]) -> None:
         message: dict[str, Any] = {"role": "assistant", "content": "ok"}
@@ -73,8 +121,9 @@ class _Handler(BaseHTTPRequestHandler):
 
 
 @contextmanager
-def _server() -> Iterator[tuple[str, list[dict[str, Any]]]]:
+def _server(*, token_limit_error: str | None = None) -> Iterator[tuple[str, list[dict[str, Any]]]]:
     _Handler.requests = []
+    _Handler.token_limit_error = token_limit_error
     server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -82,6 +131,7 @@ def _server() -> Iterator[tuple[str, list[dict[str, Any]]]]:
     try:
         yield f"http://{host}:{port}/v1", _Handler.requests
     finally:
+        _Handler.token_limit_error = None
         server.shutdown()
         server.server_close()
         thread.join(timeout=2)
@@ -124,7 +174,7 @@ def test_openai_writer_uses_completion_token_limit_parameter(monkeypatch) -> Non
         cfg = Config(
             models={
                 "default": ModelConfig(
-                    provider="openai",
+                    provider="OpenAI",
                     protocol="openai",
                     model="gpt-5.4",
                     base_url=base_url,
@@ -180,5 +230,74 @@ def test_azure_onboarding_probe_uses_completion_token_limit_parameter(monkeypatc
 
     assert result.completion_ok is True
     assert result.tool_call_ok is True
-    assert [request["body"]["max_completion_tokens"] for request in requests] == [8, 128]
+    assert [request["body"]["max_completion_tokens"] for request in requests] == [8, 512]
     assert all("max_tokens" not in request["body"] for request in requests)
+
+
+@pytest.mark.parametrize("provider", ["azure-openai", "openai"])
+def test_official_profile_falls_back_for_legacy_endpoint(monkeypatch, provider) -> None:
+    monkeypatch.setenv("PERSOME_LLM_API_KEY", "wire-secret")
+    with _server(token_limit_error="reject_completion") as (base_url, requests):
+        profile = make_profile(
+            provider,
+            model="arbitrary-deployment-name",
+            base_url=base_url,
+            api_key_env="PERSOME_LLM_API_KEY",
+            api_key="wire-secret",
+            protocol="openai",
+        )
+
+        result = probe_profile(profile)
+
+    assert result.completion_ok is True
+    assert result.tool_call_ok is True
+    assert len(requests) == 3
+    assert requests[0]["body"]["max_completion_tokens"] == 8
+    assert requests[1]["body"]["max_tokens"] == 8
+    assert requests[2]["body"]["max_tokens"] == 512
+    assert all("max_completion_tokens" not in request["body"] for request in requests[1:])
+
+
+def test_compatible_profile_falls_forward_for_current_endpoint(monkeypatch) -> None:
+    monkeypatch.setenv("PERSOME_LLM_API_KEY", "wire-secret")
+    with _server(token_limit_error="reject_legacy") as (base_url, requests):
+        profile = make_profile(
+            "custom-openai",
+            model="gpt-5.4",
+            base_url=base_url,
+            api_key_env="PERSOME_LLM_API_KEY",
+            api_key="wire-secret",
+            protocol="openai",
+        )
+
+        result = probe_profile(profile)
+
+    assert result.completion_ok is True
+    assert result.tool_call_ok is True
+    assert len(requests) == 3
+    assert requests[0]["body"]["max_tokens"] == 8
+    assert requests[1]["body"]["max_completion_tokens"] == 8
+    assert requests[2]["body"]["max_completion_tokens"] == 512
+    assert all("max_tokens" not in request["body"] for request in requests[1:])
+
+
+@pytest.mark.parametrize(
+    "token_limit_error", ["unrelated", "conflicting_unrecognized", "verbose_unrecognized"]
+)
+def test_token_limit_fallback_does_not_retry_ambiguous_400(monkeypatch, token_limit_error) -> None:
+    monkeypatch.setenv("PERSOME_LLM_API_KEY", "wire-secret")
+    with _server(token_limit_error=token_limit_error) as (base_url, requests):
+        profile = make_profile(
+            "azure-openai",
+            model="missing-deployment",
+            base_url=base_url,
+            api_key_env="PERSOME_LLM_API_KEY",
+            api_key="wire-secret",
+            protocol="openai",
+        )
+
+        result = probe_profile(profile)
+
+    assert result.completion_ok is False
+    assert result.tool_call_ok is False
+    assert len(requests) == 1

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -70,6 +70,20 @@ def test_selected_provider_routing_prefix_is_removed(monkeypatch) -> None:
     assert profile.wire_model == "gpt-4.1-mini"
 
 
+def test_explicit_provider_id_is_case_insensitive(monkeypatch) -> None:
+    _clear_provider_env(monkeypatch)
+    profile = resolve_profile(
+        ModelConfig(
+            provider="OpenAI",
+            protocol="openai",
+            model="openai/gpt-4.1-mini",
+            api_key_env=LLM_API_KEY_ENV,
+        )
+    )
+    assert profile.provider == "openai"
+    assert profile.wire_model == "gpt-4.1-mini"
+
+
 def test_local_provider_does_not_require_a_key(monkeypatch) -> None:
     _clear_provider_env(monkeypatch)
     profile = resolve_profile(

--- a/tests/test_writer_llm_ping.py
+++ b/tests/test_writer_llm_ping.py
@@ -176,6 +176,8 @@ def test_ping_stage_openai_compatible_uses_selected_endpoint(
     assert result.ok is True
     assert captured_client["base_url"] == "https://gateway.example/v1"
     assert captured_call["model"] == "gpt-4.1-mini"
+    assert captured_call["max_completion_tokens"] == 4
+    assert "max_tokens" not in captured_call
 
 
 def test_ping_stage_reports_missing_selected_credential(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What

- Map Persome's provider-neutral output limit to `max_completion_tokens` for OpenAI and Azure OpenAI.
- Keep `max_tokens` for other OpenAI-compatible providers.
- Apply the mapping consistently to onboarding probes, runtime generation, and health checks.
- Add HTTP-level regression coverage for OpenAI, Azure OpenAI, Custom OpenAI, and DeepSeek routes.

## Why

Azure OpenAI GPT-5.4 rejects `max_tokens` and requires `max_completion_tokens`. Persome previously hardcoded `max_tokens` across Chat Completions requests, so `persome llm setup` failed before saving an otherwise valid profile.

## Compatibility

The internal `ModelConfig.max_tokens` field and persisted configuration remain unchanged. Only the provider-specific wire parameter is mapped, so no config migration or public CLI change is required.

## Verification

- Rebased onto the latest `main` at `27f3992`.
- Latest-main offline suite: 2003 passed, 15 deselected.
- Focused OpenAI protocol and health-check suite: 12 passed.
- Ruff and format checks passed.
- Secret, PII, and language scans passed.
- Live Azure OpenAI GPT-5.4: completion, tool calling, profile save, and `persome llm status --check` passed.
- Live OpenAI GPT-5.4: completion, tool calling, profile save, and status check passed.
- Live Anthropic Claude Sonnet 4.5: completion, tool calling, profile save, and status check passed.
