### PR TITLE
fix: make model recovery and builds resilient

### DIFF
--- a/MODEL_FORMAT.md
+++ b/MODEL_FORMAT.md
@@ -26,6 +26,11 @@ redact by default, while the owner-only loopback viewer uses raw local content.
 Consumers must branch on `schema_version`. Package versions do not substitute
 for a schema check.
 
+The `build` object has one fixed key set in every state. While a build is in
+progress or no valid completed build exists, unavailable identity fields are
+`null`, maps are empty, and input-window bounds are `null`; these sentinels do
+not claim a successful build.
+
 ## Geometry
 
 ### Point
@@ -91,6 +96,16 @@ duration_ms, degraded_stages, status
 ```
 
 No API keys or full configuration values are copied into the manifest.
+`build_id` is the stable hash of every other manifest field; `complete` requires
+an empty `degraded_stages`, while `degraded` requires at least one stage.
+
+Live HTTP, MCP, and CLI-export snapshots use the last persisted completed or
+degraded build record. If no valid build record exists, they report `status: not_built`,
+`trigger: no_completed_build`, and a null `build_id`; inspecting the current
+database projection never fabricates a successful build. A raw
+`model-build.json` with `status: building` is exposed as `building` only while
+the process still holds `model-build.lock`. If that lock is free, the marker is
+an interrupted-build remnant and public surfaces report `not_built`.
 
 ## Stats
 

--- a/docs/capture.md
+++ b/docs/capture.md
@@ -232,7 +232,7 @@ Every successful capture write is also indexed into an FTS5 virtual table (`capt
 | `cleanup_buffer` time-based delete | FTS deletion is attempted before each JSON deletion; filesystem erasure remains authoritative if SQLite is temporarily unavailable, and the final reconciliation removes stale searchable rows after recovery. |
 | `cleanup_buffer` size-based eviction | Same, including hard-cap eviction of unabsorbed files when necessary and continued eviction after one unlink failure. |
 | Screenshot strip | **Untouched.** Strip only removes the base64 image; the indexed text (`visible_text`, `focused_value`, `window_title`, `app_name`, `url`) is unchanged. |
-| `persome rebuild-captures-index` | Clear stale rows, then index every surviving `~/.persome/capture-buffer/*.json`. Idempotent and safe whenever the index drifts. |
+| `persome rebuild-captures-index` | Clear stale rows, then index every surviving `~/.persome/capture-buffer/*.json`. Use `--merge` after snapshot recovery to preserve older rows whose JSON aged out. |
 
 **Indexed columns.** Only the searchable text is in FTS: `app_name`, `window_title`, `focused_value`, `visible_text`, `url`. Filterable metadata (timestamp, bundle_id, focused_role) lives on the `captures` table for `WHERE`-clause filtering. Screenshots are deliberately not duplicated — the JSON file on disk stays the authoritative copy of the raw image bytes.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -72,6 +72,14 @@ OPENAI_API_KEY=...
 # OPENAI_BASE_URL=https://example.test/v1
 ```
 
+The daemon and initialized CLI commands, including `persome model build`, load
+this file before resolving provider credentials. An explicitly exported shell
+variable takes precedence for that one command; the durable `env` file is not
+rewritten by such an override. The owner-local `PERSOME_LOCAL_API_TOKEN` is the
+one exception: `persome start` persists a valid exported value as the canonical
+bearer so the daemon and later CLI processes cannot end up with different
+credentials.
+
 Common model stages are `timeline`, `reducer`, `classifier`, `memory_delta`,
 `pattern_detector`, `case_extractor`, `compact`, `schema_miner`,
 `cross_domain_sweeper`, `root_synthesis`, `contradiction_check`, and
@@ -256,6 +264,7 @@ daily_tick_minute = 15
 cross_domain_enabled = true
 cross_domain_behavior_max_distance = 0.5
 cross_domain_min_confidence = 0.6
+cross_domain_max_probes = 8
 root_synthesis_enabled = true
 root_token_budget = 1500
 ```
@@ -265,7 +274,16 @@ After new Point/Line evidence, the Runtime calls the same
 `refresh_minutes` cadence. The 00:15 tick remains an unconditional daily pass.
 Both run pending state formation, enrichment, Face mining, Volume synthesis,
 Root synthesis, vectors, and layout. Forming schemas are excluded from active
-snapshots. Missing repeated evidence yields a truthful degraded build.
+snapshots. Each build makes at most `cross_domain_max_probes` cross-domain LLM
+calls. A shadow Volume is retried first only while its latest persisted result
+remains stable/promotable, so the two-observation evidence gate can make
+progress. A negative, failed, or forming retry demotes that pair behind every
+never-probed pair; older retries then rotate oldest-first. Thus stale shadows
+cannot monopolize the budget, and every finite unseen queue is reached in later
+builds. Any remainder is reported as deferred for a later build. Collisions below
+`cross_domain_min_confidence` remain dormant `forming` Markdown and cannot enter
+the Face/Volume promotion table. Missing repeated evidence yields a truthful
+degraded build.
 
 ## Writer and maintenance
 
@@ -322,8 +340,13 @@ contradiction_max_pairs = 10
 
 `markdown` is the default authority and shadows current state to evomem.
 `evomem` makes the graph authoritative and projects Markdown/FTS from it. An
-operator flips this manually; code never changes the authority. Before a
-rollback, project current evomem state to Markdown, then rebuild the index.
+operator flips this manually. Integrity recovery may temporarily write
+`unknown` when a damaged/missing config leaves both Markdown and evomem as
+plausible sources; writes and model builds remain frozen until the operator
+chooses `markdown` or `evomem`. That explicit choice is reconciled into the
+retrieval index before the guard journal is removed, and choosing `evomem`
+also reprojects its canonical state to Markdown. Before a normal rollback,
+project current evomem state to Markdown, then rebuild the index.
 
 Snapshots are verified before atomic promotion. Integrity failures are emitted
 as structured error logs. The old runtime SSE event bus no longer exists.

--- a/docs/db-schema.sql
+++ b/docs/db-schema.sql
@@ -246,6 +246,13 @@ CREATE INDEX idx_parser_ticks_ts ON parser_ticks(ts DESC);
 
 -- ---- store/schema_faces.py ----
 
+CREATE TABLE cross_domain_probe_state (
+    pair_key       TEXT PRIMARY KEY,
+    last_probed_at TEXT NOT NULL,
+    probe_count    INTEGER NOT NULL DEFAULT 1,
+    detected       INTEGER NOT NULL DEFAULT 0  -- last result was stable/promotable
+);
+
 CREATE TABLE schema_faces (
     face_id      TEXT PRIMARY KEY,
     level        INTEGER NOT NULL DEFAULT 1,   -- 1=Face, 2=Volume, 3=Root
@@ -261,6 +268,9 @@ CREATE TABLE schema_faces (
     valid_to     TEXT,
     created_at   TEXT NOT NULL
 , anchors TEXT NOT NULL DEFAULT '[]');
+
+CREATE INDEX ix_cross_domain_probe_age
+    ON cross_domain_probe_state(last_probed_at, pair_key);
 
 CREATE INDEX ix_faces_status ON schema_faces(status, level);
 

--- a/docs/model-contract.md
+++ b/docs/model-contract.md
@@ -15,9 +15,12 @@ persome model export --out model-snapshot.json
 
 `model build` uses an exclusive `<PERSOME_ROOT>/model-build.lock`. It waits up to 30 seconds by
 default; `--wait-seconds` changes the bound and `--no-wait` returns `busy` immediately. The kernel
-releases the lock on process exit. Successful or degraded runs atomically write an owner-only
-`model-build.json`; missing Points, Lines, Faces, Volumes, or Root is recorded as degraded, never
-as success. `model status` uses the same completeness rule for its `ready` result.
+releases the lock on process exit. A run first atomically records `status: building`, invalidating
+any older completed manifest before a mutating stage starts. Successful or degraded runs replace it
+with an owner-only `model-build.json`. That marker is exposed as `building` only while the process
+holds `model-build.lock`; once the lock is free, a leftover marker is exposed as `not_built`, never
+as the previous success. Missing Points, Lines, Faces, Volumes, or Root is recorded as degraded.
+`model status` also requires a valid completed/degraded manifest before reporting `ready`.
 
 ## Geometry
 
@@ -41,6 +44,15 @@ from package releases.
 Every `build` object records the core commit, stage model names, prompt hashes, a config hash, input
 window, mock/real mode, timing, and degraded stages. Configuration values themselves are not copied
 into the manifest. Fixed inputs and timestamps produce the same `build_id`.
+The live HTTP, MCP, and CLI-export projections preserve that persisted manifest
+exactly. The manifest `build_id` must match the stable hash of every other manifest field, and
+`complete`/`degraded` must agree with an empty/non-empty `degraded_stages` list. If there is no valid
+completed or degraded manifest, the projection reports
+`status: not_built`, `trigger: no_completed_build`, and a null `build_id`
+instead of synthesizing a completed build from the current database contents.
+The `not_built` and `building` states keep the same fixed build-object keys;
+unavailable commit, config hash, mode, and timestamps are null, model and prompt
+maps are empty, and the input-window bounds are null.
 
 A Face becomes active only after mined and emergent signals agree across stable footprints. A
 Volume has one honest producer (the cross-domain sweeper), so it becomes active after two stable

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -73,6 +73,8 @@ and old helper path.
 | `backup/` | SQLite safety snapshots containing personal model state |
 | `logs/` | daemon and launchd logs; may contain operational context |
 | `model-build.json` | latest build manifest and degraded-stage report |
+| `.integrity-recovery.pending.json` | crash-resumable full-database quarantine/replay journal |
+| `.integrity-config-recovery.pending.json` | config-quarantine intent retained until database authority is reconciled |
 | `.pid`, `.runtime-state.json` | compatibility PID plus owner-only generation, phase, permission, OCR-worker, and capture/privacy receipt |
 | `.daemon.lock` | lifetime single-Runtime lock inherited across background forks |
 | `.launchagent-owner` | durable intent that launchd owns Runtime lifecycle |
@@ -94,9 +96,49 @@ from authoritative `captures` rows and `entries` from Markdown/evo_nodes. It
 also handles older SQLite builds that collapse both damaged FTS projections
 into a generic malformed-database error, while verifying every regular table
 before the narrow index reset. Core database damage is still quarantined as
-`index.db.corrupt.<timestamp>` for inspection. The running daemon owns active
-SQLite writes, so `persome status`, MCP clients, and a second `persome start`
-do not repair or quarantine an open database.
+`index.db.corrupt.<timestamp>` for inspection. Persome then restores the newest
+structurally verified daily snapshot when one exists and reconciles the current
+Markdown memory projection without making LLM calls. Without a usable snapshot,
+it still rebuilds the retrieval projection and Point state from Markdown; the
+recovery marker lists database-only components that could not be reconstructed.
+In both cases the old `model-build.json` is invalidated, because Faces, Volumes,
+and Root must be verified by a fresh `persome model build` rather than reported
+as a completed build from stale metadata. Details and recovered row counts are
+written to `.integrity-recovery.json`.
+
+Before moving a damaged database, Persome atomically writes
+`.integrity-recovery.pending.json` with the exact quarantine destination and
+phase. If the process exits after quarantine, snapshot copy, or projection
+replay, the next stopped-Runtime startup resumes that journal instead of
+treating a missing `index.db` as a clean install. The journal is removed only
+after a completed recovery marker is durable. Snapshot recovery remains
+best-effort: the marker records its timestamp and warns that writes since that
+snapshot may be absent. Retained capture-buffer JSON can be reconciled with
+`persome rebuild-captures-index --merge` when the marker reports a pending
+replay. Recovery mode preserves older snapshot-backed captures whose buffer
+JSON has already aged out; the command without `--merge` remains an exact
+buffer-only rebuild and deletes such rows.
+Unreadable or semantically invalid versioned journals (missing fields, unknown
+phases, or paths outside the canonical recovery namespace) are themselves moved
+to a timestamped forensic quarantine before normal integrity checks continue;
+they do not become permanent startup blockers.
+
+Config replacement has its own earlier intent journal,
+`.integrity-config-recovery.pending.json`. Persome writes it before moving a
+corrupt `config.toml`, and keeps database replay authority unknown until the
+database is verified or restored. A structurally complete `evo_nodes` table in
+a snapshot is not by itself proof of evomem authority: it can be a lagging
+shadow from a Markdown-authoritative runtime. Recovery compares the snapshot's
+last retrieval projection with both surviving sources before replay. If neither
+source is uniquely provable, it preserves snapshot entries, snapshot nodes, and
+current Markdown, writes `write_authority = "unknown"`, and waits for the owner
+to choose. The intent is cleared only after that choice has transactionally
+rebuilt the retrieval projection; an evomem choice also reprojects canonical
+nodes to Markdown. This prevents a crash-created default from silently choosing
+either source.
+
+The running daemon owns active SQLite writes, so `persome status`, MCP clients,
+and a second `persome start` do not repair or quarantine an open database.
 
 Runtime startup also fails closed on ambiguous process state. `.daemon.lock`
 serializes concurrent starters for the daemon's entire lifetime; `.pid` is

--- a/docs/runtime-internals.md
+++ b/docs/runtime-internals.md
@@ -107,6 +107,9 @@ labels, ports, and data roots do not belong in core.
 | `model-build.lock` | cross-process build lock |
 | `session-model.lock` | cross-process terminal-session finalization lock |
 | `model-build.json` | last build manifest |
+| `.integrity-recovery.pending.json` | resumable full-database recovery phase journal |
+| `.integrity-config-recovery.pending.json` | pre-quarantine config intent and authority guard |
+| `.integrity-recovery.json` | last completed quarantine/recovery report |
 | `exports/` | owner-only snapshots |
 | `backup/` | optional SQLite snapshots |
 | `logs/` | component logs |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -371,6 +371,23 @@ levels require repeated stable evidence and model status should remain
 `model-build.json` for failed stages and `/model/graph` for the exact snapshot
 currently consumed by the viewer.
 
+After automatic database quarantine, inspect
+`~/.persome/.integrity-recovery.json`. Persome restores a verified snapshot when
+available and otherwise replays the surviving Markdown memory projection, but
+it deliberately marks the structural model as not built. Run `persome model
+build` once the Runtime LLM profile passes `persome llm status --check`; the
+Viewer will not label an unverified projection as `Build complete`.
+If config and database recovery leave
+`.integrity-config-recovery.pending.json` and `write_authority = "unknown"`,
+both Markdown and evomem were intact but neither was provably canonical. Inspect
+the retained snapshot/quarantine, then explicitly set the value to `markdown`
+or `evomem` and rerun a stopped-Runtime command. Persome reconciles the selected
+source before unfreezing; choosing evomem also replaces its conflicting
+Markdown projection.
+If the marker says `capture_buffer_replay_available: true`, run `persome
+rebuild-captures-index --merge` to upsert retained owner-only JSON without
+deleting older snapshot-backed captures before rebuilding downstream history.
+
 ## Resetting
 
 Start from scratch without reinstalling:

--- a/docs/writer.md
+++ b/docs/writer.md
@@ -117,7 +117,15 @@ stable output contributes a Face. Re-mining supersedes the prior schema in place
 `cross_domain_sweeper` compares stable, topic-distinct schemas using a
 deterministic behavior signature before an LLM judge. Confirmed repeated
 cross-domain structure becomes a Volume. Forming candidates stay outside active
-snapshots.
+snapshots. The LLM stage has a hard per-build probe budget (8 by default), with
+live shadow Volumes whose latest result is still stable/promotable ordered before
+unseen pairs so bounded builds can satisfy the unchanged two-observation
+promotion gate. A negative, failed, or low-confidence retry immediately lowers
+that shadow into the oldest-first retry queue; it cannot reserve top priority on
+later builds. Probe history is persisted locally, so every finite set of unseen
+pairs receives budget before those rejected retries return. Low-confidence
+`forming` collisions remain dormant and never contribute promotion evidence.
+Deferred candidates remain eligible for later structural builds.
 
 ### Root
 

--- a/resources/model_assets/viewer.css
+++ b/resources/model_assets/viewer.css
@@ -476,11 +476,13 @@ button {
 .stat[data-kind="root"] { --stat-color: var(--root); }
 
 .build-state {
+  --build-color: #8d8799;
+  --build-glow: rgba(141, 135, 153, 0.48);
   display: flex;
   align-items: center;
   gap: 7px;
   padding: 0 14px;
-  color: var(--muted);
+  color: var(--build-color);
   font-size: 9px;
   text-transform: capitalize;
 }
@@ -489,8 +491,28 @@ button {
   width: 5px;
   height: 5px;
   border-radius: 50%;
-  background: var(--point);
-  box-shadow: 0 0 9px rgba(78, 240, 195, 0.72);
+  background: var(--build-color);
+  box-shadow: 0 0 9px var(--build-glow);
+}
+
+.build-state--not-built {
+  --build-color: #8d8799;
+  --build-glow: rgba(141, 135, 153, 0.48);
+}
+
+.build-state--building {
+  --build-color: var(--line);
+  --build-glow: rgba(255, 196, 94, 0.68);
+}
+
+.build-state--degraded {
+  --build-color: var(--root);
+  --build-glow: rgba(255, 107, 138, 0.68);
+}
+
+.build-state--complete {
+  --build-color: var(--point);
+  --build-glow: rgba(78, 240, 195, 0.72);
 }
 
 .legend {

--- a/resources/model_assets/viewer.js
+++ b/resources/model_assets/viewer.js
@@ -630,12 +630,25 @@ function renderStatus() {
     stat.append(count, name);
     statusEl.append(stat);
   });
-  if (model.build?.status) {
+  const buildStatus = model.build?.status;
+  if (buildStatus) {
     const build = document.createElement("span");
-    build.className = "build-state";
+    const buildStateClass = {
+      not_built: "not-built",
+      building: "building",
+      degraded: "degraded",
+      complete: "complete",
+    }[buildStatus] || "not-built";
+    build.className = `build-state build-state--${buildStateClass}`;
+    build.dataset.status = buildStatus;
     const signal = document.createElement("i");
     signal.setAttribute("aria-hidden", "true");
-    build.append(signal, `Build ${model.build.status}`);
+    const label = buildStatus === "not_built"
+      ? "Not built"
+      : buildStatus === "building"
+        ? "Building…"
+        : `Build ${buildStatus}`;
+    build.append(signal, label);
     statusEl.append(build);
   }
   modelIdentityEl.textContent = model.root?.signature

--- a/src/persome/api/routes.py
+++ b/src/persome/api/routes.py
@@ -24,7 +24,11 @@ from ..capture.timestamps import newest_capture_path
 from ..config import Config
 from ..config import load as load_config
 from ..logger import get
-from ..model import ActivitySource, build_snapshot, normalize_activity_identity
+from ..model import (
+    ActivitySource,
+    build_live_snapshot,
+    normalize_activity_identity,
+)
 from ..security.auth import (
     BROWSER_BOOTSTRAP_PATH,
     BROWSER_BOOTSTRAP_TTL_SECONDS,
@@ -458,7 +462,7 @@ def model_graph() -> dict[str, Any]:
     from ..store import fts as fts_store
 
     with fts_store.cursor() as conn:
-        snapshot = build_snapshot(conn)
+        snapshot = build_live_snapshot(conn)
     return {
         "generated_at": datetime.now().astimezone().isoformat(),
         "model": snapshot,

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -21,6 +21,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+import time
 from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -46,6 +47,12 @@ app = typer.Typer(
     help="Local-first screen-context memory and personal modeling for macOS.",
 )
 console = Console()
+
+_DAEMON_STARTUP_TIMEOUT_SECONDS = 15.0
+_DAEMON_STARTUP_RETRY_SECONDS = 0.1
+_DAEMON_STARTUP_HTTP_TIMEOUT_SECONDS = 1.0
+_DAEMON_STARTUP_STOP_TIMEOUT_SECONDS = 5.0
+_DAEMON_STARTUP_KILL_TIMEOUT_SECONDS = 2.0
 
 
 def _fail_if_runtime_state_is_ambiguous() -> None:
@@ -91,6 +98,13 @@ def _daemon_lock_is_held() -> bool:
 
 def _init(*, starting_runtime: bool = False) -> config_mod.Config:
     paths.ensure_dirs()
+    # Every initialized CLI command gets the same owner-only Runtime secrets as
+    # the daemon. In particular, one-shot commands such as `model build` run
+    # LLM stages in this process and must not depend on a prior `persome start`
+    # having sourced the file. load_env_file deliberately preserves an
+    # already-exported shell value, so per-invocation debugging overrides keep
+    # precedence over the durable profile.
+    env_file_mod.load_env_file(paths.env_file())
     _fail_if_runtime_state_is_ambiguous()
     # Logger first so the integrity check's JSON-line output lands in daemon.log.
     logger_mod.setup(console=False)
@@ -98,7 +112,36 @@ def _init(*, starting_runtime: bool = False) -> config_mod.Config:
     # must never quarantine or rebuild an index while that process has it open.
     # When stopped, this remains the first database-touching operation.
     if not _read_pid() and (starting_runtime or not _daemon_lock_is_held()):
-        integrity.check_and_recover()
+        recovered = integrity.check_and_recover()
+        if paths.integrity_recovery_pending().exists():
+            console.print(
+                "[red]Persome database recovery is incomplete.[/red] "
+                f"Inspect `{paths.integrity_recovery_marker()}` and the retained "
+                "quarantine files, repair the reported source problem, then rerun "
+                "`persome model status` to resume recovery. Run `persome doctor` after "
+                "it completes. Model builds remain disabled until then."
+            )
+        elif any(item.kind == "database" for item in recovered):
+            console.print(
+                "[yellow]Persome recovered a damaged local database. "
+                "The previous model build is no longer trusted; run "
+                "`persome model build` after startup.[/yellow]"
+            )
+    database_pending = paths.integrity_recovery_pending().exists()
+    authority_pending = paths.integrity_config_recovery_pending().exists()
+    if authority_pending:
+        console.print(
+            "[red]Persome write authority is unresolved.[/red] "
+            f"Inspect `{paths.integrity_config_recovery_pending()}` and set "
+            "`[evomem].write_authority` in config.toml explicitly to `markdown` or `evomem`, "
+            "then rerun `persome model status`."
+        )
+    if starting_runtime and (database_pending or authority_pending):
+        console.print(
+            "[red]Runtime start is blocked until integrity recovery establishes a safe "
+            "database and write authority.[/red]"
+        )
+        raise typer.Exit(2)
     created = config_mod.write_default_if_missing()
     if created:
         console.print(f"[green]Created default config at {paths.config_file()}[/green]")
@@ -268,6 +311,198 @@ def _watch_parent_death() -> None:
     threading.Thread(target=_watch, name="parent-death-watch", daemon=True).start()
 
 
+def _same_runtime_process(
+    left: runtime_pid.ProcessIdentity,
+    right: runtime_pid.ProcessIdentity,
+) -> bool:
+    """Compare the generation-bound identity fields used during startup."""
+    return (
+        left.pid == right.pid
+        and left.generation == right.generation
+        and left.runtime_started_at == right.runtime_started_at
+    )
+
+
+def _probe_background_runtime(
+    cfg: config_mod.Config,
+    expected_process: runtime_pid.ProcessIdentity | None = None,
+) -> tuple[str, str, runtime_pid.ProcessIdentity | None]:
+    """Probe one background-start attempt.
+
+    The returned state is ``ready``, ``retry``, or ``fatal``. An HTTP-enabled
+    Runtime must answer its authenticated status route with this root, version,
+    and generation-bound PID. A random service already listening on the port
+    therefore cannot make ``persome start`` report a false success.
+    """
+    process = runtime_pid.resolve_recorded_process()
+    if process is None:
+        if expected_process is not None:
+            return "fatal", "the new Runtime process exited during startup", expected_process
+        return "retry", "waiting for the new Runtime process receipt", None
+    if process.generation is None or process.runtime_started_at is None:
+        return "retry", "waiting for the generation-bound Runtime receipt", process
+    if expected_process is not None and not _same_runtime_process(process, expected_process):
+        return "fatal", "the Runtime process identity changed during startup", expected_process
+
+    http_enabled = bool(cfg.mcp.auto_start and cfg.mcp.transport in {"sse", "streamable-http"})
+    if not http_enabled:
+        return "ready", "the Runtime process receipt is valid", process
+
+    import httpx
+
+    from .security.auth import auth_headers, loopback_http_url
+
+    try:
+        url = loopback_http_url(cfg.mcp.host, cfg.mcp.port, "/status")
+        response = httpx.get(
+            url,
+            headers=auth_headers(),
+            timeout=_DAEMON_STARTUP_HTTP_TIMEOUT_SECONDS,
+            trust_env=False,
+        )
+    except (RuntimeError, ValueError) as exc:
+        return "fatal", f"local HTTP authentication is not configured: {exc}", process
+    except httpx.HTTPError as exc:
+        return "retry", f"waiting for the local HTTP Runtime ({type(exc).__name__})", process
+
+    if response.status_code >= 500:
+        return (
+            "retry",
+            f"waiting for the local HTTP Runtime (HTTP {response.status_code})",
+            process,
+        )
+    if response.status_code != 200:
+        return (
+            "fatal",
+            f"port {cfg.mcp.port} answered HTTP {response.status_code}, not the expected "
+            "authenticated Persome Runtime",
+            process,
+        )
+    try:
+        payload = response.json()
+    except (UnicodeError, ValueError):
+        return "fatal", f"port {cfg.mcp.port} returned a non-Persome response", process
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not (
+        isinstance(payload, dict)
+        and payload.get("success") is True
+        and isinstance(data, dict)
+        and data.get("version") == __version__
+        and data.get("root") == str(paths.root())
+    ):
+        return (
+            "fatal",
+            f"port {cfg.mcp.port} is in use by a different or incompatible service",
+            process,
+        )
+    if data.get("daemon") != f"running pid {process.pid}":
+        return (
+            "retry",
+            f"waiting for port {cfg.mcp.port} to serve the new Runtime generation",
+            process,
+        )
+    return "ready", "the authenticated local HTTP Runtime is ready", process
+
+
+def _wait_for_background_start(
+    cfg: config_mod.Config,
+    *,
+    timeout_seconds: float = _DAEMON_STARTUP_TIMEOUT_SECONDS,
+) -> tuple[bool, str, runtime_pid.ProcessIdentity | None]:
+    """Wait a bounded time for one exact daemon generation to become usable."""
+    deadline = time.monotonic() + max(0.0, timeout_seconds)
+    expected_process: runtime_pid.ProcessIdentity | None = None
+    last_process: runtime_pid.ProcessIdentity | None = None
+    detail = "the Runtime did not publish a readiness receipt"
+    while True:
+        state, detail, process = _probe_background_runtime(cfg, expected_process)
+        if process is not None:
+            last_process = process
+        if (
+            expected_process is None
+            and process is not None
+            and process.generation is not None
+            and process.runtime_started_at is not None
+        ):
+            expected_process = process
+        if state == "ready":
+            return True, detail, expected_process or last_process
+        if state == "fatal":
+            return False, detail, expected_process or last_process
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False, f"startup timed out: {detail}", expected_process or last_process
+        time.sleep(min(_DAEMON_STARTUP_RETRY_SECONDS, remaining))
+
+
+def _terminate_failed_background_start(
+    process: runtime_pid.ProcessIdentity | None,
+) -> bool:
+    """Stop only the generation observed during this failed start attempt."""
+    if process is None:
+        return not _daemon_lock_is_held()
+    if not runtime_pid.signal_process(process, signal.SIGTERM):
+        return runtime_pid.resolve_recorded_process() is None and _clear_failed_background_receipts(
+            process
+        )
+    if runtime_pid.wait_for_exit(process, _DAEMON_STARTUP_STOP_TIMEOUT_SECONDS):
+        # SIGTERM can land before the daemon installs its cleanup handler. In
+        # that startup window the process exits but leaves its generation-bound
+        # PID/state receipts behind. Clear only receipts that still name the
+        # exact observed generation; a normal graceful shutdown has already
+        # removed them, so this is an idempotent no-op there.
+        return _clear_failed_background_receipts(process)
+    if not runtime_pid.signal_process(process, signal.SIGKILL):
+        return runtime_pid.resolve_recorded_process() is None and _clear_failed_background_receipts(
+            process
+        )
+    if not runtime_pid.wait_for_exit(process, _DAEMON_STARTUP_KILL_TIMEOUT_SECONDS):
+        return False
+    return _clear_failed_background_receipts(process)
+
+
+def _clear_failed_background_receipts(process: runtime_pid.ProcessIdentity) -> bool:
+    """Remove stale PID/state files only when they still name ``process``.
+
+    A normal SIGTERM shutdown removes both itself. This is the SIGKILL fallback:
+    validate every available receipt before unlinking so a concurrently started
+    generation can never lose its lifecycle identity.
+    """
+    if runtime_pid.same_process_is_running(process):
+        return False
+    state = runtime_pid.read_runtime_generation()
+    if state is not None and not (
+        process.generation is not None
+        and state.pid == process.pid
+        and state.generation == process.generation
+        and state.started_at == process.runtime_started_at
+    ):
+        return False
+    record = runtime_pid.read_pid_file()
+    if record is not None and not (
+        record.pid == process.pid
+        and (record.generation is None or record.generation == process.generation)
+    ):
+        return False
+    for receipt, parsed in (
+        (paths.pid_file(), record),
+        (paths.runtime_state_file(), state),
+    ):
+        if parsed is None:
+            try:
+                receipt.lstat()
+            except FileNotFoundError:
+                continue
+            except OSError:
+                return False
+            # An unreadable or malformed receipt cannot be safely attributed.
+            return False
+    for receipt in (paths.pid_file(), paths.runtime_state_file()):
+        with contextlib.suppress(FileNotFoundError):
+            receipt.unlink()
+    return not paths.pid_file().exists() and not paths.runtime_state_file().exists()
+
+
 @app.command()
 def start(
     foreground: bool = typer.Option(False, "--foreground", "-f", help="Run in this terminal."),
@@ -287,14 +522,12 @@ def start(
         console.print(f"[yellow]{exc}.[/yellow]")
         raise typer.Exit(1) from exc
     _fail_if_runtime_state_is_ambiguous()
-    cfg = _init(starting_runtime=True)
     # Source checkouts and upgrades may start without re-running install.sh.
-    # Provision the local HTTP boundary before the daemon binds; the helper is
-    # idempotent and preserves every unrelated provider secret in the env file.
+    # Provision/repair the local HTTP boundary before generalized env loading,
+    # so a malformed value in the file cannot masquerade as a shell override.
+    # The helper is idempotent and preserves every unrelated provider secret.
     env_file_mod.ensure_local_api_token(paths.env_file())
-    # Source the owner-only env file before any fork so the daemon and every
-    # subsystem reading os.environ see the same values regardless of launcher.
-    env_file_mod.load_env_file(paths.env_file())
+    cfg = _init(starting_runtime=True)
     if pid := _read_pid():
         console.print(f"[yellow]Already running (pid {pid})[/yellow]")
         raise typer.Exit(1)
@@ -319,11 +552,45 @@ def start(
         # below already hard-exits for the same reason; mirror it here.
         os._exit(0)
 
-    # Background: double-fork
-    if os.fork() != 0:
-        console.print("[green]Persome started in background.[/green]")
+    # Background: double-fork. The parent stays alive just long enough to prove
+    # that this exact new generation owns its PID receipt and authenticated HTTP
+    # endpoint. Its copy of the lifetime lock is closed before polling; the
+    # grandchild retains the inherited file description for its whole life.
+    first_child_pid = os.fork()
+    if first_child_pid != 0:
+        daemon_lock.close()
+        try:
+            ready, detail, process = _wait_for_background_start(cfg)
+        except Exception as exc:  # noqa: BLE001 - startup still needs safe cleanup
+            ready = False
+            detail = f"startup verification failed ({type(exc).__name__})"
+            process = None
+            with contextlib.suppress(Exception):
+                process = runtime_pid.resolve_recorded_process()
+        if ready:
+            console.print("[green]Persome started in background.[/green]")
+            console.print(f"Logs: {paths.logs_dir()}")
+            return
+        try:
+            cleaned = _terminate_failed_background_start(process)
+        except Exception:  # noqa: BLE001 - preserve the actionable failure path
+            cleaned = False
+        console.print(f"[red]Persome did not start correctly:[/red] {detail}")
+        if cleaned:
+            console.print("[yellow]The incomplete background Runtime was stopped.[/yellow]")
+        else:
+            console.print(
+                "[yellow]Persome could not confirm that the incomplete Runtime stopped; "
+                "run `persome stop` before retrying.[/yellow]"
+            )
+        if cfg.mcp.auto_start and cfg.mcp.transport in {"sse", "streamable-http"}:
+            console.print(
+                f"Check port {cfg.mcp.port} with "
+                f"`lsof -nP -iTCP:{cfg.mcp.port} -sTCP:LISTEN`, then retry."
+            )
         console.print(f"Logs: {paths.logs_dir()}")
-        return
+        console.print("Next: persome doctor")
+        raise typer.Exit(1)
     os.setsid()
     if os.fork() != 0:
         os._exit(0)
@@ -1069,11 +1336,10 @@ def root_synth(
     without waiting for 00:15. Calls the real LLM. ``--dry-run`` prints the would-be apex
     without upserting.
     """
-    from .config import load as load_cfg
     from .store import fts
     from .writer import root_synthesis as rs
 
-    cfg = load_cfg()
+    cfg = _init()
     with fts.cursor() as conn:
         if dry_run:
             # Gather + call + gates, but roll back the upsert by using a savepoint.
@@ -1098,11 +1364,10 @@ def correct_cmd(
     ),
 ) -> None:
     """Apply a supervised memory correction and retain its source receipts."""
-    from .config import load as load_cfg
     from .store import fts
     from .writer import correct as correct_mod
 
-    cfg = load_cfg()
+    cfg = _init()
     with fts.cursor() as conn:
         res = correct_mod.update_memory(cfg, conn, correction, source="user", dry_run=dry_run)
     typer.echo(f"correct: {res.kind}  ok={res.ok}")
@@ -1315,13 +1580,10 @@ def edge_audit(
     from .evomem import edge_audit as audit_mod
     from .store import fts
 
+    cfg = _init()
     llm_call = None
     if llm:
-        from . import config as config_mod
-        from . import paths as paths_mod
         from .writer import llm as llm_mod
-
-        cfg = config_mod.load(paths_mod.config_file())
 
         def llm_call(messages):  # noqa: F811
             return llm_mod.call_llm(cfg, "relation_extractor", messages=messages, json_mode=True)
@@ -2399,6 +2661,9 @@ app.add_typer(writer_app, name="writer")
 model_app = typer.Typer(help="Build, inspect, and export the personal model.")
 app.add_typer(model_app, name="model")
 
+_MODEL_VIEWER_STARTUP_ATTEMPTS = 20
+_MODEL_VIEWER_STARTUP_RETRY_SECONDS = 0.25
+
 
 def _local_viewer_base_url(cfg: config_mod.Config) -> str:
     """Return a loopback URL for the daemon viewer, never a LAN HTTP origin."""
@@ -2415,11 +2680,14 @@ def model_build(
     no_wait: bool = typer.Option(False, "--no-wait", help="Return busy immediately."),
 ) -> None:
     """Run the shared one-shot Point/Line/Face/Volume/Root build."""
-    from .model import ModelBuildBusy, run_model_build
+    from .model import ModelBuildBusy, ModelRecoveryIncomplete, run_model_build
 
     cfg = _init()
     try:
         result = run_model_build(cfg, wait_seconds=0.0 if no_wait else wait_seconds)
+    except ModelRecoveryIncomplete as exc:
+        console.print(f"[red]model build blocked: {exc}[/red]")
+        raise typer.Exit(2) from exc
     except ModelBuildBusy as exc:
         console.print(f"[yellow]busy: {exc}[/yellow]")
         raise typer.Exit(2) from exc
@@ -2430,6 +2698,18 @@ def model_build(
         f"{counts['evolution_lines'] + counts['relation_lines']} "
         f"faces={counts['faces']} volumes={counts['volumes']} roots={counts['roots']}"
     )
+    cross_domain = getattr(result, "stages", {}).get("cross_domain_sweeper", {})
+    if cross_domain.get("status") == "complete":
+        deferred = int(cross_domain.get("pairs_deferred", 0))
+        console.print(
+            "cross-domain: "
+            f"probed={int(cross_domain.get('pairs_probed', 0))} "
+            f"deferred={deferred} limit={int(cross_domain.get('probe_limit', 0))}"
+        )
+        if deferred:
+            console.print(
+                "[yellow]Deferred pairs stay queued for later scheduled or explicit builds.[/yellow]"
+            )
     console.print(f"manifest: {result.manifest_path}")
 
 
@@ -2439,18 +2719,18 @@ def model_export(
     raw: bool = typer.Option(False, "--raw", help="Include unredacted local text."),
 ) -> None:
     """Export the current versioned model snapshot; redacted by default."""
-    from .model import export_snapshot, load_last_manifest
+    from .model import build_live_snapshot, export_snapshot
 
     _init()
     if raw:
         console.print("[yellow]warning: --raw may contain sensitive personal data[/yellow]")
     target = Path(out).expanduser() if out else None
     with fts.cursor() as conn:
+        snapshot = build_live_snapshot(conn, redact=not raw)
         path = export_snapshot(
             conn,
             out_path=target,
-            redact=not raw,
-            build_metadata=load_last_manifest(),
+            snapshot_data=snapshot,
         )
     console.print(f"model snapshot: {path}")
 
@@ -2458,22 +2738,36 @@ def model_export(
 @model_app.command("status")
 def model_status_cmd() -> None:
     """Show live model readiness, geometry counts, and the last build id."""
-    from .model import load_last_manifest, model_status
+    from .model import build_live_snapshot, model_status
 
     _init()
     with fts.cursor() as conn:
-        status = model_status(conn)
-    last = load_last_manifest()
+        snapshot = build_live_snapshot(conn)
+        status = model_status(conn, snapshot_data=snapshot)
+    last = snapshot["build"]
+    build_status = str(last["status"])
+    if build_status == "not_built":
+        readiness = "not built"
+    elif build_status == "building":
+        readiness = "building"
+    else:
+        readiness = "ready" if status["ready"] else "not ready"
+    issues = list(status["issues"])
+    if build_status == "not_built":
+        issues.append("no_completed_build")
+    elif build_status == "building":
+        issues.append("build_in_progress")
     counts = status["stats"]
     console.print(
-        f"[bold]model: {'ready' if status['ready'] else 'not ready'}[/bold]  "
+        f"[bold]model: {readiness}[/bold]  "
         f"points={counts['points']} lines="
         f"{counts['evolution_lines'] + counts['relation_lines']} "
         f"faces={counts['faces']} volumes={counts['volumes']} roots={counts['roots']}"
     )
-    if status["issues"]:
-        console.print(f"issues: {', '.join(status['issues'])}")
-    console.print(f"last build: {last.get('build_id') if last else 'none'}")
+    if issues:
+        console.print(f"issues: {', '.join(issues)}")
+    console.print(f"build status: {build_status}")
+    console.print(f"last build: {last.get('build_id') or 'none'}")
 
 
 @model_app.command("open")
@@ -2487,21 +2781,47 @@ def model_open() -> None:
     if cfg.mcp.transport not in {"sse", "streamable-http"}:
         console.print("[red]The model viewer requires the daemon HTTP transport.[/red]")
         raise typer.Exit(1)
-    env_file_mod.load_env_file(paths.env_file())
 
     from .security.auth import BROWSER_BOOTSTRAP_PATH, auth_headers
 
     try:
         base_url = _local_viewer_base_url(cfg)
         headers = auth_headers()
-        response = httpx.post(
-            f"{base_url}{BROWSER_BOOTSTRAP_PATH}",
-            headers=headers,
-            timeout=5.0,
-            trust_env=False,
-        )
+        for attempt in range(_MODEL_VIEWER_STARTUP_ATTEMPTS):
+            try:
+                response = httpx.post(
+                    f"{base_url}{BROWSER_BOOTSTRAP_PATH}",
+                    headers=headers,
+                    timeout=5.0,
+                    trust_env=False,
+                )
+                break
+            except httpx.ConnectError:
+                # `persome start` returns after forking, just before uvicorn has
+                # necessarily bound its loopback socket. Retry only that
+                # connection-refused startup race. Any HTTP response (notably
+                # 401/403) is handled below immediately instead of being hidden
+                # behind retries. A genuinely stopped Runtime fails
+                # immediately instead of looking like another CLI hang.
+                runtime_starting = _read_pid() is not None or _daemon_lock_is_held()
+                if not runtime_starting or attempt + 1 == _MODEL_VIEWER_STARTUP_ATTEMPTS:
+                    raise
+                time.sleep(_MODEL_VIEWER_STARTUP_RETRY_SECONDS)
         response.raise_for_status()
         payload = response.json()
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code in {401, 403}:
+            console.print(
+                "[red]Local model viewer authentication failed[/red] "
+                f"(HTTP {exc.response.status_code}). The daemon and this CLI may be using "
+                "different owner credentials; restart Persome, then retry."
+            )
+        else:
+            console.print(
+                "[red]The local model viewer request failed[/red] "
+                f"(HTTP {exc.response.status_code}). Check `persome status`, then retry."
+            )
+        raise typer.Exit(1) from exc
     except (RuntimeError, ValueError, httpx.HTTPError) as exc:
         console.print(
             "[red]Could not authorize the local model viewer.[/red] "
@@ -2802,12 +3122,19 @@ def evomem_import_markdown(
 
 
 @app.command("rebuild-captures-index")
-def rebuild_captures_index() -> None:
+def rebuild_captures_index(
+    merge: bool = typer.Option(
+        False,
+        "--merge",
+        help="Upsert surviving buffer JSON without deleting older snapshot-backed rows.",
+    ),
+) -> None:
     """Reconcile captures_fts exactly from capture-buffer/*.json on disk.
 
-    Re-runnable: stale rows are cleared before every surviving JSON is indexed,
-    so this is safe whenever the captures index has fallen out of sync (for
-    example after an interrupted filesystem/SQLite cleanup).
+    By default stale rows are cleared before every surviving JSON is indexed.
+    ``--merge`` preserves existing rows and is the safe mode after restoring an
+    older database snapshot whose historical captures may predate buffer
+    retention.
     """
     import json
 
@@ -2818,9 +3145,11 @@ def rebuild_captures_index() -> None:
     indexed = 0
     skipped = 0
     with fts.cursor() as conn:
-        # Rebuild is reconciliation, not just an upsert pass. Rows whose source
-        # JSON was removed during a previous failed retention pass must vanish.
-        conn.execute("DELETE FROM captures")
+        # Exact rebuild is reconciliation, not just an upsert pass. Recovery
+        # merge intentionally preserves older snapshot rows whose source JSON
+        # has already aged out of the bounded capture buffer.
+        if not merge:
+            conn.execute("DELETE FROM captures")
         for p in files:
             try:
                 data = json.loads(p.read_text())
@@ -2851,7 +3180,8 @@ def rebuild_captures_index() -> None:
                 console.print(f"  indexed {indexed} / {len(files)}…")
 
     console.print(
-        f"[green]Captures index rebuilt: {indexed} indexed, {skipped} skipped "
+        f"[green]Captures index {'merged' if merge else 'rebuilt'}: "
+        f"{indexed} indexed, {skipped} skipped "
         f"(of {len(files)} files).[/green]"
     )
 
@@ -2953,6 +3283,7 @@ _MODEL_TABLES = (
     "memory_contradictions",
     "relation_edges",
     "schema_faces",
+    "cross_domain_probe_state",
     "evo_nodes",
     "projection_state",
     "entry_metadata",
@@ -3009,6 +3340,8 @@ def _clean_memory() -> tuple[int, int, int, int]:
             paths.model_build_lock(),
             paths.session_model_lock(),
             paths.integrity_recovery_marker(),
+            paths.integrity_recovery_pending(),
+            paths.integrity_config_recovery_pending(),
         )
     )
     artifacts += sum(
@@ -3016,6 +3349,8 @@ def _clean_memory() -> tuple[int, int, int, int]:
         for path in _private_atomic_crash_artifacts(
             paths.model_build_manifest(),
             paths.integrity_recovery_marker(),
+            paths.integrity_recovery_pending(),
+            paths.integrity_config_recovery_pending(),
         )
     )
     # Integrity-quarantine copies live beside the active DB, outside backup/.
@@ -3142,12 +3477,16 @@ def clean_all(
         paths.session_model_lock(),
         paths.paused_flag(),
         paths.integrity_recovery_marker(),
+        paths.integrity_recovery_pending(),
+        paths.integrity_config_recovery_pending(),
         paths.pid_file(),
     )
     quarantined_personal_data = tuple(paths.root().glob("*.corrupt.*"))
     atomic_crash_data = _private_atomic_crash_artifacts(
         paths.model_build_manifest(),
         paths.integrity_recovery_marker(),
+        paths.integrity_recovery_pending(),
+        paths.integrity_config_recovery_pending(),
         paths.pid_file(),
         paths.paused_flag(),
         paths.writer_state(),

--- a/src/persome/config.py
+++ b/src/persome/config.py
@@ -259,10 +259,13 @@ class SchemaConfig:
     # bounded — a low-quality collision gets a low LLM confidence → born ``forming``
     # → excluded from active model reads (only ``stable`` >= min_confidence fusions
     # are visible), and the sweeper prompt is biased to refuse strained merges. The
-    # main cost is the per-tick LLM probes, capped by the topic/behavior pre-filter.
+    # main cost is the per-tick LLM probes, hard-capped after the topic/behavior
+    # pre-filter. Existing shadow Volumes are retried before unseen pairs so the
+    # two-observation promotion gate can make progress within that budget.
     cross_domain_enabled: bool = True
     cross_domain_behavior_max_distance: float = 0.5  # ≤ this == "behavior-near" (pre-filter)
     cross_domain_min_confidence: float = 0.6  # fused schema below this is born ``forming``
+    cross_domain_max_probes: int = 8  # hard LLM-call budget per structural build
     # One bounded LLM compresses active Volume/Face/profile evidence into the
     # single level-3 Root. Default ON:
     # born active, chain-supersedes the prior root, 3 deterministic gates + fail-open
@@ -723,6 +726,7 @@ daily_tick_minute = 15            # local-time minute for the daily schema tick
 cross_domain_enabled = true       # Hy-Memory cross-domain sweeper: collide topic-far/behavior-near schemas (no embedding); low-quality fusions stay forming, only stable ones enter active model reads
 cross_domain_behavior_max_distance = 0.5  # behavior-distance ceiling for the deterministic pre-filter (≤ == behavior-near)
 cross_domain_min_confidence = 0.6 # fused cross-domain schema below this confidence is born forming (not injected)
+cross_domain_max_probes = 8       # hard LLM-call budget per build; shadow Volumes are retried before unseen pairs
 root_synthesis_enabled = true      # synthesize at most one active Root
 root_token_budget = 1500
 

--- a/src/persome/env_file.py
+++ b/src/persome/env_file.py
@@ -2,8 +2,9 @@
 
 Runtime secrets live in ``~/.persome/env``. A user may edit that owner-only
 file directly, or an embedding product may mirror secrets from its own secure
-store. Business code stays on ``os.environ.get(...)``; this loader merges the
-file's contents into ``os.environ`` once, at CLI ``start`` time, before forking.
+store. Business code stays on ``os.environ.get(...)``; initialized CLI commands
+merge the file's contents into ``os.environ`` before doing work, and ``start``
+does so before forking.
 
 Semantics:
 
@@ -13,11 +14,14 @@ Semantics:
   ignored, optional single/double-quoted values (quotes stripped, no escapes).
 * No shell expansion, no ``$VAR`` interpolation — behavior is identical for
   direct CLI and embedding-product launch paths.
+* ``PERSOME_ROOT`` is never sourced from the file stored under that root. The
+  parent process must select the data root before the owner env is located.
 """
 
 from __future__ import annotations
 
 import os
+import re
 import secrets
 import tempfile
 from pathlib import Path
@@ -28,6 +32,8 @@ _SCREENSHOT_KEY_HEX_LENGTH = 64
 LOCAL_API_TOKEN_ENV = "PERSOME_LOCAL_API_TOKEN"
 _LOCAL_API_TOKEN_MIN_BYTES = 32
 _LOCAL_API_TOKEN_MAX_BYTES = 512
+_LOCAL_API_TOKEN_RE = re.compile(r"[A-Za-z0-9_-]+\Z")
+_OWNER_ENV_BLOCKED_KEYS = frozenset({"PERSOME_ROOT"})
 
 ScreenshotKeyStatus = Literal["existing", "generated"]
 LocalAPITokenStatus = Literal["existing", "generated"]
@@ -68,6 +74,8 @@ def load_env_file(path: Path) -> int:
         if parsed is None:
             continue
         key, value = parsed
+        if key in _OWNER_ENV_BLOCKED_KEYS:
+            continue
         if key in os.environ:
             continue
         os.environ[key] = value
@@ -130,10 +138,15 @@ def is_valid_screenshot_key(value: str | None) -> bool:
 
 
 def is_valid_local_api_token(value: str | None) -> bool:
-    """Return whether ``value`` is a safe opaque local bearer credential."""
-    if value is None or value != value.strip() or "\r" in value or "\n" in value:
+    """Return whether ``value`` is a durable URL-safe bearer credential.
+
+    The canonical value is persisted without a dotenv escaping layer. Using
+    the same alphabet as ``token_urlsafe`` makes that serialization exactly
+    reversible for every later CLI or daemon process.
+    """
+    if value is None or _LOCAL_API_TOKEN_RE.fullmatch(value) is None:
         return False
-    length = len(value.encode("utf-8"))
+    length = len(value)
     return _LOCAL_API_TOKEN_MIN_BYTES <= length <= _LOCAL_API_TOKEN_MAX_BYTES
 
 
@@ -141,7 +154,9 @@ def ensure_local_api_token(path: Path) -> LocalAPITokenStatus:
     """Generate and preserve one owner-only local REST/MCP bearer token.
 
     The value is never returned or logged. Invalid/duplicate entries are
-    replaced atomically with a fresh high-entropy URL-safe token.
+    replaced atomically with a fresh high-entropy URL-safe token. A valid
+    shell-provided token becomes the durable canonical value so the daemon and
+    later CLI processes cannot diverge onto different bearer credentials.
     """
     try:
         lines = path.read_text(encoding="utf-8").splitlines()
@@ -159,18 +174,16 @@ def ensure_local_api_token(path: Path) -> LocalAPITokenStatus:
                 canonical = value
             continue
 
-    if canonical is None:
+    shell_override = os.environ.get(LOCAL_API_TOKEN_ENV)
+    if is_valid_local_api_token(shell_override):
+        canonical = shell_override
+        status: LocalAPITokenStatus = "existing"
+    elif canonical is None:
         canonical = secrets.token_urlsafe(48)
-        status: LocalAPITokenStatus = "generated"
+        status = "generated"
     else:
         status = "existing"
-    shell_override = os.environ.get(LOCAL_API_TOKEN_ENV)
     write_env_values(path, {LOCAL_API_TOKEN_ENV: canonical})
-    # Match load_env_file's documented precedence: a deliberate shell export
-    # remains a process-local debugging override instead of being silently
-    # replaced when `persome start` performs idempotent provisioning.
-    if shell_override is not None:
-        os.environ[LOCAL_API_TOKEN_ENV] = shell_override
     return status
 
 

--- a/src/persome/evomem/backfill.py
+++ b/src/persome/evomem/backfill.py
@@ -174,10 +174,11 @@ def _build_nodes(report: BackfillReport, *, user_id: str, agent_id: str) -> list
     """Parse markdown + side tables into the full node list (read-only phase)."""
     parsed_files: list[tuple[str, str, list[files_mod.ParsedEntry]]] = []
     for path in files_mod.list_memory_files():
+        name = files_mod.memory_name(path)
         try:
-            prefix = files_mod.validate_prefix(path.name)
+            prefix = files_mod.validate_prefix(name)
         except ValueError as exc:
-            _log.warning("backfill: skipping %s: %s", path.name, exc)
+            _log.warning("backfill: skipping %s: %s", name, exc)
             continue
         parsed = files_mod.read_file(path)
         report.files += 1
@@ -185,7 +186,9 @@ def _build_nodes(report: BackfillReport, *, user_id: str, agent_id: str) -> list
         if prefix == "event":
             report.skipped_event += len(parsed.entries)
             continue
-        parsed_files.append((path.name, prefix, parsed.entries))
+        if "/" in name:
+            continue
+        parsed_files.append((name, prefix, parsed.entries))
 
     with fts.cursor() as conn:
         metadata, temporal = _load_side_tables(conn)

--- a/src/persome/evomem/integrity.py
+++ b/src/persome/evomem/integrity.py
@@ -8,6 +8,7 @@ import threading
 from dataclasses import dataclass
 from pathlib import Path
 
+from .. import paths
 from ..config import Config
 from ..logger import get
 
@@ -131,6 +132,13 @@ def ensure_writes_allowed() -> None:
     ``store/entries.py`` and NodeStore writers in ``evomem/store.py``). With the
     default config the flag is never set, so this is a pure flag check —
     behaviorally identical to before."""
+    if (
+        paths.integrity_recovery_pending().exists()
+        or paths.integrity_config_recovery_pending().exists()
+    ):
+        raise WriteFrozenError(
+            "memory writes are frozen while database/config recovery is incomplete"
+        )
     reason = write_frozen()
     if reason is not None:
         raise WriteFrozenError(f"memory writes are frozen by integrity check: {reason}")

--- a/src/persome/evomem/inversion.py
+++ b/src/persome/evomem/inversion.py
@@ -51,6 +51,10 @@ _miss_count = 0
 def authority() -> str:
     """Normalize write authority and fail safely to ``markdown``."""
     raw = (config_mod.load().evomem.write_authority or "markdown").strip().lower()
+    if raw == "unknown":
+        raise integrity.WriteFrozenError(
+            "write authority is unresolved; choose markdown or evomem before writing"
+        )
     if raw not in ("markdown", "evomem"):
         _log.warning("unknown [evomem] write_authority %r — falling back to 'markdown'", raw)
         return "markdown"

--- a/src/persome/evomem/restore.py
+++ b/src/persome/evomem/restore.py
@@ -41,15 +41,18 @@ def import_from_markdown(*, dry_run: bool = False) -> RestoreReport:
     report = RestoreReport(dry_run=dry_run)
     parsed_files: list[tuple[str, list[files_mod.ParsedEntry]]] = []
     for path in files_mod.list_memory_files():
+        name = files_mod.memory_name(path)
         try:
-            prefix = files_mod.validate_prefix(path.name)
+            prefix = files_mod.validate_prefix(name)
         except ValueError as exc:
-            _log.warning("restore: skipping %s: %s", path.name, exc)
+            _log.warning("restore: skipping %s: %s", name, exc)
             continue
         if prefix == "event":
             report.skipped_event_files += 1
             continue
-        parsed_files.append((path.name, files_mod.read_file(path).entries))
+        if "/" in name:
+            continue
+        parsed_files.append((name, files_mod.read_file(path).entries))
         report.files += 1
 
     nodes = projector.rebuild_nodes_from_projection(parsed_files)

--- a/src/persome/evomem/shadow.py
+++ b/src/persome/evomem/shadow.py
@@ -72,8 +72,10 @@ def note_out_of_band_rewrite(names: Sequence[str]) -> None:
         if inversion.evomem_active():
             return
         for name in names:
+            if "/" in name:
+                continue
             try:
-                prefix = files_mod.validate_prefix(files_mod.memory_path(name).name)
+                prefix = files_mod.validate_prefix(name)
             except ValueError:
                 continue
             if prefix == "event":
@@ -104,7 +106,10 @@ def _shadow_write(conn: sqlite3.Connection, *, name: str, entry_ids: list[str]) 
     if inversion.evomem_active():
         return
     path = files_mod.memory_path(name)
-    prefix = files_mod.validate_prefix(path.name)
+    file_name = files_mod.memory_name(path)
+    if "/" in file_name:
+        return
+    prefix = files_mod.validate_prefix(file_name)
     if prefix == "event":
         return
     if not _evo_ready(conn):
@@ -191,7 +196,7 @@ def _shadow_write(conn: sqlite3.Connection, *, name: str, entry_ids: list[str]) 
         nodes.append(
             backfill.map_entry_to_node(
                 e,
-                file_name=path.name,
+                file_name=file_name,
                 prefix=prefix,
                 supersedes=preds.get(e.id, []),
                 superseded_by=(

--- a/src/persome/integrity.py
+++ b/src/persome/integrity.py
@@ -5,8 +5,8 @@ fail to start (or crash later) with no actionable message. This module runs a
 cheap check at startup, and when it finds damage it:
 
   1. renames the bad file to ``<name>.corrupt.<timestamp>`` (kept for analysis),
-  2. lets the normal code path rebuild a fresh file from defaults
-     (config: rewritten here; DB: recreated lazily by ``fts.connect``),
+  2. rebuilds config from defaults and restores the DB from the latest verified
+     snapshot when possible, then reconciles the Markdown memory projection,
   3. records an inspectable recovery marker (``.integrity-recovery.json``)
      that an embedding client or operator can surface and acknowledge,
   4. logs the check result + every quarantine as a JSON line.
@@ -19,8 +19,12 @@ or a ``tomllib`` parse error — triggers quarantine.
 
 from __future__ import annotations
 
+import contextlib
 import json
+import os
+import re
 import sqlite3
+import tempfile
 import time
 import tomllib
 from dataclasses import asdict, dataclass
@@ -42,6 +46,74 @@ _DERIVED_FTS_INTEGRITY_ERRORS = {
 }
 _DERIVED_FTS_TABLES = frozenset(_DERIVED_FTS_INTEGRITY_ERRORS.values())
 _GENERIC_MALFORMED_DB_ERROR = "database disk image is malformed"
+_SNAPSHOT_NAME_RE = re.compile(r"^evo-\d{8}\.db$")
+_PERSOME_SNAPSHOT_COLUMNS = {
+    "files": frozenset(
+        {
+            "path",
+            "prefix",
+            "description",
+            "tags",
+            "status",
+            "entry_count",
+            "created",
+            "updated",
+            "needs_compact",
+        }
+    ),
+    "entries": frozenset({"id", "path", "prefix", "timestamp", "tags", "content", "superseded"}),
+    "captures": frozenset(
+        {
+            "id",
+            "timestamp",
+            "app_name",
+            "bundle_id",
+            "window_title",
+            "focused_role",
+            "focused_value",
+            "visible_text",
+            "url",
+        }
+    ),
+}
+_EVOMEM_SNAPSHOT_COLUMNS = frozenset(
+    {
+        "node_id",
+        "user_id",
+        "agent_id",
+        "content",
+        "layer",
+        "supersedes",
+        "superseded_by",
+        "is_latest",
+        "status",
+        "file_name",
+    }
+)
+_DATABASE_RECOVERY_PHASES = frozenset(
+    {
+        "prepared",
+        "manifest_invalidated",
+        "quarantined",
+        "restoring_snapshot",
+        "snapshot_restored",
+        "replaying_without_snapshot",
+        "replaying_preserved_database",
+        "replaying_live_database_from_markdown",
+        "replayed",
+        "failed",
+        "owner_repaired",
+    }
+)
+_CONFIG_RECOVERY_PHASES = frozenset(
+    {
+        "prepared",
+        "quarantined",
+        "replacement_ready",
+        "authority_unresolved",
+        "authority_resolved",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -54,12 +126,55 @@ class QuarantinedFile:
     reason: str
 
 
+class _WriteAuthorityUnresolved(RuntimeError):
+    """Recovery found multiple intact sources but no unique canonical one."""
+
+
 def _timestamp_suffix() -> str:
     # Filesystem-safe, sorts chronologically, unique enough for startup.
     return datetime.now().strftime("%Y%m%d-%H%M%S")
 
 
-def _quarantine(path: Path) -> Path:
+def _quarantine_destination(path: Path) -> Path:
+    """Choose a collision-free quarantine path without mutating the source."""
+    suffix = _timestamp_suffix()
+    dest = path.with_name(f"{path.name}.corrupt.{suffix}")
+    n = 1
+    while dest.exists():
+        dest = path.with_name(f"{path.name}.corrupt.{suffix}.{n}")
+        n += 1
+    return dest
+
+
+def _quarantine_destination_has_artifacts(destination: Path) -> bool:
+    """Return whether a prepared quarantine has moved any SQLite artifact.
+
+    ``_quarantine`` moves WAL/SHM/journal sidecars before the main database. A
+    crash in that window therefore leaves ``destination`` absent while (for
+    example) ``destination.wal`` already exists. Such a journal has begun its
+    quarantine and must be resumed; treating the now-WAL-less live main as an
+    owner repair could silently accept stale data and discard the journal.
+    """
+    candidates = (
+        destination,
+        destination.with_name(f"{destination.name}.wal"),
+        destination.with_name(f"{destination.name}.shm"),
+        destination.with_name(f"{destination.name}.journal"),
+    )
+    for candidate in candidates:
+        try:
+            candidate.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError:
+            # An unreadable destination is not proof that quarantine never
+            # started. Fail toward the resumable recovery path.
+            return True
+        return True
+    return False
+
+
+def _quarantine(path: Path, *, destination: Path | None = None) -> Path:
     """Rename ``path`` (and any SQLite sidecars) to ``<name>.corrupt.<ts>``.
 
     Returns the destination of the main file. Sidecars (``-wal`` / ``-shm`` / ``-journal``)
@@ -68,13 +183,9 @@ def _quarantine(path: Path) -> Path:
     mandatory; otherwise the live main remains discoverable and recovery fails
     closed instead of starting beside an unsafely retained journal.
     """
-    suffix = _timestamp_suffix()
-    dest = path.with_name(f"{path.name}.corrupt.{suffix}")
-    # Avoid clobbering a marker from a previous recovery in the same second.
-    n = 1
-    while dest.exists():
-        dest = path.with_name(f"{path.name}.corrupt.{suffix}.{n}")
-        n += 1
+    dest = destination or _quarantine_destination(path)
+    if dest.exists():
+        raise RuntimeError(f"quarantine destination already exists: {dest}")
     moved: list[tuple[Path, Path]] = []
     for sidecar in (f"{path.name}-wal", f"{path.name}-shm", f"{path.name}-journal"):
         src = path.with_name(sidecar)
@@ -320,19 +431,1083 @@ def _config_corruption_reason(config_path: Path) -> str | None:
         return f"unreadable: {e}"
 
 
-def _write_recovery_marker(quarantined: list[QuarantinedFile]) -> None:
+def _write_recovery_marker(
+    quarantined: list[QuarantinedFile],
+    *,
+    database_recovery: dict[str, object] | None = None,
+) -> bool:
+    marker = paths.integrity_recovery_marker()
+    if database_recovery is None:
+        try:
+            previous = json.loads(marker.read_text(encoding="utf-8"))
+            previous_database = (
+                previous.get("database_recovery") if isinstance(previous, dict) else None
+            )
+            manifest = paths.model_build_manifest()
+            manifest_superseded = (
+                manifest.exists() and manifest.stat().st_mtime_ns > marker.stat().st_mtime_ns
+            )
+            if (
+                isinstance(previous_database, dict)
+                and previous_database.get("model_rebuild_required")
+                and not manifest_superseded
+            ):
+                database_recovery = previous_database
+        except (FileNotFoundError, json.JSONDecodeError, OSError, TypeError, ValueError):
+            pass
     payload = {
         "recovered_at": datetime.now().astimezone().isoformat(),
         "files": [asdict(q) for q in quarantined],
     }
-    marker = paths.integrity_recovery_marker()
+    if database_recovery is not None:
+        payload["database_recovery"] = database_recovery
     try:
         paths.atomic_write_private_text(
             marker,
             json.dumps(payload, ensure_ascii=False, indent=2),
         )
+        return True
     except (OSError, RuntimeError) as e:
         _log.warning("integrity: failed to write recovery marker", extra={"error": str(e)})
+        return False
+
+
+def _write_pending_recovery(payload: dict[str, object]) -> None:
+    paths.atomic_write_private_text(
+        paths.integrity_recovery_pending(),
+        json.dumps(payload, ensure_ascii=False, indent=2),
+    )
+
+
+def _retain_invalid_pending_journal(path: Path, *, label: str, error: str) -> Path | None:
+    """Keep an invalid journal for forensics without blocking normal recovery."""
+    try:
+        destination = _quarantine(path)
+    except (OSError, RuntimeError) as exc:
+        _log.warning(
+            f"integrity: could not retain invalid {label} journal",
+            extra={"path": str(path), "error": str(exc), "journal_error": error},
+        )
+        return None
+    _log.warning(
+        f"integrity: retained invalid {label} journal and resumed normal checks",
+        extra={"path": str(path), "moved_to": str(destination), "error": error},
+    )
+    return destination
+
+
+def _pending_journal_semantic_error(
+    payload: object,
+    *,
+    original: Path,
+    phases: frozenset[str],
+) -> str | None:
+    """Validate the fields that make a version-1 resume journal safe to act on."""
+    if not isinstance(payload, dict):
+        return "journal payload is not an object"
+    version = payload.get("version")
+    if isinstance(version, bool) or version != 1:
+        return "unsupported journal version"
+    phase = payload.get("phase")
+    if not isinstance(phase, str) or phase not in phases:
+        return f"unknown or missing recovery phase: {phase!r}"
+    started_at = payload.get("started_at")
+    if not isinstance(started_at, str) or not started_at.strip():
+        return "missing recovery start timestamp"
+    reason = payload.get("reason")
+    if not isinstance(reason, str) or not reason.strip():
+        return "missing recovery reason"
+    original_value = payload.get("original_path")
+    quarantine_value = payload.get("quarantine_path")
+    if not isinstance(original_value, str) or Path(original_value) != original:
+        return "journal original path is not the canonical owner path"
+    if not isinstance(quarantine_value, str):
+        return "missing quarantine path"
+    quarantine = Path(quarantine_value)
+    if (
+        not quarantine.is_absolute()
+        or quarantine.parent != original.parent
+        or not quarantine.name.startswith(f"{original.name}.corrupt.")
+    ):
+        return "journal quarantine path is outside the canonical recovery namespace"
+    return None
+
+
+def _load_pending_recovery() -> tuple[dict[str, object] | None, Path | None]:
+    try:
+        payload = json.loads(paths.integrity_recovery_pending().read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None, None
+    except (json.JSONDecodeError, OSError) as exc:
+        _log.warning("integrity: unreadable pending recovery journal", extra={"error": str(exc)})
+        retained = _retain_invalid_pending_journal(
+            paths.integrity_recovery_pending(),
+            label="database recovery",
+            error=str(exc),
+        )
+        if retained is not None:
+            return None, retained
+        return {"version": 0, "phase": "invalid", "error": str(exc)}, None
+    semantic_error = _pending_journal_semantic_error(
+        payload,
+        original=paths.index_db(),
+        phases=_DATABASE_RECOVERY_PHASES,
+    )
+    if semantic_error is not None:
+        _log.warning(
+            "integrity: invalid pending recovery journal",
+            extra={"error": semantic_error},
+        )
+        retained = _retain_invalid_pending_journal(
+            paths.integrity_recovery_pending(),
+            label="database recovery",
+            error=semantic_error,
+        )
+        if retained is not None:
+            return None, retained
+        return {"version": 0, "phase": "invalid", "error": semantic_error}, None
+    return payload, None
+
+
+def _set_pending_phase(payload: dict[str, object], phase: str) -> None:
+    payload["phase"] = phase
+    payload["updated_at"] = datetime.now().astimezone().isoformat()
+    _write_pending_recovery(payload)
+
+
+def _remove_pending_recovery() -> None:
+    try:
+        paths.integrity_recovery_pending().unlink(missing_ok=True)
+    except OSError as exc:
+        _log.warning(
+            "integrity: failed to remove completed recovery journal", extra={"error": str(exc)}
+        )
+
+
+def _write_pending_config_recovery(payload: dict[str, object]) -> None:
+    """Persist config-recovery intent before replacing the corrupt source."""
+    paths.atomic_write_private_text(
+        paths.integrity_config_recovery_pending(),
+        json.dumps(payload, ensure_ascii=False, indent=2),
+    )
+
+
+def _load_pending_config_recovery() -> tuple[dict[str, object] | None, Path | None]:
+    try:
+        payload = json.loads(paths.integrity_config_recovery_pending().read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None, None
+    except (json.JSONDecodeError, OSError) as exc:
+        _log.warning(
+            "integrity: unreadable pending config recovery intent",
+            extra={"error": str(exc)},
+        )
+        retained = _retain_invalid_pending_journal(
+            paths.integrity_config_recovery_pending(),
+            label="config recovery",
+            error=str(exc),
+        )
+        if retained is not None:
+            return None, retained
+        return {"version": 0, "phase": "invalid", "error": str(exc)}, None
+    semantic_error = _pending_journal_semantic_error(
+        payload,
+        original=paths.config_file(),
+        phases=_CONFIG_RECOVERY_PHASES,
+    )
+    if semantic_error is not None:
+        _log.warning(
+            "integrity: invalid pending config recovery intent",
+            extra={"error": semantic_error},
+        )
+        retained = _retain_invalid_pending_journal(
+            paths.integrity_config_recovery_pending(),
+            label="config recovery",
+            error=semantic_error,
+        )
+        if retained is not None:
+            return None, retained
+        return {"version": 0, "phase": "invalid", "error": semantic_error}, None
+    return payload, None
+
+
+def _set_pending_config_phase(payload: dict[str, object], phase: str) -> None:
+    payload["phase"] = phase
+    payload["updated_at"] = datetime.now().astimezone().isoformat()
+    _write_pending_config_recovery(payload)
+
+
+def _remove_pending_config_recovery() -> None:
+    try:
+        paths.integrity_config_recovery_pending().unlink(missing_ok=True)
+    except OSError as exc:
+        _log.warning(
+            "integrity: failed to remove completed config recovery intent",
+            extra={"error": str(exc)},
+        )
+
+
+def _resume_config_recovery(
+    config_path: Path,
+    payload: dict[str, object],
+) -> QuarantinedFile | None:
+    """Finish one prepared config quarantine without trusting its replacement."""
+    original = Path(str(payload["original_path"]))
+    dest = Path(str(payload["quarantine_path"]))
+    reason = str(payload["reason"])
+    prior_phase = str(payload.get("phase") or "prepared")
+    authority_was_unresolved = prior_phase == "authority_unresolved"
+    authority_was_resolved = prior_phase == "authority_resolved"
+    if (
+        original != config_path
+        or dest.parent != config_path.parent
+        or not dest.name.startswith(f"{config_path.name}.corrupt.")
+    ):
+        raise ValueError("pending config recovery contains unsafe paths")
+
+    current_reason = _config_corruption_reason(config_path)
+    if not dest.exists() and current_reason is not None:
+        _quarantine(config_path, destination=dest)
+        _set_pending_config_phase(payload, "quarantined")
+    elif not dest.exists() and config_path.exists():
+        # The owner repaired the config after intent was prepared but before
+        # quarantine. Keep the authority-unknown signal for this startup, but
+        # do not move a now-valid file aside.
+        payload["owner_repaired_before_quarantine"] = True
+        _set_pending_config_phase(payload, "replacement_ready")
+    elif dest.exists() and str(payload.get("phase")) == "prepared":
+        _set_pending_config_phase(payload, "quarantined")
+
+    if not config_path.exists():
+        config_mod.write_default_if_missing(config_path)
+    elif _config_corruption_reason(config_path) is not None:
+        # A second corrupt replacement while the first intent is pending is a
+        # new incident. Preserve it at a fresh destination rather than
+        # overwriting the original forensic copy.
+        replacement_dest = _quarantine(config_path)
+        additional = payload.get("additional_quarantine_paths")
+        if not isinstance(additional, list):
+            additional = []
+        additional.append(str(replacement_dest))
+        payload["additional_quarantine_paths"] = additional
+        config_mod.write_default_if_missing(config_path)
+    _set_pending_config_phase(
+        payload,
+        (
+            "authority_resolved"
+            if authority_was_resolved
+            else "authority_unresolved"
+            if authority_was_unresolved
+            else "replacement_ready"
+        ),
+    )
+
+    if not dest.exists():
+        return None
+    return QuarantinedFile(
+        kind="config",
+        original_path=str(original),
+        quarantine_path=str(dest),
+        reason=reason,
+    )
+
+
+def _database_has_default_evomem_nodes(db_path: Path) -> bool:
+    if not db_path.exists():
+        return False
+    conn: sqlite3.Connection | None = None
+    try:
+        conn = sqlite3.connect(
+            f"{db_path.resolve().as_uri()}?mode=ro",
+            uri=True,
+            timeout=5.0,
+        )
+        table = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='evo_nodes'"
+        ).fetchone()
+        if table is None:
+            return False
+        return (
+            conn.execute(
+                "SELECT 1 FROM evo_nodes WHERE user_id='default' AND agent_id='default' LIMIT 1"
+            ).fetchone()
+            is not None
+        )
+    except sqlite3.Error:
+        return False
+    finally:
+        if conn is not None:
+            conn.close()
+
+
+def _persist_recovered_write_authority(config_path: Path, authority: str) -> None:
+    """Make an unknown-authority recovery choice durable before unfreezing."""
+    if authority not in {"markdown", "evomem", "unknown"}:
+        raise ValueError(f"unsupported recovered write authority: {authority}")
+    import tomlkit
+    from tomlkit.items import Table
+
+    config_mod.write_default_if_missing(config_path)
+    document = tomlkit.parse(config_path.read_text(encoding="utf-8"))
+    evomem = document.get("evomem")
+    if not isinstance(evomem, Table):
+        evomem = tomlkit.table()
+        document["evomem"] = evomem
+    evomem["write_authority"] = authority
+    paths.atomic_write_private_text(config_path, tomlkit.dumps(document))
+
+
+def _choose_recovered_write_authority(
+    db_path: Path,
+    database_recovery: dict[str, object] | None,
+) -> str:
+    if database_recovery is not None:
+        canonical = str(database_recovery.get("canonical_source") or "")
+        source = str(database_recovery.get("source") or "")
+        if canonical == "markdown_projection" or source in {"markdown", "empty"}:
+            return "markdown"
+        if canonical == "verified_snapshot" or source.startswith("verified_snapshot"):
+            return "evomem"
+    return _infer_live_write_authority(db_path)
+
+
+def _infer_live_write_authority(db_path: Path) -> str:
+    """Infer an unknown healthy-DB authority only when one projection matches.
+
+    A Markdown-authoritative runtime can contain lagging shadow evo_nodes, while
+    an evomem-authoritative runtime can contain lagging projected Markdown.
+    Presence alone cannot distinguish them. The live retrieval projection is
+    the last successfully reconciled view, so compare it with both candidates
+    and fail closed if neither (or an ambiguous divergent state) matches.
+    """
+    from .store import entries as entries_mod
+    from .store import files as files_mod
+
+    if not db_path.exists():
+        return "markdown"
+    conn = sqlite3.connect(
+        f"{db_path.resolve().as_uri()}?mode=ro",
+        uri=True,
+        timeout=5.0,
+    )
+    try:
+        entries_table = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='entries'"
+        ).fetchone()
+        live = (
+            {
+                str(row[0]): (str(row[1]), str(row[2]), int(row[3]))
+                for row in conn.execute(
+                    "SELECT id, path, content, superseded FROM entries "
+                    "WHERE prefix != 'event' AND instr(path, '/') = 0"
+                ).fetchall()
+            }
+            if entries_table is not None
+            else {}
+        )
+        evo: dict[str, tuple[str, str, int]] = {}
+        table = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='evo_nodes'"
+        ).fetchone()
+        if table is not None:
+            for row in conn.execute(
+                "SELECT node_id, file_name, content, is_latest, status, supersedes "
+                "FROM evo_nodes WHERE user_id='default' AND agent_id='default'"
+            ).fetchall():
+                try:
+                    supersedes = set(json.loads(str(row[5] or "[]")))
+                except (TypeError, ValueError, json.JSONDecodeError):
+                    supersedes = set()
+                evo[str(row[0])] = (
+                    str(row[1] or ""),
+                    entries_mod._fts_content_without_provenance(  # noqa: SLF001
+                        str(row[2] or ""),
+                        supersedes=supersedes,
+                    ),
+                    0 if bool(row[3]) and str(row[4]) == "active" else 1,
+                )
+    finally:
+        conn.close()
+
+    parsed: list[tuple[str, object]] = []
+    source_state: dict[str, tuple[str, str | None, int, str | None, str | None]] = {}
+    for path in files_mod.list_memory_files(strict=True):
+        name = files_mod.memory_name(path)
+        if "/" in name or files_mod.validate_prefix(name) == "event":
+            continue
+        for entry in files_mod.read_file(path).entries:
+            if entry.id in source_state:
+                raise ValueError(
+                    f"duplicate Markdown entry id while inferring authority: {entry.id}"
+                )
+            source_state[entry.id] = entries_mod._temporal_source_state(entry)  # noqa: SLF001
+            parsed.append((name, entry))
+    supersedes_by_id = entries_mod._supersedes_by_id(source_state)  # noqa: SLF001
+    markdown = {
+        entry.id: (
+            name,
+            entries_mod._fts_content_from_markdown_entry(  # noqa: SLF001
+                entry,
+                superseded=entries_mod._superseded_from_tags(entry),  # noqa: SLF001
+                supersedes=supersedes_by_id.get(entry.id, set()),
+            ),
+            entries_mod._superseded_from_tags(entry),  # noqa: SLF001
+        )
+        for name, entry in parsed
+    }
+
+    markdown_matches = live == markdown
+    evomem_matches = live == evo
+    if not live and not markdown and not evo:
+        return "markdown"
+    if not evo and markdown_matches:
+        return "markdown"
+    if not markdown and evomem_matches:
+        return "evomem"
+    if markdown_matches and evomem_matches:
+        raise _WriteAuthorityUnresolved(
+            "could not infer write authority safely: Markdown and evomem both match "
+            "the last live projection"
+        )
+    raise RuntimeError(
+        "could not infer write authority safely: Markdown and evomem projections diverge"
+    )
+
+
+def _explicit_pending_write_authority(
+    config_path: Path,
+    pending_config: dict[str, object] | None,
+) -> str | None:
+    """Return an authority only when the pending journal proves owner intent.
+
+    A replacement default is not a choice. Once recovery has asked the owner to
+    choose (or has durably recorded that choice), however, the current valid
+    config is the input needed to resume a previously non-destructive replay.
+    """
+    if pending_config is None:
+        return None
+    phase = str(pending_config.get("phase") or "")
+    if not (
+        pending_config.get("owner_repaired_before_quarantine")
+        or phase in {"authority_unresolved", "authority_resolved"}
+    ):
+        return None
+    authority = config_mod.load(config_path).evomem.write_authority.strip().lower()
+    return authority if authority in {"markdown", "evomem"} else None
+
+
+def _has_reconcilable_memory_state(db_path: Path) -> bool:
+    """Return whether an authority choice can change durable memory state."""
+    from .store import files as files_mod
+
+    if _database_has_default_evomem_nodes(db_path):
+        return True
+    for path in files_mod.list_memory_files(strict=True):
+        name = files_mod.memory_name(path)
+        if "/" in name or files_mod.validate_prefix(name) == "event":
+            continue
+        if files_mod.read_file(path).entries:
+            return True
+    return False
+
+
+def _copy_verified_snapshot(snapshot: Path, db_path: Path) -> None:
+    """Atomically copy one verified SQLite snapshot into the live DB path."""
+    paths.ensure_private_file(snapshot)
+    fd, temp_name = tempfile.mkstemp(
+        prefix=f".{db_path.name}.restore-",
+        suffix=".tmp",
+        dir=db_path.parent,
+    )
+    os.close(fd)
+    temp = Path(temp_name)
+    source: sqlite3.Connection | None = None
+    target: sqlite3.Connection | None = None
+    try:
+        source = sqlite3.connect(f"{snapshot.resolve().as_uri()}?mode=ro", uri=True, timeout=5.0)
+        target = sqlite3.connect(temp, timeout=5.0)
+        source.backup(target)
+        rows = target.execute(f"PRAGMA integrity_check({_INTEGRITY_CHECK_LIMIT})").fetchall()
+        if [str(row[0]) for row in rows] != ["ok"]:
+            raise sqlite3.DatabaseError("restored snapshot failed integrity_check")
+        target.close()
+        target = None
+        source.close()
+        source = None
+        paths.ensure_private_file(temp)
+        temp.replace(db_path)
+        paths.ensure_private_file(db_path)
+    finally:
+        if target is not None:
+            target.close()
+        if source is not None:
+            source.close()
+        temp.unlink(missing_ok=True)
+
+
+def _restore_latest_verified_snapshot(db_path: Path) -> tuple[Path, bool] | None:
+    """Restore the newest structurally valid daily snapshot, if one exists."""
+    from .evomem import integrity as evomem_integrity
+
+    backup_dir = paths.backup_dir()
+    if not backup_dir.is_dir():
+        return None
+    candidates = sorted(
+        (path for path in backup_dir.glob("evo-*.db") if _SNAPSHOT_NAME_RE.fullmatch(path.name)),
+        reverse=True,
+    )
+    for snapshot in candidates:
+        try:
+            paths.ensure_private_file(snapshot)
+            conn = sqlite3.connect(
+                f"{snapshot.resolve().as_uri()}?mode=ro",
+                uri=True,
+                timeout=5.0,
+            )
+            try:
+                valid_schema = all(
+                    {
+                        str(row[1])
+                        for row in conn.execute(f"PRAGMA table_info({table})").fetchall()
+                    }.issuperset(required)
+                    for table, required in _PERSOME_SNAPSHOT_COLUMNS.items()
+                )
+                entries_sql_row = conn.execute(
+                    "SELECT sql FROM sqlite_master WHERE name='entries' AND type='table'"
+                ).fetchone()
+                entries_sql = str(entries_sql_row[0] or "") if entries_sql_row else ""
+                valid_schema = valid_schema and "VIRTUAL TABLE" in entries_sql.upper()
+                valid_schema = valid_schema and "USING FTS5" in entries_sql.upper()
+                evo_columns = {
+                    str(row[1]) for row in conn.execute("PRAGMA table_info(evo_nodes)").fetchall()
+                }
+                has_valid_evomem = evo_columns.issuperset(_EVOMEM_SNAPSHOT_COLUMNS)
+            finally:
+                conn.close()
+            if not valid_schema:
+                _log.warning(
+                    "integrity: skipped foreign or incomplete recovery snapshot",
+                    extra={"path": str(snapshot)},
+                )
+                continue
+            violations = evomem_integrity.verify_snapshot(snapshot)
+            if any(violation.structural for violation in violations):
+                _log.warning(
+                    "integrity: skipped invalid recovery snapshot",
+                    extra={"path": str(snapshot)},
+                )
+                continue
+            _copy_verified_snapshot(snapshot, db_path)
+            if not has_valid_evomem:
+                # Pre-evomem snapshots remain valuable for captures/timeline,
+                # but their absent/incomplete node table cannot be treated as
+                # canonical. Remove it from the live copy so NodeStore can
+                # safely recreate it from current Markdown.
+                live = sqlite3.connect(db_path)
+                try:
+                    live.execute("DROP TABLE IF EXISTS evo_nodes")
+                    live.commit()
+                finally:
+                    live.close()
+            _log.warning(
+                "integrity: restored verified database snapshot",
+                extra={"path": str(snapshot), "evomem_canonical": has_valid_evomem},
+            )
+            return snapshot, has_valid_evomem
+        except (OSError, RuntimeError, sqlite3.Error) as exc:
+            _log.warning(
+                "integrity: recovery snapshot restore failed",
+                extra={"path": str(snapshot), "error": str(exc)},
+            )
+    return None
+
+
+def _repopulate_after_quarantine(
+    *,
+    snapshot_restored: bool,
+    authority_unknown: bool = False,
+    write_authority_override: str | None = None,
+    strict_authority_resolution: bool = False,
+) -> dict[str, object]:
+    """Rebuild current memory projections without LLM calls or a new snapshot.
+
+    The corrupt DB itself has already been retained as the rollback/forensic
+    artifact. Taking a normal pre-restore snapshot here could overwrite the
+    same day's last known-good snapshot with a newly-created empty database.
+    """
+    from .evomem import inversion as evo_inversion
+    from .evomem.store import NodeStore, upsert_node
+    from .store import entries as entries_mod
+    from .store import files as files_mod
+    from .store import fts, index_md, projector
+
+    if write_authority_override not in {None, "markdown", "evomem"}:
+        raise ValueError(f"unsupported recovery write authority: {write_authority_override}")
+    write_authority = write_authority_override or (
+        "unknown" if authority_unknown else evo_inversion.authority()
+    )
+    # When both config and DB were damaged, a verified snapshot is the only
+    # trustworthy canonical signal; the rewritten default config must not make
+    # a potentially stale Markdown projection win by accident. Without a
+    # snapshot, Markdown remains the only best-effort recovery source.
+    restore_nodes_from_markdown = not snapshot_restored or write_authority == "markdown"
+    parsed_files: list[tuple[str, list[files_mod.ParsedEntry]]] = []
+    skipped_event_files = 0
+    direct_markdown_files = 0
+    skipped_invalid_files = 0
+    direct_entry_sources: dict[str, str] = {}
+    memory_files = files_mod.list_memory_files(strict=True)
+    for path in memory_files:
+        name = files_mod.memory_name(path)
+        try:
+            prefix = files_mod.validate_prefix(name)
+        except ValueError as exc:
+            skipped_invalid_files += 1
+            _log.warning("integrity: skipping memory projection %s: %s", name, exc)
+            continue
+        if prefix == "event" or "/" in name:
+            direct = files_mod.read_file(path)
+            for entry in direct.entries:
+                previous = direct_entry_sources.get(entry.id)
+                if previous is not None and previous != name:
+                    raise ValueError(
+                        f"duplicate direct Markdown entry id {entry.id!r} "
+                        f"in {previous!r} and {name!r}"
+                    )
+                direct_entry_sources[entry.id] = name
+            if prefix == "event":
+                skipped_event_files += 1
+            else:
+                direct_markdown_files += 1
+            continue
+        if restore_nodes_from_markdown:
+            parsed_files.append((name, files_mod.read_file(path).entries))
+
+    nodes = projector.rebuild_nodes_from_projection(parsed_files)
+    if strict_authority_resolution and skipped_invalid_files:
+        raise ValueError(
+            "cannot resolve write authority while unsupported Markdown memory files are present"
+        )
+    current_node_keys = {(node.node_id, node.user_id, node.agent_id) for node in nodes}
+    if len(current_node_keys) != len(nodes):
+        seen: set[tuple[str, str, str]] = set()
+        duplicates: set[tuple[str, str, str]] = set()
+        for node in nodes:
+            key = (node.node_id, node.user_id, node.agent_id)
+            if key in seen:
+                duplicates.add(key)
+            seen.add(key)
+        sample = ", ".join(key[0] for key in sorted(duplicates)[:5])
+        raise ValueError(f"duplicate Markdown memory node id(s): {sample}")
+    stale_node_keys: list[tuple[str, str, str]] = []
+    direct_nodes_removed = 0
+    derived_geometry_rows_invalidated = 0
+    NodeStore()  # create/migrate the canonical node table before one recovery transaction
+    with fts.cursor() as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            # event-* and nested skills/* are direct-Markdown namespaces under
+            # every authority. Delete only nodes whose stored filename proves
+            # they belong to that direct namespace. A basename-only row is
+            # ambiguous with a legitimate evomem top-level file, so fail closed
+            # instead of silently choosing one source and deleting the other.
+            for entry_id, source_name in sorted(direct_entry_sources.items()):
+                row = conn.execute(
+                    "SELECT file_name FROM evo_nodes "
+                    "WHERE node_id=? AND user_id='default' AND agent_id='default'",
+                    (entry_id,),
+                ).fetchone()
+                if row is None:
+                    continue
+                node_file_name = str(row[0] or "")
+                if node_file_name != source_name:
+                    raise ValueError(
+                        f"direct Markdown entry id {entry_id!r} from {source_name!r} "
+                        f"collides with canonical evomem file {node_file_name!r}"
+                    )
+                direct_nodes_removed += conn.execute(
+                    "DELETE FROM evo_nodes "
+                    "WHERE node_id=? AND user_id='default' AND agent_id='default'",
+                    (entry_id,),
+                ).rowcount
+            direct_nodes_removed += conn.execute(
+                "DELETE FROM evo_nodes WHERE user_id='default' AND agent_id='default' "
+                "AND (file_name LIKE 'event-%' OR instr(file_name, '/') > 0)"
+            ).rowcount
+            # A verified snapshot can be older than the Markdown projection.
+            # Under Markdown authority, remove only snapshot nodes that were
+            # previously exposed through the non-event retrieval projection
+            # and are now absent from the complete, successfully parsed source.
+            # DB-native/unprojected and event nodes remain untouched.
+            if snapshot_restored and write_authority == "markdown" and skipped_invalid_files == 0:
+                projected = (
+                    conn.execute(
+                        "SELECT node_id, user_id, agent_id FROM evo_nodes "
+                        "WHERE user_id='default' AND agent_id='default'"
+                    ).fetchall()
+                    if strict_authority_resolution
+                    else conn.execute(
+                        "SELECT n.node_id, n.user_id, n.agent_id "
+                        "FROM evo_nodes n JOIN entries e ON e.id = n.node_id "
+                        "WHERE n.user_id='default' AND n.agent_id='default' "
+                        "AND e.prefix != 'event'"
+                    ).fetchall()
+                )
+                stale_node_keys = [
+                    (str(row[0]), str(row[1]), str(row[2]))
+                    for row in projected
+                    if (str(row[0]), str(row[1]), str(row[2])) not in current_node_keys
+                ]
+                conn.executemany(
+                    "DELETE FROM evo_nodes WHERE node_id=? AND user_id=? AND agent_id=?",
+                    stale_node_keys,
+                )
+            # Faces, Volumes, Root, and their probe queue are rebuildable output,
+            # not recovery authority. Always discard snapshot copies so malformed
+            # or stale geometry cannot break the viewer before the required build.
+            # Relation edges are retained for a known evomem snapshot, but must
+            # be cleared when current Markdown/direct sources removed or changed
+            # Points that those relations may expose.
+            tables_to_invalidate = ["schema_faces", "cross_domain_probe_state"]
+            if (
+                (snapshot_restored and restore_nodes_from_markdown)
+                or stale_node_keys
+                or direct_nodes_removed
+            ):
+                tables_to_invalidate.append("relation_edges")
+            for table in tables_to_invalidate:
+                if conn.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+                    (table,),
+                ).fetchone():
+                    derived_geometry_rows_invalidated += conn.execute(
+                        f"DELETE FROM {table}"
+                    ).rowcount
+            for node in nodes:
+                upsert_node(conn, node, user_id=node.user_id, agent_id=node.agent_id)
+            # Recovery has either restored canonical snapshot nodes or just
+            # reconstructed them from the complete Markdown projection. Use
+            # that unified graph to rebuild retrieval, including nested skill
+            # paths; direct event Markdown remains the intentional fallback.
+            projection_files, projection_entries = entries_mod.rebuild_index(
+                conn,
+                source_authority="evomem",
+                allow_incomplete_recovery=True,
+            )
+            if restore_nodes_from_markdown:
+                for name, parsed_entries in parsed_files:
+                    parsed = files_mod.read_file(files_mod.memory_path(name))
+                    fts.upsert_file(
+                        conn,
+                        fts.FileRow(
+                            path=name,
+                            prefix=files_mod.validate_prefix(name),
+                            description=parsed.description,
+                            tags=" ".join(parsed.tags),
+                            status=parsed.status,
+                            entry_count=len(parsed_entries),
+                            created=parsed.created,
+                            updated=parsed.updated,
+                            needs_compact=1 if parsed.needs_compact else 0,
+                        ),
+                    )
+            conn.execute("COMMIT")
+        except BaseException:
+            conn.execute("ROLLBACK")
+            raise
+        try:
+            index_md.rebuild(conn)
+            index_rebuilt = True
+            index_error = None
+        except (OSError, RuntimeError, ValueError) as exc:
+            index_rebuilt = False
+            index_error = str(exc)
+            _log.warning(
+                "integrity: memory index.md rebuild failed after database recovery",
+                extra={"error": str(exc)},
+            )
+
+    return {
+        "write_authority": write_authority,
+        "canonical_source": (
+            "markdown_projection" if restore_nodes_from_markdown else "verified_snapshot"
+        ),
+        "markdown_files": len(parsed_files),
+        "skipped_event_files": skipped_event_files,
+        "direct_markdown_files": direct_markdown_files,
+        "skipped_invalid_files": skipped_invalid_files,
+        "nodes": len(nodes),
+        "projection_files": projection_files,
+        "projection_entries": projection_entries,
+        "stale_projected_nodes_removed": len(stale_node_keys),
+        "legacy_direct_nodes_removed": direct_nodes_removed,
+        "derived_geometry_rows_invalidated": derived_geometry_rows_invalidated,
+        "index_md_rebuilt": index_rebuilt,
+        "index_md_error": index_error,
+    }
+
+
+def _reconcile_resolved_write_authority(authority: str) -> dict[str, object]:
+    """Apply one explicit authority choice before clearing its guard journal.
+
+    The shared recovery transaction rebuilds ``entries`` from the chosen source,
+    reconciles Point state when Markdown wins, and invalidates derived geometry.
+    When evomem wins, also overwrite its non-exempt Markdown projections and
+    verify that the surviving sources now agree. Projection writes are
+    idempotent; any partial filesystem failure keeps the journal for retry.
+    """
+    from .evomem import inversion as evo_inversion
+    from .store import fts
+
+    if authority not in {"markdown", "evomem"}:
+        raise ValueError(f"unsupported resolved write authority: {authority}")
+    result = _repopulate_after_quarantine(
+        snapshot_restored=True,
+        authority_unknown=False,
+        write_authority_override=authority,
+        strict_authority_resolution=True,
+    )
+    if authority != "evomem":
+        return result
+
+    with fts.cursor() as conn:
+        evo_inversion.project_live_all(conn)
+        canonical_nodes = int(
+            conn.execute(
+                "SELECT count(*) FROM evo_nodes WHERE user_id='default' AND agent_id='default'"
+            ).fetchone()[0]
+        )
+    if canonical_nodes:
+        try:
+            inferred = _infer_live_write_authority(paths.index_db())
+        except _WriteAuthorityUnresolved as exc:
+            if "both match the last live projection" not in str(exc):
+                raise
+        else:
+            raise RuntimeError(
+                "evomem authority reconciliation did not align Markdown with canonical nodes "
+                f"(remaining source: {inferred})"
+            )
+    return result
+
+
+def _invalidate_model_manifest() -> bool:
+    """Remove build metadata that belongs to the quarantined database."""
+    manifest = paths.model_build_manifest()
+    try:
+        manifest.unlink(missing_ok=True)
+        return True
+    except OSError as exc:
+        _log.warning(
+            "integrity: failed to invalidate stale model build manifest",
+            extra={"path": str(manifest), "error": str(exc)},
+        )
+        return False
+
+
+def _capture_buffer_replay_available() -> bool:
+    try:
+        return any(paths.capture_buffer_dir().glob("*.json"))
+    except OSError:
+        return False
+
+
+def _snapshot_modified_at(snapshot: Path | None) -> str | None:
+    if snapshot is None:
+        return None
+    try:
+        return datetime.fromtimestamp(snapshot.stat().st_mtime).astimezone().isoformat()
+    except OSError:
+        return None
+
+
+def _recover_database_projection(
+    *,
+    authority_unknown: bool,
+    manifest_was_present: bool,
+    manifest_invalidated: bool,
+    preserve_existing: bool = False,
+    existing_canonical_baseline: bool | None = None,
+    write_authority_override: str | None = None,
+    pending: dict[str, object] | None = None,
+) -> dict[str, object]:
+    """Restore/replay a database after its damaged predecessor is quarantined."""
+    db_path = paths.index_db()
+    snapshot: Path | None = None
+    snapshot_has_evomem = False
+    try:
+        if preserve_existing:
+            if pending is not None:
+                _set_pending_phase(
+                    pending,
+                    (
+                        "replaying_preserved_database"
+                        if existing_canonical_baseline is not False
+                        else "replaying_live_database_from_markdown"
+                    ),
+                )
+        else:
+            if pending is not None:
+                _set_pending_phase(pending, "restoring_snapshot")
+            restored = _restore_latest_verified_snapshot(db_path)
+            if restored is not None:
+                snapshot, snapshot_has_evomem = restored
+            if pending is not None:
+                if snapshot is not None:
+                    pending["snapshot_path"] = str(snapshot)
+                    pending["snapshot_has_evomem"] = snapshot_has_evomem
+                    _set_pending_phase(pending, "snapshot_restored")
+                else:
+                    _set_pending_phase(pending, "replaying_without_snapshot")
+        has_database_baseline = preserve_existing or snapshot is not None
+        canonical_baseline = (snapshot is not None and snapshot_has_evomem) or (
+            preserve_existing
+            and (
+                preserve_existing
+                if existing_canonical_baseline is None
+                else existing_canonical_baseline
+            )
+        )
+        recovery_authority = write_authority_override
+        if authority_unknown and canonical_baseline and recovery_authority is None:
+            # A complete evo_nodes table proves that an evomem source exists,
+            # not that it was authoritative. It may be a lagging shadow from a
+            # Markdown-authoritative runtime. Compare the restored snapshot's
+            # last retrieval projection with *both* surviving sources before
+            # any deletes/upserts. Only a single-source match is conclusive.
+            try:
+                recovery_authority = _infer_live_write_authority(db_path)
+            except (RuntimeError, ValueError) as exc:
+                raise _WriteAuthorityUnresolved(
+                    "verified snapshot and current Markdown preserve multiple possible "
+                    f"write authorities; owner choice required ({exc})"
+                ) from exc
+        projection = _repopulate_after_quarantine(
+            snapshot_restored=canonical_baseline,
+            authority_unknown=authority_unknown,
+            write_authority_override=recovery_authority,
+        )
+        source = (
+            (
+                "existing_recovered_database"
+                if canonical_baseline
+                else "existing_live_database+markdown"
+            )
+            if preserve_existing
+            else "verified_snapshot+markdown"
+            if snapshot is not None
+            and projection["canonical_source"] == "markdown_projection"
+            and int(projection["markdown_files"]) > 0
+            else "verified_snapshot"
+            if snapshot is not None
+            else "markdown"
+            if int(projection["projection_files"]) > 0
+            else "empty"
+        )
+        capture_replay_available = _capture_buffer_replay_available()
+        recovery: dict[str, object] = {
+            "status": "restored",
+            "source": source,
+            "snapshot_path": str(snapshot) if snapshot is not None else None,
+            "snapshot_modified_at": _snapshot_modified_at(snapshot),
+            "snapshot_has_evomem": snapshot_has_evomem,
+            "preserved_existing_database": preserve_existing,
+            **projection,
+            # A daily snapshot can predate the corruption and Markdown is an
+            # approximate projection under evomem authority. Never claim an
+            # exact/lossless restore from either source.
+            "lossy": True,
+            "recovery_completeness": "best_effort",
+            "potentially_lost_since_snapshot": has_database_baseline,
+            "not_recovered_without_snapshot": (
+                []
+                if has_database_baseline
+                else [
+                    (
+                        "captures_pending_replay"
+                        if capture_replay_available
+                        else "captures_unavailable"
+                    ),
+                    "timeline_blocks",
+                    "sessions",
+                    "relation_edges",
+                    "structural_geometry",
+                ]
+            ),
+            "capture_buffer_replay_available": capture_replay_available,
+            "capture_recovery": (
+                "pending_replay"
+                if capture_replay_available
+                else "snapshot_only"
+                if has_database_baseline
+                else "unavailable"
+            ),
+            "model_rebuild_required": True,
+            "stale_manifest_was_present": manifest_was_present,
+            "manifest_invalidated": manifest_invalidated,
+            "reconciled_write_authority": (
+                "markdown" if projection.get("canonical_source") == "markdown_projection" else None
+            ),
+        }
+        _log.warning(
+            "integrity: rebuilt database projections after quarantine",
+            extra={
+                "source": source,
+                "nodes": projection["nodes"],
+                "entries": projection["projection_entries"],
+            },
+        )
+        return recovery
+    except Exception as exc:  # noqa: BLE001 - retain startup availability
+        # A verified snapshot remains useful even if a newer Markdown projection
+        # cannot be parsed. Without one, create a healthy empty DB so startup
+        # remains available and report the loss.
+        if not db_path.exists():
+            try:
+                from .store import fts
+
+                with fts.cursor(db_path):
+                    pass
+            except Exception:  # noqa: BLE001 - original error is primary
+                pass
+        _log.warning(
+            "integrity: database projection recovery failed",
+            extra={"error": str(exc), "snapshot_restored": snapshot is not None},
+        )
+        has_database_baseline = preserve_existing or snapshot is not None
+        authority_resolution_required = isinstance(exc, _WriteAuthorityUnresolved)
+        return {
+            "status": "partial" if has_database_baseline else "failed",
+            "source": (
+                (
+                    "existing_recovered_database"
+                    if existing_canonical_baseline is not False
+                    else "existing_live_database+markdown"
+                )
+                if preserve_existing
+                else "verified_snapshot"
+                if snapshot is not None
+                else "none"
+            ),
+            "snapshot_path": str(snapshot) if snapshot is not None else None,
+            "snapshot_modified_at": _snapshot_modified_at(snapshot),
+            "snapshot_has_evomem": snapshot_has_evomem,
+            "error": str(exc),
+            "authority_resolution_required": authority_resolution_required,
+            "preserved_authority_sources": (
+                ["snapshot_entries", "snapshot_evo_nodes", "current_markdown"]
+                if authority_resolution_required
+                else []
+            ),
+            "lossy": True,
+            "recovery_completeness": "best_effort",
+            "potentially_lost_since_snapshot": has_database_baseline,
+            "preserved_existing_database": preserve_existing,
+            "capture_buffer_replay_available": _capture_buffer_replay_available(),
+            "model_rebuild_required": True,
+            "stale_manifest_was_present": manifest_was_present,
+            "manifest_invalidated": manifest_invalidated,
+        }
 
 
 def check_and_recover() -> list[QuarantinedFile]:
@@ -349,69 +1524,499 @@ def check_and_recover() -> list[QuarantinedFile]:
 
     db_path = paths.index_db()
     config_path = paths.config_file()
+    config_was_missing = not config_path.exists()
+    missing_config_needs_guard = config_was_missing and (
+        db_path.exists() or paths.integrity_recovery_pending().exists()
+    )
+    pending_config, invalid_config_journal = _load_pending_config_recovery()
+    config_authority_unknown = (
+        missing_config_needs_guard
+        or pending_config is not None
+        or invalid_config_journal is not None
+    )
+    if invalid_config_journal is not None:
+        quarantined.append(
+            QuarantinedFile(
+                kind="config_recovery_journal",
+                original_path=str(paths.integrity_config_recovery_pending()),
+                quarantine_path=str(invalid_config_journal),
+                reason="invalid recovery journal",
+            )
+        )
+    config_recovery_resolved = False
+    authority_persisted = not config_authority_unknown
+    database_safe_to_finalize = False
     rebuilt_derived_fts = False
     deferred_derived_fts_repair = False
+    database_recovery: dict[str, object] | None = None
 
-    try:
-        db_reason = _db_corruption_reason(db_path)
-    except Exception as e:  # defensive: never let the check abort startup
-        db_reason = None
-        _log.warning("integrity: DB check errored, assuming healthy", extra={"error": str(e)})
-    if db_reason is not None:
-        derived_fts_repair = _try_rebuild_derived_fts(db_path)
-        if derived_fts_repair is True:
-            rebuilt_derived_fts = True
-            _log.warning(
-                "integrity: rebuilt derived FTS indexes",
-                extra={"path": str(db_path), "reason": db_reason},
-            )
-        elif derived_fts_repair is None:
-            deferred_derived_fts_repair = True
-            _log.warning(
-                "integrity: deferred derived FTS repair",
-                extra={"path": str(db_path), "reason": db_reason},
-            )
-        else:
-            dest = _quarantine(db_path)
-            quarantined.append(
-                QuarantinedFile(
-                    kind="database",
-                    original_path=str(db_path),
-                    quarantine_path=str(dest),
-                    reason=db_reason,
-                )
-            )
-            _log.warning(
-                "integrity: quarantined corrupt database",
-                extra={"path": str(db_path), "moved_to": str(dest), "reason": db_reason},
-            )
-            # The DB is recreated lazily on the next fts.connect(); nothing to do.
-
+    # Config must be usable before a database replay chooses Markdown or
+    # evomem authority. Persist intent before replacing a corrupt config: a
+    # crash after the rename/default write but before the DB journal must not
+    # make that fresh default look like known Markdown authority next time.
     try:
         config_reason = _config_corruption_reason(config_path)
     except Exception as e:  # defensive
         config_reason = None
         _log.warning("integrity: config check errored, assuming healthy", extra={"error": str(e)})
-    if config_reason is not None:
-        dest = _quarantine(config_path)
+    if pending_config is not None:
+        try:
+            resumed_config = _resume_config_recovery(config_path, pending_config)
+            config_recovery_resolved = True
+            if resumed_config is not None:
+                quarantined.append(resumed_config)
+            config_reason = str(pending_config.get("reason") or config_reason or "unknown")
+            _log.warning(
+                "integrity: resumed incomplete config recovery",
+                extra={"quarantine_path": pending_config.get("quarantine_path")},
+            )
+        except Exception as exc:  # noqa: BLE001 - retain intent and fail authority closed
+            _log.warning(
+                "integrity: pending config recovery failed",
+                extra={"error": str(exc)},
+            )
+    elif config_reason is not None or missing_config_needs_guard:
+        config_authority_unknown = True
+        dest = _quarantine_destination(config_path)
+        recovery_reason = config_reason or "config missing while database authority was unknown"
+        pending_config = {
+            "version": 1,
+            "phase": "prepared",
+            "started_at": datetime.now().astimezone().isoformat(),
+            "original_path": str(config_path),
+            "quarantine_path": str(dest),
+            "reason": recovery_reason,
+        }
+        try:
+            _write_pending_config_recovery(pending_config)
+            recovered_config = _resume_config_recovery(config_path, pending_config)
+            config_recovery_resolved = True
+            if recovered_config is not None:
+                quarantined.append(recovered_config)
+            _log.warning(
+                "integrity: recovered missing or corrupt config to a guarded default",
+                extra={
+                    "path": str(config_path),
+                    "moved_to": str(dest),
+                    "reason": recovery_reason,
+                },
+            )
+        except Exception as exc:  # noqa: BLE001 - never mutate without durable intent
+            _log.warning(
+                "integrity: config quarantine/recovery interrupted",
+                extra={"error": str(exc)},
+            )
+
+    explicit_pending_authority = _explicit_pending_write_authority(config_path, pending_config)
+    pending, invalid_database_journal = _load_pending_recovery()
+    invalid_journal_manifest_was_present = False
+    invalid_journal_manifest_invalidated = False
+    if invalid_database_journal is not None:
         quarantined.append(
             QuarantinedFile(
-                kind="config",
-                original_path=str(config_path),
-                quarantine_path=str(dest),
-                reason=config_reason,
+                kind="database_recovery_journal",
+                original_path=str(paths.integrity_recovery_pending()),
+                quarantine_path=str(invalid_database_journal),
+                reason="invalid recovery journal",
             )
         )
-        # Rebuild a fresh default config so the daemon starts with sane values.
-        config_mod.write_default_if_missing(config_path)
-        _log.warning(
-            "integrity: quarantined corrupt config, rebuilt default",
-            extra={"path": str(config_path), "moved_to": str(dest), "reason": config_reason},
-        )
+        invalid_journal_manifest_was_present = paths.model_build_manifest().exists()
+        invalid_journal_manifest_invalidated = _invalidate_model_manifest()
+    if pending is not None:
+        try:
+            original = Path(str(pending["original_path"]))
+            dest = Path(str(pending["quarantine_path"]))
+            reason = str(pending["reason"])
+            if (
+                original != db_path
+                or dest.parent != db_path.parent
+                or not dest.name.startswith(f"{db_path.name}.corrupt.")
+            ):
+                raise ValueError("pending recovery journal contains unsafe database paths")
+            resume_phase = str(pending.get("phase") or "prepared")
+            manifest_was_present = bool(pending.get("manifest_was_present"))
+            manifest_invalidated = _invalidate_model_manifest()
+            live_reason_before_quarantine = (
+                _db_corruption_reason(original) if original.exists() else None
+            )
+            owner_repaired = (
+                not _quarantine_destination_has_artifacts(dest)
+                and original.exists()
+                and live_reason_before_quarantine is None
+            )
+            if owner_repaired:
+                pending["owner_repaired_before_quarantine"] = True
+                database_recovery = {
+                    "status": "restored",
+                    "source": "owner_repaired_database",
+                    "preserved_existing_database": True,
+                    "lossy": True,
+                    "recovery_completeness": "owner_managed",
+                    "model_rebuild_required": True,
+                    "stale_manifest_was_present": manifest_was_present,
+                    "manifest_invalidated": manifest_invalidated,
+                }
+                pending["database_recovery"] = database_recovery
+                _set_pending_phase(pending, "owner_repaired")
+                _log.warning(
+                    "integrity: preserved owner-repaired healthy database",
+                    extra={"path": str(original)},
+                )
+            else:
+                if resume_phase == "prepared":
+                    _set_pending_phase(pending, "manifest_invalidated")
+                if not dest.exists() and original.exists():
+                    _quarantine(original, destination=dest)
+                if resume_phase in {"prepared", "manifest_invalidated"}:
+                    _set_pending_phase(pending, "quarantined")
+                if dest.exists():
+                    quarantined.append(
+                        QuarantinedFile(
+                            kind="database",
+                            original_path=str(original),
+                            quarantine_path=str(dest),
+                            reason=reason,
+                        )
+                    )
+
+                saved_recovery = pending.get("database_recovery")
+                live_database_healthy = db_path.exists() and _db_corruption_reason(db_path) is None
+                saved_restored = (
+                    isinstance(saved_recovery, dict) and saved_recovery.get("status") == "restored"
+                )
+                if saved_restored and live_database_healthy:
+                    database_recovery = saved_recovery
+                else:
+                    saved_source = (
+                        str(saved_recovery.get("source"))
+                        if isinstance(saved_recovery, dict)
+                        else ""
+                    )
+                    phase_has_trusted_snapshot = (
+                        resume_phase == "snapshot_restored"
+                        and pending.get("snapshot_has_evomem") is not False
+                    )
+                    saved_has_trusted_snapshot = saved_source == "verified_snapshot" and (
+                        not isinstance(saved_recovery, dict)
+                        or saved_recovery.get("snapshot_has_evomem") is not False
+                    )
+                    trusted_existing_baseline = live_database_healthy and (
+                        phase_has_trusted_snapshot
+                        or resume_phase == "replaying_preserved_database"
+                        or saved_source == "existing_recovered_database"
+                        or saved_has_trusted_snapshot
+                    )
+                    if db_path.exists() and not live_database_healthy:
+                        retry_dest = _quarantine_destination(db_path)
+                        _quarantine(db_path, destination=retry_dest)
+                        additional = pending.get("additional_quarantine_paths")
+                        if not isinstance(additional, list):
+                            additional = []
+                        additional.append(str(retry_dest))
+                        pending["additional_quarantine_paths"] = additional
+                        _write_pending_recovery(pending)
+                        quarantined.append(
+                            QuarantinedFile(
+                                kind="database_retry",
+                                original_path=str(db_path),
+                                quarantine_path=str(retry_dest),
+                                reason="untrusted live database left by interrupted recovery",
+                            )
+                        )
+                    database_recovery = _recover_database_projection(
+                        authority_unknown=(
+                            bool(pending.get("authority_unknown")) or config_authority_unknown
+                        ),
+                        manifest_was_present=manifest_was_present,
+                        manifest_invalidated=manifest_invalidated,
+                        preserve_existing=live_database_healthy,
+                        existing_canonical_baseline=trusted_existing_baseline,
+                        write_authority_override=explicit_pending_authority,
+                        pending=pending,
+                    )
+                    pending["database_recovery"] = database_recovery
+                    _set_pending_phase(
+                        pending,
+                        "replayed" if database_recovery.get("status") == "restored" else "failed",
+                    )
+            _log.warning(
+                "integrity: resumed incomplete database recovery",
+                extra={"quarantine_path": str(dest)},
+            )
+            database_safe_to_finalize = database_recovery.get("status") == "restored"
+        except Exception as exc:  # noqa: BLE001 - journal must keep startup fail-open
+            _log.warning("integrity: pending database recovery failed", extra={"error": str(exc)})
+            database_recovery = {
+                "status": "failed",
+                "source": "pending_recovery",
+                "error": str(exc),
+                "lossy": True,
+                "model_rebuild_required": True,
+                "manifest_invalidated": _invalidate_model_manifest(),
+            }
+    else:
+        database_check_succeeded = False
+        try:
+            db_reason = _db_corruption_reason(db_path)
+            database_check_succeeded = True
+        except Exception as e:  # defensive: never let the check abort startup
+            db_reason = None
+            _log.warning("integrity: DB check errored, assuming healthy", extra={"error": str(e)})
+        if db_reason is not None:
+            derived_fts_repair = _try_rebuild_derived_fts(db_path)
+            if derived_fts_repair is True:
+                rebuilt_derived_fts = True
+                database_safe_to_finalize = True
+                _log.warning(
+                    "integrity: rebuilt derived FTS indexes",
+                    extra={"path": str(db_path), "reason": db_reason},
+                )
+            elif derived_fts_repair is None:
+                deferred_derived_fts_repair = True
+                _log.warning(
+                    "integrity: deferred derived FTS repair",
+                    extra={"path": str(db_path), "reason": db_reason},
+                )
+            else:
+                dest = _quarantine_destination(db_path)
+                manifest_was_present = paths.model_build_manifest().exists()
+                pending = {
+                    "version": 1,
+                    "phase": "prepared",
+                    "started_at": datetime.now().astimezone().isoformat(),
+                    "original_path": str(db_path),
+                    "quarantine_path": str(dest),
+                    "reason": db_reason,
+                    "authority_unknown": config_authority_unknown,
+                    "manifest_was_present": manifest_was_present,
+                }
+                try:
+                    _write_pending_recovery(pending)
+                    manifest_invalidated = _invalidate_model_manifest()
+                    _set_pending_phase(pending, "manifest_invalidated")
+                    _quarantine(db_path, destination=dest)
+                    _set_pending_phase(pending, "quarantined")
+                    quarantined.append(
+                        QuarantinedFile(
+                            kind="database",
+                            original_path=str(db_path),
+                            quarantine_path=str(dest),
+                            reason=db_reason,
+                        )
+                    )
+                    _log.warning(
+                        "integrity: quarantined corrupt database",
+                        extra={
+                            "path": str(db_path),
+                            "moved_to": str(dest),
+                            "reason": db_reason,
+                        },
+                    )
+                    database_recovery = _recover_database_projection(
+                        authority_unknown=config_authority_unknown,
+                        manifest_was_present=manifest_was_present,
+                        manifest_invalidated=manifest_invalidated,
+                        write_authority_override=explicit_pending_authority,
+                        pending=pending,
+                    )
+                    pending["database_recovery"] = database_recovery
+                    _set_pending_phase(
+                        pending,
+                        "replayed" if database_recovery.get("status") == "restored" else "failed",
+                    )
+                except Exception as exc:  # noqa: BLE001 - retain journal for next startup
+                    _log.warning(
+                        "integrity: database quarantine/recovery interrupted",
+                        extra={"error": str(exc)},
+                    )
+                    database_recovery = {
+                        "status": "failed",
+                        "source": "pending_recovery",
+                        "error": str(exc),
+                        "lossy": True,
+                        "model_rebuild_required": True,
+                        "manifest_invalidated": _invalidate_model_manifest(),
+                    }
+                database_safe_to_finalize = database_recovery.get("status") == "restored"
+        elif database_check_succeeded:
+            database_safe_to_finalize = True
+
+    if invalid_database_journal is not None:
+        if database_recovery is None and database_safe_to_finalize:
+            database_recovery = {
+                "status": "restored",
+                "source": "verified_live_database_after_invalid_journal",
+                "preserved_existing_database": True,
+                "lossy": True,
+                "recovery_completeness": "best_effort",
+                "model_rebuild_required": True,
+                "stale_manifest_was_present": invalid_journal_manifest_was_present,
+                "manifest_invalidated": invalid_journal_manifest_invalidated,
+            }
+        elif database_recovery is not None:
+            database_recovery["invalid_pending_journal_quarantined"] = str(invalid_database_journal)
+            database_recovery["stale_manifest_was_present"] = bool(
+                database_recovery.get("stale_manifest_was_present")
+                or invalid_journal_manifest_was_present
+            )
+            database_recovery["manifest_invalidated"] = bool(
+                database_recovery.get("manifest_invalidated")
+                or invalid_journal_manifest_invalidated
+            )
+
+    if database_recovery is not None and database_recovery.get("authority_resolution_required"):
+        # The snapshot/live DB and Markdown are both intact, but neither can be
+        # selected without inventing authority. Preserve both, freeze writes,
+        # and turn the generated default into an explicit owner prompt.
+        database_safe_to_finalize = False
+        config_authority_unknown = True
+        try:
+            _persist_recovered_write_authority(config_path, "unknown")
+            if pending_config is None:
+                pending_config = {
+                    "version": 1,
+                    "phase": "authority_unresolved",
+                    "started_at": datetime.now().astimezone().isoformat(),
+                    "original_path": str(config_path),
+                    "quarantine_path": str(_quarantine_destination(config_path)),
+                    "reason": "multiple intact write-authority sources need an owner choice",
+                }
+                _write_pending_config_recovery(pending_config)
+                config_recovery_resolved = True
+            else:
+                pending_config["authority_error"] = str(database_recovery.get("error") or "")
+                _set_pending_config_phase(pending_config, "authority_unresolved")
+        except Exception as exc:  # noqa: BLE001 - both journals remain fail-closed
+            _log.warning(
+                "integrity: failed to persist snapshot authority prompt",
+                extra={"error": str(exc)},
+            )
+
+    if config_authority_unknown and database_safe_to_finalize:
+        try:
+            current_authority = config_mod.load(config_path).evomem.write_authority.strip().lower()
+            pending_config_phase = (
+                str(pending_config.get("phase") or "") if pending_config is not None else ""
+            )
+            explicit_recovery_choice = pending_config is not None and (
+                pending_config.get("owner_repaired_before_quarantine")
+                or pending_config_phase in {"authority_unresolved", "authority_resolved"}
+            )
+            if explicit_recovery_choice:
+                resolved_authority = current_authority
+                if resolved_authority not in {"markdown", "evomem"}:
+                    raise ValueError(
+                        "recovered config still needs an explicit write authority choice"
+                    )
+            else:
+                resolved_authority = _choose_recovered_write_authority(db_path, database_recovery)
+            reconciliation_required = explicit_recovery_choice or not (
+                database_recovery is not None
+                and database_recovery.get("reconciled_write_authority") == resolved_authority
+            )
+            if reconciliation_required:
+                reconciliation_required = _has_reconcilable_memory_state(db_path)
+            reconciliation: dict[str, object] | None = None
+            if reconciliation_required:
+                authority_manifest_was_present = paths.model_build_manifest().exists()
+                authority_manifest_invalidated = _invalidate_model_manifest()
+                if database_recovery is None:
+                    database_recovery = {
+                        "status": "partial",
+                        "source": "write_authority_reconciliation",
+                        "lossy": False,
+                        "recovery_completeness": "authority_pending",
+                        "model_rebuild_required": True,
+                        "stale_manifest_was_present": authority_manifest_was_present,
+                        "manifest_invalidated": authority_manifest_invalidated,
+                    }
+                else:
+                    database_recovery["model_rebuild_required"] = True
+                    database_recovery["stale_manifest_was_present"] = bool(
+                        database_recovery.get("stale_manifest_was_present")
+                        or authority_manifest_was_present
+                    )
+                    database_recovery["manifest_invalidated"] = bool(
+                        database_recovery.get("manifest_invalidated")
+                        or authority_manifest_invalidated
+                    )
+                reconciliation = _reconcile_resolved_write_authority(resolved_authority)
+                database_recovery["status"] = "restored"
+                database_recovery["recovery_completeness"] = "authority_reconciled"
+            _persist_recovered_write_authority(config_path, resolved_authority)
+            authority_persisted = True
+            if pending_config is not None:
+                pending_config["resolved_write_authority"] = resolved_authority
+                _set_pending_config_phase(pending_config, "authority_resolved")
+            if database_recovery is not None:
+                database_recovery["resolved_write_authority"] = resolved_authority
+                if reconciliation is not None:
+                    database_recovery["authority_reconciliation"] = reconciliation
+        except Exception as exc:  # noqa: BLE001 - keep guard intent until durable
+            database_safe_to_finalize = False
+            if database_recovery is None:
+                authority_manifest_was_present = paths.model_build_manifest().exists()
+                authority_manifest_invalidated = _invalidate_model_manifest()
+                database_recovery = {
+                    "status": "partial",
+                    "source": "write_authority_resolution",
+                    "lossy": False,
+                    "recovery_completeness": "authority_pending",
+                    "model_rebuild_required": True,
+                    "stale_manifest_was_present": authority_manifest_was_present,
+                    "manifest_invalidated": authority_manifest_invalidated,
+                    "authority_resolution_required": True,
+                    "authority_error": str(exc),
+                }
+            else:
+                database_recovery["status"] = "partial"
+                database_recovery["authority_resolution_required"] = True
+                database_recovery["authority_error"] = str(exc)
+            with contextlib.suppress(Exception):
+                _persist_recovered_write_authority(config_path, "unknown")
+                if pending_config is None:
+                    pending_config = {
+                        "version": 1,
+                        "phase": "authority_unresolved",
+                        "started_at": datetime.now().astimezone().isoformat(),
+                        "original_path": str(config_path),
+                        "quarantine_path": str(_quarantine_destination(config_path)),
+                        "reason": "write authority could not be inferred safely",
+                    }
+                    _write_pending_config_recovery(pending_config)
+                    config_recovery_resolved = True
+                else:
+                    pending_config["authority_error"] = str(exc)
+                    _set_pending_config_phase(pending_config, "authority_unresolved")
+            _log.warning(
+                "integrity: failed to persist recovered write authority",
+                extra={"error": str(exc)},
+            )
 
     elapsed_ms = (time.perf_counter() - started) * 1000.0
-    if quarantined:
-        _write_recovery_marker(quarantined)
+    marker_written = False
+    if quarantined or database_recovery is not None:
+        marker_written = _write_recovery_marker(
+            quarantined,
+            database_recovery=database_recovery,
+        )
+        if (
+            marker_written
+            and pending is not None
+            and database_recovery is not None
+            and database_recovery.get("status") == "restored"
+        ):
+            _remove_pending_recovery()
+    if (
+        pending_config is not None
+        and config_recovery_resolved
+        and database_safe_to_finalize
+        and authority_persisted
+    ):
+        config_is_valid = config_path.exists() and _config_corruption_reason(config_path) is None
+        config_was_quarantined = any(item.kind == "config" for item in quarantined)
+        if config_is_valid and (not config_was_quarantined or marker_written):
+            _remove_pending_config_recovery()
     _log.info(
         "integrity check complete",
         extra={
@@ -419,6 +2024,9 @@ def check_and_recover() -> list[QuarantinedFile]:
             "recovered": len(quarantined),
             "derived_repaired": int(rebuilt_derived_fts),
             "derived_repair_deferred": int(deferred_derived_fts_repair),
+            "database_recovery": (
+                database_recovery.get("status") if database_recovery is not None else None
+            ),
             "status": (
                 "recovered"
                 if quarantined

--- a/src/persome/mcp/server.py
+++ b/src/persome/mcp/server.py
@@ -148,9 +148,9 @@ def _read_memory(  # type: ignore[no-untyped-def]
 
 def _get_model_snapshot(conn, *, redact: bool = True) -> dict[str, Any]:  # type: ignore[no-untyped-def]
     """Project the live personal model through the same versioned contract as CLI export."""
-    from ..model import build_snapshot, load_last_manifest
+    from ..model import build_live_snapshot
 
-    return build_snapshot(conn, redact=redact, build_metadata=load_last_manifest())
+    return build_live_snapshot(conn, redact=redact)
 
 
 def _search(  # type: ignore[no-untyped-def]

--- a/src/persome/model/__init__.py
+++ b/src/persome/model/__init__.py
@@ -13,12 +13,20 @@ from .build import (
     ModelBuildBusy,
     ModelBuildCoordinator,
     ModelBuildResult,
+    ModelRecoveryIncomplete,
     PipelineOutcome,
+    build_live_snapshot,
     load_last_manifest,
+    load_live_manifest,
     run_model_build,
 )
 from .entity_source import EntityEvent, EntitySource, MemoryPersonNameSource
-from .manifest import create_build_manifest, detect_core_commit, prompt_hashes
+from .manifest import (
+    create_build_manifest,
+    detect_core_commit,
+    is_valid_build_manifest,
+    prompt_hashes,
+)
 from .schema_reader import active_schema_inferences, active_schema_inferences_with_sources
 from .snapshot import (
     SCHEMA_VERSION,
@@ -36,6 +44,7 @@ __all__ = [
     "ModelBuildBusy",
     "ModelBuildCoordinator",
     "ModelBuildResult",
+    "ModelRecoveryIncomplete",
     "ModelContractError",
     "PipelineOutcome",
     "SOURCE_KINDS",
@@ -47,11 +56,14 @@ __all__ = [
     "active_schema_inferences",
     "active_schema_inferences_with_sources",
     "build_snapshot",
+    "build_live_snapshot",
     "create_build_manifest",
     "detect_core_commit",
     "export_snapshot",
     "load_last_manifest",
+    "load_live_manifest",
     "is_activity_identity",
+    "is_valid_build_manifest",
     "model_status",
     "normalize_activity_identity",
     "prompt_hashes",

--- a/src/persome/model/build.py
+++ b/src/persome/model/build.py
@@ -15,7 +15,7 @@ from typing import Any
 from .. import paths
 from ..evomem.store import NodeStore
 from ..store import fts
-from .manifest import create_build_manifest
+from .manifest import create_build_manifest, is_valid_build_manifest
 from .snapshot import build_snapshot
 
 DEFAULT_WAIT_SECONDS = 30.0
@@ -30,10 +30,31 @@ _MODEL_STAGES = (
     "cross_domain_sweeper",
     "root_synthesis",
 )
+_PERSISTED_MANIFEST_KEYS = frozenset(
+    {
+        "build_id",
+        "core_commit",
+        "models",
+        "prompt_hashes",
+        "config_hash",
+        "input_window",
+        "mode",
+        "trigger",
+        "status",
+        "degraded_stages",
+        "started_at",
+        "completed_at",
+        "duration_ms",
+    }
+)
 
 
 class ModelBuildBusy(RuntimeError):
     """Another process still owns the model-build lock after the requested wait."""
+
+
+class ModelRecoveryIncomplete(RuntimeError):
+    """Crash recovery has not established a safe database/write authority."""
 
 
 @dataclass
@@ -181,11 +202,16 @@ def _run_pipeline(cfg: Any) -> PipelineOutcome:
                 conn,
                 behavior_max_distance=cfg.schema.cross_domain_behavior_max_distance,
                 min_confidence=cfg.schema.cross_domain_min_confidence,
+                max_probes=cfg.schema.cross_domain_max_probes,
             )
         return {
             "written": result.written_count,
             "pairs_considered": result.pairs_considered,
+            "eligible_pairs": result.eligible_pairs,
             "pairs_probed": result.pairs_probed,
+            "probe_limit": result.probe_limit,
+            "pairs_deferred": result.pairs_deferred,
+            "collisions": result.collisions,
         }
 
     _run_stage(
@@ -262,6 +288,151 @@ def load_last_manifest() -> dict[str, Any] | None:
     return payload if isinstance(payload, dict) else None
 
 
+def _recovery_marker_blocks_manifest() -> bool:
+    if paths.integrity_recovery_pending().exists():
+        return True
+    marker = paths.integrity_recovery_marker()
+    try:
+        payload = json.loads(marker.read_text(encoding="utf-8"))
+        database = payload.get("database_recovery") if isinstance(payload, dict) else None
+        if not isinstance(database, dict) or not database.get("model_rebuild_required"):
+            return False
+        return paths.model_build_manifest().stat().st_mtime_ns <= marker.stat().st_mtime_ns
+    except FileNotFoundError:
+        return False
+    except (json.JSONDecodeError, OSError, TypeError, ValueError):
+        # A malformed old recovery marker cannot prove that the current
+        # manifest is stale. The manifest's own strict validation still applies.
+        return False
+
+
+def _not_built_manifest() -> dict[str, Any]:
+    return {
+        "build_id": None,
+        "core_commit": None,
+        "models": {},
+        "prompt_hashes": {},
+        "config_hash": None,
+        "input_window": {"start": None, "end": None},
+        "mode": None,
+        "status": "not_built",
+        "trigger": "no_completed_build",
+        "started_at": None,
+        "completed_at": None,
+        "duration_ms": 0,
+        "degraded_stages": [],
+    }
+
+
+def _building_manifest(manifest: dict[str, Any] | None) -> dict[str, Any]:
+    marker_is_current = manifest is not None and manifest.get("status") == "building"
+    return {
+        "build_id": None,
+        "core_commit": None,
+        "models": {},
+        "prompt_hashes": {},
+        "config_hash": None,
+        "input_window": {"start": None, "end": None},
+        "mode": None,
+        "status": "building",
+        "trigger": manifest.get("trigger", "unknown") if marker_is_current else "unknown",
+        "started_at": manifest.get("started_at") if marker_is_current else None,
+        "completed_at": None,
+        "duration_ms": 0,
+        "degraded_stages": [],
+    }
+
+
+def _classify_persisted_manifest(manifest: dict[str, Any] | None) -> dict[str, Any]:
+    recovery_blocked = _recovery_marker_blocks_manifest()
+    if (
+        manifest is not None
+        and not recovery_blocked
+        and manifest.keys() >= _PERSISTED_MANIFEST_KEYS
+        and isinstance(manifest.get("started_at"), str)
+        and isinstance(manifest.get("completed_at"), str)
+        and is_valid_build_manifest(manifest)
+    ):
+        return manifest
+    return _not_built_manifest()
+
+
+@contextmanager
+def _shared_build_lock_if_available() -> Iterator[bool]:
+    """Hold a shared build lock when no structural build is already active."""
+    try:
+        handle = paths.open_private_lock_file(paths.model_build_lock())
+    except (OSError, RuntimeError):
+        yield False
+        return
+    acquired = False
+    try:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_SH | fcntl.LOCK_NB)
+            acquired = True
+        except BlockingIOError:
+            pass
+        yield acquired
+    finally:
+        if acquired:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        handle.close()
+
+
+def load_live_manifest() -> dict[str, Any]:
+    """Return truthful metadata for a live projection or export.
+
+    Merely reading the current database is not a model build. A missing,
+    malformed, or interrupted manifest must therefore never be replaced by the
+    snapshot helper's synthetic ``complete`` metadata. The shared lock closes
+    the pre-marker race where a builder owns the exclusive lock but has not yet
+    replaced the previous completed manifest.
+    """
+    with _shared_build_lock_if_available() as shared_lock_acquired:
+        manifest = load_last_manifest()
+        if not shared_lock_acquired:
+            return _building_manifest(manifest)
+        return _classify_persisted_manifest(manifest)
+
+
+def build_live_snapshot(
+    conn: Any,
+    *,
+    redact: bool = True,
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    """Read one transactionally stable geometry + manifest projection.
+
+    A shared build lock prevents a new explicit structural build from starting
+    between manifest and geometry reads. If a build already owns the exclusive
+    lock, the public manifest is ``building`` and the SQLite savepoint still
+    gives all geometry queries one WAL snapshot.
+    """
+    with _shared_build_lock_if_available() as shared_lock_acquired:
+        if shared_lock_acquired:
+            # Our own shared lock would make a separate exclusive-lock probe
+            # look busy. With the shared lock held, no structural writer can
+            # start, so classify the persisted manifest directly.
+            build_metadata = _classify_persisted_manifest(load_last_manifest())
+        else:
+            build_metadata = _building_manifest(load_last_manifest())
+        savepoint = "persome_live_model_snapshot"
+        conn.execute(f"SAVEPOINT {savepoint}")
+        try:
+            snapshot = build_snapshot(
+                conn,
+                redact=redact,
+                generated_at=generated_at,
+                build_metadata=build_metadata,
+            )
+            conn.execute(f"RELEASE SAVEPOINT {savepoint}")
+            return snapshot
+        except BaseException:
+            conn.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+            conn.execute(f"RELEASE SAVEPOINT {savepoint}")
+            raise
+
+
 def run_model_build(
     cfg: Any,
     *,
@@ -272,11 +443,31 @@ def run_model_build(
     now: Callable[[], datetime] | None = None,
 ) -> ModelBuildResult:
     """Run one idempotent build and persist its reproducibility manifest."""
+    if (
+        paths.integrity_recovery_pending().exists()
+        or paths.integrity_config_recovery_pending().exists()
+    ):
+        raise ModelRecoveryIncomplete(
+            "database/config recovery is incomplete; repair the reported source and rerun "
+            "a stopped-Runtime CLI command before building"
+        )
     clock = now or (lambda: datetime.now(UTC))
     coordinator = coordinator or ModelBuildCoordinator()
     with coordinator.acquire(wait_seconds=wait_seconds):
         started_dt = clock()
         started_monotonic = time.monotonic()
+        _write_json_owner_only(
+            paths.model_build_manifest(),
+            {
+                "build_id": None,
+                "status": "building",
+                "trigger": trigger,
+                "started_at": started_dt.isoformat(),
+                "completed_at": None,
+                "duration_ms": 0,
+                "degraded_stages": [],
+            },
+        )
         NodeStore()  # ensure the Point store exists even on a completely fresh root
         outcome = pipeline_runner(cfg)
 

--- a/src/persome/model/manifest.py
+++ b/src/persome/model/manifest.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import os
 import subprocess
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -14,6 +15,33 @@ from typing import Any
 def _stable_hash(value: Any) -> str:
     payload = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def is_valid_build_manifest(manifest: Mapping[str, Any]) -> bool:
+    """Return whether persisted build metadata is internally trustworthy.
+
+    ``build_id`` signs every other persisted field, including fields added by a
+    future schema revision. Status also has to agree with ``degraded_stages`` so
+    a re-hashed but contradictory manifest cannot be presented as complete.
+    """
+    build_id = manifest.get("build_id")
+    degraded_stages = manifest.get("degraded_stages")
+    status = manifest.get("status")
+    if (
+        not isinstance(build_id, str)
+        or not build_id.strip()
+        or not isinstance(degraded_stages, list)
+        or not all(isinstance(stage, str) and stage for stage in degraded_stages)
+        or status not in {"complete", "degraded"}
+        or (status == "complete") != (not degraded_stages)
+    ):
+        return False
+    unsigned = {key: value for key, value in manifest.items() if key != "build_id"}
+    try:
+        expected = _stable_hash(unsigned)[:20]
+    except (TypeError, ValueError):
+        return False
+    return build_id == expected
 
 
 def prompt_hashes(prompt_dir: Path | None = None) -> dict[str, str]:

--- a/src/persome/model/snapshot.py
+++ b/src/persome/model/snapshot.py
@@ -345,8 +345,14 @@ def build_snapshot(
     if len(roots) > 1:
         raise ModelContractError(f"expected at most one live Root, found {len(roots)}")
 
-    build = create_build_manifest(started_at=timestamp, completed_at=timestamp)
-    build.update(build_metadata or {})
+    # A caller-supplied live manifest is already the complete truth surface.
+    # Do not merge not_built/building sentinels into a freshly fabricated
+    # successful manifest with unrelated hashes and commit metadata.
+    build = (
+        dict(build_metadata)
+        if build_metadata is not None
+        else create_build_manifest(started_at=timestamp, completed_at=timestamp)
+    )
     snapshot = {
         "schema_version": SCHEMA_VERSION,
         "generated_at": timestamp,
@@ -393,9 +399,15 @@ def validate_snapshot(snapshot: dict[str, Any]) -> None:
         raise ModelContractError("model snapshot must contain zero or one live Root")
 
 
-def model_status(conn: sqlite3.Connection) -> dict[str, Any]:
+def model_status(
+    conn: sqlite3.Connection,
+    *,
+    snapshot_data: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """Return a compact readiness/status view backed by the same model contract."""
-    snapshot = build_snapshot(conn)
+    snapshot = snapshot_data if snapshot_data is not None else build_snapshot(conn)
+    if snapshot_data is not None:
+        validate_snapshot(snapshot)
     issues: list[str] = []
     if not snapshot["points"]:
         issues.append("no_points")
@@ -424,14 +436,19 @@ def export_snapshot(
     redact: bool = True,
     build_metadata: dict[str, Any] | None = None,
     generated_at: str | None = None,
+    snapshot_data: dict[str, Any] | None = None,
 ) -> Path:
     """Atomically write a model snapshot. Exports are redacted and mode 0600 by default."""
-    snapshot = build_snapshot(
-        conn,
-        redact=redact,
-        build_metadata=build_metadata,
-        generated_at=generated_at,
-    )
+    snapshot = snapshot_data
+    if snapshot is None:
+        snapshot = build_snapshot(
+            conn,
+            redact=redact,
+            build_metadata=build_metadata,
+            generated_at=generated_at,
+        )
+    else:
+        validate_snapshot(snapshot)
     target = out_path
     if target is None:
         stamp = snapshot["generated_at"].replace(":", "-").replace("+", "_")

--- a/src/persome/paths.py
+++ b/src/persome/paths.py
@@ -104,6 +104,21 @@ def integrity_recovery_marker() -> Path:
     return root() / ".integrity-recovery.json"
 
 
+def integrity_recovery_pending() -> Path:
+    """Crash-resumable journal for a full database quarantine/replay."""
+    return root() / ".integrity-recovery.pending.json"
+
+
+def integrity_config_recovery_pending() -> Path:
+    """Crash-resumable intent for config quarantine before DB inspection.
+
+    This is separate from the database journal because it must be durable
+    before a corrupt config is replaced.  Until it is cleared, a subsequent
+    database recovery must not infer write authority from the fresh default.
+    """
+    return root() / ".integrity-config-recovery.pending.json"
+
+
 def backup_dir() -> Path:
     """Daily ``VACUUM INTO`` snapshots of ``index.db`` (``evo-YYYYMMDD.db``).
 

--- a/src/persome/store/entries.py
+++ b/src/persome/store/entries.py
@@ -295,6 +295,7 @@ def create_file(
         raise ValueError("description is required")
     prefix = _ensure_prefix(name)
     path = files_mod.memory_path(name)
+    file_name = files_mod.memory_name(path)
     # Lock around the exists-check + write so two concurrent classifiers
     # deciding to create the same file don't both pass the check and have
     # the second clobber the first's freshly written content.
@@ -310,7 +311,7 @@ def create_file(
         fts.upsert_file(
             conn,
             fts.FileRow(
-                path=path.name,
+                path=file_name,
                 prefix=prefix,
                 description=description,
                 tags=" ".join(tags),
@@ -321,7 +322,7 @@ def create_file(
                 needs_compact=0,
             ),
         )
-    logger.info("created file: %s (status=%s)", path.name, status)
+    logger.info("created file: %s (status=%s)", file_name, status)
     return path
 
 
@@ -338,12 +339,13 @@ def set_file_status(conn: sqlite3.Connection, *, name: str, status: str) -> None
     if evo_inversion.routes_to_engine(name):
         return evo_inversion.set_file_status(conn, name=name, status=status)
     path = files_mod.memory_path(name)
+    file_name = files_mod.memory_name(path)
     if not path.exists():
         return
     # `update_frontmatter` takes the file lock itself (non-reentrant), so don't
     # wrap it in another. The DB update is independent and doesn't need the lock.
     files_mod.update_frontmatter(path, {"status": status})
-    conn.execute("UPDATE files SET status = ? WHERE path = ?", (status, path.name))
+    conn.execute("UPDATE files SET status = ? WHERE path = ?", (status, file_name))
     conn.commit()
     logger.info("file status set: %s -> %s", path.name, status)
 
@@ -380,6 +382,7 @@ def append_entry(
             occurred_at=occurred_at,
         )
     path = files_mod.memory_path(name)
+    file_name = files_mod.memory_name(path)
     if not path.exists():
         raise FileNotFoundError(f"{path.name} does not exist; call create_file first")
     prefix = _ensure_prefix(name)
@@ -425,7 +428,7 @@ def append_entry(
         derived_append_rows(
             conn,
             entry_id=entry_id,
-            path_name=path.name,
+            path_name=file_name,
             prefix=prefix,
             ts=ts,
             tags_str=" ".join(all_tags),
@@ -437,7 +440,7 @@ def append_entry(
         fts.upsert_file(
             conn,
             fts.FileRow(
-                path=path.name,
+                path=file_name,
                 prefix=prefix,
                 description=str(post.metadata.get("description", "")),
                 tags=" ".join(post.metadata.get("tags", []) or []),
@@ -539,6 +542,7 @@ def supersede_entry(
             occurred_at=occurred_at,
         )
     path = files_mod.memory_path(name)
+    file_name = files_mod.memory_name(path)
     if not path.exists():
         raise FileNotFoundError(path.name)
 
@@ -613,7 +617,7 @@ def supersede_entry(
             conn,
             old_entry_id=old_entry_id,
             new_entry_id=new_id,
-            path_name=path.name,
+            path_name=file_name,
             prefix=prefix,
             ts=ts,
             tags_str=" ".join(new_tags),
@@ -625,7 +629,7 @@ def supersede_entry(
         fts.upsert_file(
             conn,
             fts.FileRow(
-                path=path.name,
+                path=file_name,
                 prefix=prefix,
                 description=str(post.metadata.get("description", "")),
                 tags=" ".join(post.metadata.get("tags", []) or []),
@@ -646,6 +650,7 @@ def mark_entry_deleted(conn: sqlite3.Connection, *, name: str, entry_id: str) ->
     if evo_inversion.routes_to_engine(name):
         return evo_inversion.mark_entry_deleted(conn, name=name, entry_id=entry_id)
     path = files_mod.memory_path(name)
+    file_name = files_mod.memory_name(path)
     if not path.exists():
         raise FileNotFoundError(path.name)
     with files_mod.file_lock(path):
@@ -716,7 +721,7 @@ def mark_entry_deleted(conn: sqlite3.Connection, *, name: str, entry_id: str) ->
             fts.upsert_file(
                 conn,
                 fts.FileRow(
-                    path=path.name,
+                    path=file_name,
                     prefix=prefix,
                     description=str(post.metadata.get("description", "")),
                     tags=" ".join(post.metadata.get("tags", []) or []),
@@ -753,11 +758,20 @@ def _retryable_rebuild_error(exc: BaseException) -> bool:
     return "locked" in message or "busy" in message
 
 
-def rebuild_index(conn: sqlite3.Connection) -> tuple[int, int]:
+def rebuild_index(
+    conn: sqlite3.Connection,
+    *,
+    source_authority: str | None = None,
+    allow_incomplete_recovery: bool = False,
+) -> tuple[int, int]:
+    if not allow_incomplete_recovery:
+        evo_integrity.ensure_writes_allowed()
+    if source_authority not in {None, "markdown", "evomem"}:
+        raise ValueError("source_authority must be 'markdown', 'evomem', or None")
     max_attempts = 5
     for attempt in range(1, max_attempts + 1):
         try:
-            return _rebuild_index_once(conn)
+            return _rebuild_index_once(conn, source_authority=source_authority)
         except BaseException as exc:
             if attempt == max_attempts or not _retryable_rebuild_error(exc):
                 raise
@@ -770,14 +784,20 @@ def rebuild_index(conn: sqlite3.Connection) -> tuple[int, int]:
     raise AssertionError("unreachable")
 
 
-def _rebuild_index_once(conn: sqlite3.Connection) -> tuple[int, int]:
+def _rebuild_index_once(
+    conn: sqlite3.Connection,
+    *,
+    source_authority: str | None,
+) -> tuple[int, int]:
     savepoint = "persome_rebuild_index"
     conn.execute(f"SAVEPOINT {savepoint}")
     try:
-        if evo_inversion.evomem_active():
-            result = _rebuild_from_evo_nodes(conn)
-        else:
-            result = _rebuild_from_markdown(conn)
+        use_evomem = (
+            evo_inversion.evomem_active()
+            if source_authority is None
+            else source_authority == "evomem"
+        )
+        result = _rebuild_from_evo_nodes(conn) if use_evomem else _rebuild_from_markdown(conn)
         # Rebuild is a reconciliation boundary. Derived rows for source entries
         # that no longer exist must not retain deleted personal text or vectors.
         conn.execute(
@@ -856,14 +876,15 @@ def _markdown_temporal_bounds(
     source_by_id = {entry_id: "the canonical evomem store" for entry_id in timestamp_by_id}
     source_state_by_id: dict[str, tuple[str, str | None, int, str | None, str | None]] = {}
     for path, _prefix in sources:
+        source_name = files_mod.memory_name(path)
         parsed = files_mod.read_file(path)
         for entry in parsed.entries:
             previous_source = source_by_id.get(entry.id)
             if previous_source is not None:
                 raise ValueError(
-                    f"duplicate entry id {entry.id!r} in {previous_source!r} and {path.name!r}"
+                    f"duplicate entry id {entry.id!r} in {previous_source!r} and {source_name!r}"
                 )
-            source_by_id[entry.id] = path.name
+            source_by_id[entry.id] = source_name
             timestamp_by_id[entry.id] = entry.timestamp
             source_state_by_id[entry.id] = _temporal_source_state(entry)
 
@@ -916,10 +937,11 @@ def _ingest_markdown_file(
     supersedes_by_id: dict[str, set[str]] | None = None,
 ) -> int:
     parsed = files_mod.read_file(path)
+    name = files_mod.memory_name(path)
     fts.upsert_file(
         conn,
         fts.FileRow(
-            path=path.name,
+            path=name,
             prefix=prefix,
             description=parsed.description,
             tags=" ".join(parsed.tags),
@@ -934,7 +956,7 @@ def _ingest_markdown_file(
         if expected_source_state is not None:
             expected = expected_source_state.get(e.id)
             if expected is None or _temporal_source_state(e) != expected:
-                raise _RebuildSourceChanged(f"Markdown source {path.name!r} changed during rebuild")
+                raise _RebuildSourceChanged(f"Markdown source {name!r} changed during rebuild")
         superseded = _superseded_from_tags(e)
         # Only strip the strike markers off entries we judged superseded —
         # a refined-from / live entry keeps its body verbatim so a legitimate
@@ -947,7 +969,7 @@ def _ingest_markdown_file(
         fts.insert_entry(
             conn,
             id=e.id,
-            path=path.name,
+            path=name,
             prefix=prefix,
             timestamp=e.timestamp,
             tags=" ".join(e.tags),
@@ -981,11 +1003,11 @@ def _rebuild_from_markdown(conn: sqlite3.Connection) -> tuple[int, int]:
     # required because a superseded entry may point to a successor in another
     # Markdown file.
     memory_files = files_mod.list_memory_files()
-    source_names = {path.name for path in memory_files}
+    source_names = {files_mod.memory_name(path) for path in memory_files}
     sources: list[tuple[Path, str]] = []
     for path in memory_files:
         try:
-            prefix = _ensure_prefix(path.name)
+            prefix = _ensure_prefix(files_mod.memory_name(path))
         except ValueError as exc:
             logger.warning("skipping %s: %s", path.name, exc)
             continue
@@ -1016,9 +1038,108 @@ def _rebuild_from_markdown(conn: sqlite3.Connection) -> tuple[int, int]:
         )
     if entry_count != len(temporal_by_id):
         raise _RebuildSourceChanged("Markdown entries changed during rebuild")
-    if {path.name for path in files_mod.list_memory_files()} != source_names:
+    if {files_mod.memory_name(path) for path in files_mod.list_memory_files()} != source_names:
         raise _RebuildSourceChanged("Markdown file set changed during rebuild")
     return len(sources), entry_count
+
+
+def _legacy_nested_skill_node_ids(
+    conn: sqlite3.Connection,
+    *,
+    rows: list[sqlite3.Row],
+    memory_files: list[Path],
+) -> set[str]:
+    """Identify old basename-shadow rows only when their origin is provable.
+
+    Older runtimes shadowed ``skills/skill-*.md`` entries into ``evo_nodes``
+    with only ``skill-*.md`` in ``file_name``.  Under evomem authority that row
+    looks like a canonical top-level source, while the nested Markdown remains
+    a direct source, so a rebuild sees the same entry id twice.
+
+    A basename is not enough to delete a canonical node.  Treat a row as the
+    legacy shadow only when all three independent records agree: the unique
+    Markdown entry lives at the corresponding nested path, its semantic content
+    matches the node, and the existing retrieval row is the exact projection of
+    that nested source.  Any collision with incomplete or divergent evidence is
+    left untouched and the rebuild is rejected.
+    """
+    from ..evomem.store import _row_to_node
+
+    parsed_sources: dict[str, list[tuple[str, files_mod.ParsedEntry]]] = {}
+    source_names: set[str] = set()
+    for path in memory_files:
+        source_name = files_mod.memory_name(path)
+        source_names.add(source_name)
+        parsed = files_mod.read_file(path)
+        for entry in parsed.entries:
+            parsed_sources.setdefault(entry.id, []).append((source_name, entry))
+
+    legacy_ids: set[str] = set()
+    for row in rows:
+        node = _row_to_node(row)
+        if (
+            "/" in node.file_name
+            or not node.file_name.startswith("skill-")
+            or not node.file_name.endswith(".md")
+        ):
+            continue
+        nested_name = f"skills/{node.file_name}"
+        matches = parsed_sources.get(node.node_id, [])
+        nested_matches = [(name, entry) for name, entry in matches if name == nested_name]
+        if not nested_matches:
+            continue
+        if len(matches) != 1 or len(nested_matches) != 1:
+            raise ValueError(
+                f"ambiguous legacy nested skill node {node.node_id!r}: "
+                f"Markdown identity is not unique; refusing automatic migration"
+            )
+        _source_name, entry = nested_matches[0]
+        superseded = _superseded_from_tags(entry)
+        semantic_content = _content_from_markdown_entry(entry, superseded=superseded)
+        expected_fts_content = _fts_content_from_markdown_entry(
+            entry,
+            superseded=superseded,
+            supersedes=set(node.supersedes),
+        )
+        retrieval_rows = conn.execute(
+            "SELECT id, path, prefix, timestamp, tags, content, superseded FROM entries WHERE id=?",
+            (node.node_id,),
+        ).fetchall()
+        expected_retrieval_tail = (
+            "skill",
+            entry.timestamp,
+            " ".join(entry.tags),
+            expected_fts_content,
+            superseded,
+        )
+        actual_retrieval = [
+            (
+                str(current["id"]),
+                str(current["path"]),
+                str(current["prefix"]),
+                str(current["timestamp"]),
+                str(current["tags"] or ""),
+                str(current["content"]),
+                int(current["superseded"] or 0),
+            )
+            for current in retrieval_rows
+        ]
+        exact_nested_projection = [(node.node_id, nested_name, *expected_retrieval_tail)]
+        # The same old versions that lost ``skills/`` in evo_nodes also used
+        # Path.name in the FTS/files projection. Accept that legacy source shape
+        # only when no physical top-level file exists; otherwise the basename
+        # cannot prove which source produced the node.
+        exact_legacy_projection = [(node.node_id, node.file_name, *expected_retrieval_tail)]
+        source_is_proven = actual_retrieval == exact_nested_projection or (
+            actual_retrieval == exact_legacy_projection and node.file_name not in source_names
+        )
+        if node.content != semantic_content or not source_is_proven:
+            raise ValueError(
+                f"ambiguous legacy nested skill node {node.node_id!r}: "
+                f"content or source projection differs; refusing automatic migration"
+            )
+        legacy_ids.add(node.node_id)
+    return legacy_ids
 
 
 def _rebuild_from_evo_nodes(conn: sqlite3.Connection) -> tuple[int, int]:
@@ -1026,10 +1147,34 @@ def _rebuild_from_evo_nodes(conn: sqlite3.Connection) -> tuple[int, int]:
     from ..evomem.store import _row_to_node
     from . import projector
 
-    groups: dict[str, list] = {}
-    for r in conn.execute(
+    memory_files = files_mod.list_memory_files()
+    node_rows = conn.execute(
         "SELECT * FROM evo_nodes WHERE user_id='default' AND agent_id='default' ORDER BY node_id"
-    ).fetchall():
+    ).fetchall()
+    legacy_nested_ids = _legacy_nested_skill_node_ids(
+        conn,
+        rows=node_rows,
+        memory_files=memory_files,
+    )
+    for node_id in sorted(legacy_nested_ids):
+        deleted = conn.execute(
+            "DELETE FROM evo_nodes WHERE node_id=? AND user_id='default' AND agent_id='default'",
+            (node_id,),
+        ).rowcount
+        if deleted != 1:
+            raise _RebuildSourceChanged(
+                f"legacy nested skill node {node_id!r} changed during rebuild"
+            )
+    if legacy_nested_ids:
+        logger.info(
+            "rebuild: removed %d verified legacy nested-skill shadow node(s)",
+            len(legacy_nested_ids),
+        )
+
+    groups: dict[str, list] = {}
+    for r in node_rows:
+        if str(r["node_id"]) in legacy_nested_ids:
+            continue
         node = _row_to_node(r)
         if not node.file_name:
             continue
@@ -1046,14 +1191,14 @@ def _rebuild_from_evo_nodes(conn: sqlite3.Connection) -> tuple[int, int]:
         for node in nodes:
             external_timestamp_by_id[node.node_id] = projector._heading_ts(node)
 
-    memory_files = files_mod.list_memory_files()
-    source_names = {path.name for path in memory_files}
+    source_names = {files_mod.memory_name(path) for path in memory_files}
     markdown_sources: list[tuple[Path, str]] = []
     for path in memory_files:
-        if path.name in groups:
+        name = files_mod.memory_name(path)
+        if name in groups:
             continue
         try:
-            prefix = _ensure_prefix(path.name)
+            prefix = _ensure_prefix(name)
         except ValueError as exc:
             logger.warning("skipping %s: %s", path.name, exc)
             continue
@@ -1158,7 +1303,7 @@ def _rebuild_from_evo_nodes(conn: sqlite3.Connection) -> tuple[int, int]:
         file_count += 1
     if markdown_entry_count != len(markdown_temporal):
         raise _RebuildSourceChanged("Markdown entries changed during rebuild")
-    if {path.name for path in files_mod.list_memory_files()} != source_names:
+    if {files_mod.memory_name(path) for path in files_mod.list_memory_files()} != source_names:
         raise _RebuildSourceChanged("Markdown file set changed during rebuild")
 
     # the file-level metadata truth). But a row that once had nodes, now has NONE

--- a/src/persome/store/files.py
+++ b/src/persome/store/files.py
@@ -318,9 +318,87 @@ def update_frontmatter(path: Path, updates: dict[str, Any]) -> None:
         atomic_write_text(path, frontmatter.dumps(post) + "\n")
 
 
-def list_memory_files() -> list[Path]:
-    if not paths.memory_dir().exists():
+def list_memory_files(*, strict: bool = False) -> list[Path]:
+    """List supported memory Markdown without following filesystem links.
+
+    Normal reads skip unsafe or transiently unreadable candidates. Recovery
+    callers pass ``strict=True`` because treating an incomplete discovery as a
+    complete source set could incorrectly delete snapshot-backed canonical
+    nodes that merely failed discovery.
+    """
+    memory_dir = paths.memory_dir()
+    if not memory_dir.exists():
         return []
-    return sorted(
-        p for p in paths.memory_dir().iterdir() if p.suffix == ".md" and p.name != "index.md"
-    )
+    if memory_dir.is_symlink():
+        if strict:
+            raise RuntimeError(f"memory directory must not be a symlink: {memory_dir}")
+        return []
+    candidates: list[Path] = []
+    try:
+        with os.scandir(memory_dir) as root_entries:
+            for entry in root_entries:
+                try:
+                    if entry.is_file(follow_symlinks=False):
+                        if entry.name.endswith(".md") and entry.name != "index.md":
+                            candidates.append(Path(entry.path))
+                        continue
+                    if entry.name.endswith(".md") and entry.name != "index.md":
+                        if strict:
+                            raise RuntimeError(
+                                f"memory Markdown must be one regular file: {entry.path}"
+                            )
+                        continue
+                    if entry.name in VALID_SUBDIRS and entry.is_symlink():
+                        if strict:
+                            raise RuntimeError(
+                                f"memory subdirectory must not be a symlink: {entry.path}"
+                            )
+                        continue
+                    if entry.name not in VALID_SUBDIRS or not entry.is_dir(follow_symlinks=False):
+                        continue
+                    with os.scandir(entry.path) as nested_entries:
+                        for nested in nested_entries:
+                            if nested.is_file(follow_symlinks=False):
+                                if nested.name.endswith(".md") and nested.name != "index.md":
+                                    candidates.append(Path(nested.path))
+                                continue
+                            if nested.name.endswith(".md") and nested.name != "index.md" and strict:
+                                raise RuntimeError(
+                                    f"memory Markdown must be one regular file: {nested.path}"
+                                )
+                except OSError as exc:
+                    if strict:
+                        raise RuntimeError(
+                            f"memory discovery failed for {entry.path}: {exc}"
+                        ) from exc
+                    continue
+    except OSError as exc:
+        if strict:
+            raise RuntimeError(f"memory discovery failed for {memory_dir}: {exc}") from exc
+        return []
+
+    files: list[Path] = []
+    memory_root = memory_dir.resolve()
+    for path in candidates:
+        try:
+            paths.ensure_private_file(path)
+            path.resolve(strict=True).relative_to(memory_root)
+            memory_name(path)
+        except (OSError, RuntimeError, ValueError) as exc:
+            if strict:
+                raise RuntimeError(f"unsafe or unreadable memory file {path}: {exc}") from exc
+            continue
+        files.append(path)
+    return sorted(files, key=memory_name)
+
+
+def memory_name(path: Path) -> str:
+    """Return the canonical root-relative name for a supported memory file."""
+    try:
+        name = path.relative_to(paths.memory_dir()).as_posix()
+    except ValueError as exc:
+        raise ValueError(f"memory file is outside the data root: {path}") from exc
+    expected = memory_path(name)
+    if expected != path:
+        raise ValueError(f"unsupported memory file path: {path}")
+    return name

--- a/src/persome/store/schema_faces.py
+++ b/src/persome/store/schema_faces.py
@@ -69,6 +69,14 @@ CREATE TABLE IF NOT EXISTS schema_faces (
     created_at   TEXT NOT NULL
 );
 CREATE INDEX IF NOT EXISTS ix_faces_status ON schema_faces(status, level);
+CREATE TABLE IF NOT EXISTS cross_domain_probe_state (
+    pair_key       TEXT PRIMARY KEY,
+    last_probed_at TEXT NOT NULL,
+    probe_count    INTEGER NOT NULL DEFAULT 1,
+    detected       INTEGER NOT NULL DEFAULT 0  -- last result was stable/promotable
+);
+CREATE INDEX IF NOT EXISTS ix_cross_domain_probe_age
+    ON cross_domain_probe_state(last_probed_at, pair_key);
 """
 
 

--- a/src/persome/writer/cross_domain_sweeper.py
+++ b/src/persome/writer/cross_domain_sweeper.py
@@ -8,7 +8,7 @@ import sqlite3
 from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -32,6 +32,7 @@ _TRACE_WINDOW_MINUTES = 15
 # Pre-filter thresholds (overridable via SchemaConfig).
 _DEFAULT_BEHAVIOR_MAX_DISTANCE = 0.5  # ≤ this behavior distance == "behavior-near"
 _DEFAULT_MIN_CONFIDENCE = 0.6  # fused schema below this is born ``forming``
+_DEFAULT_MAX_PROBES = 8  # hard per-build LLM-call budget
 # Topic token-overlap ceiling: above this the two schemas are too on-topic to be a
 # cross-domain pair (the LLM would just dedup them). Generous — source-distinctness
 # already does most of the work; this only drops near-identical propositions.
@@ -75,7 +76,10 @@ class CrossSweepResult:
 
     written: list[stage.WrittenSchema] = field(default_factory=list)
     pairs_considered: int = 0
+    eligible_pairs: int = 0  # survived deterministic topic/behavior filters
     pairs_probed: int = 0  # survived the behavior pre-filter, sent to the LLM
+    probe_limit: int = _DEFAULT_MAX_PROBES
+    pairs_deferred: int = 0  # eligible but left for a later build by the hard budget
     collisions: int = 0  # LLM said detected=true
 
     @property
@@ -448,36 +452,43 @@ def _persist_cross_schema(
     # EACH parent — a signal-only contribution (empty members, so the parents'
     # mined footprint history stays untouched) that can escalate the parent's
     # provenance to ``both``. Shadow-only SQLite write, fail-open.
-    try:
-        parent_anchors: set[str] = set()
-        for parent in (a, b):
-            row = schema_faces._find_match(  # noqa: SLF001 — same-module family
-                conn, signature=parent.central, members=set(), level=1
-            )
-            if row is not None:
-                with contextlib.suppress(TypeError, ValueError):
-                    parent_anchors.update(json.loads(row["anchors"] or "[]"))
-        body_id = schema_faces.record_face(
-            conn,
-            source=schema_faces.PROVENANCE_EMERGENT,
-            signature=central,
-            members=[a.name, b.name],
-            confidence=collision.confidence,
-            level=2,
-            anchors=sorted(parent_anchors),
-        )
-        schema_faces.maybe_promote(conn, body_id)
-        for parent in (a, b):
-            pid = schema_faces.record_face(
+    if status == "stable":
+        try:
+            # The normal sweep preloads scheduling state, which creates this
+            # table as a side effect. Keep the persistence station independently
+            # safe as well: direct/recovery callers may land the first stable
+            # collision before any scheduling read has run.
+            schema_faces.ensure_schema(conn)
+            parent_anchors: set[str] = set()
+            for parent in (a, b):
+                row = schema_faces._find_match(  # noqa: SLF001 — same-module family
+                    conn, signature=parent.central, members=set(), level=1
+                )
+                if row is not None:
+                    with contextlib.suppress(TypeError, ValueError):
+                        parent_anchors.update(json.loads(row["anchors"] or "[]"))
+            body_id = schema_faces.record_face(
                 conn,
                 source=schema_faces.PROVENANCE_EMERGENT,
-                signature=parent.central,
-                members=[],
+                signature=central,
+                members=[a.name, b.name],
                 confidence=collision.confidence,
+                level=2,
+                anchors=sorted(parent_anchors),
             )
-            schema_faces.maybe_promote(conn, pid)
-    except Exception:
-        logger.exception("schema_faces record failed for %s", name)
+            schema_faces.maybe_promote(conn, body_id)
+            for parent in (a, b):
+                pid = schema_faces.record_face(
+                    conn,
+                    source=schema_faces.PROVENANCE_EMERGENT,
+                    signature=parent.central,
+                    members=[],
+                    confidence=collision.confidence,
+                )
+                schema_faces.maybe_promote(conn, pid)
+        except Exception:
+            logger.exception("schema_faces record failed for %s", name)
+            raise
     return stage.WrittenSchema(
         path=name,
         status=status,
@@ -485,6 +496,129 @@ def _persist_cross_schema(
         expected_inferences=list(collision.expected_inferences),
         updated_in_place=updated_in_place,
     )
+
+
+@dataclass(frozen=True)
+class _CandidatePair:
+    """One deterministic, pre-filtered cross-domain probe candidate."""
+
+    a: _StableSchema
+    b: _StableSchema
+    sig_a: BehaviorSignature
+    sig_b: BehaviorSignature
+    priority: int
+    last_probed_at: str | None = None
+
+    @property
+    def sort_key(self) -> tuple[int, str, str, str]:
+        lo, hi = sorted((self.a.name, self.b.name))
+        return (self.priority, self.last_probed_at or "", lo, hi)
+
+    @property
+    def pair_key(self) -> str:
+        return _pair_key(self.a.name, self.b.name)
+
+
+def _pair_key(a_name: str, b_name: str) -> str:
+    return json.dumps(sorted((a_name, b_name)), ensure_ascii=False, separators=(",", ":"))
+
+
+@dataclass(frozen=True)
+class _ProbeHistory:
+    """Last persisted scheduling result for one pair.
+
+    ``promotable`` means the last probe produced stable evidence that was
+    eligible for the Volume promotion path. A negative, failed, or forming
+    result is false and must not leave an old shadow at highest priority.
+    """
+
+    last_probed_at: str
+    promotable: bool
+
+
+def _probe_history(conn: sqlite3.Connection) -> dict[str, _ProbeHistory]:
+    schema_faces.ensure_schema(conn)
+    return {
+        str(row[0]): _ProbeHistory(last_probed_at=str(row[1]), promotable=bool(row[2]))
+        for row in conn.execute(
+            "SELECT pair_key, last_probed_at, detected FROM cross_domain_probe_state"
+        ).fetchall()
+    }
+
+
+def _record_probe(candidate: _CandidatePair, conn: sqlite3.Connection, *, detected: bool) -> None:
+    conn.execute(
+        "INSERT INTO cross_domain_probe_state"
+        " (pair_key, last_probed_at, probe_count, detected) VALUES (?, ?, 1, ?)"
+        " ON CONFLICT(pair_key) DO UPDATE SET"
+        " last_probed_at=excluded.last_probed_at,"
+        " probe_count=cross_domain_probe_state.probe_count + 1,"
+        " detected=excluded.detected",
+        (
+            candidate.pair_key,
+            datetime.now(UTC).isoformat(),
+            1 if detected else 0,
+        ),
+    )
+
+
+def _record_probe_fail_open(
+    candidate: _CandidatePair,
+    conn: sqlite3.Connection,
+    *,
+    detected: bool,
+) -> None:
+    try:
+        _record_probe(candidate, conn, detected=detected)
+    except Exception:  # pragma: no cover - scheduling metadata must not abort the stage
+        logger.exception("cross-domain probe history write failed for %s", candidate.pair_key)
+
+
+def _live_volume_pair_statuses(conn: sqlite3.Connection) -> dict[frozenset[str], str]:
+    """Map live two-schema Volume footprints to ``shadow`` or ``active``.
+
+    The cross-domain sweeper is the honest producer for level-2 objects. A live
+    shadow pair needs another independent sweep observation before promotion, so
+    it is the most valuable use of a bounded probe budget.
+    """
+    schema_faces.ensure_schema(conn)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT members, status FROM schema_faces "
+        "WHERE level = 2 AND valid_to IS NULL AND status IN ('shadow', 'active')"
+    ).fetchall()
+    statuses: dict[frozenset[str], str] = {}
+    for row in rows:
+        try:
+            members = frozenset(str(member) for member in json.loads(row["members"]))
+        except (TypeError, ValueError, json.JSONDecodeError):
+            continue
+        if len(members) != 2:
+            continue
+        # A shadow row always wins if a damaged/legacy store happens to contain
+        # duplicate live footprints: it is the one that still needs evidence.
+        status = str(row["status"])
+        if status == "shadow" or members not in statuses:
+            statuses[members] = status
+    return statuses
+
+
+def _candidate_priority(
+    a: _StableSchema,
+    b: _StableSchema,
+    volume_statuses: dict[frozenset[str], str],
+    probe_history: dict[str, _ProbeHistory],
+) -> int:
+    pair_key = _pair_key(a.name, b.name)
+    history = probe_history.get(pair_key)
+    status = volume_statuses.get(frozenset((a.name, b.name)))
+    if status == "shadow" and (history is None or history.promotable):
+        return 0
+    if status is None and history is None:
+        return 1
+    if status != "active":
+        return 2
+    return 3  # active pairs refresh after corroborating, unseen, and rejected pairs
 
 
 # ── main entry ────────────────────────────────────────────────────────────────
@@ -496,17 +630,23 @@ def sweep_cross_domain(
     *,
     behavior_max_distance: float = _DEFAULT_BEHAVIOR_MAX_DISTANCE,
     min_confidence: float = _DEFAULT_MIN_CONFIDENCE,
+    max_probes: int = _DEFAULT_MAX_PROBES,
     llm_call: Callable[[list[dict]], Any] | None = None,
 ) -> CrossSweepResult:
     """Pair stable schemas, behavior-prefilter, LLM-judge collisions, land fusions.
 
     Behavior signatures pre-filter pairs cheaply (behavior-near + topic-distinct);
-    only survivors hit the LLM. ``llm_call`` is injectable for tests. A per-pair
-    failure is logged and skipped — the sweep never aborts (schema is a decoration,
-    must not cascade).
+    only survivors hit the LLM, up to ``max_probes`` per call. Shadows whose
+    last observation was still promotable are retried first, then unseen pairs,
+    then negative/forming/failed retries oldest-first, and finally active pairs.
+    This prevents a stale shadow from permanently consuming a bounded budget.
+    Ties use schema filenames for deterministic ordering. ``llm_call`` is
+    injectable for tests. A per-pair failure is logged and skipped — the sweep
+    never aborts (schema is a decoration, must not cascade).
     """
+    probe_limit = max(0, int(max_probes))
     schemas = _load_stable_schemas(conn)
-    result = CrossSweepResult()
+    result = CrossSweepResult(probe_limit=probe_limit)
     if len(schemas) < 2:
         return result
 
@@ -515,26 +655,81 @@ def sweep_cross_domain(
     sigs: dict[str, BehaviorSignature] = {
         s.name: _schema_behavior_signature(conn, s.source_path) for s in schemas
     }
+    volume_statuses = _live_volume_pair_statuses(conn)
+    probe_history = _probe_history(conn)
+    candidates: list[_CandidatePair] = []
 
     for i in range(len(schemas)):
         for j in range(i + 1, len(schemas)):
-            a, b = schemas[i], schemas[j]
+            # Normalize A/B as well as queue order. The entries query is newest
+            # first, so insertion timestamps must not change prompt orientation.
+            a, b = sorted((schemas[i], schemas[j]), key=lambda schema: schema.name)
             result.pairs_considered += 1
             if not _topic_distinct(a, b):
                 continue
             sig_a, sig_b = sigs[a.name], sigs[b.name]
             if _signature_distance(sig_a, sig_b) > behavior_max_distance:
                 continue  # behavior too different — not a cross-domain twin
-            result.pairs_probed += 1
-            try:
-                collision = _probe_collision(cfg, a, b, sig_a, sig_b, call)
-            except Exception:  # pragma: no cover - defensive; one bad pair can't kill the sweep
-                logger.exception("cross-domain probe failed on %s × %s", a.name, b.name)
-                continue
-            if not collision.detected:
-                continue
-            result.collisions += 1
-            written = _persist_cross_schema(conn, a, b, collision, stable_threshold=min_confidence)
-            if written is not None:
-                result.written.append(written)
+            history = probe_history.get(_pair_key(a.name, b.name))
+            candidates.append(
+                # The history table is intentionally consulted once per build:
+                # each result affects the next scheduling pass, never the order
+                # of candidates already selected in this one.
+                _CandidatePair(
+                    a=a,
+                    b=b,
+                    sig_a=sig_a,
+                    sig_b=sig_b,
+                    priority=_candidate_priority(a, b, volume_statuses, probe_history),
+                    last_probed_at=history.last_probed_at if history is not None else None,
+                )
+            )
+
+    candidates.sort(key=lambda candidate: candidate.sort_key)
+    result.eligible_pairs = len(candidates)
+    result.pairs_deferred = max(0, len(candidates) - probe_limit)
+
+    for candidate in candidates[:probe_limit]:
+        result.pairs_probed += 1
+        a, b = candidate.a, candidate.b
+        try:
+            collision = _probe_collision(cfg, a, b, candidate.sig_a, candidate.sig_b, call)
+        except Exception:  # pragma: no cover - defensive; one bad pair can't kill the sweep
+            logger.exception("cross-domain probe failed on %s × %s", a.name, b.name)
+            _record_probe_fail_open(candidate, conn, detected=False)
+            continue
+        if not collision.detected:
+            _record_probe_fail_open(candidate, conn, detected=False)
+            continue
+        result.collisions += 1
+        try:
+            written = _persist_cross_schema(
+                conn,
+                a,
+                b,
+                collision,
+                stable_threshold=min_confidence,
+            )
+        except Exception:  # pragma: no cover - one failed projection must not monopolize the queue
+            logger.exception("cross-domain persistence failed on %s × %s", a.name, b.name)
+            _record_probe_fail_open(candidate, conn, detected=False)
+            continue
+        # The historical column is named ``detected`` for compatibility. Its
+        # scheduling meaning is stricter: only stable output is promotable.
+        _record_probe_fail_open(
+            candidate,
+            conn,
+            detected=written is not None and written.status == "stable",
+        )
+        if written is not None:
+            result.written.append(written)
+
+    if result.pairs_deferred:
+        logger.info(
+            "cross-domain probe budget reached: probed=%d eligible=%d deferred=%d limit=%d",
+            result.pairs_probed,
+            result.eligible_pairs,
+            result.pairs_deferred,
+            result.probe_limit,
+        )
     return result

--- a/src/persome/writer/tools.py
+++ b/src/persome/writer/tools.py
@@ -178,7 +178,7 @@ def tool_flag_compact(
     if evo_inversion.routes_to_engine(path):
         evo_inversion.flag_needs_compact(conn, name=path, value=True)
     else:
-        fts.set_needs_compact(conn, p.name, True)
+        fts.set_needs_compact(conn, files_mod.memory_name(p), True)
         files_mod.update_frontmatter(p, {"needs_compact": True})
     state.flagged_compact.append(path)
     logger.info("flag_compact: %s (%s)", path, reason)

--- a/tests/test_cli_capture_rebuild.py
+++ b/tests/test_cli_capture_rebuild.py
@@ -1,0 +1,78 @@
+"""Recovery-safe capture-index reconciliation CLI tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from persome import cli, paths
+from persome.store import fts
+
+
+def _seed_snapshot_only_capture() -> None:
+    with fts.cursor() as conn:
+        fts.insert_capture(
+            conn,
+            id="snapshot-only",
+            timestamp="2026-06-01T00:00:00+00:00",
+            app_name="Archive",
+            bundle_id="com.persome.archive",
+            window_title="Older snapshot capture",
+            focused_role="AXTextArea",
+            focused_value="historical",
+            visible_text="historical snapshot evidence",
+            url="https://example.test/archive",
+        )
+
+
+def _write_buffer_capture() -> Path:
+    target = paths.capture_buffer_dir() / "buffer-new.json"
+    target.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-07-12T00:00:00+00:00",
+                "window_meta": {
+                    "app_name": "Browser",
+                    "bundle_id": "com.persome.browser",
+                    "title": "New buffer capture",
+                },
+                "focused_element": {"role": "AXTextField", "value": "fresh"},
+                "visible_text": "fresh retained buffer evidence",
+                "url": "https://example.test/fresh",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return target
+
+
+def test_rebuild_captures_merge_preserves_snapshot_rows_and_upserts_buffer(ac_root: Path) -> None:
+    _seed_snapshot_only_capture()
+    _write_buffer_capture()
+
+    result = CliRunner().invoke(cli.app, ["rebuild-captures-index", "--merge"])
+
+    assert result.exit_code == 0, result.output
+    assert "Captures index merged" in result.output
+    with fts.cursor() as conn:
+        ids = {row[0] for row in conn.execute("SELECT id FROM captures").fetchall()}
+        historical_hits = fts.search_captures(conn, query="historical", limit=5)
+        fresh_hits = fts.search_captures(conn, query="fresh", limit=5)
+    assert ids == {"snapshot-only", "buffer-new"}
+    assert [hit.id for hit in historical_hits] == ["snapshot-only"]
+    assert [hit.id for hit in fresh_hits] == ["buffer-new"]
+
+
+def test_rebuild_captures_default_remains_exact_buffer_reconciliation(ac_root: Path) -> None:
+    _seed_snapshot_only_capture()
+    _write_buffer_capture()
+
+    result = CliRunner().invoke(cli.app, ["rebuild-captures-index"])
+
+    assert result.exit_code == 0, result.output
+    assert "Captures index rebuilt" in result.output
+    with fts.cursor() as conn:
+        ids = {row[0] for row in conn.execute("SELECT id FROM captures").fetchall()}
+    assert ids == {"buffer-new"}

--- a/tests/test_cli_lifecycle.py
+++ b/tests/test_cli_lifecycle.py
@@ -2,10 +2,32 @@
 
 from __future__ import annotations
 
+import json
+from types import SimpleNamespace
+
 import pytest
 from typer.testing import CliRunner
 
 from persome import cli
+
+
+class _FakeLock:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _http_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        mcp=SimpleNamespace(
+            auto_start=True,
+            transport="streamable-http",
+            host="127.0.0.1",
+            port=8742,
+        )
+    )
 
 
 def test_init_skips_mutable_integrity_recovery_while_daemon_is_running(
@@ -21,6 +43,24 @@ def test_init_skips_mutable_integrity_recovery_while_daemon_is_running(
     cfg = cli._init()
 
     assert cfg is not None
+
+
+def test_start_initialization_is_blocked_by_unresolved_authority(
+    ac_root, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(cli, "_read_pid", lambda: None)
+    monkeypatch.setattr(cli, "_daemon_lock_is_held", lambda: False)
+    monkeypatch.setattr(cli.integrity, "check_and_recover", lambda: [])
+    paths = cli.paths
+    paths.atomic_write_private_text(
+        paths.integrity_config_recovery_pending(),
+        '{"version": 1, "phase": "authority_unresolved"}',
+    )
+
+    with pytest.raises(cli.typer.Exit) as exc:
+        cli._init(starting_runtime=True)
+
+    assert exc.value.exit_code == 2
 
 
 def test_start_short_circuits_before_initialization_when_already_running(
@@ -87,3 +127,212 @@ def test_non_starting_client_skips_integrity_during_pid_publication_window(
         assert cli._init() is not None
     finally:
         lock.close()
+
+
+def test_cli_surfaces_database_recovery_and_model_rebuild_next_step(
+    ac_root, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(cli, "_read_pid", lambda: None)
+    monkeypatch.setattr(cli, "_daemon_lock_is_held", lambda: False)
+    monkeypatch.setattr(
+        cli.integrity,
+        "check_and_recover",
+        lambda: [
+            cli.integrity.QuarantinedFile(
+                kind="database",
+                original_path="index.db",
+                quarantine_path="index.db.corrupt.test",
+                reason="synthetic corruption",
+            )
+        ],
+    )
+
+    result = CliRunner().invoke(cli.app, ["model", "status"])
+
+    assert result.exit_code == 0, result.output
+    assert "recovered a damaged local database" in result.output
+    assert "persome model build" in result.output
+
+
+def test_background_start_reports_success_only_after_readiness(
+    ac_root, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    lock = _FakeLock()
+    cfg = _http_config()
+    observed: list[str] = []
+    monkeypatch.setattr(cli, "_fail_if_runtime_state_is_ambiguous", lambda: None)
+    monkeypatch.setattr(cli, "_read_pid", lambda: None)
+    monkeypatch.setattr(cli, "_acquire_daemon_lock", lambda: lock)
+    monkeypatch.setattr(cli.env_file_mod, "ensure_local_api_token", lambda _path: "existing")
+    monkeypatch.setattr(cli, "_init", lambda **_kwargs: cfg)
+    monkeypatch.setattr(cli.os, "fork", lambda: 4321)
+    monkeypatch.setattr(
+        cli,
+        "_wait_for_background_start",
+        lambda _cfg: (observed.append("ready") or True, "ready", SimpleNamespace(pid=4242)),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_terminate_failed_background_start",
+        lambda _process: pytest.fail("a ready Runtime must not be terminated"),
+    )
+
+    result = CliRunner().invoke(cli.app, ["start"])
+
+    assert result.exit_code == 0, result.output
+    assert observed == ["ready"]
+    assert lock.closed is True
+    assert "Persome started in background." in result.output
+
+
+def test_background_start_failure_stops_child_and_reports_port_owner(
+    ac_root, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    lock = _FakeLock()
+    cfg = _http_config()
+    process = SimpleNamespace(pid=4242)
+    terminated: list[object] = []
+    monkeypatch.setattr(cli, "_fail_if_runtime_state_is_ambiguous", lambda: None)
+    monkeypatch.setattr(cli, "_read_pid", lambda: None)
+    monkeypatch.setattr(cli, "_acquire_daemon_lock", lambda: lock)
+    monkeypatch.setattr(cli.env_file_mod, "ensure_local_api_token", lambda _path: "existing")
+    monkeypatch.setattr(cli, "_init", lambda **_kwargs: cfg)
+    monkeypatch.setattr(cli.os, "fork", lambda: 4321)
+    monkeypatch.setattr(
+        cli,
+        "_wait_for_background_start",
+        lambda _cfg: (
+            False,
+            "port 8742 is in use by a different or incompatible service",
+            process,
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_terminate_failed_background_start",
+        lambda value: terminated.append(value) or True,
+    )
+
+    result = CliRunner().invoke(cli.app, ["start"])
+
+    assert result.exit_code == 1, result.output
+    assert lock.closed is True
+    assert terminated == [process]
+    assert "Persome started in background." not in result.output
+    assert "did not start correctly" in result.output
+    assert "incomplete background Runtime was stopped" in result.output
+    assert "lsof -nP -iTCP:8742 -sTCP:LISTEN" in result.output
+    assert "persome doctor" in result.output
+
+
+def test_failed_background_cleanup_escalates_only_the_observed_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = SimpleNamespace(pid=4242)
+    signals: list[tuple[object, int]] = []
+    cleared: list[object] = []
+    waits = iter([False, True])
+    monkeypatch.setattr(
+        cli.runtime_pid,
+        "signal_process",
+        lambda target, sig: signals.append((target, sig)) or True,
+    )
+    monkeypatch.setattr(
+        cli.runtime_pid,
+        "wait_for_exit",
+        lambda target, timeout: next(waits),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_clear_failed_background_receipts",
+        lambda target: cleared.append(target) or True,
+    )
+
+    assert cli._terminate_failed_background_start(process) is True
+    assert signals == [(process, cli.signal.SIGTERM), (process, cli.signal.SIGKILL)]
+    assert cleared == [process]
+
+
+def test_sigterm_startup_exit_clears_matching_stale_runtime_receipts(
+    ac_root, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    generation = "b" * 32
+    started_at = 1_752_300_000.0
+    process = SimpleNamespace(
+        pid=4242,
+        generation=generation,
+        runtime_started_at=started_at,
+    )
+    cli.paths.atomic_write_private_text(cli.paths.pid_file(), str(process.pid))
+    cli.paths.atomic_write_private_text(
+        cli.paths.runtime_state_file(),
+        json.dumps(
+            {
+                "schema_version": 1,
+                "pid": process.pid,
+                "generation": generation,
+                "started_at": started_at,
+                "updated_at": started_at,
+            }
+        ),
+    )
+    signals: list[tuple[object, int]] = []
+    monkeypatch.setattr(
+        cli.runtime_pid,
+        "signal_process",
+        lambda target, sig: signals.append((target, sig)) or True,
+    )
+    monkeypatch.setattr(cli.runtime_pid, "wait_for_exit", lambda _target, _timeout: True)
+    monkeypatch.setattr(cli.runtime_pid, "same_process_is_running", lambda _process: False)
+
+    assert cli._terminate_failed_background_start(process) is True
+    assert signals == [(process, cli.signal.SIGTERM)]
+    assert not cli.paths.pid_file().exists()
+    assert not cli.paths.runtime_state_file().exists()
+
+
+def test_sigterm_graceful_exit_cleanup_is_idempotent(
+    ac_root, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    process = SimpleNamespace(
+        pid=4242,
+        generation="c" * 32,
+        runtime_started_at=1_752_300_000.0,
+    )
+    monkeypatch.setattr(cli.runtime_pid, "signal_process", lambda _target, _sig: True)
+    monkeypatch.setattr(cli.runtime_pid, "wait_for_exit", lambda _target, _timeout: True)
+    monkeypatch.setattr(cli.runtime_pid, "same_process_is_running", lambda _process: False)
+
+    assert cli._terminate_failed_background_start(process) is True
+    assert not cli.paths.pid_file().exists()
+    assert not cli.paths.runtime_state_file().exists()
+
+
+def test_sigkill_cleanup_removes_only_matching_stale_runtime_receipts(
+    ac_root, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    generation = "a" * 32
+    started_at = 1_752_300_000.0
+    process = SimpleNamespace(
+        pid=4242,
+        generation=generation,
+        runtime_started_at=started_at,
+    )
+    cli.paths.atomic_write_private_text(cli.paths.pid_file(), str(process.pid))
+    cli.paths.atomic_write_private_text(
+        cli.paths.runtime_state_file(),
+        json.dumps(
+            {
+                "schema_version": 1,
+                "pid": process.pid,
+                "generation": generation,
+                "started_at": started_at,
+                "updated_at": started_at,
+            }
+        ),
+    )
+    monkeypatch.setattr(cli.runtime_pid, "same_process_is_running", lambda _process: False)
+
+    assert cli._clear_failed_background_receipts(process) is True
+    assert not cli.paths.pid_file().exists()
+    assert not cli.paths.runtime_state_file().exists()

--- a/tests/test_cli_local_access.py
+++ b/tests/test_cli_local_access.py
@@ -7,6 +7,7 @@ import stat
 import subprocess
 import webbrowser
 from pathlib import Path
+from types import SimpleNamespace
 
 import httpx
 from typer.testing import CliRunner
@@ -17,6 +18,25 @@ from persome.env_file import LOCAL_API_TOKEN_ENV
 
 def _mode(path: Path) -> int:
     return stat.S_IMODE(path.stat().st_mode)
+
+
+def _http_runtime_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        mcp=SimpleNamespace(
+            auto_start=True,
+            transport="streamable-http",
+            host="127.0.0.1",
+            port=8742,
+        )
+    )
+
+
+def _runtime_process() -> SimpleNamespace:
+    return SimpleNamespace(
+        pid=4242,
+        generation="generation-4242",
+        runtime_started_at=1_752_300_000.0,
+    )
 
 
 def test_model_open_exchanges_bearer_for_one_time_browser_url(ac_root: Path, monkeypatch) -> None:
@@ -86,6 +106,207 @@ def test_model_open_rejects_absolute_bootstrap_url(ac_root: Path, monkeypatch) -
 
     assert result.exit_code == 1
     assert "invalid browser capability" in result.output
+
+
+def test_model_open_retries_daemon_startup_connection_race(ac_root: Path, monkeypatch) -> None:
+    token = "t" * 48
+    monkeypatch.setenv(LOCAL_API_TOKEN_ENV, token)
+    calls: list[str] = []
+    delays: list[float] = []
+
+    def fake_post(url: str, **_kwargs):  # type: ignore[no-untyped-def]
+        calls.append(url)
+        if len(calls) < 3:
+            raise httpx.ConnectError(
+                "daemon socket not bound yet",
+                request=httpx.Request("POST", url),
+            )
+        return httpx.Response(
+            200,
+            json={
+                "success": True,
+                "data": {
+                    "bootstrap_url": "/auth/browser-bootstrap?nonce=" + "n" * 43,
+                },
+            },
+            request=httpx.Request("POST", url),
+        )
+
+    opened: list[str] = []
+    monkeypatch.setattr(httpx, "post", fake_post)
+    monkeypatch.setattr(cli, "_daemon_lock_is_held", lambda: True)
+    monkeypatch.setattr(cli.time, "sleep", delays.append)
+    monkeypatch.setattr(webbrowser, "open", lambda url, new=0: opened.append(url) or True)
+
+    result = CliRunner().invoke(cli.app, ["model", "open"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        "http://127.0.0.1:8742/auth/browser-bootstrap",
+        "http://127.0.0.1:8742/auth/browser-bootstrap",
+        "http://127.0.0.1:8742/auth/browser-bootstrap",
+    ]
+    assert delays == [
+        cli._MODEL_VIEWER_STARTUP_RETRY_SECONDS,
+        cli._MODEL_VIEWER_STARTUP_RETRY_SECONDS,
+    ]
+    assert len(opened) == 1
+
+
+def test_model_open_does_not_retry_authentication_failure(ac_root: Path, monkeypatch) -> None:
+    monkeypatch.setenv(LOCAL_API_TOKEN_ENV, "t" * 48)
+    calls: list[str] = []
+    delays: list[float] = []
+
+    def fake_post(url: str, **_kwargs):  # type: ignore[no-untyped-def]
+        calls.append(url)
+        return httpx.Response(
+            401,
+            json={"success": False, "error": "unauthorized"},
+            request=httpx.Request("POST", url),
+        )
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+    monkeypatch.setattr(cli.time, "sleep", delays.append)
+    monkeypatch.setattr(
+        webbrowser,
+        "open",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("browser opened")),
+    )
+
+    result = CliRunner().invoke(cli.app, ["model", "open"])
+
+    assert result.exit_code == 1
+    assert len(calls) == 1
+    assert delays == []
+    assert "authentication failed" in result.output
+    assert "HTTP 401" in result.output
+
+
+def test_model_open_startup_retry_is_bounded(ac_root: Path, monkeypatch) -> None:
+    monkeypatch.setenv(LOCAL_API_TOKEN_ENV, "t" * 48)
+    calls: list[str] = []
+    delays: list[float] = []
+
+    def connection_refused(url: str, **_kwargs):  # type: ignore[no-untyped-def]
+        calls.append(url)
+        raise httpx.ConnectError(
+            "daemon socket not bound",
+            request=httpx.Request("POST", url),
+        )
+
+    monkeypatch.setattr(httpx, "post", connection_refused)
+    monkeypatch.setattr(cli, "_daemon_lock_is_held", lambda: True)
+    monkeypatch.setattr(cli.time, "sleep", delays.append)
+
+    result = CliRunner().invoke(cli.app, ["model", "open"])
+
+    assert result.exit_code == 1
+    assert len(calls) == cli._MODEL_VIEWER_STARTUP_ATTEMPTS
+    assert len(delays) == cli._MODEL_VIEWER_STARTUP_ATTEMPTS - 1
+    assert "Could not authorize" in result.output
+
+
+def test_model_open_fails_immediately_when_runtime_is_stopped(ac_root: Path, monkeypatch) -> None:
+    monkeypatch.setenv(LOCAL_API_TOKEN_ENV, "t" * 48)
+    calls: list[str] = []
+    delays: list[float] = []
+
+    def connection_refused(url: str, **_kwargs):  # type: ignore[no-untyped-def]
+        calls.append(url)
+        raise httpx.ConnectError(
+            "daemon socket not bound",
+            request=httpx.Request("POST", url),
+        )
+
+    monkeypatch.setattr(httpx, "post", connection_refused)
+    monkeypatch.setattr(cli, "_daemon_lock_is_held", lambda: False)
+    monkeypatch.setattr(cli, "_read_pid", lambda: None)
+    monkeypatch.setattr(cli.time, "sleep", delays.append)
+
+    result = CliRunner().invoke(cli.app, ["model", "open"])
+
+    assert result.exit_code == 1
+    assert len(calls) == 1
+    assert delays == []
+    assert "Could not authorize" in result.output
+
+
+def test_background_start_probe_requires_authenticated_persome_identity(
+    ac_root: Path, monkeypatch
+) -> None:
+    token = "s" * 48
+    process = _runtime_process()
+    request: dict[str, object] = {}
+    monkeypatch.setenv(LOCAL_API_TOKEN_ENV, token)
+    monkeypatch.setattr(cli.runtime_pid, "resolve_recorded_process", lambda: process)
+
+    def fake_get(url: str, **kwargs):  # type: ignore[no-untyped-def]
+        request.update(url=url, **kwargs)
+        return httpx.Response(
+            200,
+            json={
+                "success": True,
+                "data": {
+                    "version": cli.__version__,
+                    "root": str(cli.paths.root()),
+                    "daemon": f"running pid {process.pid}",
+                },
+            },
+            request=httpx.Request("GET", url),
+        )
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    state, detail, observed = cli._probe_background_runtime(_http_runtime_config())
+
+    assert state == "ready"
+    assert "authenticated local HTTP Runtime" in detail
+    assert observed is process
+    assert request["url"] == "http://127.0.0.1:8742/status"
+    assert request["headers"] == {"Authorization": f"Bearer {token}"}
+    assert request["trust_env"] is False
+
+
+def test_background_start_probe_rejects_non_persome_service_on_port(
+    ac_root: Path, monkeypatch
+) -> None:
+    process = _runtime_process()
+    monkeypatch.setenv(LOCAL_API_TOKEN_ENV, "s" * 48)
+    monkeypatch.setattr(cli.runtime_pid, "resolve_recorded_process", lambda: process)
+    monkeypatch.setattr(
+        httpx,
+        "get",
+        lambda url, **_kwargs: httpx.Response(
+            200,
+            json={"status": "ok"},
+            request=httpx.Request("GET", url),
+        ),
+    )
+
+    state, detail, observed = cli._probe_background_runtime(_http_runtime_config())
+
+    assert state == "fatal"
+    assert "different or incompatible service" in detail
+    assert observed is process
+
+
+def test_background_start_wait_is_bounded_when_socket_never_binds(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        cli,
+        "_probe_background_runtime",
+        lambda _cfg, _expected=None: ("retry", "socket not bound", None),
+    )
+
+    ready, detail, process = cli._wait_for_background_start(
+        _http_runtime_config(), timeout_seconds=0
+    )
+
+    assert ready is False
+    assert "startup timed out" in detail
+    assert process is None
 
 
 def test_cli_client_installers_use_stdio_without_bearer(ac_root: Path, monkeypatch) -> None:

--- a/tests/test_cli_model.py
+++ b/tests/test_cli_model.py
@@ -1,0 +1,207 @@
+"""CLI coverage for one-shot personal-model operations."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from typer.testing import CliRunner
+
+from persome import cli, paths
+from persome import model as model_mod
+from persome.writer import correct as correct_mod
+from persome.writer import root_synthesis as root_synthesis_mod
+
+
+@pytest.mark.parametrize(
+    ("shell_value", "expected"),
+    [
+        (None, "key-from-owner-env"),
+        ("key-from-shell", "key-from-shell"),
+    ],
+    ids=["owner-env", "shell-precedence"],
+)
+def test_model_build_loads_runtime_env_before_llm_work(
+    ac_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    shell_value: str | None,
+    expected: str,
+) -> None:
+    """A standalone model build sees the saved key without a daemon process."""
+    env_path = paths.env_file()
+    env_path.write_text("PERSOME_LLM_API_KEY=key-from-owner-env\n", encoding="utf-8")
+    if shell_value is None:
+        # Track the initially absent variable so pytest restores it after the
+        # loader mutates os.environ directly.
+        monkeypatch.setenv("PERSOME_LLM_API_KEY", "temporary")
+        monkeypatch.delenv("PERSOME_LLM_API_KEY")
+    else:
+        monkeypatch.setenv("PERSOME_LLM_API_KEY", shell_value)
+
+    seen: list[str | None] = []
+
+    def fake_build(_cfg, **_kwargs):  # type: ignore[no-untyped-def]
+        seen.append(os.environ.get("PERSOME_LLM_API_KEY"))
+        return SimpleNamespace(
+            status="complete",
+            stages={
+                "cross_domain_sweeper": {
+                    "status": "complete",
+                    "pairs_probed": 8,
+                    "pairs_deferred": 3,
+                    "probe_limit": 8,
+                }
+            },
+            stats={
+                "points": 1,
+                "evolution_lines": 1,
+                "relation_lines": 0,
+                "faces": 1,
+                "volumes": 1,
+                "roots": 1,
+            },
+            manifest_path=paths.model_build_manifest(),
+        )
+
+    monkeypatch.setattr(model_mod, "run_model_build", fake_build)
+
+    result = CliRunner().invoke(cli.app, ["model", "build"])
+
+    assert result.exit_code == 0, result.output
+    assert seen == [expected]
+    assert "cross-domain: probed=8 deferred=3 limit=8" in result.output
+    assert "Deferred pairs stay queued" in result.output
+
+
+def test_model_build_cli_reports_integrity_recovery_block(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(cli, "_init", lambda: SimpleNamespace())
+    paths.atomic_write_private_text(
+        paths.integrity_config_recovery_pending(),
+        '{"version": 1, "phase": "authority_unresolved"}',
+    )
+
+    result = CliRunner().invoke(cli.app, ["model", "build"])
+
+    assert result.exit_code == 2
+    assert "model build blocked" in result.output
+    assert "recovery is incomplete" in result.output
+
+
+def test_model_export_without_build_manifest_is_truthfully_not_built(ac_root: Path) -> None:
+    output = ac_root / "model-export.json"
+
+    result = CliRunner().invoke(cli.app, ["model", "export", "--out", str(output)])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["build"]["status"] == "not_built"
+    assert payload["build"]["trigger"] == "no_completed_build"
+    assert payload["build"]["build_id"] is None
+
+
+def test_model_export_uses_one_transactionally_stable_snapshot(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output = ac_root / "stable-model-export.json"
+    sentinel = {"schema_version": 1, "source": "live-reader"}
+    calls: list[tuple[str, object]] = []
+
+    def fake_live_snapshot(_conn, *, redact=True):  # type: ignore[no-untyped-def]
+        calls.append(("read", redact))
+        return sentinel
+
+    def fake_export(_conn, *, out_path, snapshot_data, **_kwargs):  # type: ignore[no-untyped-def]
+        calls.append(("write", snapshot_data))
+        out_path.write_text("{}\n", encoding="utf-8")
+        return out_path
+
+    monkeypatch.setattr(model_mod, "build_live_snapshot", fake_live_snapshot)
+    monkeypatch.setattr(model_mod, "export_snapshot", fake_export)
+
+    result = CliRunner().invoke(cli.app, ["model", "export", "--out", str(output)])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [("read", True), ("write", sentinel)]
+
+
+def test_root_synth_loads_runtime_env(ac_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    paths.env_file().write_text("PERSOME_LLM_API_KEY=key-for-root\n", encoding="utf-8")
+    monkeypatch.setenv("PERSOME_LLM_API_KEY", "temporary")
+    monkeypatch.delenv("PERSOME_LLM_API_KEY")
+    seen: list[str | None] = []
+
+    def fake_synthesis(_cfg, _conn):  # type: ignore[no-untyped-def]
+        seen.append(os.environ.get("PERSOME_LLM_API_KEY"))
+        return SimpleNamespace(reason="written", face_id="root-test")
+
+    monkeypatch.setattr(root_synthesis_mod, "synthesize_root", fake_synthesis)
+
+    result = CliRunner().invoke(cli.app, ["root-synth"])
+
+    assert result.exit_code == 0, result.output
+    assert seen == ["key-for-root"]
+
+
+def test_correct_loads_runtime_env(ac_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    paths.env_file().write_text("PERSOME_LLM_API_KEY=key-for-correction\n", encoding="utf-8")
+    monkeypatch.setenv("PERSOME_LLM_API_KEY", "temporary")
+    monkeypatch.delenv("PERSOME_LLM_API_KEY")
+    seen: list[str | None] = []
+
+    def fake_update(_cfg, _conn, _correction, **_kwargs):  # type: ignore[no-untyped-def]
+        seen.append(os.environ.get("PERSOME_LLM_API_KEY"))
+        return SimpleNamespace(kind="updated", ok=True, applied=[], reason="")
+
+    monkeypatch.setattr(correct_mod, "update_memory", fake_update)
+
+    result = CliRunner().invoke(cli.app, ["correct", "This is a test correction."])
+
+    assert result.exit_code == 0, result.output
+    assert seen == ["key-for-correction"]
+
+
+def test_model_status_rejects_incomplete_completed_manifest(ac_root: Path) -> None:
+    paths.atomic_write_private_text(
+        paths.model_build_manifest(),
+        json.dumps({"status": "complete", "build_id": "incomplete"}),
+    )
+
+    result = CliRunner().invoke(cli.app, ["model", "status"])
+
+    assert result.exit_code == 0, result.output
+    assert "model: not built" in result.output
+    assert "no_completed_build" in result.output
+    assert "build status: not_built" in result.output
+    assert "last build: none" in result.output
+
+
+def test_model_status_reports_active_build(ac_root: Path) -> None:
+    coordinator = model_mod.ModelBuildCoordinator()
+    with coordinator.acquire(wait_seconds=0):
+        paths.atomic_write_private_text(
+            paths.model_build_manifest(),
+            json.dumps(
+                {
+                    "build_id": None,
+                    "status": "building",
+                    "trigger": "test-cli",
+                    "started_at": "2026-07-12T08:00:00+00:00",
+                    "completed_at": None,
+                    "duration_ms": 0,
+                    "degraded_stages": [],
+                }
+            ),
+        )
+
+        result = CliRunner().invoke(cli.app, ["model", "status"])
+
+    assert result.exit_code == 0, result.output
+    assert "model: building" in result.output
+    assert "build_in_progress" in result.output
+    assert "build status: building" in result.output
+    assert "last build: none" in result.output

--- a/tests/test_cross_domain_sweeper.py
+++ b/tests/test_cross_domain_sweeper.py
@@ -10,6 +10,7 @@ from persome.config import Config
 from persome.model import schema_reader
 from persome.store import entries as entries_mod
 from persome.store import files as files_mod
+from persome.store import schema_faces
 from persome.timeline import store as timeline_store
 from persome.writer import cross_domain_sweeper as sweeper
 from persome.writer import schema_miner_stage as stage
@@ -218,6 +219,277 @@ def test_no_collision_writes_nothing(ac_root):
         assert res.written_count == 0
         assert res.collisions == 0
         assert res.pairs_probed == 1  # ungrounded → pre-filter passes; LLM said no
+
+
+def test_probe_budget_is_hard_and_pair_order_is_deterministic(ac_root):
+    from persome.store import fts
+
+    with fts.cursor() as conn:
+        # Seed out of lexical order: scheduling must not inherit insertion or
+        # timestamp order from the entries projection.
+        for name, central in (
+            ("schema-gamma.md", "Repeatedly sample while tuning databases"),
+            ("schema-alpha.md", "Collect maps before planning travel"),
+            ("schema-delta.md", "Verify experience before hiring interviews"),
+            ("schema-beta.md", "Track heart rate throughout training"),
+        ):
+            _seed_schema(conn, name, central, [f"Inference derived from: {central}"])
+
+        probed: list[str] = []
+
+        def fake(messages):
+            probed.append(messages[1]["content"])
+            return _fake_llm({"detected": False})(messages)
+
+        result = sweeper.sweep_cross_domain(Config(), conn, max_probes=2, llm_call=fake)
+
+        assert result.pairs_considered == 6
+        assert result.eligible_pairs == 6
+        assert result.probe_limit == 2
+        assert result.pairs_probed == 2
+        assert result.pairs_deferred == 4
+        assert len(probed) == 2
+        assert "## Schema A (topic: alpha.md)" in probed[0]
+        assert "## Schema B (topic: beta.md)" in probed[0]
+        assert "## Schema A (topic: alpha.md)" in probed[1]
+        assert "## Schema B (topic: delta.md)" in probed[1]
+
+
+def test_deferred_pairs_rotate_into_later_builds(ac_root):
+    from persome.store import fts
+
+    with fts.cursor() as conn:
+        for name, central in (
+            ("schema-alpha.md", "Collect maps before travel"),
+            ("schema-beta.md", "Track heart rate during training"),
+            ("schema-delta.md", "Verify experience before interviews"),
+            ("schema-gamma.md", "Sample repeatedly while tuning"),
+        ):
+            _seed_schema(conn, name, central, [f"Inference from {central}"])
+
+        first: list[str] = []
+        second: list[str] = []
+
+        def record(target):  # type: ignore[no-untyped-def]
+            def fake(messages):  # type: ignore[no-untyped-def]
+                target.append(messages[1]["content"])
+                return _fake_llm({"detected": False})(messages)
+
+            return fake
+
+        one = sweeper.sweep_cross_domain(Config(), conn, max_probes=2, llm_call=record(first))
+        two = sweeper.sweep_cross_domain(Config(), conn, max_probes=2, llm_call=record(second))
+
+        assert one.pairs_deferred == 4
+        assert two.pairs_deferred == 4
+        assert len(first) == len(second) == 2
+        assert set(first).isdisjoint(second)
+
+
+def test_shadow_volume_is_reprobed_first_and_promoted_without_weakening_gate(ac_root):
+    from persome.store import fts
+
+    with fts.cursor() as conn:
+        _seed_schema(conn, "schema-alpha.md", "Check maps before travel", ["Confirm routes early"])
+        _seed_schema(
+            conn,
+            "schema-beta.md",
+            "Track heart rate during training",
+            ["Adjust intensity from measurements"],
+        )
+        _seed_schema(
+            conn,
+            "schema-gamma.md",
+            "Repeat samples while tuning",
+            ["Collect measurements before deciding"],
+        )
+
+        shadow_id = schema_faces.record_face(
+            conn,
+            source=schema_faces.PROVENANCE_EMERGENT,
+            signature="Measure continuously before adjusting",
+            members=["schema-beta.md", "schema-gamma.md"],
+            confidence=0.82,
+            level=2,
+        )
+        before = conn.execute(
+            "SELECT status, observations FROM schema_faces WHERE face_id = ?", (shadow_id,)
+        ).fetchone()
+        assert tuple(before) == ("shadow", 1)
+
+        probed: list[str] = []
+
+        def fake(messages):
+            probed.append(messages[1]["content"])
+            return _fake_llm(
+                {
+                    "detected": True,
+                    "central_proposition": "Measure continuously before adjusting",
+                    "supporting_summary": "Both domains use measurement loops to guide changes",
+                    "expected_inferences": ["Samples before acting under uncertainty"],
+                    "confidence": 0.84,
+                }
+            )(messages)
+
+        result = sweeper.sweep_cross_domain(Config(), conn, max_probes=1, llm_call=fake)
+
+        assert result.eligible_pairs == 3
+        assert result.pairs_probed == 1
+        assert result.pairs_deferred == 2
+        assert len(probed) == 1
+        assert "topic: beta.md" in probed[0] and "topic: gamma.md" in probed[0]
+        after = conn.execute(
+            "SELECT status, observations, footprints FROM schema_faces WHERE face_id = ?",
+            (shadow_id,),
+        ).fetchone()
+        assert after[0] == "active"
+        assert after[1] == 2
+        assert len(json.loads(after[2])) == 2
+
+
+def test_negative_shadow_retry_yields_budget_to_every_unseen_pair(ac_root):
+    """A stale shadow gets one priority retry, then joins the rotating queue."""
+    from persome.store import fts
+
+    with fts.cursor() as conn:
+        for name, central in (
+            ("schema-alpha.md", "Check maps before travel"),
+            ("schema-beta.md", "Track heart rate during training"),
+            ("schema-delta.md", "Verify experience before interviews"),
+            ("schema-gamma.md", "Repeat samples while tuning databases"),
+        ):
+            _seed_schema(conn, name, central, [f"Inference from {central}"])
+
+        shadow_id = schema_faces.record_face(
+            conn,
+            source=schema_faces.PROVENANCE_EMERGENT,
+            signature="Prepare with measurements before committing",
+            members=["schema-alpha.md", "schema-beta.md"],
+            confidence=0.82,
+            level=2,
+        )
+        probed: list[str] = []
+
+        def reject(messages):  # type: ignore[no-untyped-def]
+            probed.append(messages[1]["content"])
+            return _fake_llm({"detected": False})(messages)
+
+        # Four schemas produce six eligible pairs. The shadow consumes the
+        # first one-probe build, then its negative result must let each of the
+        # five unseen pairs run in the next five builds.
+        for _ in range(6):
+            result = sweeper.sweep_cross_domain(Config(), conn, max_probes=1, llm_call=reject)
+            assert result.eligible_pairs == 6
+            assert result.pairs_probed == 1
+
+        assert "topic: alpha.md" in probed[0] and "topic: beta.md" in probed[0]
+        assert len(set(probed)) == 6
+        history = conn.execute(
+            "SELECT probe_count, detected FROM cross_domain_probe_state WHERE pair_key = ?",
+            (sweeper._pair_key("schema-alpha.md", "schema-beta.md"),),
+        ).fetchone()
+        assert tuple(history) == (1, 0)
+        shadow = conn.execute(
+            "SELECT status, observations FROM schema_faces WHERE face_id = ?",
+            (shadow_id,),
+        ).fetchone()
+        assert tuple(shadow) == ("shadow", 1)
+
+
+def test_probe_history_write_failure_does_not_abort_sweep(ac_root, monkeypatch):
+    from persome.store import fts
+
+    with fts.cursor() as conn:
+        _seed_schema(conn, "schema-alpha.md", "Check maps before travel", ["Confirm routes"])
+        _seed_schema(
+            conn,
+            "schema-beta.md",
+            "Track heart rate during training",
+            ["Adjust from measurements"],
+        )
+        monkeypatch.setattr(
+            sweeper,
+            "_record_probe",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("history unavailable")),
+        )
+
+        result = sweeper.sweep_cross_domain(
+            Config(),
+            conn,
+            max_probes=1,
+            llm_call=_fake_llm({"detected": False}),
+        )
+
+    assert result.pairs_probed == 1
+    assert result.written == []
+
+
+def test_failed_volume_evidence_is_not_recorded_as_promotable(ac_root, monkeypatch):
+    from persome.store import fts
+
+    with fts.cursor() as conn:
+        _seed_schema(conn, "schema-alpha.md", "Check maps before travel", ["Confirm routes"])
+        _seed_schema(
+            conn,
+            "schema-beta.md",
+            "Track heart rate during training",
+            ["Adjust from measurements"],
+        )
+        monkeypatch.setattr(
+            schema_faces,
+            "record_face",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("face write failed")),
+        )
+        collision = _fake_llm(
+            {
+                "detected": True,
+                "central_proposition": "Measure before adjusting",
+                "supporting_summary": "Both domains gather evidence first",
+                "expected_inferences": ["Samples before acting"],
+                "confidence": 0.9,
+            }
+        )
+
+        result = sweeper.sweep_cross_domain(Config(), conn, max_probes=1, llm_call=collision)
+        history = conn.execute("SELECT detected FROM cross_domain_probe_state").fetchone()
+
+    assert result.written == []
+    assert history is not None and history[0] == 0
+
+
+def test_repeated_low_confidence_collision_never_promotes_volume(ac_root):
+    from persome.store import fts
+
+    with fts.cursor() as conn:
+        _seed_schema(conn, "schema-alpha.md", "Check maps before travel", ["Confirm routes"])
+        _seed_schema(
+            conn,
+            "schema-beta.md",
+            "Track heart rate during training",
+            ["Adjust from measurements"],
+        )
+        fake = _fake_llm(
+            {
+                "detected": True,
+                "central_proposition": "Measure before adjusting",
+                "supporting_summary": "Both domains gather evidence first",
+                "expected_inferences": ["Samples before acting"],
+                "confidence": 0.3,
+            }
+        )
+
+        first = sweeper.sweep_cross_domain(Config(), conn, llm_call=fake)
+        second = sweeper.sweep_cross_domain(Config(), conn, llm_call=fake)
+
+        assert [first.written[0].status, second.written[0].status] == ["forming", "forming"]
+        assert (
+            conn.execute(
+                "SELECT count(*) FROM schema_faces WHERE level=2 AND status='active'"
+            ).fetchone()[0]
+            == 0
+        )
+        assert conn.execute("SELECT count(*) FROM schema_faces WHERE level=2").fetchone()[0] == 0
+        assert conn.execute("SELECT detected FROM cross_domain_probe_state").fetchone()[0] == 0
 
 
 def test_fewer_than_two_schemas_is_noop(ac_root):

--- a/tests/test_env_file.py
+++ b/tests/test_env_file.py
@@ -34,6 +34,23 @@ def test_does_not_overwrite_existing(tmp_path: Path, monkeypatch: pytest.MonkeyP
     assert os.environ["KEEP_ME"] == "shell-wins"
 
 
+def test_owner_env_cannot_redirect_persome_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A file under one root cannot redirect initialization to another root."""
+    monkeypatch.delenv("PERSOME_ROOT", raising=False)
+    monkeypatch.delenv("SAFE_OWNER_KEY", raising=False)
+    path = tmp_path / "env"
+    path.write_text(
+        f"PERSOME_ROOT={tmp_path / 'different-root'}\nSAFE_OWNER_KEY=loaded\n",
+        encoding="utf-8",
+    )
+
+    assert load_env_file(path) == 1
+    assert "PERSOME_ROOT" not in os.environ
+    assert os.environ["SAFE_OWNER_KEY"] == "loaded"
+
+
 def test_comments_blanks_and_quotes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     for name in ("A_KEY", "B_KEY", "C_KEY"):
         monkeypatch.delenv(name, raising=False)
@@ -130,7 +147,10 @@ def test_ensure_screenshot_key_replaces_invalid_duplicates(tmp_path: Path) -> No
     assert env_file.is_valid_screenshot_key(canonical[0])
 
 
-def test_ensure_local_api_token_generates_owner_only_secret(tmp_path: Path) -> None:
+def test_ensure_local_api_token_generates_owner_only_secret(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(env_file.LOCAL_API_TOKEN_ENV, raising=False)
     path = tmp_path / "env"
     path.write_text("KEEP=yes\n", encoding="utf-8")
 
@@ -146,7 +166,10 @@ def test_ensure_local_api_token_generates_owner_only_secret(tmp_path: Path) -> N
     assert "KEEP=yes" in path.read_text(encoding="utf-8")
 
 
-def test_ensure_local_api_token_preserves_valid_value(tmp_path: Path) -> None:
+def test_ensure_local_api_token_preserves_valid_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(env_file.LOCAL_API_TOKEN_ENV, raising=False)
     path = tmp_path / "env"
     original = "local-token-" + "a" * 40
     path.write_text(f"{env_file.LOCAL_API_TOKEN_ENV}={original}\n", encoding="utf-8")
@@ -157,7 +180,10 @@ def test_ensure_local_api_token_preserves_valid_value(tmp_path: Path) -> None:
     assert original in path.read_text(encoding="utf-8")
 
 
-def test_ensure_local_api_token_replaces_invalid_duplicates(tmp_path: Path) -> None:
+def test_ensure_local_api_token_replaces_invalid_duplicates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(env_file.LOCAL_API_TOKEN_ENV, raising=False)
     path = tmp_path / "env"
     path.write_text(
         f"{env_file.LOCAL_API_TOKEN_ENV}=short\n{env_file.LOCAL_API_TOKEN_ENV}=also-short\n",
@@ -174,7 +200,7 @@ def test_ensure_local_api_token_replaces_invalid_duplicates(tmp_path: Path) -> N
     assert env_file.is_valid_local_api_token(values[0])
 
 
-def test_ensure_local_api_token_preserves_shell_override(
+def test_ensure_local_api_token_persists_shell_override_as_canonical(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     path = tmp_path / "env"
@@ -186,4 +212,78 @@ def test_ensure_local_api_token_preserves_shell_override(
     assert env_file.ensure_local_api_token(path) == "existing"
 
     assert os.environ[env_file.LOCAL_API_TOKEN_ENV] == shell_token
-    assert file_token in path.read_text(encoding="utf-8")
+    payload = path.read_text(encoding="utf-8")
+    assert f"{env_file.LOCAL_API_TOKEN_ENV}={shell_token}" in payload
+    assert file_token not in payload
+
+    # A later process without the original shell export must load the same
+    # credential the daemon used at startup.
+    monkeypatch.delenv(env_file.LOCAL_API_TOKEN_ENV)
+    assert env_file.load_env_file(path) == 1
+    assert os.environ[env_file.LOCAL_API_TOKEN_ENV] == shell_token
+
+
+@pytest.mark.parametrize(
+    "unsafe_shell_token",
+    [
+        '"' + "q" * 40 + '"',
+        "'" + "q" * 40 + "'",
+        "q" * 40 + "+",
+        chr(233) * 32,
+    ],
+    ids=["double-quoted", "single-quoted", "non-url-safe", "non-ascii"],
+)
+def test_ensure_local_api_token_repairs_non_reversible_shell_value(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    unsafe_shell_token: str,
+) -> None:
+    path = tmp_path / "env"
+    monkeypatch.setenv(env_file.LOCAL_API_TOKEN_ENV, unsafe_shell_token)
+
+    assert env_file.ensure_local_api_token(path) == "generated"
+
+    disk_value = path.read_text(encoding="utf-8").strip().partition("=")[2]
+    assert env_file.is_valid_local_api_token(disk_value)
+    assert disk_value != unsafe_shell_token
+    assert os.environ[env_file.LOCAL_API_TOKEN_ENV] == disk_value
+
+    # Simulate a later CLI process: the byte-for-byte same canonical token is
+    # recovered, so the daemon and browser client cannot diverge.
+    monkeypatch.delenv(env_file.LOCAL_API_TOKEN_ENV)
+    assert env_file.load_env_file(path) == 1
+    assert os.environ[env_file.LOCAL_API_TOKEN_ENV] == disk_value
+
+
+def test_ensure_local_api_token_repairs_invalid_process_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "env"
+    path.write_text(
+        f"{env_file.LOCAL_API_TOKEN_ENV}=short\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(env_file.LOCAL_API_TOKEN_ENV, "also-short")
+
+    assert env_file.ensure_local_api_token(path) == "generated"
+
+    disk_value = path.read_text(encoding="utf-8").strip().partition("=")[2]
+    assert env_file.is_valid_local_api_token(disk_value)
+    assert os.environ[env_file.LOCAL_API_TOKEN_ENV] == disk_value
+
+
+def test_invalid_file_token_cannot_survive_load_then_provision(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "env"
+    path.write_text(f"{env_file.LOCAL_API_TOKEN_ENV}=short\n", encoding="utf-8")
+    monkeypatch.setenv(env_file.LOCAL_API_TOKEN_ENV, "temporary")
+    monkeypatch.delenv(env_file.LOCAL_API_TOKEN_ENV)
+
+    assert env_file.load_env_file(path) == 1
+    assert os.environ[env_file.LOCAL_API_TOKEN_ENV] == "short"
+    assert env_file.ensure_local_api_token(path) == "generated"
+
+    disk_value = path.read_text(encoding="utf-8").strip().partition("=")[2]
+    assert env_file.is_valid_local_api_token(disk_value)
+    assert os.environ[env_file.LOCAL_API_TOKEN_ENV] == disk_value

--- a/tests/test_evomem/test_inversion.py
+++ b/tests/test_evomem/test_inversion.py
@@ -8,6 +8,7 @@ import pytest
 
 from persome.evomem import integrity as evo_integrity
 from persome.evomem import inversion as evo_inversion
+from persome.evomem.models import MemoryLayer, MemoryNode
 from persome.store import entries, fts
 from persome.store import files as files_mod
 
@@ -243,6 +244,59 @@ def test_shadow_write_disabled_under_evomem_authority(
             "SELECT COUNT(*) c FROM evo_nodes WHERE file_name LIKE 'skill%'"
         ).fetchone()["c"]
     assert rows == 0
+
+
+def test_nested_skill_stays_direct_markdown_with_initialized_shadow(ac_root: Path) -> None:
+    from persome.evomem.store import NodeStore
+
+    NodeStore().save(
+        MemoryNode(
+            node_id="baseline-node",
+            content="baseline",
+            layer=MemoryLayer.L2_FACT,
+            file_name="project-baseline.md",
+        )
+    )
+    with fts.cursor() as conn:
+        entries.create_file(conn, name="skills/skill-shadow.md", description="d", tags=[])
+        entry_id = entries.append_entry(
+            conn,
+            name="skills/skill-shadow.md",
+            content="direct markdown skill",
+            tags=[],
+        )
+        count = conn.execute(
+            "SELECT count(*) FROM evo_nodes WHERE node_id=?", (entry_id,)
+        ).fetchone()[0]
+
+    assert count == 0
+
+
+def test_markdown_shadow_uses_canonical_filename_when_suffix_is_omitted(ac_root: Path) -> None:
+    from persome.evomem.store import NodeStore
+
+    NodeStore().save(
+        MemoryNode(
+            node_id="baseline-node",
+            content="baseline",
+            layer=MemoryLayer.L2_FACT,
+            file_name="project-baseline.md",
+        )
+    )
+    with fts.cursor() as conn:
+        entries.create_file(conn, name="project-no-suffix", description="d", tags=[])
+        entry_id = entries.append_entry(
+            conn,
+            name="project-no-suffix",
+            content="canonical shadow identity",
+            tags=[],
+        )
+        row = conn.execute(
+            "SELECT file_name FROM evo_nodes WHERE node_id=?", (entry_id,)
+        ).fetchone()
+
+    assert row is not None
+    assert row["file_name"] == "project-no-suffix.md"
 
 
 def test_rollback_flip_back_restores_legacy_path_and_shadow(

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -5,13 +5,19 @@ from __future__ import annotations
 import json
 import sqlite3
 import time
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
 
 from persome import config as config_mod
 from persome import integrity, paths
-from persome.store import entries, fts
+from persome.evomem import backup
+from persome.evomem.models import MemoryLayer, MemoryNode
+from persome.evomem.store import NodeStore
+from persome.model import create_build_manifest, load_live_manifest
+from persome.store import entries, fts, relation_edges, schema_faces
+from persome.store import files as files_mod
 
 
 def _make_healthy_db() -> Path:
@@ -19,6 +25,19 @@ def _make_healthy_db() -> Path:
     with fts.cursor() as conn:
         conn.execute("SELECT 1")
     return paths.index_db()
+
+
+def _pending_payload(db: Path, quarantine: Path, *, reason: str) -> dict[str, object]:
+    return {
+        "version": 1,
+        "phase": "prepared",
+        "started_at": "2026-07-12T10:00:00+08:00",
+        "original_path": str(db),
+        "quarantine_path": str(quarantine),
+        "reason": reason,
+        "authority_unknown": False,
+        "manifest_was_present": True,
+    }
 
 
 def test_healthy_db_and_config_are_not_quarantined(ac_root: Path) -> None:
@@ -43,6 +62,10 @@ def test_missing_files_are_not_corruption(ac_root: Path) -> None:
 
     assert recovered == []
     assert not paths.integrity_recovery_marker().exists()
+    assert not paths.integrity_recovery_pending().exists()
+    assert not paths.integrity_config_recovery_pending().exists()
+    assert not paths.index_db().exists()
+    assert not paths.config_file().exists()
 
 
 def test_empty_db_file_is_treated_as_healthy(ac_root: Path) -> None:
@@ -72,6 +95,1654 @@ def test_corrupt_db_is_quarantined_and_rebuilt(ac_root: Path) -> None:
     with fts.cursor() as conn:
         rows = conn.execute("PRAGMA integrity_check").fetchall()
     assert [r[0] for r in rows] == ["ok"]
+
+
+def test_corrupt_db_replays_memory_and_invalidates_stale_model_build(ac_root: Path) -> None:
+    with fts.cursor() as conn:
+        entries.create_file(
+            conn,
+            name="project-recovery.md",
+            description="Database recovery proof",
+            tags=["recovery"],
+        )
+        entry_id = entries.append_entry(
+            conn,
+            name="project-recovery.md",
+            content="Durable memory survives full database quarantine.",
+            tags=["recovery"],
+        )
+    paths.atomic_write_private_text(
+        paths.model_build_manifest(),
+        json.dumps({"status": "complete", "build_id": "stale-build"}),
+    )
+    paths.index_db().write_bytes(b"not-a-sqlite-database" * 100)
+
+    recovered = integrity.check_and_recover()
+
+    assert [item.kind for item in recovered] == ["database"]
+    assert not paths.model_build_manifest().exists()
+    with fts.cursor() as conn:
+        row = conn.execute(
+            "SELECT content FROM entries WHERE id=?",
+            (entry_id,),
+        ).fetchone()
+        node = conn.execute(
+            "SELECT content FROM evo_nodes WHERE node_id=?",
+            (entry_id,),
+        ).fetchone()
+    assert row is not None and row[0] == "Durable memory survives full database quarantine."
+    assert node is not None and node[0] == row[0]
+
+    marker = json.loads(paths.integrity_recovery_marker().read_text())
+    database = marker["database_recovery"]
+    assert database["status"] == "restored"
+    assert database["source"] == "markdown"
+    assert database["nodes"] == 1
+    assert database["projection_entries"] == 1
+    assert database["model_rebuild_required"] is True
+    assert database["stale_manifest_was_present"] is True
+    assert database["manifest_invalidated"] is True
+    assert database["lossy"] is True
+    assert "structural_geometry" in database["not_recovered_without_snapshot"]
+
+
+def test_corrupt_db_replays_projection_under_evomem_authority(ac_root: Path) -> None:
+    config_mod.write_default_if_missing()
+    with fts.cursor() as conn:
+        entries.create_file(
+            conn,
+            name="project-evomem-recovery.md",
+            description="Evomem recovery proof",
+            tags=[],
+        )
+        entry_id = entries.append_entry(
+            conn,
+            name="project-evomem-recovery.md",
+            content="The projected graph can be restored as canonical state.",
+            tags=[],
+        )
+    config_text = paths.config_file().read_text(encoding="utf-8")
+    assert 'write_authority = "markdown"' in config_text
+    paths.atomic_write_private_text(
+        paths.config_file(),
+        config_text.replace('write_authority = "markdown"', 'write_authority = "evomem"'),
+    )
+    paths.index_db().write_bytes(b"evomem-database-corruption" * 100)
+
+    integrity.check_and_recover()
+
+    with fts.cursor() as conn:
+        entry = conn.execute("SELECT content FROM entries WHERE id=?", (entry_id,)).fetchone()
+        node = conn.execute("SELECT content FROM evo_nodes WHERE node_id=?", (entry_id,)).fetchone()
+    assert (
+        entry is not None and entry[0] == "The projected graph can be restored as canonical state."
+    )
+    assert node is not None and node[0] == entry[0]
+    marker = json.loads(paths.integrity_recovery_marker().read_text())
+    assert marker["database_recovery"]["status"] == "restored"
+
+
+@pytest.mark.parametrize(
+    "config_state",
+    ["valid", "corrupt", "missing"],
+    ids=["evomem-config", "corrupt-config", "missing-config"],
+)
+def test_verified_snapshot_wins_over_stale_markdown_when_markdown_is_not_known_authority(
+    ac_root: Path,
+    config_state: str,
+) -> None:
+    config_mod.write_default_if_missing()
+    with fts.cursor() as conn:
+        entries.create_file(
+            conn,
+            name="project-canonical-snapshot.md",
+            description="Canonical snapshot proof",
+            tags=[],
+        )
+        entry_id = entries.append_entry(
+            conn,
+            name="project-canonical-snapshot.md",
+            content="STALE MARKDOWN PROJECTION",
+            tags=[],
+        )
+    NodeStore().save(
+        MemoryNode(
+            node_id=entry_id,
+            content="CANONICAL SNAPSHOT VALUE",
+            layer=MemoryLayer.L2_FACT,
+            file_name="project-canonical-snapshot.md",
+        )
+    )
+    config_text = paths.config_file().read_text(encoding="utf-8")
+    paths.atomic_write_private_text(
+        paths.config_file(),
+        config_text.replace('write_authority = "markdown"', 'write_authority = "  EVOMEM  "'),
+    )
+    snapshot = backup.create_snapshot(
+        now=datetime(2026, 7, 12, 9, 0, tzinfo=UTC),
+        structural_only=True,
+    )
+    assert snapshot is not None
+    if config_state == "corrupt":
+        paths.config_file().write_text("[[[ corrupt config", encoding="utf-8")
+    elif config_state == "missing":
+        paths.config_file().unlink()
+    paths.index_db().write_bytes(b"evomem-database-corruption" * 100)
+
+    integrity.check_and_recover()
+
+    with fts.cursor() as conn:
+        node = conn.execute("SELECT content FROM evo_nodes WHERE node_id=?", (entry_id,)).fetchone()
+        entry = conn.execute("SELECT content FROM entries WHERE id=?", (entry_id,)).fetchone()
+    assert node is not None and node[0] == "CANONICAL SNAPSHOT VALUE"
+    assert entry is not None
+    assert "STALE MARKDOWN PROJECTION" in (
+        paths.memory_dir() / "project-canonical-snapshot.md"
+    ).read_text(encoding="utf-8")
+    database = json.loads(paths.integrity_recovery_marker().read_text())["database_recovery"]
+    if config_state == "valid":
+        assert entry[0] == node[0]
+        assert config_mod.load().evomem.write_authority.strip().lower() == "evomem"
+        with fts.cursor() as conn:
+            entries.rebuild_index(conn)
+            rebuilt = conn.execute("SELECT content FROM entries WHERE id=?", (entry_id,)).fetchone()
+        assert rebuilt is not None and rebuilt[0] == "CANONICAL SNAPSHOT VALUE"
+        assert database["status"] == "restored"
+        assert database["source"] == "verified_snapshot"
+        assert database["write_authority"] == "evomem"
+        assert database["canonical_source"] == "verified_snapshot"
+    else:
+        assert entry[0] == "STALE MARKDOWN PROJECTION"
+        assert config_mod.load().evomem.write_authority == "unknown"
+        assert paths.integrity_recovery_pending().exists()
+        assert paths.integrity_config_recovery_pending().exists()
+        assert database["status"] == "partial"
+        assert database["authority_resolution_required"] is True
+
+
+def test_unknown_authority_snapshot_preserves_lagging_shadow_until_owner_chooses(
+    ac_root: Path,
+) -> None:
+    config_mod.write_default_if_missing()
+    with fts.cursor() as conn:
+        entries.create_file(
+            conn,
+            name="project-snapshot-authority.md",
+            description="Snapshot authority ambiguity",
+            tags=[],
+        )
+        entry_id = entries.append_entry(
+            conn,
+            name="project-snapshot-authority.md",
+            content="MARKDOWN CANONICAL CANDIDATE",
+            tags=[],
+        )
+    NodeStore().save(
+        MemoryNode(
+            node_id=entry_id,
+            content="LAGGING EVOMEM SHADOW CANDIDATE",
+            layer=MemoryLayer.L2_FACT,
+            file_name="project-snapshot-authority.md",
+        )
+    )
+    snapshot = backup.create_snapshot(
+        now=datetime(2026, 7, 12, 9, 0, tzinfo=UTC),
+        structural_only=True,
+    )
+    assert snapshot is not None
+    paths.config_file().write_text("[[[ corrupt config", encoding="utf-8")
+    paths.index_db().write_bytes(b"snapshot-authority-corruption" * 100)
+
+    integrity.check_and_recover()
+
+    assert config_mod.load().evomem.write_authority == "unknown"
+    assert paths.integrity_config_recovery_pending().exists()
+    assert paths.integrity_recovery_pending().exists()
+    with fts.cursor() as conn:
+        entry = conn.execute("SELECT content FROM entries WHERE id=?", (entry_id,)).fetchone()
+        node = conn.execute("SELECT content FROM evo_nodes WHERE node_id=?", (entry_id,)).fetchone()
+    assert entry is not None and entry[0] == "MARKDOWN CANONICAL CANDIDATE"
+    assert node is not None and node[0] == "LAGGING EVOMEM SHADOW CANDIDATE"
+    assert "MARKDOWN CANONICAL CANDIDATE" in (
+        paths.memory_dir() / "project-snapshot-authority.md"
+    ).read_text(encoding="utf-8")
+    database = json.loads(paths.integrity_recovery_marker().read_text())["database_recovery"]
+    assert database["status"] == "partial"
+    assert database["authority_resolution_required"] is True
+    assert database["preserved_authority_sources"] == [
+        "snapshot_entries",
+        "snapshot_evo_nodes",
+        "current_markdown",
+    ]
+
+
+def test_config_recovery_intent_closes_crash_gap_before_database_journal(
+    ac_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_mod.write_default_if_missing()
+    with fts.cursor() as conn:
+        entries.create_file(
+            conn,
+            name="project-config-crash-gap.md",
+            description="Config crash-gap proof",
+            tags=[],
+        )
+        entry_id = entries.append_entry(
+            conn,
+            name="project-config-crash-gap.md",
+            content="STALE MARKDOWN AFTER CONFIG CRASH",
+            tags=[],
+        )
+    NodeStore().save(
+        MemoryNode(
+            node_id=entry_id,
+            content="CANONICAL SNAPSHOT AFTER CONFIG CRASH",
+            layer=MemoryLayer.L2_FACT,
+            file_name="project-config-crash-gap.md",
+        )
+    )
+    config_text = paths.config_file().read_text(encoding="utf-8")
+    paths.atomic_write_private_text(
+        paths.config_file(),
+        config_text.replace('write_authority = "markdown"', 'write_authority = "evomem"'),
+    )
+    snapshot = backup.create_snapshot(
+        now=datetime(2026, 7, 12, 9, 0, tzinfo=UTC),
+        structural_only=True,
+    )
+    assert snapshot is not None
+    paths.index_db().write_bytes(b"database-corrupt-during-config-recovery" * 100)
+    paths.config_file().write_text("[[[ corrupt config", encoding="utf-8")
+
+    def _crash_before_database_journal(_payload: dict[str, object]) -> None:
+        raise KeyboardInterrupt("synthetic process crash")
+
+    with monkeypatch.context() as crash:
+        crash.setattr(integrity, "_write_pending_recovery", _crash_before_database_journal)
+        with pytest.raises(KeyboardInterrupt, match="synthetic process crash"):
+            integrity.check_and_recover()
+
+    assert paths.integrity_config_recovery_pending().exists()
+    assert not paths.integrity_recovery_pending().exists()
+    assert config_mod.load().models["default"].model
+
+    recovered = integrity.check_and_recover()
+
+    assert sorted(item.kind for item in recovered) == ["config", "database"]
+    assert paths.integrity_config_recovery_pending().exists()
+    assert paths.integrity_recovery_pending().exists()
+    assert config_mod.load().evomem.write_authority == "unknown"
+    with fts.cursor() as conn:
+        node = conn.execute("SELECT content FROM evo_nodes WHERE node_id=?", (entry_id,)).fetchone()
+        entry = conn.execute("SELECT content FROM entries WHERE id=?", (entry_id,)).fetchone()
+    assert node is not None and node[0] == "CANONICAL SNAPSHOT AFTER CONFIG CRASH"
+    assert entry is not None and entry[0] == "STALE MARKDOWN AFTER CONFIG CRASH"
+
+    config_text = paths.config_file().read_text(encoding="utf-8")
+    paths.atomic_write_private_text(
+        paths.config_file(),
+        config_text.replace('write_authority = "unknown"', 'write_authority = "evomem"'),
+    )
+    integrity.check_and_recover()
+
+    assert not paths.integrity_config_recovery_pending().exists()
+    assert not paths.integrity_recovery_pending().exists()
+    assert config_mod.load().evomem.write_authority == "evomem"
+    with fts.cursor() as conn:
+        entries.rebuild_index(conn)
+        rebuilt = conn.execute("SELECT content FROM entries WHERE id=?", (entry_id,)).fetchone()
+    assert rebuilt is not None and rebuilt[0] == "CANONICAL SNAPSHOT AFTER CONFIG CRASH"
+    database = json.loads(paths.integrity_recovery_marker().read_text())["database_recovery"]
+    assert database["write_authority"] == "evomem"
+    assert database["canonical_source"] == "verified_snapshot"
+
+
+def test_owner_repaired_config_intent_is_cleared_after_healthy_database_check(
+    ac_root: Path,
+) -> None:
+    _make_healthy_db()
+    config_mod.write_default_if_missing()
+    NodeStore().save(
+        MemoryNode(
+            node_id="shadow-node",
+            content="A shadow node must not override an explicit owner repair.",
+            layer=MemoryLayer.L2_FACT,
+            file_name="project-shadow.md",
+        )
+    )
+    valid_config = paths.config_file().read_text(encoding="utf-8")
+    paths.config_file().write_text("[[[ corrupt before owner repair", encoding="utf-8")
+    reason = integrity._config_corruption_reason(paths.config_file())
+    assert reason is not None
+    quarantine = integrity._quarantine_destination(paths.config_file())
+    integrity._write_pending_config_recovery(
+        {
+            "version": 1,
+            "phase": "prepared",
+            "started_at": "2026-07-12T10:00:00+08:00",
+            "original_path": str(paths.config_file()),
+            "quarantine_path": str(quarantine),
+            "reason": reason,
+        }
+    )
+    paths.atomic_write_private_text(paths.config_file(), valid_config)
+
+    recovered = integrity.check_and_recover()
+
+    assert recovered == []
+    assert not quarantine.exists()
+    assert not paths.integrity_config_recovery_pending().exists()
+    assert paths.integrity_recovery_marker().exists()
+    assert config_mod.load().evomem.write_authority == "markdown"
+    with fts.cursor() as conn:
+        assert (
+            conn.execute("SELECT count(*) FROM evo_nodes WHERE node_id='shadow-node'").fetchone()[0]
+            == 0
+        )
+
+
+def test_owner_repaired_config_reconciles_opposite_live_projection(ac_root: Path) -> None:
+    config_mod.write_default_if_missing()
+    with fts.cursor() as conn:
+        entries.create_file(
+            conn,
+            name="project-owner-repair-choice.md",
+            description="Owner repair chooses evomem",
+            tags=[],
+        )
+        entry_id = entries.append_entry(
+            conn,
+            name="project-owner-repair-choice.md",
+            content="OLD MARKDOWN LIVE VALUE",
+            tags=[],
+        )
+    NodeStore().save(
+        MemoryNode(
+            node_id=entry_id,
+            content="OWNER CHOSEN EVOMEM VALUE",
+            layer=MemoryLayer.L2_FACT,
+            file_name="project-owner-repair-choice.md",
+        )
+    )
+    evomem_config = (
+        paths.config_file()
+        .read_text(encoding="utf-8")
+        .replace(
+            'write_authority = "markdown"',
+            'write_authority = "evomem"',
+        )
+    )
+    paths.config_file().write_text("[[[ corrupt before owner repair", encoding="utf-8")
+    reason = integrity._config_corruption_reason(paths.config_file())
+    assert reason is not None
+    quarantine = integrity._quarantine_destination(paths.config_file())
+    integrity._write_pending_config_recovery(
+        {
+            "version": 1,
+            "phase": "prepared",
+            "started_at": "2026-07-12T10:00:00+08:00",
+            "original_path": str(paths.config_file()),
+            "quarantine_path": str(quarantine),
+            "reason": reason,
+        }
+    )
+    paths.atomic_write_private_text(paths.config_file(), evomem_config)
+
+    integrity.check_and_recover()
+
+    assert config_mod.load().evomem.write_authority == "evomem"
+    assert not paths.integrity_config_recovery_pending().exists()
+    with fts.cursor() as conn:
+        entry = conn.execute("SELECT content FROM entries WHERE id=?", (entry_id,)).fetchone()
+    assert entry is not None and entry[0] == "OWNER CHOSEN EVOMEM VALUE"
+    markdown = (paths.memory_dir() / "project-owner-repair-choice.md").read_text(encoding="utf-8")
+    assert "OWNER CHOSEN EVOMEM VALUE" in markdown
+    assert "OLD MARKDOWN LIVE VALUE" not in markdown
+
+
+def test_authority_resolved_phase_preserves_durable_owner_choice(ac_root: Path) -> None:
+    config_mod.write_default_if_missing()
+    with fts.cursor() as conn:
+        entries.create_file(
+            conn,
+            name="project-resolved-crash.md",
+            description="Resolved authority crash window",
+            tags=[],
+        )
+        entry_id = entries.append_entry(
+            conn,
+            name="project-resolved-crash.md",
+            content="SAME VALUE",
+            tags=[],
+        )
+    NodeStore().save(
+        MemoryNode(
+            node_id=entry_id,
+            content="SAME VALUE",
+            layer=MemoryLayer.L2_FACT,
+            file_name="project-resolved-crash.md",
+        )
+    )
+    quarantine = integrity._quarantine_destination(paths.config_file())
+    paths.atomic_write_private_text(quarantine, "previous corrupt config")
+    integrity._write_pending_config_recovery(
+        {
+            "version": 1,
+            "phase": "authority_resolved",
+            "started_at": "2026-07-12T10:00:00+08:00",
+            "original_path": str(paths.config_file()),
+            "quarantine_path": str(quarantine),
+            "reason": "crash after owner selected markdown",
+            "resolved_write_authority": "markdown",
+        }
+    )
+
+    integrity.check_and_recover()
+
+    assert config_mod.load().evomem.write_authority == "markdown"
+    assert not paths.integrity_config_recovery_pending().exists()
+    with fts.cursor() as conn:
+        assert conn.execute("SELECT content FROM entries WHERE id=?", (entry_id,)).fetchone()[
+            0
+        ] == ("SAME VALUE")
+
+
+@pytest.mark.parametrize("last_live_projection", ["markdown", "evomem"])
+def test_corrupt_config_with_divergent_projections_fails_closed_until_owner_chooses(
+    ac_root: Path,
+    last_live_projection: str,
+) -> None:
+    config_mod.write_default_if_missing()
+    with fts.cursor() as conn:
+        entries.create_file(
+            conn,
+            name="project-authority-inference.md",
+            description="Authority inference",
+            tags=[],
+        )
+        entry_id = entries.append_entry(
+            conn,
+            name="project-authority-inference.md",
+            content="MARKDOWN PROJECTION VALUE",
+            tags=[],
+        )
+    NodeStore().save(
+        MemoryNode(
+            node_id=entry_id,
+            content="EVOMEM CANONICAL VALUE",
+            layer=MemoryLayer.L2_FACT,
+            file_name="project-authority-inference.md",
+        )
+    )
+    if last_live_projection == "evomem":
+        with fts.cursor() as conn:
+            entries.rebuild_index(conn, source_authority="evomem")
+    paths.config_file().write_text("[[[ corrupt config", encoding="utf-8")
+
+    integrity.check_and_recover()
+
+    assert config_mod.load().evomem.write_authority == "unknown"
+    assert paths.integrity_config_recovery_pending().exists()
+    with fts.cursor() as conn:
+        content = conn.execute("SELECT content FROM entries WHERE id=?", (entry_id,)).fetchone()[0]
+    assert content == (
+        "EVOMEM CANONICAL VALUE"
+        if last_live_projection == "evomem"
+        else "MARKDOWN PROJECTION VALUE"
+    )
+
+    # Explicit owner resolution unfreezes the pending intent without guessing.
+    config_text = paths.config_file().read_text(encoding="utf-8")
+    paths.atomic_write_private_text(
+        paths.config_file(),
+        config_text.replace(
+            'write_authority = "unknown"',
+            f'write_authority = "{last_live_projection}"',
+        ),
+    )
+    integrity.check_and_recover()
+
+    assert not paths.integrity_config_recovery_pending().exists()
+    assert config_mod.load().evomem.write_authority == last_live_projection
+    with fts.cursor() as conn:
+        entries.rebuild_index(conn)
+        resolved = conn.execute("SELECT content FROM entries WHERE id=?", (entry_id,)).fetchone()[0]
+    assert resolved == content
+
+
+def test_unknown_authority_invalidates_completed_model_manifest(ac_root: Path) -> None:
+    config_mod.write_default_if_missing()
+    with fts.cursor() as conn:
+        entries.create_file(
+            conn,
+            name="project-authority-manifest.md",
+            description="Authority manifest guard",
+            tags=[],
+        )
+        entry_id = entries.append_entry(
+            conn,
+            name="project-authority-manifest.md",
+            content="MARKDOWN AUTHORITY CANDIDATE",
+            tags=[],
+        )
+    NodeStore().save(
+        MemoryNode(
+            node_id=entry_id,
+            content="EVOMEM AUTHORITY CANDIDATE",
+            layer=MemoryLayer.L2_FACT,
+            file_name="project-authority-manifest.md",
+        )
+    )
+    manifest = create_build_manifest(
+        core_commit="0123456789abcdef",
+        started_at="2026-07-12T09:00:00+08:00",
+        completed_at="2026-07-12T09:01:00+08:00",
+    )
+    paths.atomic_write_private_text(paths.model_build_manifest(), json.dumps(manifest))
+    paths.config_file().write_text("[[[ corrupt config", encoding="utf-8")
+
+    integrity.check_and_recover()
+
+    assert not paths.model_build_manifest().exists()
+    assert load_live_manifest()["status"] == "not_built"
+    database = json.loads(paths.integrity_recovery_marker().read_text())["database_recovery"]
+    assert database["status"] == "partial"
+    assert database["model_rebuild_required"] is True
+    assert database["stale_manifest_was_present"] is True
+    assert database["manifest_invalidated"] is True
+
+
+@pytest.mark.parametrize(
+    ("last_live_projection", "owner_choice", "expected"),
+    [
+        ("evomem", "markdown", "MARKDOWN OWNER VALUE"),
+        ("markdown", "evomem", "EVOMEM OWNER VALUE"),
+    ],
+)
+def test_owner_choice_reconciles_opposite_live_projection_before_unfreezing(
+    ac_root: Path,
+    last_live_projection: str,
+    owner_choice: str,
+    expected: str,
+) -> None:
+    config_mod.write_default_if_missing()
+    with fts.cursor() as conn:
+        entries.create_file(
+            conn,
+            name="project-opposite-choice.md",
+            description="Opposite authority choice",
+            tags=[],
+        )
+        entry_id = entries.append_entry(
+            conn,
+            name="project-opposite-choice.md",
+            content="MARKDOWN OWNER VALUE",
+            tags=[],
+        )
+    NodeStore().save(
+        MemoryNode(
+            node_id=entry_id,
+            content="EVOMEM OWNER VALUE",
+            layer=MemoryLayer.L2_FACT,
+            file_name="project-opposite-choice.md",
+        )
+    )
+    if last_live_projection == "evomem":
+        with fts.cursor() as conn:
+            entries.rebuild_index(conn, source_authority="evomem")
+    paths.config_file().write_text("[[[ corrupt config", encoding="utf-8")
+
+    integrity.check_and_recover()
+    assert config_mod.load().evomem.write_authority == "unknown"
+    config_text = paths.config_file().read_text(encoding="utf-8")
+    paths.atomic_write_private_text(
+        paths.config_file(),
+        config_text.replace('write_authority = "unknown"', f'write_authority = "{owner_choice}"'),
+    )
+
+    integrity.check_and_recover()
+
+    assert config_mod.load().evomem.write_authority == owner_choice
+    assert not paths.integrity_config_recovery_pending().exists()
+    with fts.cursor() as conn:
+        entry = conn.execute("SELECT content FROM entries WHERE id=?", (entry_id,)).fetchone()
+        node = conn.execute("SELECT content FROM evo_nodes WHERE node_id=?", (entry_id,)).fetchone()
+    assert entry is not None and entry[0] == expected
+    if owner_choice == "markdown":
+        assert node is not None and node[0] == expected
+    else:
+        markdown = (paths.memory_dir() / "project-opposite-choice.md").read_text(encoding="utf-8")
+        assert expected in markdown
+        assert "MARKDOWN OWNER VALUE" not in markdown
+
+
+@pytest.mark.parametrize("config_state", ["corrupt", "missing"])
+def test_pending_database_resume_treats_later_config_damage_as_unknown_authority(
+    ac_root: Path,
+    config_state: str,
+) -> None:
+    config_mod.write_default_if_missing()
+    with fts.cursor() as conn:
+        entries.create_file(
+            conn,
+            name="project-pending-config-damage.md",
+            description="Pending recovery config proof",
+            tags=[],
+        )
+        entry_id = entries.append_entry(
+            conn,
+            name="project-pending-config-damage.md",
+            content="STALE MARKDOWN DURING PENDING RECOVERY",
+            tags=[],
+        )
+    NodeStore().save(
+        MemoryNode(
+            node_id=entry_id,
+            content="CANONICAL SNAPSHOT DURING PENDING RECOVERY",
+            layer=MemoryLayer.L2_FACT,
+            file_name="project-pending-config-damage.md",
+        )
+    )
+    config_text = paths.config_file().read_text(encoding="utf-8")
+    paths.atomic_write_private_text(
+        paths.config_file(),
+        config_text.replace('write_authority = "markdown"', 'write_authority = "evomem"'),
+    )
+    snapshot = backup.create_snapshot(
+        now=datetime(2026, 7, 12, 9, 0, tzinfo=UTC),
+        structural_only=True,
+    )
+    assert snapshot is not None
+    db = paths.index_db()
+    db.write_bytes(b"pending-database-config-damage" * 100)
+    quarantine = integrity._quarantine_destination(db)
+    integrity._write_pending_recovery(
+        _pending_payload(db, quarantine, reason="synthetic pending database recovery")
+    )
+    integrity._quarantine(db, destination=quarantine)
+    if config_state == "corrupt":
+        paths.config_file().write_text("[[[ corrupt while pending", encoding="utf-8")
+    else:
+        paths.config_file().unlink()
+
+    integrity.check_and_recover()
+
+    assert paths.integrity_recovery_pending().exists()
+    assert paths.integrity_config_recovery_pending().exists()
+    assert config_mod.load().evomem.write_authority == "unknown"
+    with fts.cursor() as conn:
+        node = conn.execute("SELECT content FROM evo_nodes WHERE node_id=?", (entry_id,)).fetchone()
+        entry = conn.execute("SELECT content FROM entries WHERE id=?", (entry_id,)).fetchone()
+    assert node is not None and node[0] == "CANONICAL SNAPSHOT DURING PENDING RECOVERY"
+    assert entry is not None and entry[0] == "STALE MARKDOWN DURING PENDING RECOVERY"
+    database = json.loads(paths.integrity_recovery_marker().read_text())["database_recovery"]
+    assert database["authority_resolution_required"] is True
+
+    config_text = paths.config_file().read_text(encoding="utf-8")
+    paths.atomic_write_private_text(
+        paths.config_file(),
+        config_text.replace('write_authority = "unknown"', 'write_authority = "evomem"'),
+    )
+    integrity.check_and_recover()
+
+    assert not paths.integrity_recovery_pending().exists()
+    assert not paths.integrity_config_recovery_pending().exists()
+    with fts.cursor() as conn:
+        resolved = conn.execute("SELECT content FROM entries WHERE id=?", (entry_id,)).fetchone()
+    assert resolved is not None and resolved[0] == "CANONICAL SNAPSHOT DURING PENDING RECOVERY"
+
+
+def test_markdown_authority_does_not_resurrect_forgotten_snapshot_node(ac_root: Path) -> None:
+    config_mod.write_default_if_missing()
+    with fts.cursor() as conn:
+        entries.create_file(
+            conn,
+            name="project-forgotten.md",
+            description="Forgetting recovery proof",
+            tags=[],
+        )
+        entry_id = entries.append_entry(
+            conn,
+            name="project-forgotten.md",
+            content="MUST STAY FORGOTTEN",
+            tags=[],
+        )
+    NodeStore().save(
+        MemoryNode(
+            node_id=entry_id,
+            content="MUST STAY FORGOTTEN",
+            layer=MemoryLayer.L2_FACT,
+            file_name="project-forgotten.md",
+        )
+    )
+    NodeStore(user_id="other-user", agent_id="other-agent").save(
+        MemoryNode(
+            node_id=entry_id,
+            content="OTHER SCOPE REMAINS CANONICAL",
+            layer=MemoryLayer.L2_FACT,
+            file_name="project-foreign-scope.md",
+        )
+    )
+    with fts.cursor() as conn:
+        schema_faces.upsert_root(
+            conn,
+            signature="Root derived from the soon-forgotten memory",
+            members=[entry_id],
+        )
+        relation_edges.add_edge(
+            conn,
+            src_identity="self",
+            dst_identity="forgotten-project",
+            predicate="engaged_with",
+            src_kind="self",
+            dst_kind="project",
+            provenance="inferred",
+            confidence=0.9,
+            status="active",
+        )
+        conn.execute(
+            "INSERT INTO cross_domain_probe_state"
+            " (pair_key, last_probed_at, probe_count, detected) VALUES (?, ?, 1, 1)",
+            ('["forgotten-a","forgotten-b"]', "2026-07-12T00:00:00+00:00"),
+        )
+    snapshot = backup.create_snapshot(
+        now=datetime(2026, 7, 12, 9, 0, tzinfo=UTC),
+        structural_only=True,
+    )
+    assert snapshot is not None
+    (paths.memory_dir() / "project-forgotten.md").unlink()
+    paths.index_db().write_bytes(b"markdown-database-corruption" * 100)
+
+    integrity.check_and_recover()
+
+    with fts.cursor() as conn:
+        assert (
+            conn.execute("SELECT count(*) FROM entries WHERE id=?", (entry_id,)).fetchone()[0] == 0
+        )
+        assert (
+            conn.execute(
+                "SELECT count(*) FROM evo_nodes "
+                "WHERE node_id=? AND user_id='default' AND agent_id='default'",
+                (entry_id,),
+            ).fetchone()[0]
+            == 0
+        )
+        other_scope = conn.execute(
+            "SELECT content FROM evo_nodes "
+            "WHERE node_id=? AND user_id='other-user' AND agent_id='other-agent'",
+            (entry_id,),
+        ).fetchone()
+        assert conn.execute("SELECT count(*) FROM relation_edges").fetchone()[0] == 0
+        assert conn.execute("SELECT count(*) FROM schema_faces").fetchone()[0] == 0
+        assert conn.execute("SELECT count(*) FROM cross_domain_probe_state").fetchone()[0] == 0
+    assert other_scope is not None and other_scope[0] == "OTHER SCOPE REMAINS CANONICAL"
+    database = json.loads(paths.integrity_recovery_marker().read_text())["database_recovery"]
+    assert database["stale_projected_nodes_removed"] == 1
+    assert database["derived_geometry_rows_invalidated"] >= 3
+
+
+def test_incomplete_strict_markdown_discovery_never_deletes_snapshot_node(
+    ac_root: Path, tmp_path: Path
+) -> None:
+    config_mod.write_default_if_missing()
+    with fts.cursor() as conn:
+        entries.create_file(
+            conn,
+            name="project-discovery-guard.md",
+            description="Strict discovery guard",
+            tags=[],
+        )
+        entry_id = entries.append_entry(
+            conn,
+            name="project-discovery-guard.md",
+            content="SNAPSHOT NODE MUST SURVIVE",
+            tags=[],
+        )
+    NodeStore().save(
+        MemoryNode(
+            node_id=entry_id,
+            content="SNAPSHOT NODE MUST SURVIVE",
+            layer=MemoryLayer.L2_FACT,
+            file_name="project-discovery-guard.md",
+        )
+    )
+    snapshot = backup.create_snapshot(
+        now=datetime(2026, 7, 12, 9, 0, tzinfo=UTC),
+        structural_only=True,
+    )
+    assert snapshot is not None
+    memory = paths.memory_dir() / "project-discovery-guard.md"
+    memory.unlink()
+    outside = tmp_path / "outside.md"
+    outside.write_text("UNTRUSTED EXTERNAL SOURCE", encoding="utf-8")
+    memory.symlink_to(outside)
+    paths.index_db().write_bytes(b"strict-discovery-database-corruption" * 100)
+
+    integrity.check_and_recover()
+
+    recovery = json.loads(paths.integrity_recovery_marker().read_text())["database_recovery"]
+    assert recovery["status"] == "partial"
+    assert "memory Markdown must be one regular file" in recovery["error"]
+    with fts.cursor() as conn:
+        node = conn.execute("SELECT content FROM evo_nodes WHERE node_id=?", (entry_id,)).fetchone()
+    assert node is not None and node[0] == "SNAPSHOT NODE MUST SURVIVE"
+
+
+def test_markdown_authority_refreshes_file_metadata_after_snapshot(ac_root: Path) -> None:
+    config_mod.write_default_if_missing()
+    with fts.cursor() as conn:
+        entries.create_file(
+            conn,
+            name="project-frontmatter.md",
+            description="OLD DESCRIPTION",
+            tags=["old"],
+        )
+        entries.append_entry(
+            conn,
+            name="project-frontmatter.md",
+            content="Current entry content.",
+            tags=[],
+        )
+    snapshot = backup.create_snapshot(
+        now=datetime(2026, 7, 12, 9, 0, tzinfo=UTC),
+        structural_only=True,
+    )
+    assert snapshot is not None
+    files_mod.update_frontmatter(
+        paths.memory_dir() / "project-frontmatter.md",
+        {"description": "NEW DESCRIPTION", "tags": ["new"], "status": "archived"},
+    )
+    paths.index_db().write_bytes(b"frontmatter-database-corruption" * 100)
+
+    integrity.check_and_recover()
+
+    with fts.cursor() as conn:
+        row = conn.execute(
+            "SELECT description, tags, status FROM files WHERE path='project-frontmatter.md'"
+        ).fetchone()
+    assert tuple(row) == ("NEW DESCRIPTION", "new", "archived")
+
+
+def test_nested_skill_projection_is_replayed_after_full_quarantine(ac_root: Path) -> None:
+    with fts.cursor() as conn:
+        entries.create_file(
+            conn,
+            name="skills/skill-recovery.md",
+            description="Nested skill recovery",
+            tags=[],
+        )
+        entry_id = entries.append_entry(
+            conn,
+            name="skills/skill-recovery.md",
+            content="Nested behavioral memory survives quarantine.",
+            tags=[],
+        )
+    paths.index_db().write_bytes(b"nested-skill-database-corruption" * 100)
+
+    integrity.check_and_recover()
+
+    with fts.cursor() as conn:
+        entry = conn.execute("SELECT path, content FROM entries WHERE id=?", (entry_id,)).fetchone()
+        node_count = conn.execute(
+            "SELECT count(*) FROM evo_nodes WHERE node_id=?", (entry_id,)
+        ).fetchone()[0]
+    assert entry is not None and tuple(entry) == (
+        "skills/skill-recovery.md",
+        "Nested behavioral memory survives quarantine.",
+    )
+    assert node_count == 0
+
+
+def test_evomem_snapshot_recovery_keeps_nested_skill_as_direct_markdown(ac_root: Path) -> None:
+    config_mod.write_default_if_missing()
+    NodeStore().save(
+        MemoryNode(
+            node_id="baseline-node",
+            content="baseline",
+            layer=MemoryLayer.L2_FACT,
+            file_name="project-baseline.md",
+        )
+    )
+    with fts.cursor() as conn:
+        entries.create_file(
+            conn,
+            name="skills/skill-snapshot-recovery.md",
+            description="Direct nested skill",
+            tags=[],
+        )
+        entry_id = entries.append_entry(
+            conn,
+            name="skills/skill-snapshot-recovery.md",
+            content="Direct skill survives evomem snapshot recovery.",
+            tags=[],
+        )
+    NodeStore().save(
+        MemoryNode(
+            node_id=entry_id,
+            content="OLD SNAPSHOT SKILL",
+            layer=MemoryLayer.L2_FACT,
+            file_name="skills/skill-snapshot-recovery.md",
+        )
+    )
+    config_text = paths.config_file().read_text(encoding="utf-8")
+    paths.atomic_write_private_text(
+        paths.config_file(),
+        config_text.replace('write_authority = "markdown"', 'write_authority = "evomem"'),
+    )
+    snapshot = backup.create_snapshot(
+        now=datetime(2026, 7, 12, 9, 0, tzinfo=UTC),
+        structural_only=True,
+    )
+    assert snapshot is not None
+    paths.index_db().write_bytes(b"nested-evomem-snapshot-corruption" * 100)
+
+    integrity.check_and_recover()
+
+    with fts.cursor() as conn:
+        entry = conn.execute("SELECT path, content FROM entries WHERE id=?", (entry_id,)).fetchone()
+        node_count = conn.execute(
+            "SELECT count(*) FROM evo_nodes WHERE node_id=?", (entry_id,)
+        ).fetchone()[0]
+    assert entry is not None and tuple(entry) == (
+        "skills/skill-snapshot-recovery.md",
+        "Direct skill survives evomem snapshot recovery.",
+    )
+    assert node_count == 0
+
+
+def test_nested_skill_legacy_cleanup_preserves_same_named_top_level_snapshot_node(
+    ac_root: Path,
+) -> None:
+    config_mod.write_default_if_missing()
+    with fts.cursor() as conn:
+        entries.create_file(
+            conn,
+            name="skill-same.md",
+            description="Canonical top-level skill",
+            tags=[],
+        )
+        top_id = entries.append_entry(
+            conn,
+            name="skill-same.md",
+            content="TOP LEVEL CANONICAL SKILL",
+            tags=[],
+        )
+        entries.create_file(
+            conn,
+            name="skills/skill-same.md",
+            description="Direct nested skill",
+            tags=[],
+        )
+        nested_id = entries.append_entry(
+            conn,
+            name="skills/skill-same.md",
+            content="NESTED DIRECT SKILL",
+            tags=[],
+        )
+    NodeStore().save(
+        MemoryNode(
+            node_id=top_id,
+            content="TOP LEVEL CANONICAL SKILL",
+            layer=MemoryLayer.L2_FACT,
+            file_name="skill-same.md",
+        )
+    )
+    # A modern accidental shadow row retains the direct nested filename and is
+    # therefore safe to identify and remove during recovery.
+    NodeStore().save(
+        MemoryNode(
+            node_id=nested_id,
+            content="LEGACY NESTED SNAPSHOT VALUE",
+            layer=MemoryLayer.L2_FACT,
+            file_name="skills/skill-same.md",
+        )
+    )
+    NodeStore(user_id="other-user", agent_id="other-agent").save(
+        MemoryNode(
+            node_id=nested_id,
+            content="OTHER SCOPE MUST SURVIVE",
+            layer=MemoryLayer.L2_FACT,
+            file_name="skill-same.md",
+        )
+    )
+    config_text = paths.config_file().read_text(encoding="utf-8")
+    paths.atomic_write_private_text(
+        paths.config_file(),
+        config_text.replace('write_authority = "markdown"', 'write_authority = "evomem"'),
+    )
+    snapshot = backup.create_snapshot(
+        now=datetime(2026, 7, 12, 9, 0, tzinfo=UTC),
+        structural_only=True,
+    )
+    assert snapshot is not None
+    paths.index_db().write_bytes(b"same-name-snapshot-corruption" * 100)
+
+    integrity.check_and_recover()
+
+    with fts.cursor() as conn:
+        top_node = conn.execute(
+            "SELECT file_name, content FROM evo_nodes WHERE node_id=?", (top_id,)
+        ).fetchone()
+        nested_node = conn.execute(
+            "SELECT file_name, content FROM evo_nodes "
+            "WHERE node_id=? AND user_id='default' AND agent_id='default'",
+            (nested_id,),
+        ).fetchone()
+        other_scope_node = conn.execute(
+            "SELECT file_name, content FROM evo_nodes "
+            "WHERE node_id=? AND user_id='other-user' AND agent_id='other-agent'",
+            (nested_id,),
+        ).fetchone()
+        top_entry = conn.execute(
+            "SELECT path, content FROM entries WHERE id=?", (top_id,)
+        ).fetchone()
+        nested_entry = conn.execute(
+            "SELECT path, content FROM entries WHERE id=?", (nested_id,)
+        ).fetchone()
+
+    assert top_node is not None and tuple(top_node) == (
+        "skill-same.md",
+        "TOP LEVEL CANONICAL SKILL",
+    )
+    assert nested_node is None
+    assert other_scope_node is not None and tuple(other_scope_node) == (
+        "skill-same.md",
+        "OTHER SCOPE MUST SURVIVE",
+    )
+    assert top_entry is not None and tuple(top_entry) == (
+        "skill-same.md",
+        "TOP LEVEL CANONICAL SKILL",
+    )
+    assert nested_entry is not None and tuple(nested_entry) == (
+        "skills/skill-same.md",
+        "NESTED DIRECT SKILL",
+    )
+
+
+def test_ambiguous_basename_only_nested_node_fails_closed(ac_root: Path) -> None:
+    config_mod.write_default_if_missing()
+    with fts.cursor() as conn:
+        entries.create_file(
+            conn,
+            name="skills/skill-ambiguous.md",
+            description="Direct nested skill",
+            tags=[],
+        )
+        entry_id = entries.append_entry(
+            conn,
+            name="skills/skill-ambiguous.md",
+            content="DIRECT NESTED VALUE",
+            tags=[],
+        )
+    NodeStore().save(
+        MemoryNode(
+            node_id=entry_id,
+            content="AMBIGUOUS CANONICAL VALUE",
+            layer=MemoryLayer.L2_FACT,
+            file_name="skill-ambiguous.md",
+        )
+    )
+    config_text = paths.config_file().read_text(encoding="utf-8")
+    paths.atomic_write_private_text(
+        paths.config_file(),
+        config_text.replace('write_authority = "markdown"', 'write_authority = "evomem"'),
+    )
+    snapshot = backup.create_snapshot(
+        now=datetime(2026, 7, 12, 9, 0, tzinfo=UTC),
+        structural_only=True,
+    )
+    assert snapshot is not None
+    paths.index_db().write_bytes(b"ambiguous-direct-node-corruption" * 100)
+
+    integrity.check_and_recover()
+
+    recovery = json.loads(paths.integrity_recovery_marker().read_text())["database_recovery"]
+    assert recovery["status"] == "partial"
+    assert "collides with canonical evomem file" in recovery["error"]
+    with fts.cursor() as conn:
+        node = conn.execute(
+            "SELECT content FROM evo_nodes "
+            "WHERE node_id=? AND user_id='default' AND agent_id='default'",
+            (entry_id,),
+        ).fetchone()
+    assert node is not None and node[0] == "AMBIGUOUS CANONICAL VALUE"
+
+
+def test_corrupt_db_restores_verified_snapshot_before_projection_replay(ac_root: Path) -> None:
+    with fts.cursor() as conn:
+        fts.insert_capture(
+            conn,
+            id="capture-from-snapshot",
+            timestamp="2026-07-12T00:00:00+00:00",
+            app_name="Test App",
+            bundle_id="com.persome.test",
+            window_title="Verified snapshot recovery",
+            focused_role="AXTextArea",
+            focused_value="snapshot",
+            visible_text="capture survives through the verified backup",
+            url="https://example.test/snapshot",
+        )
+    snapshot = backup.create_snapshot(
+        now=datetime(2026, 7, 12, 9, 0, tzinfo=UTC),
+        structural_only=True,
+    )
+    assert snapshot is not None
+    paths.index_db().write_bytes(b"full-database-corruption" * 100)
+
+    integrity.check_and_recover()
+
+    with fts.cursor() as conn:
+        assert (
+            conn.execute(
+                "SELECT count(*) FROM captures WHERE id='capture-from-snapshot'"
+            ).fetchone()[0]
+            == 1
+        )
+    marker = json.loads(paths.integrity_recovery_marker().read_text())
+    database = marker["database_recovery"]
+    assert database["status"] == "restored"
+    assert database["source"] == "verified_snapshot"
+    assert database["snapshot_path"] == str(snapshot)
+    assert database["lossy"] is True
+    assert database["recovery_completeness"] == "best_effort"
+    assert database["potentially_lost_since_snapshot"] is True
+    assert database["snapshot_modified_at"]
+    assert database["not_recovered_without_snapshot"] == []
+
+
+def test_foreign_newer_snapshot_is_skipped_for_older_persome_snapshot(ac_root: Path) -> None:
+    with fts.cursor() as conn:
+        fts.insert_capture(
+            conn,
+            id="valuable-capture",
+            timestamp="2026-07-11T00:00:00+00:00",
+            app_name="Test App",
+            bundle_id="com.persome.test",
+            window_title="Persome snapshot",
+            focused_role="AXTextArea",
+            focused_value="valuable",
+            visible_text="valuable capture in a genuine Persome snapshot",
+            url="https://example.test/genuine",
+        )
+    genuine = backup.create_snapshot(
+        now=datetime(2026, 7, 11, 9, 0, tzinfo=UTC),
+        structural_only=True,
+    )
+    assert genuine is not None
+    foreign = paths.backup_dir() / "evo-20260712.db"
+    conn = sqlite3.connect(foreign)
+    try:
+        conn.execute("CREATE TABLE files(path TEXT)")
+        conn.execute("CREATE TABLE entries(id TEXT)")
+        conn.execute("CREATE TABLE captures(id TEXT)")
+        conn.commit()
+    finally:
+        conn.close()
+    paths.index_db().write_bytes(b"full-database-corruption" * 100)
+
+    integrity.check_and_recover()
+
+    with fts.cursor() as conn:
+        assert (
+            conn.execute("SELECT count(*) FROM captures WHERE id='valuable-capture'").fetchone()[0]
+            == 1
+        )
+    database = json.loads(paths.integrity_recovery_marker().read_text())["database_recovery"]
+    assert database["snapshot_path"] == str(genuine)
+
+
+def test_projection_replay_failure_is_reported_without_losing_startup(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths.index_db().write_bytes(b"full-database-corruption" * 100)
+    paths.atomic_write_private_text(
+        paths.model_build_manifest(),
+        json.dumps({"status": "complete", "build_id": "stale-build"}),
+    )
+    monkeypatch.setattr(
+        integrity,
+        "_repopulate_after_quarantine",
+        lambda **_kwargs: (_ for _ in ()).throw(ValueError("synthetic projection failure")),
+    )
+
+    recovered = integrity.check_and_recover()
+
+    assert [item.kind for item in recovered] == ["database"]
+    assert not paths.model_build_manifest().exists()
+    with fts.cursor() as conn:
+        assert [row[0] for row in conn.execute("PRAGMA integrity_check")] == ["ok"]
+    marker = json.loads(paths.integrity_recovery_marker().read_text())
+    database = marker["database_recovery"]
+    assert database["status"] == "failed"
+    assert database["source"] == "none"
+    assert "synthetic projection failure" in database["error"]
+    assert database["model_rebuild_required"] is True
+
+
+def test_duplicate_markdown_ids_fail_recovery_instead_of_collapsing(ac_root: Path) -> None:
+    with fts.cursor() as conn:
+        entries.create_file(
+            conn,
+            name="project-duplicate-recovery.md",
+            description="Duplicate recovery guard",
+            tags=[],
+        )
+        entry_id = entries.append_entry(
+            conn,
+            name="project-duplicate-recovery.md",
+            content="FIRST VALUE",
+            tags=[],
+        )
+    memory = paths.memory_dir() / "project-duplicate-recovery.md"
+    files_mod.atomic_write_text(
+        memory,
+        memory.read_text(encoding="utf-8")
+        + f"\n\n## [2026-07-12T10:00:00+00:00] {{id: {entry_id}}}\nSECOND VALUE\n",
+    )
+    paths.index_db().write_bytes(b"duplicate-id-database-corruption" * 100)
+
+    integrity.check_and_recover()
+
+    database = json.loads(paths.integrity_recovery_marker().read_text())["database_recovery"]
+    assert database["status"] == "failed"
+    assert "duplicate Markdown memory node id" in database["error"]
+    with fts.cursor() as conn:
+        assert conn.execute("SELECT count(*) FROM entries").fetchone()[0] == 0
+
+
+def test_recovery_resumes_after_crash_immediately_after_quarantine(ac_root: Path) -> None:
+    with fts.cursor() as conn:
+        entries.create_file(
+            conn,
+            name="project-resumable-recovery.md",
+            description="Resumable recovery",
+            tags=[],
+        )
+        entry_id = entries.append_entry(
+            conn,
+            name="project-resumable-recovery.md",
+            content="Recovery resumes from its journal.",
+            tags=[],
+        )
+    manifest = create_build_manifest(
+        core_commit="0123456789abcdef",
+        started_at="2026-07-12T09:00:00+08:00",
+        completed_at="2026-07-12T09:01:00+08:00",
+    )
+    paths.atomic_write_private_text(paths.model_build_manifest(), json.dumps(manifest))
+    db = paths.index_db()
+    db.write_bytes(b"crash-resume-corruption" * 100)
+    quarantine = integrity._quarantine_destination(db)
+    integrity._write_pending_recovery(
+        _pending_payload(db, quarantine, reason="synthetic crash after quarantine")
+    )
+    integrity._quarantine(db, destination=quarantine)
+
+    assert load_live_manifest()["status"] == "not_built"
+    recovered = integrity.check_and_recover()
+
+    assert [item.kind for item in recovered] == ["database"]
+    assert not paths.integrity_recovery_pending().exists()
+    assert not paths.model_build_manifest().exists()
+    with fts.cursor() as conn:
+        assert (
+            conn.execute("SELECT count(*) FROM entries WHERE id=?", (entry_id,)).fetchone()[0] == 1
+        )
+
+
+def test_recovery_resumes_after_snapshot_copy_before_projection_replay(ac_root: Path) -> None:
+    with fts.cursor() as conn:
+        fts.insert_capture(
+            conn,
+            id="capture-before-crash",
+            timestamp="2026-07-12T00:00:00+00:00",
+            app_name="Test App",
+            bundle_id="com.persome.test",
+            window_title="Crash phase",
+            focused_role="AXTextArea",
+            focused_value="resume",
+            visible_text="snapshot copy survives resumed replay",
+            url="https://example.test/crash-phase",
+        )
+    snapshot = backup.create_snapshot(
+        now=datetime(2026, 7, 12, 9, 0, tzinfo=UTC),
+        structural_only=True,
+    )
+    assert snapshot is not None
+    db = paths.index_db()
+    db.write_bytes(b"snapshot-phase-corruption" * 100)
+    quarantine = integrity._quarantine_destination(db)
+    pending = _pending_payload(db, quarantine, reason="synthetic crash after snapshot copy")
+    integrity._write_pending_recovery(pending)
+    integrity._quarantine(db, destination=quarantine)
+    integrity._copy_verified_snapshot(snapshot, db)
+    with fts.cursor() as conn:
+        fts.insert_capture(
+            conn,
+            id="post-recovery-capture",
+            timestamp="2026-07-12T00:01:00+00:00",
+            app_name="Test App",
+            bundle_id="com.persome.test",
+            window_title="After snapshot copy",
+            focused_role="AXTextArea",
+            focused_value="preserve",
+            visible_text="healthy live database must not be overwritten on resume",
+            url="https://example.test/post-recovery",
+        )
+    integrity._set_pending_phase(pending, "snapshot_restored")
+
+    integrity.check_and_recover()
+
+    assert not paths.integrity_recovery_pending().exists()
+    with fts.cursor() as conn:
+        assert (
+            conn.execute(
+                "SELECT count(*) FROM captures WHERE id='capture-before-crash'"
+            ).fetchone()[0]
+            == 1
+        )
+        assert (
+            conn.execute(
+                "SELECT count(*) FROM captures WHERE id='post-recovery-capture'"
+            ).fetchone()[0]
+            == 1
+        )
+
+
+def test_pending_recovery_preserves_owner_repaired_healthy_database(ac_root: Path) -> None:
+    config_mod.write_default_if_missing()
+    with fts.cursor() as conn:
+        fts.insert_capture(
+            conn,
+            id="owner-repaired-capture",
+            timestamp="2026-07-12T00:00:00+00:00",
+            app_name="Test App",
+            bundle_id="com.persome.test",
+            window_title="Owner repaired database",
+            focused_role="AXTextArea",
+            focused_value="preserve",
+            visible_text="healthy owner repair must stay live",
+            url="https://example.test/owner-repair",
+        )
+    manifest = create_build_manifest(
+        core_commit="0123456789abcdef",
+        started_at="2026-07-12T09:00:00+08:00",
+        completed_at="2026-07-12T09:01:00+08:00",
+    )
+    paths.atomic_write_private_text(paths.model_build_manifest(), json.dumps(manifest))
+    db = paths.index_db()
+    quarantine = integrity._quarantine_destination(db)
+    integrity._write_pending_recovery(
+        _pending_payload(db, quarantine, reason="database was repaired by owner")
+    )
+
+    recovered = integrity.check_and_recover()
+
+    assert recovered == []
+    assert db.exists()
+    assert not quarantine.exists()
+    assert not paths.integrity_recovery_pending().exists()
+    assert not paths.model_build_manifest().exists()
+    with fts.cursor() as conn:
+        assert (
+            conn.execute(
+                "SELECT count(*) FROM captures WHERE id='owner-repaired-capture'"
+            ).fetchone()[0]
+            == 1
+        )
+    database = json.loads(paths.integrity_recovery_marker().read_text())["database_recovery"]
+    assert database["source"] == "owner_repaired_database"
+    assert database["preserved_existing_database"] is True
+
+
+def test_pending_recovery_resumes_when_sidecar_moved_before_main_database(
+    ac_root: Path,
+) -> None:
+    config_mod.write_default_if_missing()
+    with fts.cursor() as conn:
+        entries.create_file(
+            conn,
+            name="project-sidecar-crash.md",
+            description="Sidecar-first quarantine crash",
+            tags=[],
+        )
+        entry_id = entries.append_entry(
+            conn,
+            name="project-sidecar-crash.md",
+            content="Recovery must resume after a sidecar-only quarantine artifact.",
+            tags=[],
+        )
+    db = paths.index_db()
+    quarantine = integrity._quarantine_destination(db)
+    pending = _pending_payload(db, quarantine, reason="synthetic crash after WAL move")
+    integrity._write_pending_recovery(pending)
+    # ``_quarantine`` moves sidecars before the main file. Emulate a process
+    # death after that first rename: the live main is still structurally healthy
+    # without its WAL, but this is not an owner repair.
+    quarantined_wal = quarantine.with_name(f"{quarantine.name}.wal")
+    paths.atomic_write_private_text(quarantined_wal, "already moved WAL bytes")
+
+    recovered = integrity.check_and_recover()
+
+    assert any(item.kind == "database" for item in recovered)
+    assert quarantine.exists()
+    assert quarantined_wal.exists()
+    assert not paths.integrity_recovery_pending().exists()
+    with fts.cursor() as conn:
+        assert (
+            conn.execute("SELECT count(*) FROM entries WHERE id=?", (entry_id,)).fetchone()[0] == 1
+        )
+    database = json.loads(paths.integrity_recovery_marker().read_text())["database_recovery"]
+    assert database["source"] != "owner_repaired_database"
+
+
+def test_failed_recovery_retries_and_preserves_post_failure_writes(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_mod.write_default_if_missing()
+    with fts.cursor() as conn:
+        entries.create_file(
+            conn,
+            name="project-retry-recovery.md",
+            description="Retry recovery",
+            tags=[],
+        )
+        entry_id = entries.append_entry(
+            conn,
+            name="project-retry-recovery.md",
+            content="Markdown recovery succeeds on retry.",
+            tags=[],
+        )
+    paths.index_db().write_bytes(b"retryable-database-corruption" * 100)
+
+    with monkeypatch.context() as first_attempt:
+        first_attempt.setattr(
+            integrity,
+            "_repopulate_after_quarantine",
+            lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("transient replay failure")),
+        )
+        integrity.check_and_recover()
+
+    pending = json.loads(paths.integrity_recovery_pending().read_text())
+    assert pending["phase"] == "failed"
+    assert pending["database_recovery"]["status"] == "failed"
+    with fts.cursor() as conn:
+        fts.insert_capture(
+            conn,
+            id="capture-after-failed-recovery",
+            timestamp="2026-07-12T00:02:00+00:00",
+            app_name="Test App",
+            bundle_id="com.persome.test",
+            window_title="Post failure write",
+            focused_role="AXTextArea",
+            focused_value="preserve",
+            visible_text="must survive the successful retry",
+            url="https://example.test/retry-write",
+        )
+
+    integrity.check_and_recover()
+
+    assert not paths.integrity_recovery_pending().exists()
+    with fts.cursor() as conn:
+        assert (
+            conn.execute("SELECT count(*) FROM entries WHERE id=?", (entry_id,)).fetchone()[0] == 1
+        )
+        assert (
+            conn.execute(
+                "SELECT count(*) FROM captures WHERE id='capture-after-failed-recovery'"
+            ).fetchone()[0]
+            == 1
+        )
+
+
+def test_invalid_database_recovery_journal_is_retained_then_recovered(ac_root: Path) -> None:
+    config_mod.write_default_if_missing()
+    with fts.cursor() as conn:
+        entries.create_file(
+            conn,
+            name="project-invalid-journal.md",
+            description="Invalid journal recovery",
+            tags=[],
+        )
+        entry_id = entries.append_entry(
+            conn,
+            name="project-invalid-journal.md",
+            content="Recovery must not remain blocked.",
+            tags=[],
+        )
+    paths.index_db().write_bytes(b"invalid-journal-database-corruption" * 100)
+    paths.atomic_write_private_text(paths.integrity_recovery_pending(), '{"version":')
+
+    recovered = integrity.check_and_recover()
+
+    assert {item.kind for item in recovered} == {"database_recovery_journal", "database"}
+    assert not paths.integrity_recovery_pending().exists()
+    assert list(ac_root.glob(".integrity-recovery.pending.json.corrupt.*"))
+    with fts.cursor() as conn:
+        assert (
+            conn.execute("SELECT count(*) FROM entries WHERE id=?", (entry_id,)).fetchone()[0] == 1
+        )
+
+
+@pytest.mark.parametrize("defect", ["missing_fields", "unknown_phase", "unsafe_path"])
+def test_semantically_invalid_database_journal_is_quarantined_and_recovery_continues(
+    ac_root: Path,
+    defect: str,
+) -> None:
+    config_mod.write_default_if_missing()
+    with fts.cursor() as conn:
+        entries.create_file(
+            conn,
+            name="project-semantic-journal.md",
+            description="Semantic journal recovery",
+            tags=[],
+        )
+        entry_id = entries.append_entry(
+            conn,
+            name="project-semantic-journal.md",
+            content="A malformed version-one journal must not wedge recovery.",
+            tags=[],
+        )
+    db = paths.index_db()
+    db.write_bytes(b"semantic-journal-database-corruption" * 100)
+    quarantine = integrity._quarantine_destination(db)
+    payload = _pending_payload(db, quarantine, reason="semantic journal test")
+    if defect == "missing_fields":
+        payload = {"version": 1}
+    elif defect == "unknown_phase":
+        payload["phase"] = "teleported"
+    else:
+        payload["quarantine_path"] = str(ac_root.parent / "unsafe" / quarantine.name)
+    paths.atomic_write_private_text(paths.integrity_recovery_pending(), json.dumps(payload))
+
+    recovered = integrity.check_and_recover()
+
+    assert {item.kind for item in recovered} == {"database_recovery_journal", "database"}
+    assert not paths.integrity_recovery_pending().exists()
+    assert list(ac_root.glob(".integrity-recovery.pending.json.corrupt.*"))
+    with fts.cursor() as conn:
+        assert (
+            conn.execute("SELECT count(*) FROM entries WHERE id=?", (entry_id,)).fetchone()[0] == 1
+        )
+
+
+def test_invalid_config_recovery_journal_does_not_block_config_repair(ac_root: Path) -> None:
+    _make_healthy_db()
+    paths.config_file().write_text("[[[ invalid config", encoding="utf-8")
+    paths.atomic_write_private_text(
+        paths.integrity_config_recovery_pending(),
+        '{"version":',
+    )
+
+    recovered = integrity.check_and_recover()
+
+    assert {item.kind for item in recovered} == {"config_recovery_journal", "config"}
+    assert not paths.integrity_config_recovery_pending().exists()
+    assert list(ac_root.glob(".integrity-config-recovery.pending.json.corrupt.*"))
+    assert config_mod.load().evomem.write_authority == "markdown"
+
+
+@pytest.mark.parametrize("defect", ["missing_fields", "unknown_phase", "unsafe_path"])
+def test_semantically_invalid_config_journal_is_quarantined_and_config_repair_continues(
+    ac_root: Path,
+    defect: str,
+) -> None:
+    _make_healthy_db()
+    paths.config_file().write_text("[[[ invalid config", encoding="utf-8")
+    quarantine = integrity._quarantine_destination(paths.config_file())
+    payload: dict[str, object] = {
+        "version": 1,
+        "phase": "prepared",
+        "started_at": "2026-07-12T10:00:00+08:00",
+        "original_path": str(paths.config_file()),
+        "quarantine_path": str(quarantine),
+        "reason": "semantic config journal test",
+    }
+    if defect == "missing_fields":
+        payload = {"version": 1}
+    elif defect == "unknown_phase":
+        payload["phase"] = "teleported"
+    else:
+        payload["quarantine_path"] = str(ac_root.parent / "unsafe" / quarantine.name)
+    paths.atomic_write_private_text(paths.integrity_config_recovery_pending(), json.dumps(payload))
+
+    recovered = integrity.check_and_recover()
+
+    assert {item.kind for item in recovered} == {"config_recovery_journal", "config"}
+    assert not paths.integrity_config_recovery_pending().exists()
+    assert list(ac_root.glob(".integrity-config-recovery.pending.json.corrupt.*"))
+    assert config_mod.load().evomem.write_authority == "markdown"
+
+
+def test_recovery_marker_blocks_stale_manifest_when_invalidation_fails(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest = create_build_manifest(
+        core_commit="0123456789abcdef",
+        started_at="2026-07-12T09:00:00+08:00",
+        completed_at="2026-07-12T09:01:00+08:00",
+    )
+    paths.atomic_write_private_text(paths.model_build_manifest(), json.dumps(manifest))
+    paths.index_db().write_bytes(b"manifest-invalidation-corruption" * 100)
+    monkeypatch.setattr(integrity, "_invalidate_model_manifest", lambda: False)
+
+    integrity.check_and_recover()
+
+    assert paths.model_build_manifest().exists()
+    assert load_live_manifest()["status"] == "not_built"
+    database = json.loads(paths.integrity_recovery_marker().read_text())["database_recovery"]
+    assert database["manifest_invalidated"] is False
+
+    # A later config-only recovery must not overwrite the sole monotonic guard
+    # that keeps the stale manifest untrusted.
+    paths.config_file().write_text("[[[ later config corruption", encoding="utf-8")
+    integrity.check_and_recover()
+
+    assert load_live_manifest()["status"] == "not_built"
+    preserved = json.loads(paths.integrity_recovery_marker().read_text())["database_recovery"]
+    assert preserved["model_rebuild_required"] is True
+    assert preserved["manifest_invalidated"] is False
 
 
 def test_malformed_derived_captures_fts_is_rebuilt_without_quarantine(ac_root: Path) -> None:
@@ -296,6 +1967,19 @@ def test_recovery_marker_written_with_paths(ac_root: Path) -> None:
 
 
 def test_both_db_and_config_corrupt_recovers_both(ac_root: Path) -> None:
+    with fts.cursor() as conn:
+        entries.create_file(
+            conn,
+            name="project-combined-recovery.md",
+            description="Combined recovery",
+            tags=[],
+        )
+        entry_id = entries.append_entry(
+            conn,
+            name="project-combined-recovery.md",
+            content="Configuration is repaired before memory is replayed.",
+            tags=[],
+        )
     paths.index_db().write_bytes(b"garbage-not-sqlite" * 100)
     paths.config_file().write_text("[[[ not toml")
 
@@ -305,6 +1989,15 @@ def test_both_db_and_config_corrupt_recovers_both(ac_root: Path) -> None:
     assert kinds == ["config", "database"]
     payload = json.loads(paths.integrity_recovery_marker().read_text())
     assert len(payload["files"]) == 2
+    assert payload["database_recovery"]["status"] == "restored"
+    with fts.cursor() as conn:
+        assert (
+            conn.execute(
+                "SELECT count(*) FROM entries WHERE id=?",
+                (entry_id,),
+            ).fetchone()[0]
+            == 1
+        )
 
 
 def test_no_stale_wal_sidecars_survive_next_to_rebuilt_db(ac_root: Path) -> None:

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1,13 +1,32 @@
 """Test MCP tool functions directly (bypassing FastMCP wiring)."""
 
+import json
 from pathlib import Path
 
-from persome import __version__
+from persome import __version__, paths
+from persome import model as model_mod
 from persome.mcp import captures as captures_mod
 from persome.mcp import server as mcp_server
+from persome.model import ModelBuildCoordinator, create_build_manifest
 from persome.store import entries as entries_mod
 from persome.store import fts
 from persome.timeline import store as timeline_store
+
+BUILD_KEYS = {
+    "build_id",
+    "completed_at",
+    "config_hash",
+    "core_commit",
+    "degraded_stages",
+    "duration_ms",
+    "input_window",
+    "mode",
+    "models",
+    "prompt_hashes",
+    "started_at",
+    "status",
+    "trigger",
+}
 
 
 def test_list_memories(ac_root: Path) -> None:
@@ -68,6 +87,71 @@ def test_get_model_snapshot_uses_versioned_contract(ac_root: Path) -> None:
     assert out["points"] == []
     assert out["root"] is None
     assert out["stats"]["roots"] == 0
+    assert set(out["build"]) == BUILD_KEYS
+    assert out["build"]["status"] == "not_built"
+    assert out["build"]["trigger"] == "no_completed_build"
+    assert out["build"]["build_id"] is None
+
+
+def test_get_model_snapshot_uses_transactionally_stable_live_reader(
+    ac_root: Path, monkeypatch
+) -> None:
+    sentinel = {"schema_version": 1, "source": "live-reader"}
+    calls = []
+
+    def fake_live_snapshot(conn, *, redact=True):  # type: ignore[no-untyped-def]
+        calls.append((conn, redact))
+        return sentinel
+
+    monkeypatch.setattr(model_mod, "build_live_snapshot", fake_live_snapshot)
+    with fts.cursor() as conn:
+        out = mcp_server._get_model_snapshot(conn, redact=False)
+
+    assert out is sentinel
+    assert len(calls) == 1
+    assert calls[0][1] is False
+
+
+def test_get_model_snapshot_keeps_build_contract_while_building(ac_root: Path) -> None:
+    marker = {
+        "build_id": None,
+        "status": "building",
+        "trigger": "test-mcp",
+        "started_at": "2026-07-12T08:00:00+00:00",
+        "completed_at": None,
+        "duration_ms": 0,
+        "degraded_stages": [],
+    }
+    coordinator = ModelBuildCoordinator()
+    with coordinator.acquire(wait_seconds=0):
+        paths.atomic_write_private_text(paths.model_build_manifest(), json.dumps(marker))
+        with fts.cursor() as conn:
+            out = mcp_server._get_model_snapshot(conn)
+
+    assert out["build"]["status"] == "building"
+    assert set(out["build"]) == BUILD_KEYS
+
+
+def test_get_model_snapshot_preserves_saved_manifest(ac_root: Path) -> None:
+    manifest = create_build_manifest(
+        core_commit="0123456789abcdef",
+        models={"timeline": "fixture-model"},
+        config={"fixture": True},
+        degraded_stages=["root_synthesis"],
+        started_at="2026-07-12T08:00:00+00:00",
+        completed_at="2026-07-12T08:01:00+00:00",
+        duration_ms=60_000,
+        trigger="test-fixture",
+        mode="mock",
+    )
+    paths.atomic_write_private_text(
+        paths.model_build_manifest(),
+        json.dumps(manifest, ensure_ascii=False),
+    )
+    with fts.cursor() as conn:
+        out = mcp_server._get_model_snapshot(conn)
+
+    assert out["build"] == manifest
 
 
 def test_server_reports_runtime_version(ac_root: Path) -> None:

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -2,14 +2,35 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 
+import pytest
+
+from persome import paths
 from persome.api import routes
 from persome.api.model_view import render_memory_view
 from persome.evomem.models import MemoryLayer, MemoryNode
 from persome.evomem.store import NodeStore
+from persome.model import ModelBuildCoordinator, create_build_manifest
 from persome.store import fts
 from persome.store import relation_edges as edges_store
+
+BUILD_KEYS = {
+    "build_id",
+    "completed_at",
+    "config_hash",
+    "core_commit",
+    "degraded_stages",
+    "duration_ms",
+    "input_window",
+    "mode",
+    "models",
+    "prompt_hashes",
+    "started_at",
+    "status",
+    "trigger",
+}
 
 
 def _save_point(
@@ -30,6 +51,21 @@ def _save_point(
 
 
 class TestGraphJson:
+    def test_graph_uses_transactionally_stable_live_reader(self, ac_root, monkeypatch):
+        sentinel = {"schema_version": 1, "source": "live-reader"}
+        calls = []
+
+        def fake_live_snapshot(conn):  # type: ignore[no-untyped-def]
+            calls.append(conn)
+            return sentinel
+
+        monkeypatch.setattr(routes, "build_live_snapshot", fake_live_snapshot)
+
+        graph = routes.model_graph()
+
+        assert graph["model"] is sentinel
+        assert len(calls) == 1
+
     def test_graph_is_the_canonical_snapshot(self, ac_root):
         _save_point(node_id="point-runtime", content="The runtime stores local context.")
 
@@ -51,6 +87,70 @@ class TestGraphJson:
         graph = routes.model_graph()
         assert graph["model"]["points"] == []
         assert graph["model"]["stats"]["points"] == 0
+        build = graph["model"]["build"]
+        assert set(build) == BUILD_KEYS
+        assert build["status"] == "not_built"
+        assert build["trigger"] == "no_completed_build"
+        assert build["build_id"] is None
+        assert build["started_at"] is None
+        assert build["completed_at"] is None
+
+    def test_incomplete_saved_manifest_does_not_fabricate_completed_build(self, ac_root):
+        paths.atomic_write_private_text(
+            paths.model_build_manifest(),
+            json.dumps({"status": "complete", "build_id": "incomplete"}),
+        )
+
+        build = routes.model_graph()["model"]["build"]
+
+        assert build["status"] == "not_built"
+        assert build["build_id"] is None
+
+    def test_active_build_is_exposed_as_building(self, ac_root):
+        coordinator = ModelBuildCoordinator()
+        with coordinator.acquire(wait_seconds=0):
+            paths.atomic_write_private_text(
+                paths.model_build_manifest(),
+                json.dumps(
+                    {
+                        "build_id": None,
+                        "status": "building",
+                        "trigger": "test-route",
+                        "started_at": "2026-07-12T08:00:00+00:00",
+                        "completed_at": None,
+                        "duration_ms": 0,
+                        "degraded_stages": [],
+                    }
+                ),
+            )
+
+            build = routes.model_graph()["model"]["build"]
+
+        assert build["status"] == "building"
+        assert set(build) == BUILD_KEYS
+        assert build["trigger"] == "test-route"
+        assert build["build_id"] is None
+
+    @pytest.mark.parametrize("degraded_stages", [[], ["root_synthesis"]])
+    def test_saved_build_manifest_is_preserved(self, ac_root, degraded_stages):
+        manifest = create_build_manifest(
+            core_commit="0123456789abcdef",
+            models={"timeline": "fixture-model"},
+            config={"fixture": True},
+            input_window={"start": "2026-07-01T00:00:00+00:00", "end": None},
+            degraded_stages=degraded_stages,
+            started_at="2026-07-12T08:00:00+00:00",
+            completed_at="2026-07-12T08:01:00+00:00",
+            duration_ms=60_000,
+            trigger="test-fixture",
+            mode="mock",
+        )
+        paths.atomic_write_private_text(
+            paths.model_build_manifest(),
+            json.dumps(manifest, ensure_ascii=False),
+        )
+
+        assert routes.model_graph()["model"]["build"] == manifest
 
 
 class TestViewPage:
@@ -91,6 +191,22 @@ class TestViewPage:
         assert b'fetch("/model' not in viewer.body
         assert b"ACESFilmicToneMapping" in viewer.body
         assert b"model.root?.signature" in viewer.body
+        assert b'buildStatus === "not_built"' in viewer.body
+        assert b'buildStatus === "building"' in viewer.body
+        assert "Building…".encode() in viewer.body
+        assert b'not_built: "not-built"' in viewer.body
+        assert b'building: "building"' in viewer.body
+        assert b'degraded: "degraded"' in viewer.body
+        assert b'complete: "complete"' in viewer.body
+        assert b"build-state--${buildStateClass}" in viewer.body
+        assert b".build-state--not-built" in css.body
+        assert b".build-state--building" in css.body
+        assert b".build-state--degraded" in css.body
+        assert b".build-state--complete" in css.body
+        assert b"--build-color: #8d8799" in css.body
+        assert b"--build-color: var(--line)" in css.body
+        assert b"--build-color: var(--root)" in css.body
+        assert b"--build-color: var(--point)" in css.body
         assert b"controls.zoomToCursor = true" in viewer.body
         assert b"window.__persomeZoomState" in viewer.body
         assert b"if (!REDUCED_MOTION)" in viewer.body

--- a/tests/test_model_snapshot.py
+++ b/tests/test_model_snapshot.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -9,17 +10,20 @@ from pathlib import Path
 import pytest
 
 from persome import config as config_mod
+from persome import paths
 from persome.evomem.models import MemoryLayer, MemoryNode, MemoryStatus
 from persome.evomem.store import NodeStore
 from persome.model import (
     ModelBuildBusy,
     ModelBuildCoordinator,
     ModelContractError,
+    ModelRecoveryIncomplete,
     PipelineOutcome,
     build_snapshot,
     create_build_manifest,
     export_snapshot,
     load_last_manifest,
+    load_live_manifest,
     model_status,
     run_model_build,
 )
@@ -28,6 +32,12 @@ from persome.store import relation_edges as edges
 
 FIXTURE = Path(__file__).parent / "fixtures" / "runtime_model" / "model_seed.json"
 GOLDEN = Path(__file__).parent / "fixtures" / "runtime_model" / "model_snapshot_v1.golden.json"
+
+
+def _rehash_manifest(manifest: dict) -> None:
+    unsigned = {key: value for key, value in manifest.items() if key != "build_id"}
+    payload = json.dumps(unsigned, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    manifest["build_id"] = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:20]
 
 
 def _seed_model(monkeypatch: pytest.MonkeyPatch) -> dict:
@@ -324,6 +334,138 @@ def test_empty_model_build_is_degraded_not_success(ac_root) -> None:
     assert result.manifest["degraded_stages"] == ["model_contract"]
     assert result.stats["points"] == 0
     assert result.stats["roots"] == 0
+
+
+def test_interrupted_model_build_invalidates_previous_completed_manifest(ac_root) -> None:
+    cfg = config_mod.load(ac_root / "config.toml")
+    first = run_model_build(
+        cfg,
+        pipeline_runner=lambda _cfg: PipelineOutcome(),
+        now=lambda: datetime(2026, 7, 10, 8, 0, tzinfo=UTC),
+        trigger="first-build",
+    )
+    assert load_live_manifest()["build_id"] == first.manifest["build_id"]
+
+    def interrupted(_cfg):  # type: ignore[no-untyped-def]
+        raise RuntimeError("synthetic interruption")
+
+    with pytest.raises(RuntimeError, match="synthetic interruption"):
+        run_model_build(
+            cfg,
+            pipeline_runner=interrupted,
+            now=lambda: datetime(2026, 7, 10, 9, 0, tzinfo=UTC),
+            trigger="interrupted-build",
+        )
+
+    assert load_last_manifest()["status"] == "building"
+    assert load_live_manifest()["status"] == "not_built"
+
+
+@pytest.mark.parametrize("pending_kind", ["database", "config"])
+def test_model_build_is_blocked_while_integrity_recovery_is_pending(
+    ac_root,
+    pending_kind,
+) -> None:
+    cfg = config_mod.load(ac_root / "config.toml")
+    pending_path = (
+        paths.integrity_recovery_pending()
+        if pending_kind == "database"
+        else paths.integrity_config_recovery_pending()
+    )
+    paths.atomic_write_private_text(pending_path, '{"version": 1}')
+
+    with pytest.raises(ModelRecoveryIncomplete, match="recovery is incomplete"):
+        run_model_build(cfg, pipeline_runner=lambda _cfg: PipelineOutcome())
+
+    assert not paths.model_build_manifest().exists()
+
+
+def test_active_building_manifest_is_live_only_while_lock_is_held(ac_root) -> None:
+    coordinator = ModelBuildCoordinator()
+    marker = {
+        "build_id": None,
+        "status": "building",
+        "trigger": "test-active",
+        "started_at": "2026-07-12T08:00:00+00:00",
+        "completed_at": None,
+        "duration_ms": 0,
+        "degraded_stages": [],
+    }
+    with coordinator.acquire(wait_seconds=0):
+        paths.atomic_write_private_text(
+            paths.model_build_manifest(),
+            json.dumps(marker),
+        )
+        live = load_live_manifest()
+        assert all(live[key] == value for key, value in marker.items())
+        assert set(live) == set(json.loads(GOLDEN.read_text(encoding="utf-8"))["build"])
+
+    assert load_last_manifest() == marker
+    assert load_live_manifest()["status"] == "not_built"
+
+
+def test_build_lock_hides_previous_manifest_before_building_marker(ac_root, tmp_path) -> None:
+    previous = create_build_manifest(
+        core_commit="0123456789abcdef",
+        prompt_dir=tmp_path / "missing-prompts",
+        started_at="2026-07-12T07:00:00+00:00",
+        completed_at="2026-07-12T07:01:00+00:00",
+        trigger="previous-build",
+        mode="mock",
+    )
+    paths.atomic_write_private_text(paths.model_build_manifest(), json.dumps(previous))
+
+    coordinator = ModelBuildCoordinator()
+    with coordinator.acquire(wait_seconds=0):
+        # The exclusive lock is acquired before run_model_build writes its
+        # provisional marker. Never expose the previous completed manifest in
+        # that window.
+        live = load_live_manifest()
+
+    assert live["status"] == "building"
+    assert live["build_id"] is None
+    assert live["trigger"] == "unknown"
+    assert live["started_at"] is None
+
+
+def test_live_manifest_rejects_tampered_build_id(ac_root, tmp_path) -> None:
+    manifest = create_build_manifest(
+        core_commit="0123456789abcdef",
+        prompt_dir=tmp_path / "missing-prompts",
+        degraded_stages=["root_synthesis"],
+        started_at="2026-07-12T08:00:00+00:00",
+        completed_at="2026-07-12T08:01:00+00:00",
+        mode="mock",
+    )
+    manifest["status"] = "complete"
+    paths.atomic_write_private_text(paths.model_build_manifest(), json.dumps(manifest))
+
+    assert load_live_manifest()["status"] == "not_built"
+
+
+@pytest.mark.parametrize(
+    ("status", "degraded_stages"),
+    [("complete", ["root_synthesis"]), ("degraded", [])],
+)
+def test_live_manifest_rejects_rehashed_status_stage_contradiction(
+    ac_root,
+    tmp_path,
+    status,
+    degraded_stages,
+) -> None:
+    manifest = create_build_manifest(
+        core_commit="0123456789abcdef",
+        prompt_dir=tmp_path / "missing-prompts",
+        started_at="2026-07-12T08:00:00+00:00",
+        completed_at="2026-07-12T08:01:00+00:00",
+        mode="mock",
+    )
+    manifest["status"] = status
+    manifest["degraded_stages"] = degraded_stages
+    _rehash_manifest(manifest)
+    paths.atomic_write_private_text(paths.model_build_manifest(), json.dumps(manifest))
+
+    assert load_live_manifest()["status"] == "not_built"
 
 
 def test_model_build_lock_no_wait_reports_busy(ac_root) -> None:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -10,6 +10,43 @@ from persome.store import files as files_mod
 from persome.store import fts, index_md
 
 
+def test_memory_discovery_rejects_symlinked_external_markdown(
+    ac_root: Path, tmp_path: Path
+) -> None:
+    outside = tmp_path / "outside-private.md"
+    outside.write_text("EXTERNAL PRIVATE CONTENT", encoding="utf-8")
+    skills = ac_root / "memory" / "skills"
+    skills.mkdir(parents=True, exist_ok=True)
+    leak = skills / "skill-leak.md"
+    leak.symlink_to(outside)
+
+    assert leak not in files_mod.list_memory_files()
+    with fts.cursor() as conn:
+        files, rows = entries_mod.rebuild_index(conn)
+        hits = fts.search(conn, query="EXTERNAL")
+    assert (files, rows) == (0, 0)
+    assert hits == []
+
+
+def test_memory_discovery_does_not_traverse_symlinked_external_directory(
+    ac_root: Path, tmp_path: Path
+) -> None:
+    outside = tmp_path / "outside-skills"
+    outside.mkdir()
+    (outside / "skill-leak.md").write_text(
+        "EXTERNAL DIRECTORY PRIVATE CONTENT",
+        encoding="utf-8",
+    )
+    (ac_root / "memory" / "skills").symlink_to(outside, target_is_directory=True)
+
+    assert files_mod.list_memory_files() == []
+    with fts.cursor() as conn:
+        files, rows = entries_mod.rebuild_index(conn)
+        hits = fts.search(conn, query="EXTERNAL")
+    assert (files, rows) == (0, 0)
+    assert hits == []
+
+
 def test_make_id_uniqueness() -> None:
     ids = {entries_mod.make_id("2026-04-21T10:30") for _ in range(200)}
     assert len(ids) == 200
@@ -46,6 +83,220 @@ def test_create_append_search(ac_root: Path) -> None:
         # GLOB path filter
         hits3 = fts.search(conn, query="Python", path_patterns=["project-*.md"], top_k=5)
         assert len(hits3) >= 1
+
+
+def test_nested_and_top_level_files_with_same_basename_keep_distinct_identities(
+    ac_root: Path,
+) -> None:
+    top_name = "skill-same.md"
+    nested_name = "skills/skill-same.md"
+
+    with fts.cursor() as conn:
+        entries_mod.create_file(
+            conn,
+            name=top_name,
+            description="Top-level skill",
+            tags=["top"],
+        )
+        entries_mod.create_file(
+            conn,
+            name=nested_name,
+            description="Nested direct skill",
+            tags=["nested"],
+        )
+        top_id = entries_mod.append_entry(
+            conn,
+            name=top_name,
+            content="Top-level behavior",
+            tags=["top"],
+        )
+        nested_id = entries_mod.append_entry(
+            conn,
+            name=nested_name,
+            content="Nested behavior",
+            tags=["nested"],
+        )
+        entries_mod.set_file_status(conn, name=nested_name, status="dormant")
+
+        before = {
+            row["path"]: (row["description"], row["status"])
+            for row in conn.execute(
+                "SELECT path, description, status FROM files ORDER BY path"
+            ).fetchall()
+        }
+        entry_paths = {
+            row["id"]: row["path"]
+            for row in conn.execute(
+                "SELECT id, path FROM entries WHERE id IN (?, ?)",
+                (top_id, nested_id),
+            ).fetchall()
+        }
+
+        assert before == {
+            top_name: ("Top-level skill", "active"),
+            nested_name: ("Nested direct skill", "dormant"),
+        }
+        assert entry_paths == {top_id: top_name, nested_id: nested_name}
+
+        assert entries_mod.rebuild_index(conn) == (2, 2)
+        after = {
+            row["path"]: (row["description"], row["status"])
+            for row in conn.execute(
+                "SELECT path, description, status FROM files ORDER BY path"
+            ).fetchall()
+        }
+        rebuilt_entry_paths = {
+            row["id"]: row["path"]
+            for row in conn.execute(
+                "SELECT id, path FROM entries WHERE id IN (?, ?)",
+                (top_id, nested_id),
+            ).fetchall()
+        }
+
+    assert after == before
+    assert rebuilt_entry_paths == entry_paths
+
+
+def test_evomem_rebuild_migrates_verified_legacy_nested_skill_shadow(
+    ac_root: Path,
+) -> None:
+    """Upgrade a pre-fix basename shadow without losing the direct source."""
+    from persome import config as config_mod
+    from persome import paths
+    from persome.evomem.models import MemoryLayer, MemoryNode
+    from persome.evomem.store import NodeStore
+
+    nested_name = "skills/skill-upgrade.md"
+    content = "Prefer explicit proof before changing durable state."
+    with fts.cursor() as conn:
+        entries_mod.create_file(
+            conn,
+            name=nested_name,
+            description="Direct behavioral memory",
+            tags=["behavior"],
+        )
+        entry_id = entries_mod.append_entry(
+            conn,
+            name=nested_name,
+            content=content,
+            tags=["observed"],
+        )
+
+    # Old shadow.py used Path.name here, erasing the ``skills/`` identity.
+    NodeStore().save(
+        MemoryNode(
+            node_id=entry_id,
+            content=content,
+            layer=MemoryLayer.L2_FACT,
+            file_name="skill-upgrade.md",
+            tags="observed",
+        )
+    )
+    NodeStore(user_id="other-user", agent_id="other-agent").save(
+        MemoryNode(
+            node_id=entry_id,
+            content="Other scope remains independent.",
+            layer=MemoryLayer.L2_FACT,
+            file_name="skill-upgrade.md",
+        )
+    )
+    with fts.cursor() as conn:
+        # Complete the on-disk shape produced by the affected versions: both
+        # the canonical-node route and the derived source route lost skills/.
+        conn.execute(
+            "UPDATE entries SET path='skill-upgrade.md' WHERE id=?",
+            (entry_id,),
+        )
+        conn.execute(
+            "UPDATE files SET path='skill-upgrade.md' WHERE path=?",
+            (nested_name,),
+        )
+    config_mod.write_default_if_missing()
+    paths.atomic_write_private_text(
+        paths.config_file(),
+        paths.config_file()
+        .read_text(encoding="utf-8")
+        .replace('write_authority = "markdown"', 'write_authority = "evomem"'),
+    )
+
+    with fts.cursor() as conn:
+        assert entries_mod.rebuild_index(conn) == (1, 1)
+        default_node = conn.execute(
+            "SELECT 1 FROM evo_nodes WHERE node_id=? AND user_id='default' AND agent_id='default'",
+            (entry_id,),
+        ).fetchone()
+        other_node = conn.execute(
+            "SELECT file_name, content FROM evo_nodes "
+            "WHERE node_id=? AND user_id='other-user' AND agent_id='other-agent'",
+            (entry_id,),
+        ).fetchone()
+        rebuilt = conn.execute(
+            "SELECT path, content FROM entries WHERE id=?",
+            (entry_id,),
+        ).fetchall()
+
+    assert default_node is None
+    assert other_node is not None and tuple(other_node) == (
+        "skill-upgrade.md",
+        "Other scope remains independent.",
+    )
+    assert [tuple(row) for row in rebuilt] == [(nested_name, content)]
+
+
+@pytest.mark.parametrize("ambiguity", ["source", "content"])
+def test_evomem_rebuild_rejects_ambiguous_legacy_nested_skill_shadow(
+    ac_root: Path,
+    ambiguity: str,
+) -> None:
+    from persome.evomem.models import MemoryLayer, MemoryNode
+    from persome.evomem.store import NodeStore
+
+    nested_name = "skills/skill-ambiguous-upgrade.md"
+    content = "Nested source must win only with complete proof."
+    with fts.cursor() as conn:
+        entries_mod.create_file(conn, name=nested_name, description="d", tags=[])
+        entry_id = entries_mod.append_entry(
+            conn,
+            name=nested_name,
+            content=content,
+            tags=[],
+        )
+        if ambiguity == "source":
+            entries_mod.create_file(
+                conn,
+                name="skill-ambiguous-upgrade.md",
+                description="Potential top-level source",
+                tags=[],
+            )
+    node_content = content if ambiguity == "source" else "DIVERGENT CANONICAL CONTENT"
+    NodeStore().save(
+        MemoryNode(
+            node_id=entry_id,
+            content=node_content,
+            layer=MemoryLayer.L2_FACT,
+            file_name="skill-ambiguous-upgrade.md",
+        )
+    )
+
+    # Exercise both proof failures: a basename with a possible top-level source,
+    # and a node whose canonical content disagrees with the nested entry.
+    with fts.cursor() as conn:
+        conn.execute(
+            "UPDATE entries SET path='skill-ambiguous-upgrade.md' WHERE id=?",
+            (entry_id,),
+        )
+        with pytest.raises(ValueError, match="source projection differs"):
+            entries_mod.rebuild_index(conn, source_authority="evomem")
+        node = conn.execute(
+            "SELECT file_name, content FROM evo_nodes "
+            "WHERE node_id=? AND user_id='default' AND agent_id='default'",
+            (entry_id,),
+        ).fetchone()
+
+    assert node is not None and tuple(node) == (
+        "skill-ambiguous-upgrade.md",
+        node_content,
+    )
 
 
 def test_search_multiterm_is_or_ranked_not_and(ac_root: Path) -> None:

--- a/tests/test_writer_tools.py
+++ b/tests/test_writer_tools.py
@@ -52,6 +52,39 @@ def test_dispatch_read_memory(ac_root: Path) -> None:
         assert len(r["entries"]) == 1
 
 
+def test_flag_compact_keeps_nested_same_basename_identity(ac_root: Path) -> None:
+    with fts.cursor() as conn:
+        entries_mod.create_file(
+            conn,
+            name="skill-same.md",
+            description="Top-level skill",
+            tags=[],
+        )
+        entries_mod.create_file(
+            conn,
+            name="skills/skill-same.md",
+            description="Nested skill",
+            tags=[],
+        )
+        state = wtools.CommitState()
+
+        result = wtools.tool_flag_compact(
+            conn,
+            path="skills/skill-same.md",
+            reason="nested only",
+            state=state,
+        )
+        flags = {
+            row["path"]: row["needs_compact"]
+            for row in conn.execute(
+                "SELECT path, needs_compact FROM files ORDER BY path"
+            ).fetchall()
+        }
+
+    assert result == {"ok": True}
+    assert flags == {"skill-same.md": 0, "skills/skill-same.md": 1}
+
+
 def test_dispatch_search(ac_root: Path) -> None:
     with fts.cursor() as conn:
         entries_mod.create_file(


### PR DESCRIPTION
## What changed

- make SQLite/config recovery crash-resumable, replay canonical Markdown safely, preserve forensic artifacts, and freeze writes when source authority is ambiguous
- reconcile an explicit Markdown/evomem owner choice before unfreezing, including legacy nested skill-memory identities and interrupted WAL quarantine
- invalidate stale model manifests and derived geometry after recovery, and expose truthful `not_built` / `building` / `degraded` states
- read model geometry and build metadata through one lock- and transaction-consistent snapshot for HTTP, MCP, status, and export
- load the saved runtime environment consistently for CLI model work, harden the owner-local bearer token, verify background startup against the launched generation, and clean stale receipts after failed starts
- add merge-mode capture replay and bound/rotate cross-domain probes so model builds do not appear hung or perform unbounded LLM calls
- improve viewer state feedback and update the recovery, model-contract, capture, configuration, and operations documentation

## Why

A quarantined or partially restored database could leave an empty retrieval/model projection while an old successful manifest still made the UI look complete. Several crash windows could also discard WAL-backed rows, select the wrong write authority, or permanently wedge startup on a malformed recovery journal. Separately, standalone CLI builds did not always load the saved provider key, startup could report success before the intended daemon owned the port, and public model readers could observe mixed manifest/geometry generations.

## User impact

Updates and recovery now fail closed without silently dropping personal state, provide actionable owner choices when authority cannot be proven, and resume safely after interruption. Successful onboarding/startup proves the expected daemon is healthy, while model status and the local viewer accurately reflect whether a build exists or is still running.

## Validation

- `PERSOME_LLM_MOCK=1 uv run pytest -m "not macos and not integration" -q` — 1804 passed, 15 deselected
- focused recovery/runtime/model regression suites — 234 passed before merging main; 174 merged critical-path tests passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `git diff --check origin/main...HEAD`
- secret, PII, and English-language release scans — clean
