### PR TITLE
release: prepare v0.3.0

### DIFF
--- a/.github/releases/v0.3.0.md
+++ b/.github/releases/v0.3.0.md
@@ -1,0 +1,68 @@
+# Persome Runtime v0.3.0
+
+Persome v0.3.0 narrows the public Runtime around local capture, durable personal
+memory, the inspectable Point/Line/Face/Volume/Root model, and MCP. It replaces
+the early alpha's implicit setup assumptions with explicit onboarding, stronger
+owner-local security, and transactional updates.
+
+## Highlights
+
+- repeatable `persome onboard` permission, OCR, daemon, and fresh-capture proof;
+- provider-aware LLM setup for Anthropic, OpenAI-compatible services, Azure, and
+  local endpoints, with completion and tool-calling checks before saving;
+- owner-local bearer protection for REST, viewer, and HTTP MCP routes, plus
+  origin, request-size, and local-runtime hardening;
+- transactional `persome update` with lifecycle restoration and rollback after
+  failures or interrupts;
+- safe repair of derived SQLite/FTS indexes without deleting personal-model
+  state, plus temporal-history preservation during rebuilds;
+- redesigned local model viewer, dense synthetic showcase, and an explicit
+  model-share card that never publishes without the owner's action;
+- cleaner stdio MCP lifecycle and isolated test roots;
+- removal of the legacy terminal Chat surface so the standalone Runtime stays
+  focused on capture, memory, modeling, and agent access through MCP.
+
+## Install
+
+```bash
+git clone https://github.com/Intuition-Lab/personal-model.git
+cd personal-model
+bash install.sh
+
+persome status
+persome model open
+```
+
+Existing installations can update transactionally from any directory:
+
+```bash
+persome update
+```
+
+The GitHub Release includes a source distribution, wheel, and `SHA256SUMS`.
+`install.sh` remains the supported first-run path because it compiles the macOS
+AX helpers, establishes private local state, runs provider setup, and proves the
+permission and capture path. The same wheel and source distribution are the
+artifacts published to PyPI.
+
+## Verification
+
+The release workflow verifies the locked dependency graph, hash-constrained
+build backend, offline test suite with mocked LLMs, ruff, shell syntax,
+secret/PII/language/documentation scans, synthetic MCP transport, clean wheel
+installation outside the checkout, bundled Swift/Three.js/PP-OCRv6 resources,
+checksums, and GitHub artifact provenance.
+
+## Compatibility notes
+
+- Live capture requires macOS 13 or newer.
+- Apple Silicon supports bundled local OCR; Intel Macs keep AX capture, Runtime,
+  and MCP but do not receive the Paddle OCR runtime.
+- The legacy `persome chat` command and browser Chat routes were removed. Connect
+  Claude Code, Codex, Claude Desktop, Cursor, opencode, or another client through
+  `persome mcp` instead.
+- Except canonical `GET /health`, local HTTP surfaces now require the
+  owner-generated API token or the one-use viewer capability. Use
+  `persome model open` instead of opening `/model` directly.
+- There is still no hosted account, sync service, telemetry, meeting-audio
+  capture, or remote deployment contract.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Release
 
 # Builds and verifies source/wheel artifacts, then creates a GitHub Release when
-# a version tag is pushed. PyPI publishing is intentionally not part of the
-# public-alpha launch contract.
+# a version tag is pushed. Until trusted publishing is automated, maintainers
+# publish the exact verified dist artifacts to PyPI as a separate release step.
 #
 # Cut a release:
 #   1. bump `version` in pyproject.toml + `__version__` in src/persome/__init__.py

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,14 +2,14 @@ cff-version: 1.2.0
 message: "If you use Persome Runtime, please cite this software."
 title: "Persome Runtime"
 type: software
-version: "0.2.2"
+version: "0.3.0"
 license: Apache-2.0
 repository-code: "https://github.com/Intuition-Lab/personal-model"
 url: "https://github.com/Intuition-Lab/personal-model"
 identifiers:
   - type: url
-    value: "https://github.com/Intuition-Lab/personal-model/releases/tag/v0.2.2"
-    description: "Persome Runtime v0.2.2 release"
+    value: "https://github.com/Intuition-Lab/personal-model/releases/tag/v0.3.0"
+    description: "Persome Runtime v0.3.0 release"
 abstract: >-
   Local-first screen-context memory daemon for macOS. It captures Accessibility
   tree events, distills them into persistent Markdown memory and SQLite indexes,

--- a/openapi.json
+++ b/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Persome API",
     "description": "Local-first screen-context memory and personal-model REST API.",
-    "version": "0.2.2"
+    "version": "0.3.0"
   },
   "paths": {
     "/health": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "persome-core"
-version = "0.2.2"
+version = "0.3.0"
 description = "Local-first macOS Runtime for screen-context memory, personal modeling, and MCP."
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/src/persome/__init__.py
+++ b/src/persome/__init__.py
@@ -1,3 +1,3 @@
 """Persome Runtime: local screen-context memory and personal modeling."""
 
-__version__ = "0.2.2"
+__version__ = "0.3.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1167,7 +1167,7 @@ wheels = [
 
 [[package]]
 name = "persome-core"
-version = "0.2.2"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- bump Persome Runtime and generated contracts to 0.3.0
- add release notes for onboarding, security, updater, model viewer, and MCP changes
- document that PyPI reuses the exact verified GitHub release artifacts

## Validation

- 1697 passed, 15 deselected
- ruff check and format check
- secret, PII, language, documentation, OpenAPI, and DB schema gates
- synthetic MCP transport with 16 tools and receipt verification
- clean Python 3.11 wheel install outside the checkout
- Twine metadata check for wheel and sdist

This PR must be merged with a merge commit.