### PR TITLE
feat: share personal constellation to X

### DIFF
--- a/docs/model-contract.md
+++ b/docs/model-contract.md
@@ -64,7 +64,12 @@ The viewer presents that hierarchy as a personal constellation: a Root-centered 
 Volume and Face orbit structures, Point clouds, and restrained ambient depth cues. Its editorial
 frame uses the live Root signature as the model's plain-language identity statement so each view is
 recognizably personal without changing the snapshot. The `Local only` treatment is descriptive, not
-a publishing control: the viewer does not upload, export, or share model content.
+a publishing control. The viewer never uploads the model or exposes its owner-only URL. An explicit
+`Share` action renders a fixed-size PNG locally from the unlabeled WebGL constellation, adds only
+aggregate layer counts and Persome branding, downloads it, and opens an X composer with standard
+copy and tags. Node labels, Root signature, receipts, source names, timestamps, and viewer
+credentials are excluded from the share artifact; the owner attaches the downloaded image and
+confirms the post in X.
 
 Visible node labels and their Point, Face, Volume, Root, or context meshes open the same provenance
 detail panel. Labels are keyboard-focusable; Escape closes the selection. Lines remain visual

--- a/docs/model-contract.md
+++ b/docs/model-contract.md
@@ -65,11 +65,11 @@ Volume and Face orbit structures, Point clouds, and restrained ambient depth cue
 frame uses the live Root signature as the model's plain-language identity statement so each view is
 recognizably personal without changing the snapshot. The `Local only` treatment is descriptive, not
 a publishing control. The viewer never uploads the model or exposes its owner-only URL. An explicit
-`Share` action renders a fixed-size PNG locally from the unlabeled WebGL constellation, adds only
-aggregate layer counts and Persome branding, downloads it, and opens an X composer with standard
-copy and tags. Node labels, Root signature, receipts, source names, timestamps, and viewer
-credentials are excluded from the share artifact; the owner attaches the downloaded image and
-confirms the post in X.
+`Share` action renders a fixed-size PNG locally from the unlabeled WebGL constellation, adds the Root
+identity statement, up to three highest-level Volume or Face signatures, aggregate layer counts, and
+Persome branding, downloads it, and opens an X composer with standard copy and tags. Individual
+Point labels, receipts, source names, timestamps, and viewer credentials are excluded from the share
+artifact; the owner attaches the downloaded image and confirms the post in X.
 
 Visible node labels and their Point, Face, Volume, Root, or context meshes open the same provenance
 detail panel. Labels are keyboard-focusable; Escape closes the selection. Lines remain visual

--- a/resources/model_assets/share.mjs
+++ b/resources/model_assets/share.mjs
@@ -1,0 +1,156 @@
+export const SHARE_CARD_WIDTH = 1200;
+export const SHARE_CARD_HEIGHT = 675;
+export const SHARE_FILE_NAME = "my-persome-constellation.png";
+export const SHARE_URL = "https://github.com/Intuition-Lab/personal-model";
+export const SHARE_HASHTAGS = ["Persome", "PersonalAI"];
+export const SHARE_TEXT = [
+  "My Mac has been quietly learning the shape of how I work.",
+  "",
+  "This is my personal constellation — built locally from real context with Persome.",
+  "",
+  "Build yours →",
+].join("\n");
+
+export function buildXIntentUrl({
+  text = SHARE_TEXT,
+  url = SHARE_URL,
+  hashtags = SHARE_HASHTAGS,
+} = {}) {
+  const params = new URLSearchParams();
+  params.set("text", text);
+  params.set("url", url);
+  params.set("hashtags", hashtags.join(","));
+  return `https://x.com/intent/tweet?${params.toString()}`;
+}
+
+export function shareStats(model = {}) {
+  const stats = model.stats || {};
+  const lineCount = (stats.evolution_lines || 0) + (stats.relation_lines || 0);
+  return [
+    ["POINTS", stats.points || model.points?.length || 0],
+    ["LINES", lineCount || model.lines?.length || 0],
+    ["FACES", stats.faces || model.faces?.length || 0],
+    ["VOLUMES", stats.volumes || model.volumes?.length || 0],
+    ["ROOT", stats.roots || Number(Boolean(model.root))],
+  ];
+}
+
+function drawCover(context, source, width, height) {
+  const sourceWidth = source.width || source.videoWidth || width;
+  const sourceHeight = source.height || source.videoHeight || height;
+  const scale = Math.max(width / sourceWidth, height / sourceHeight);
+  const drawWidth = sourceWidth * scale;
+  const drawHeight = sourceHeight * scale;
+  context.drawImage(
+    source,
+    (width - drawWidth) / 2,
+    (height - drawHeight) / 2,
+    drawWidth,
+    drawHeight,
+  );
+}
+
+function drawBrandMark(context, x, y) {
+  context.save();
+  context.strokeStyle = "rgba(255, 255, 255, 0.22)";
+  context.lineWidth = 1;
+  context.beginPath();
+  context.arc(x, y, 18, 0, Math.PI * 2);
+  context.stroke();
+
+  const nodes = [
+    [0, -6, "#ff6b8a"],
+    [-6, 5, "#ff64d6"],
+    [7, 5, "#7798ff"],
+  ];
+  context.strokeStyle = "rgba(255, 255, 255, 0.19)";
+  context.beginPath();
+  context.moveTo(x, y - 6);
+  context.lineTo(x - 6, y + 5);
+  context.lineTo(x + 7, y + 5);
+  context.closePath();
+  context.stroke();
+  nodes.forEach(([dx, dy, color]) => {
+    context.fillStyle = color;
+    context.shadowColor = color;
+    context.shadowBlur = 10;
+    context.beginPath();
+    context.arc(x + dx, y + dy, 3, 0, Math.PI * 2);
+    context.fill();
+  });
+  context.restore();
+}
+
+export function drawShareCard(context, source, model = {}) {
+  const width = SHARE_CARD_WIDTH;
+  const height = SHARE_CARD_HEIGHT;
+
+  context.save();
+  context.fillStyle = "#070610";
+  context.fillRect(0, 0, width, height);
+
+  const aura = context.createRadialGradient(760, 300, 20, 760, 300, 610);
+  aura.addColorStop(0, "rgba(105, 92, 210, 0.24)");
+  aura.addColorStop(0.46, "rgba(49, 35, 91, 0.13)");
+  aura.addColorStop(1, "rgba(7, 6, 16, 0)");
+  context.fillStyle = aura;
+  context.fillRect(0, 0, width, height);
+
+  context.save();
+  context.globalAlpha = 0.96;
+  drawCover(context, source, width, height);
+  context.restore();
+
+  const textScrim = context.createLinearGradient(0, 0, 680, 0);
+  textScrim.addColorStop(0, "rgba(7, 6, 16, 0.96)");
+  textScrim.addColorStop(0.56, "rgba(7, 6, 16, 0.46)");
+  textScrim.addColorStop(1, "rgba(7, 6, 16, 0)");
+  context.fillStyle = textScrim;
+  context.fillRect(0, 0, 760, height);
+
+  const edge = context.createLinearGradient(0, height - 170, 0, height);
+  edge.addColorStop(0, "rgba(7, 6, 16, 0)");
+  edge.addColorStop(1, "rgba(7, 6, 16, 0.88)");
+  context.fillStyle = edge;
+  context.fillRect(0, height - 170, width, 170);
+
+  drawBrandMark(context, 72, 66);
+  context.shadowBlur = 0;
+  context.fillStyle = "rgba(248, 246, 255, 0.96)";
+  context.font = "700 22px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+  context.fillText("Persome", 105, 62);
+  context.fillStyle = "rgba(164, 158, 181, 0.9)";
+  context.font = "700 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+  context.fillText("PERSONAL MODEL", 105, 80);
+
+  context.fillStyle = "rgba(195, 188, 210, 0.86)";
+  context.font = "700 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+  context.fillText("A LIVING MAP OF WHAT YOU NOTICE, REPEAT, AND BECOME", 54, 326);
+
+  const headline = context.createLinearGradient(54, 350, 430, 510);
+  headline.addColorStop(0, "#fff8fc");
+  headline.addColorStop(0.52, "#ff85cf");
+  headline.addColorStop(1, "#8ea4ff");
+  context.fillStyle = headline;
+  context.font = "650 58px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+  context.fillText("My personal", 52, 397);
+  context.fillText("constellation.", 52, 458);
+
+  let statX = 56;
+  shareStats(model).forEach(([label, value]) => {
+    context.fillStyle = "rgba(248, 246, 255, 0.94)";
+    context.font = "650 18px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+    context.fillText(String(value), statX, 554);
+    context.fillStyle = "rgba(137, 130, 153, 0.92)";
+    context.font = "700 9px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+    context.fillText(label, statX, 571);
+    statX += label === "VOLUMES" ? 92 : 78;
+  });
+
+  context.fillStyle = "rgba(152, 145, 171, 0.9)";
+  context.font = "650 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+  context.fillText("GENERATED LOCALLY · SHARED BY YOU", 54, 628);
+  context.textAlign = "right";
+  context.fillText("github.com/Intuition-Lab/personal-model", width - 52, 628);
+  context.restore();
+}

--- a/resources/model_assets/share.mjs
+++ b/resources/model_assets/share.mjs
@@ -35,6 +35,72 @@ export function shareStats(model = {}) {
   ];
 }
 
+function cleanNarrative(value, limit = 220) {
+  const text = String(value || "").replace(/\s+/g, " ").trim();
+  if (text.length <= limit) return text;
+  return `${text.slice(0, Math.max(0, limit - 1)).trimEnd()}…`;
+}
+
+function narrativeStrength(item) {
+  const evidence = item.observations
+    || item.source_receipts?.length
+    || item.member_receipts?.length
+    || 0;
+  return (Number(item.confidence) || 0) * 1000 + evidence;
+}
+
+export function shareNarrative(model = {}) {
+  const candidates = [
+    ...(model.volumes || []).map((item) => ({ ...item, kind: "VOLUME" })),
+    ...(model.faces || []).map((item) => ({ ...item, kind: "FACE" })),
+  ].filter((item) => item.signature);
+  candidates.sort((a, b) => {
+    const kindDelta = Number(b.kind === "VOLUME") - Number(a.kind === "VOLUME");
+    if (kindDelta) return kindDelta;
+    return narrativeStrength(b) - narrativeStrength(a) || String(a.id).localeCompare(String(b.id));
+  });
+  return {
+    root: cleanNarrative(
+      model.root?.signature,
+      240,
+    ) || "A living personal model, shaped by real context over time.",
+    highlights: candidates.slice(0, 3).map((item) => ({
+      kind: item.kind,
+      text: cleanNarrative(item.signature, 110),
+    })),
+  };
+}
+
+function wrappedLines(context, text, maxWidth, maxLines) {
+  const words = String(text || "").split(/\s+/).filter(Boolean);
+  const lines = [];
+  let current = "";
+  words.forEach((word) => {
+    const next = current ? `${current} ${word}` : word;
+    if (context.measureText(next).width <= maxWidth || !current) {
+      current = next;
+      return;
+    }
+    lines.push(current);
+    current = word;
+  });
+  if (current) lines.push(current);
+  if (lines.length <= maxLines) return lines;
+  const visible = lines.slice(0, maxLines);
+  let last = visible[maxLines - 1];
+  while (last && context.measureText(`${last}…`).width > maxWidth) {
+    last = last.slice(0, -1).trimEnd();
+  }
+  visible[maxLines - 1] = `${last}…`;
+  return visible;
+}
+
+function drawWrappedText(context, text, x, y, maxWidth, lineHeight, maxLines) {
+  const lines = wrappedLines(context, text, maxWidth, maxLines);
+  lines.forEach((line, index) => context.fillText(line, x, y + index * lineHeight));
+  return lines.length;
+}
+
 function drawCover(context, source, width, height) {
   const sourceWidth = source.width || source.videoWidth || width;
   const sourceHeight = source.height || source.videoHeight || height;
@@ -84,6 +150,7 @@ function drawBrandMark(context, x, y) {
 export function drawShareCard(context, source, model = {}) {
   const width = SHARE_CARD_WIDTH;
   const height = SHARE_CARD_HEIGHT;
+  const narrative = shareNarrative(model);
 
   context.save();
   context.fillStyle = "#070610";
@@ -125,25 +192,60 @@ export function drawShareCard(context, source, model = {}) {
 
   context.fillStyle = "rgba(195, 188, 210, 0.86)";
   context.font = "700 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
-  context.fillText("A LIVING MAP OF WHAT YOU NOTICE, REPEAT, AND BECOME", 54, 326);
+  context.fillText("A LIVING MAP OF WHAT YOU NOTICE, REPEAT, AND BECOME", 54, 286);
 
-  const headline = context.createLinearGradient(54, 350, 430, 510);
+  const headline = context.createLinearGradient(54, 310, 430, 430);
   headline.addColorStop(0, "#fff8fc");
   headline.addColorStop(0.52, "#ff85cf");
   headline.addColorStop(1, "#8ea4ff");
   context.fillStyle = headline;
-  context.font = "650 58px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
-  context.fillText("My personal", 52, 397);
-  context.fillText("constellation.", 52, 458);
+  context.font = "650 52px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+  context.fillText("My personal", 52, 349);
+  context.fillText("constellation.", 52, 403);
+
+  context.fillStyle = "rgba(255, 100, 214, 0.9)";
+  context.font = "750 9px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+  context.fillText("CURRENT MODEL", 55, 442);
+  context.fillStyle = "rgba(229, 224, 238, 0.88)";
+  context.font = "500 14px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+  drawWrappedText(context, narrative.root, 54, 466, 430, 20, 3);
+
+  if (narrative.highlights.length) {
+    const panelX = 746;
+    const panelY = 468;
+    const panelWidth = 404;
+    const panelHeight = 132;
+    context.fillStyle = "rgba(9, 8, 18, 0.78)";
+    context.strokeStyle = "rgba(255, 255, 255, 0.12)";
+    context.lineWidth = 1;
+    context.beginPath();
+    context.roundRect(panelX, panelY, panelWidth, panelHeight, 16);
+    context.fill();
+    context.stroke();
+    context.fillStyle = "rgba(162, 154, 181, 0.9)";
+    context.font = "750 9px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+    context.fillText("KEY PATTERNS", panelX + 18, panelY + 24);
+    narrative.highlights.forEach((highlight, index) => {
+      const rowY = panelY + 49 + index * 25;
+      context.fillStyle = highlight.kind === "VOLUME" ? "#7798ff" : "#ff64d6";
+      context.beginPath();
+      context.arc(panelX + 20, rowY - 4, 3, 0, Math.PI * 2);
+      context.fill();
+      context.fillStyle = "rgba(226, 221, 237, 0.9)";
+      context.font = "550 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+      const line = wrappedLines(context, highlight.text, panelWidth - 52, 1)[0] || "";
+      context.fillText(line, panelX + 32, rowY);
+    });
+  }
 
   let statX = 56;
   shareStats(model).forEach(([label, value]) => {
     context.fillStyle = "rgba(248, 246, 255, 0.94)";
     context.font = "650 18px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
-    context.fillText(String(value), statX, 554);
+    context.fillText(String(value), statX, 566);
     context.fillStyle = "rgba(137, 130, 153, 0.92)";
     context.font = "700 9px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
-    context.fillText(label, statX, 571);
+    context.fillText(label, statX, 583);
     statX += label === "VOLUMES" ? 92 : 78;
   });
 

--- a/resources/model_assets/viewer.css
+++ b/resources/model_assets/viewer.css
@@ -177,7 +177,8 @@ button {
 
 .layers button,
 .icon-button,
-.zoom-value {
+.zoom-value,
+.share-button {
   min-height: 34px;
   border: 1px solid transparent;
   background: transparent;
@@ -217,7 +218,8 @@ button {
 
 .layers button:hover,
 .icon-button:hover,
-.zoom-value:hover {
+.zoom-value:hover,
+.share-button:hover {
   border-color: var(--border);
   background: rgba(255, 255, 255, 0.07);
   color: var(--text);
@@ -229,7 +231,8 @@ button {
 
 .layers button:active,
 .icon-button:active,
-.zoom-value:active {
+.zoom-value:active,
+.share-button:active {
   transform: scale(0.96);
 }
 
@@ -299,6 +302,41 @@ button {
   border-radius: 50%;
   background: var(--point);
   box-shadow: 0 0 9px rgba(78, 240, 195, 0.75);
+}
+
+.share-button {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 40px;
+  padding: 0 13px 0 10px;
+  border: 1px solid rgba(255, 100, 214, 0.26);
+  border-radius: 999px;
+  background: linear-gradient(110deg, rgba(255, 100, 214, 0.15), rgba(119, 152, 255, 0.13));
+  color: #f5eefa;
+  cursor: pointer;
+  transition: color 160ms ease, background 160ms ease, border-color 160ms ease, transform 160ms ease;
+}
+
+.share-button span {
+  display: grid;
+  width: 21px;
+  height: 21px;
+  place-items: center;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.1);
+  font-size: 10px;
+  font-weight: 800;
+}
+
+.share-button b {
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.share-button:disabled {
+  opacity: 0.55;
+  cursor: wait;
 }
 
 .icon-button {
@@ -754,6 +792,65 @@ button {
   color: #ff9cae;
 }
 
+.share-notice {
+  position: absolute;
+  z-index: 18;
+  right: 24px;
+  bottom: 82px;
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  width: min(330px, calc(100vw - 48px));
+  padding: 13px 15px;
+  border: 1px solid rgba(78, 240, 195, 0.24);
+  border-radius: 15px;
+  background: rgba(10, 9, 19, 0.92);
+  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.34), inset 0 1px 0 rgba(255, 255, 255, 0.045);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+}
+
+.share-notice[hidden] {
+  display: none;
+}
+
+.share-notice > span {
+  display: grid;
+  width: 32px;
+  height: 32px;
+  flex: none;
+  place-items: center;
+  border-radius: 50%;
+  background: rgba(78, 240, 195, 0.11);
+  color: var(--point);
+  font-size: 16px;
+}
+
+.share-notice div {
+  display: grid;
+  gap: 4px;
+}
+
+.share-notice strong {
+  font-size: 11px;
+  font-weight: 680;
+}
+
+.share-notice small {
+  color: var(--muted);
+  font-size: 9px;
+  line-height: 1.45;
+}
+
+.share-notice.failed {
+  border-color: rgba(255, 107, 138, 0.28);
+}
+
+.share-notice.failed > span {
+  background: rgba(255, 107, 138, 0.11);
+  color: var(--root);
+}
+
 .model-label {
   --label-accent: var(--text);
   appearance: none;
@@ -824,6 +921,16 @@ button {
 }
 
 @media (min-width: 1181px) and (max-width: 1360px) {
+  .share-button {
+    width: 40px;
+    padding: 0;
+    justify-content: center;
+  }
+
+  .share-button b {
+    display: none;
+  }
+
   .status {
     max-width: calc(50vw - 294px);
   }
@@ -906,6 +1013,21 @@ button {
   .view-actions {
     grid-column: 2;
     grid-row: 1;
+  }
+
+  .share-button {
+    width: 40px;
+    padding: 0;
+    justify-content: center;
+  }
+
+  .share-button b {
+    display: none;
+  }
+
+  .share-notice {
+    right: 10px;
+    bottom: 76px;
   }
 
   .story {
@@ -1058,6 +1180,7 @@ button {
   .layers button,
   .icon-button,
   .zoom-value,
+  .share-button,
   .model-label {
     transition: none;
   }

--- a/resources/model_assets/viewer.js
+++ b/resources/model_assets/viewer.js
@@ -112,6 +112,7 @@ let fitDistance = 12;
 let zoomGoalDistance = null;
 let lastZoomPercent = null;
 let lastFrameTime = performance.now();
+let shareReady = false;
 const layerVisible = { points: true, lines: true, faces: true, volumes: true, root: true };
 const kindLayers = { point: "points", context: "points", face: "faces", volume: "volumes", root: "root" };
 const raycaster = new THREE.Raycaster();
@@ -671,7 +672,7 @@ function showShareNotice(title, message, failed = false) {
 }
 
 function setShareBusy(busy) {
-  shareButton.disabled = busy;
+  shareButton.disabled = busy || !shareReady;
   shareButton.setAttribute("aria-busy", String(busy));
   shareButton.querySelector("b").textContent = busy ? "Preparing…" : "Share";
 }
@@ -914,10 +915,16 @@ async function loadModel(force = false) {
     model = payload.model;
     modelGeneratedAt = payload.generated_at || "";
     modelFingerprint = nextFingerprint;
+    shareReady = Boolean(
+      model.points.length || model.faces.length || model.volumes.length || model.root,
+    );
+    setShareBusy(false);
     updateTimelineBounds();
     buildScene();
     errorEl.hidden = true;
   } catch (error) {
+    shareReady = false;
+    setShareBusy(false);
     errorEl.textContent = `Unable to load the personal model. ${error.message || error}`;
     errorEl.hidden = false;
   }

--- a/resources/model_assets/viewer.js
+++ b/resources/model_assets/viewer.js
@@ -2,6 +2,13 @@ import * as THREE from "three";
 import { OrbitControls } from "three/addons/controls/OrbitControls.js";
 import { CSS2DObject, CSS2DRenderer } from "three/addons/renderers/CSS2DRenderer.js";
 import { computeClusterLayout, zoomMath } from "./layout.mjs";
+import {
+  SHARE_CARD_HEIGHT,
+  SHARE_CARD_WIDTH,
+  SHARE_FILE_NAME,
+  buildXIntentUrl,
+  drawShareCard,
+} from "./share.mjs";
 
 const COLORS = {
   points: 0x4ef0c3,
@@ -29,6 +36,8 @@ const sliderLabel = document.getElementById("as-of-label");
 const zoomOutButton = document.getElementById("zoom-out");
 const zoomResetButton = document.getElementById("zoom-reset");
 const zoomInButton = document.getElementById("zoom-in");
+const shareButton = document.getElementById("share-x");
+const shareNoticeEl = document.getElementById("share-notice");
 
 const scene = new THREE.Scene();
 scene.fog = new THREE.FogExp2(0x070610, 0.026);
@@ -648,6 +657,97 @@ function pauseAutoRotate() {
   document.getElementById("rotate").setAttribute("aria-pressed", "false");
 }
 
+function showShareNotice(title, message, failed = false) {
+  const heading = shareNoticeEl.querySelector("strong");
+  const detail = shareNoticeEl.querySelector("small");
+  heading.textContent = title;
+  detail.textContent = message;
+  shareNoticeEl.classList.toggle("failed", failed);
+  shareNoticeEl.hidden = false;
+  window.clearTimeout(showShareNotice.timer);
+  showShareNotice.timer = window.setTimeout(() => {
+    shareNoticeEl.hidden = true;
+  }, 9000);
+}
+
+function setShareBusy(busy) {
+  shareButton.disabled = busy;
+  shareButton.setAttribute("aria-busy", String(busy));
+  shareButton.querySelector("b").textContent = busy ? "Preparing…" : "Share";
+}
+
+function createShareCardBlob() {
+  renderer.render(scene, camera);
+  const canvas = document.createElement("canvas");
+  canvas.width = SHARE_CARD_WIDTH;
+  canvas.height = SHARE_CARD_HEIGHT;
+  const context = canvas.getContext("2d");
+  if (!context) return Promise.reject(new Error("Canvas export is unavailable"));
+  drawShareCard(context, renderer.domElement, model);
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) resolve(blob);
+      else reject(new Error("The constellation image could not be encoded"));
+    }, "image/png");
+  });
+}
+
+function downloadShareCard(blob) {
+  const href = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = href;
+  anchor.download = SHARE_FILE_NAME;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  window.setTimeout(() => URL.revokeObjectURL(href), 1000);
+}
+
+function paintShareHandoff(popup) {
+  if (!popup) return;
+  popup.document.title = "Preparing your Persome constellation";
+  popup.document.body.innerHTML = `
+    <main style="min-height:100vh;display:grid;place-items:center;margin:0;background:#070610;color:#f7f4ff;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">
+      <section style="width:min(440px,calc(100vw - 48px));padding:38px;border:1px solid rgba(255,255,255,.12);border-radius:24px;background:linear-gradient(145deg,rgba(255,100,214,.11),rgba(119,152,255,.08));box-shadow:0 30px 100px rgba(0,0,0,.45)">
+        <p style="margin:0 0 18px;color:#ff83cf;font-size:11px;font-weight:750;letter-spacing:.16em">PERSOME · SHARE TO X</p>
+        <h1 style="margin:0;font-size:34px;line-height:1.05;letter-spacing:-.045em">Your constellation is downloading.</h1>
+        <p style="margin:18px 0 24px;color:#b8b1c7;font-size:15px;line-height:1.65">In X, click the image button and choose <strong style="color:#fff">${SHARE_FILE_NAME}</strong>. Your copy and tags are already filled in.</p>
+        <div style="height:3px;overflow:hidden;border-radius:99px;background:rgba(255,255,255,.08)"><i style="display:block;width:100%;height:100%;transform-origin:left;background:linear-gradient(90deg,#ff64d6,#7798ff);animation:load 1.8s ease forwards"></i></div>
+        <style>@keyframes load{from{transform:scaleX(0)}to{transform:scaleX(1)}}</style>
+      </section>
+    </main>`;
+}
+
+async function shareToX() {
+  const popup = window.open("about:blank", "_blank");
+  paintShareHandoff(popup);
+  setShareBusy(true);
+  pauseAutoRotate();
+  try {
+    const blob = await createShareCardBlob();
+    downloadShareCard(blob);
+    showShareNotice(
+      "Constellation downloaded",
+      `Add ${SHARE_FILE_NAME} with the image button in X.`,
+    );
+    const intentUrl = buildXIntentUrl();
+    window.setTimeout(() => {
+      if (popup && !popup.closed) {
+        popup.opener = null;
+        popup.location.replace(intentUrl);
+        popup.focus();
+      } else {
+        window.location.assign(intentUrl);
+      }
+      setShareBusy(false);
+    }, 1800);
+  } catch (error) {
+    if (popup && !popup.closed) popup.close();
+    showShareNotice("Share image failed", error.message || String(error), true);
+    setShareBusy(false);
+  }
+}
+
 function syncSelectionState() {
   const activeKey = selected ? selectionKey(selected.kind, selected.id) : null;
   selectionTargets.forEach((targets, key) => {
@@ -1014,6 +1114,7 @@ controls.addEventListener("start", () => {
 });
 document.getElementById("reset").addEventListener("click", resetCamera);
 document.getElementById("close-detail").addEventListener("click", clearSelection);
+shareButton.addEventListener("click", shareToX);
 
 slider.addEventListener("input", () => {
   updateCutoff();

--- a/src/persome/api/model_view.py
+++ b/src/persome/api/model_view.py
@@ -43,7 +43,7 @@ _MEMORY_VIEW_TEMPLATE = """<!doctype html>
       </div>
       <div class="view-actions">
         <span class="privacy-badge"><i aria-hidden="true"></i>Local only</span>
-        <button id="share-x" class="share-button" type="button" aria-label="Share your constellation to X" title="Share your constellation to X">
+        <button id="share-x" class="share-button" type="button" aria-label="Share your constellation to X" title="Share your constellation to X" disabled>
           <span aria-hidden="true">X</span><b>Share</b>
         </button>
         <div class="zoom-controls" role="group" aria-label="Zoom controls">

--- a/src/persome/api/model_view.py
+++ b/src/persome/api/model_view.py
@@ -43,6 +43,9 @@ _MEMORY_VIEW_TEMPLATE = """<!doctype html>
       </div>
       <div class="view-actions">
         <span class="privacy-badge"><i aria-hidden="true"></i>Local only</span>
+        <button id="share-x" class="share-button" type="button" aria-label="Share your constellation to X" title="Share your constellation to X">
+          <span aria-hidden="true">X</span><b>Share</b>
+        </button>
         <div class="zoom-controls" role="group" aria-label="Zoom controls">
           <button id="zoom-out" class="icon-button" type="button" aria-label="Zoom out" title="Zoom out (−)">−</button>
           <button id="zoom-reset" class="zoom-value" type="button" aria-label="Reset zoom to 100 percent" title="Reset zoom (0)">100%</button>
@@ -87,6 +90,11 @@ _MEMORY_VIEW_TEMPLATE = """<!doctype html>
     </div>
 
     <div id="error" class="error" role="alert" hidden></div>
+
+    <div id="share-notice" class="share-notice" role="status" aria-live="polite" hidden>
+      <span aria-hidden="true">↓</span>
+      <div><strong>Constellation downloaded</strong><small>Add my-persome-constellation.png in X.</small></div>
+    </div>
 
     <footer class="timeline">
       <button id="play" class="icon-button" type="button" aria-label="Play model history" aria-pressed="false" title="Play model history">▶</button>

--- a/src/persome/api/routes.py
+++ b/src/persome/api/routes.py
@@ -421,6 +421,7 @@ def model_view(request: Request) -> HTMLResponse:
 _MODEL_ASSETS = {
     "three.module.js",
     "layout.mjs",
+    "share.mjs",
     "viewer.css",
     "viewer.js",
     "jsm/controls/OrbitControls.js",

--- a/tests/js/model_share.test.mjs
+++ b/tests/js/model_share.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  SHARE_CARD_HEIGHT,
+  SHARE_CARD_WIDTH,
+  SHARE_FILE_NAME,
+  SHARE_HASHTAGS,
+  SHARE_TEXT,
+  SHARE_URL,
+  buildXIntentUrl,
+  shareStats,
+} from "../../resources/model_assets/share.mjs";
+
+test("builds an X composer URL with the standard copy, destination, and tags", () => {
+  const intent = new URL(buildXIntentUrl());
+
+  assert.equal(intent.origin, "https://x.com");
+  assert.equal(intent.pathname, "/intent/tweet");
+  assert.equal(intent.searchParams.get("text"), SHARE_TEXT);
+  assert.equal(intent.searchParams.get("url"), SHARE_URL);
+  assert.equal(intent.searchParams.get("hashtags"), SHARE_HASHTAGS.join(","));
+  assert.ok(!intent.href.includes("localhost"));
+  assert.ok(!intent.href.includes("/model/"));
+});
+
+test("keeps the share artifact fixed, portable, and aggregate-only", () => {
+  assert.equal(SHARE_CARD_WIDTH, 1200);
+  assert.equal(SHARE_CARD_HEIGHT, 675);
+  assert.equal(SHARE_FILE_NAME, "my-persome-constellation.png");
+
+  assert.deepEqual(
+    shareStats({
+      stats: {
+        points: 424,
+        evolution_lines: 120,
+        relation_lines: 26,
+        faces: 12,
+        volumes: 4,
+        roots: 1,
+      },
+    }),
+    [
+      ["POINTS", 424],
+      ["LINES", 146],
+      ["FACES", 12],
+      ["VOLUMES", 4],
+      ["ROOT", 1],
+    ],
+  );
+});

--- a/tests/js/model_share.test.mjs
+++ b/tests/js/model_share.test.mjs
@@ -9,6 +9,7 @@ import {
   SHARE_TEXT,
   SHARE_URL,
   buildXIntentUrl,
+  shareNarrative,
   shareStats,
 } from "../../resources/model_assets/share.mjs";
 
@@ -24,7 +25,7 @@ test("builds an X composer URL with the standard copy, destination, and tags", (
   assert.ok(!intent.href.includes("/model/"));
 });
 
-test("keeps the share artifact fixed, portable, and aggregate-only", () => {
+test("keeps the share artifact fixed and portable", () => {
   assert.equal(SHARE_CARD_WIDTH, 1200);
   assert.equal(SHARE_CARD_HEIGHT, 675);
   assert.equal(SHARE_FILE_NAME, "my-persome-constellation.png");
@@ -48,4 +49,32 @@ test("keeps the share artifact fixed, portable, and aggregate-only", () => {
       ["ROOT", 1],
     ],
   );
+});
+
+test("selects a bounded personal summary and highest-level key patterns", () => {
+  const narrative = shareNarrative({
+    root: {
+      signature: "A focused systems builder who turns context into auditable work.",
+      receipts: ["private-root-receipt"],
+    },
+    volumes: [
+      { id: "volume-low", signature: "Lower-confidence structure.", confidence: 0.7 },
+      { id: "volume-high", signature: "Trusted personal AI connects context and correction.", confidence: 0.96 },
+    ],
+    faces: [
+      { id: "face-high", signature: "Focused work starts with a small plan.", confidence: 0.99 },
+      { id: "face-second", signature: "Research claims are checked against evidence.", confidence: 0.91 },
+    ],
+  });
+
+  assert.equal(
+    narrative.root,
+    "A focused systems builder who turns context into auditable work.",
+  );
+  assert.deepEqual(narrative.highlights, [
+    { kind: "VOLUME", text: "Trusted personal AI connects context and correction." },
+    { kind: "VOLUME", text: "Lower-confidence structure." },
+    { kind: "FACE", text: "Focused work starts with a small plan." },
+  ]);
+  assert.ok(!JSON.stringify(narrative).includes("private-root-receipt"));
 });

--- a/tests/test_model_layout_asset.py
+++ b/tests/test_model_layout_asset.py
@@ -7,13 +7,18 @@ from pathlib import Path
 import pytest
 
 
-def test_cluster_layout_node_suite() -> None:
+def test_model_viewer_node_suite() -> None:
     node = shutil.which("node")
     if node is None:
         pytest.skip("Node.js is unavailable")
     root = Path(__file__).resolve().parents[1]
     result = subprocess.run(
-        [node, "--test", "tests/js/model_layout.test.mjs"],
+        [
+            node,
+            "--test",
+            "tests/js/model_layout.test.mjs",
+            "tests/js/model_share.test.mjs",
+        ],
         cwd=root,
         capture_output=True,
         text=True,

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -65,6 +65,8 @@ class TestViewPage:
         assert "Points" in body and "Volumes" in body and "Root" in body
         assert "The shape" in body and "of you." in body
         assert "Local only" in body
+        assert 'id="share-x"' in body
+        assert 'id="share-notice"' in body
         assert 'aria-label="Zoom controls"' in body
         assert 'id="zoom-out"' in body
         assert 'id="zoom-reset"' in body
@@ -74,13 +76,17 @@ class TestViewPage:
     def test_bundled_viewer_assets_are_served(self, ac_root):
         three = routes.model_asset("three.module.js")
         layout = routes.model_asset("layout.mjs")
+        share = routes.model_asset("share.mjs")
         viewer = routes.model_asset("viewer.js")
         css = routes.model_asset("viewer.css")
 
         assert len(three.body) > 1_000_000
         assert b"class WebGLRenderer" in three.body
         assert b"computeClusterLayout" in layout.body
+        assert b"buildXIntentUrl" in share.body
+        assert b"drawShareCard" in share.body
         assert b'from "./layout.mjs"' in viewer.body
+        assert b'from "./share.mjs"' in viewer.body
         assert b"model.points" in viewer.body
         assert b"model.lines" in viewer.body
         assert b"model.faces" in viewer.body
@@ -92,17 +98,23 @@ class TestViewPage:
         assert b"ACESFilmicToneMapping" in viewer.body
         assert b"model.root?.signature" in viewer.body
         assert b"controls.zoomToCursor = true" in viewer.body
+        assert b"downloadShareCard" in viewer.body
+        assert b"window.open" in viewer.body
+        assert b"my-persome-constellation.png" in share.body
         assert b"window.__persomeZoomState" in viewer.body
         assert b"if (!REDUCED_MOTION)" in viewer.body
         assert b'event.key === "+"' in viewer.body
         assert b'event.key === "-"' in viewer.body
         assert b'event.key === "0"' in viewer.body
         assert b".zoom-controls" in css.body
+        assert b".share-button" in css.body
+        assert b".share-notice" in css.body
         assert b"(min-width: 1181px) and (max-width: 1360px)" in css.body
         assert b"top: 116px" in css.body
         assert b"prefers-reduced-motion" in css.body
         assert viewer.media_type == "text/javascript"
         assert layout.media_type == "text/javascript"
+        assert share.media_type == "text/javascript"
         assert css.media_type == "text/css"
 
     def test_viewer_interaction_contract_prefers_labels_over_lines(self, ac_root):

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -66,6 +66,7 @@ class TestViewPage:
         assert "The shape" in body and "of you." in body
         assert "Local only" in body
         assert 'id="share-x"' in body
+        assert 'title="Share your constellation to X" disabled>' in body
         assert 'id="share-notice"' in body
         assert 'aria-label="Zoom controls"' in body
         assert 'id="zoom-out"' in body
@@ -99,6 +100,7 @@ class TestViewPage:
         assert b"model.root?.signature" in viewer.body
         assert b"controls.zoomToCursor = true" in viewer.body
         assert b"downloadShareCard" in viewer.body
+        assert b"shareReady = Boolean" in viewer.body
         assert b"window.open" in viewer.body
         assert b"my-persome-constellation.png" in share.body
         assert b"window.__persomeZoomState" in viewer.body


### PR DESCRIPTION
## Summary

- add a responsive `Share to X` control to the local `/model` viewer
- render and automatically download a 1200×675 branded constellation card locally
- include the Root identity, up to three high-level patterns, and aggregate geometry counts while excluding receipts, source names, local URLs, and viewer credentials
- open X with standard copy, the public GitHub URL, and `#Persome #PersonalAI`, with an explicit handoff explaining how to attach the downloaded image
- keep sharing disabled until a non-empty model has loaded

## Review

A full local review found and fixed one pre-load race where Share could be clicked before model data was ready. No remaining blocking findings.

## Validation

- `PERSOME_LLM_MOCK=1 uv run pytest -m "not macos and not integration" -q` — 1697 passed, 15 deselected
- focused route and JavaScript viewer tests — 13 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- secret, PII, and language scans
- desktop/mobile visual checks
- real Chrome/X composer check for copy, link, tags, and automatic image download flow
