### PR TITLE
release: publish personal-model v0.3.1 to PyPI

### DIFF
--- a/.github/releases/v0.3.1.md
+++ b/.github/releases/v0.3.1.md
@@ -1,0 +1,46 @@
+# Persome Runtime v0.3.1
+
+Persome v0.3.1 adds the first official PyPI distribution and keeps the existing
+source-update path compatible with v0.3.0 installations.
+
+## Install from PyPI
+
+```bash
+uv tool install personal-model
+persome onboard
+```
+
+The PyPI distribution is named `personal-model`; the installed command remains
+`persome`. `persome onboard` performs provider setup, explains and requests the
+effective macOS permissions, verifies bundled OCR when enabled, starts the
+Runtime, and requires a mode-appropriate fresh capture/readiness receipt.
+
+Upgrade a PyPI installation with its package manager and re-run Runtime proof:
+
+```bash
+uv tool upgrade personal-model
+persome onboard
+```
+
+Source installation remains supported:
+
+```bash
+git clone https://github.com/Intuition-Lab/personal-model.git
+cd personal-model
+bash install.sh
+```
+
+## Publishing and compatibility
+
+- PyPI publication uses GitHub Actions Trusted Publishing with the protected
+  `pypi` environment; no long-lived PyPI token is stored in GitHub.
+- The PyPI wheel and source distribution are built from the same tagged source,
+  smoke-tested outside the checkout, and published only after the GitHub Release
+  job succeeds.
+- The root source project retains its `persome-core` compatibility identifier so
+  the already released v0.3.0 updater continues to accept new source checkouts.
+  Runtime code recognizes both distribution metadata names.
+
+All v0.3.0 onboarding, owner-local API protection, transactional updates,
+model-recovery hardening, local viewer, MCP, and privacy guarantees remain in
+this release.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Release
 
-# Builds and verifies source/wheel artifacts, then creates a GitHub Release when
-# a version tag is pushed. Until trusted publishing is automated, maintainers
-# publish the exact verified dist artifacts to PyPI as a separate release step.
+# Builds and verifies source/wheel artifacts, creates a GitHub Release, then
+# publishes the separately named `personal-model` distribution to PyPI through
+# Trusted Publishing. The root `persome-core` name remains an update-source
+# compatibility contract for already released runtimes.
 #
 # Cut a release:
 #   1. bump `version` in pyproject.toml + `__version__` in src/persome/__init__.py
@@ -137,15 +138,62 @@ jobs:
               assert (bundled / relative).is_file(), relative
           PY
 
+      - name: Build PyPI sdist + wheel
+        run: |
+          uv run --no-sync python scripts/build_pypi_dist.py --out-dir pypi-dist
+          cd pypi-dist
+          sha256sum ./*.whl ./*.tar.gz > SHA256SUMS
+          sha256sum --check SHA256SUMS
+
+      - name: Smoke-test PyPI wheel
+        run: |
+          uv venv /tmp/personal-model-wheel --python 3.11
+          uv pip install --python /tmp/personal-model-wheel/bin/python --require-hashes \
+            --no-build --requirement /tmp/persome-runtime.txt
+          uv pip install --python /tmp/personal-model-wheel/bin/python --no-deps \
+            pypi-dist/personal_model-*.whl
+          cd /tmp
+          PERSOME_ROOT=/tmp/personal-model-smoke-root \
+            /tmp/personal-model-wheel/bin/persome --help >/dev/null
+          /tmp/personal-model-wheel/bin/python - <<'PY'
+          from importlib.metadata import PackageNotFoundError, version
+          from importlib.resources import files
+          from persome import __version__
+
+          assert version("personal-model") == __version__
+          try:
+              version("persome-core")
+          except PackageNotFoundError:
+              pass
+          else:
+              raise AssertionError("PyPI wheel must be named personal-model")
+          bundled = files("persome") / "_bundled"
+          assert (bundled / "mac-ax-helper.swift").is_file()
+          assert (bundled / "model_assets" / "viewer.js").is_file()
+          assert (
+              bundled / "ocr_models" / "PP-OCRv6_tiny_rec" / "inference.pdiparams"
+          ).is_file()
+          PY
+
       - name: Attest release artifacts
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
         with:
           subject-checksums: dist/SHA256SUMS
 
+      - name: Attest PyPI artifacts
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+        with:
+          subject-checksums: pypi-dist/SHA256SUMS
+
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dist
           path: dist/
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: pypi-dist
+          path: pypi-dist/
 
   github-release:
     needs: build
@@ -173,3 +221,31 @@ jobs:
             --title "$GITHUB_REF_NAME" \
             --notes-file ".github/releases/${GITHUB_REF_NAME}.md" \
             --verify-tag
+
+  pypi-publish:
+    needs: [build, github-release]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/personal-model
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.10.9"
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: pypi-dist
+          path: pypi-dist/
+
+      - name: Verify PyPI artifacts
+        run: |
+          cd pypi-dist
+          sha256sum --check SHA256SUMS
+
+      - name: Publish personal-model to PyPI
+        run: uv publish pypi-dist/*.whl pypi-dist/*.tar.gz

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,14 +2,14 @@ cff-version: 1.2.0
 message: "If you use Persome Runtime, please cite this software."
 title: "Persome Runtime"
 type: software
-version: "0.3.0"
+version: "0.3.1"
 license: Apache-2.0
 repository-code: "https://github.com/Intuition-Lab/personal-model"
 url: "https://github.com/Intuition-Lab/personal-model"
 identifiers:
   - type: url
-    value: "https://github.com/Intuition-Lab/personal-model/releases/tag/v0.3.0"
-    description: "Persome Runtime v0.3.0 release"
+    value: "https://github.com/Intuition-Lab/personal-model/releases/tag/v0.3.1"
+    description: "Persome Runtime v0.3.1 release"
 abstract: >-
   Local-first screen-context memory daemon for macOS. It captures Accessibility
   tree events, distills them into persistent Markdown memory and SQLite indexes,

--- a/README.md
+++ b/README.md
@@ -84,6 +84,26 @@ against repository-pinned SHA-256 digests; the Runtime environment is installed
 from the committed `uv.lock`, and the complete build-backend closure is
 hash-constrained rather than resolved afresh.
 
+Install the published PyPI distribution with `uv` and run the same explicit
+onboarding proof:
+
+```bash
+uv tool install personal-model
+persome onboard
+```
+
+The distribution is named `personal-model`; the installed CLI remains
+`persome`. The source installer below remains the most explicit first-run path
+and is also used by transactional updates.
+
+Upgrade a PyPI/`uv tool` installation with its package manager, then re-run the
+same Runtime proof:
+
+```bash
+uv tool upgrade personal-model
+persome onboard
+```
+
 ```bash
 git clone https://github.com/Intuition-Lab/personal-model.git
 cd personal-model
@@ -126,7 +146,8 @@ ingest runner instead of pretending that its daemon produced an AX frame.
 
 ### Update an existing installation
 
-Run the updater from any directory; no Git checkout is required:
+For an installation created by `install.sh`, run the transactional updater from
+any directory; no Git checkout is required:
 
 ```bash
 persome update

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -160,6 +160,35 @@ for relative in required:
 PY
 ```
 
+The public PyPI distribution is built from the same tracked source with the
+name declared by `tool.persome.release.pypi-distribution`. The root project
+keeps the `persome-core` compatibility name because the v0.3.0 updater validates
+that field before handing off to a newer installer. Build and inspect the PyPI
+artifacts independently:
+
+```bash
+rm -rf pypi-dist /tmp/personal-model-wheel
+uv run python scripts/build_pypi_dist.py --out-dir pypi-dist
+uv venv /tmp/personal-model-wheel --python 3.11
+uv pip install --python /tmp/personal-model-wheel/bin/python \
+  --require-hashes --no-build --requirement /tmp/persome-runtime.txt
+uv pip install --python /tmp/personal-model-wheel/bin/python \
+  --no-deps pypi-dist/personal_model-*.whl
+/tmp/personal-model-wheel/bin/python - <<'PY'
+from importlib.metadata import version
+from persome import __version__
+
+assert version("personal-model") == __version__
+PY
+/tmp/personal-model-wheel/bin/persome --help
+```
+
+PyPI installations are owned by their Python tool manager rather than
+`<PERSOME_ROOT>/venv`. Upgrade them with `uv tool upgrade personal-model` (or
+the corresponding pipx/pip command), then run `persome onboard` to restart and
+re-prove the Runtime. `persome update` detects this shape and exits with those
+instructions instead of attempting the source installer's atomic venv exchange.
+
 In an interactive macOS session, `install.sh` runs `persome onboard`. For the
 standard Apple Silicon daemon mode, onboarding separately requests Accessibility
 for the source-versioned capture helper and event watcher, requests Screen
@@ -229,7 +258,10 @@ gh attestation verify persome_core-*.tar.gz \
 The release workflow accepts only an administrator-protected version tag whose
 commit is reachable from `origin/main`. Its Actions are pinned to full commit
 SHAs and its default token permission is read-only; only the final release job
-receives `contents: write`.
+receives `contents: write`. After that GitHub Release succeeds, the `pypi-publish`
+job downloads the already verified `personal_model` artifacts and publishes
+through the GitHub `pypi` environment with OIDC `id-token: write`; no PyPI API
+token is stored in the repository.
 
 ## 7. Build record
 

--- a/openapi.json
+++ b/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Persome API",
     "description": "Local-first screen-context memory and personal-model REST API.",
-    "version": "0.3.0"
+    "version": "0.3.1"
   },
   "paths": {
     "/health": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "persome-core"
-version = "0.3.0"
+version = "0.3.1"
 description = "Local-first macOS Runtime for screen-context memory, personal modeling, and MCP."
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -60,6 +60,12 @@ Homepage = "https://github.com/Intuition-Lab/personal-model"
 Repository = "https://github.com/Intuition-Lab/personal-model"
 Issues = "https://github.com/Intuition-Lab/personal-model/issues"
 Documentation = "https://github.com/Intuition-Lab/personal-model/tree/main/docs"
+
+[tool.persome.release]
+# Keep the root project name as `persome-core` so the v0.3.0 updater can still
+# validate and install future source checkouts. Public PyPI artifacts are built
+# from the same tagged tree with this distribution name.
+pypi-distribution = "personal-model"
 
 [build-system]
 requires = ["hatchling==1.31.0"]

--- a/scripts/build_pypi_dist.py
+++ b/scripts/build_pypi_dist.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Build the public PyPI distribution from the current tagged source tree.
+
+The root project name remains ``persome-core`` as an update-source compatibility
+contract for already released runtimes. This builder stages the same tracked
+source and changes only the distribution name declared in ``pyproject.toml``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import tempfile
+import tomllib
+from pathlib import Path
+
+ROOT_DISTRIBUTION = "persome-core"
+
+
+def _tracked_files(root: Path) -> list[Path]:
+    result = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "-z"],
+        check=True,
+        capture_output=True,
+    )
+    return [Path(item.decode()) for item in result.stdout.split(b"\0") if item]
+
+
+def _rewrite_distribution_name(pyproject: Path) -> tuple[str, str]:
+    raw = pyproject.read_text(encoding="utf-8")
+    data = tomllib.loads(raw)
+    project = data.get("project", {})
+    root_name = project.get("name")
+    version = project.get("version")
+    public_name = (
+        data.get("tool", {}).get("persome", {}).get("release", {}).get("pypi-distribution")
+    )
+    if root_name != ROOT_DISTRIBUTION:
+        raise RuntimeError(f"unexpected root distribution name: {root_name!r}")
+    if not isinstance(version, str) or not version:
+        raise RuntimeError("project.version must be a non-empty string")
+    if not isinstance(public_name, str) or not public_name:
+        raise RuntimeError("tool.persome.release.pypi-distribution is required")
+    declaration = f'name = "{ROOT_DISTRIBUTION}"'
+    if raw.count(declaration) != 1:
+        raise RuntimeError(f"expected one exact {declaration!r} declaration")
+    pyproject.write_text(
+        raw.replace(declaration, f'name = "{public_name}"', 1),
+        encoding="utf-8",
+    )
+    return public_name, version
+
+
+def build(root: Path, out_dir: Path) -> tuple[Path, Path]:
+    root = root.resolve()
+    out_dir = out_dir.resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="persome-pypi-stage-") as temporary:
+        stage = Path(temporary) / "source"
+        stage.mkdir()
+        for relative in _tracked_files(root):
+            source = root / relative
+            target = stage / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if source.is_symlink():
+                target.symlink_to(source.readlink())
+            elif source.is_file():
+                shutil.copy2(source, target)
+
+        public_name, version = _rewrite_distribution_name(stage / "pyproject.toml")
+        normalized = public_name.replace("-", "_")
+        for stale in out_dir.glob(f"{normalized}-*"):
+            stale.unlink()
+        subprocess.run(
+            [
+                "uv",
+                "build",
+                "--project",
+                str(stage),
+                "--out-dir",
+                str(out_dir),
+                "--build-constraints",
+                str(stage / "build-constraints.txt"),
+                "--require-hashes",
+            ],
+            check=True,
+        )
+
+    wheel = out_dir / f"{normalized}-{version}-py3-none-any.whl"
+    sdist = out_dir / f"{normalized}-{version}.tar.gz"
+    if not wheel.is_file() or not sdist.is_file():
+        raise RuntimeError(f"missing expected PyPI artifacts: {wheel.name}, {sdist.name}")
+    return wheel, sdist
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out-dir", type=Path, default=Path("pypi-dist"))
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parents[1]
+    wheel, sdist = build(root, args.out_dir)
+    print(wheel)
+    print(sdist)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/persome/__init__.py
+++ b/src/persome/__init__.py
@@ -1,3 +1,3 @@
 """Persome Runtime: local screen-context memory and personal modeling."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -215,19 +215,20 @@ def _capture_continuity(hours: float = 1.0) -> tuple[int, float | None]:
 
 def _install_source() -> str:
     """Return the editable-install source path recorded in direct_url.json."""
-    try:
-        import importlib.metadata
+    import importlib.metadata
 
-        dist = importlib.metadata.distribution("persome-core")
-        raw = dist.read_text("direct_url.json")
-        if raw:
-            data = json.loads(raw)
-            url = str(data.get("url", ""))
-            if url.startswith("file://"):
-                return url[7:]
-            return url
-    except Exception:  # noqa: BLE001
-        pass
+    for distribution_name in ("personal-model", "persome-core"):
+        try:
+            dist = importlib.metadata.distribution(distribution_name)
+            raw = dist.read_text("direct_url.json")
+            if raw:
+                data = json.loads(raw)
+                url = str(data.get("url", ""))
+                if url.startswith("file://"):
+                    return url[7:]
+                return url
+        except Exception:  # noqa: BLE001
+            continue
     return "unknown"
 
 
@@ -923,6 +924,17 @@ def update(
 ) -> None:
     """Update the installed Persome Runtime and prove it is healthy."""
     from . import updater
+
+    if updater.is_external_package_install():
+        console.print(
+            "[yellow]This Persome CLI is managed by a Python package manager.[/yellow]\n"
+            "Upgrade the public distribution, then re-run Runtime proof:\n\n"
+            "  [bold]uv tool upgrade personal-model[/bold]\n"
+            "  [bold]persome onboard[/bold]\n\n"
+            "For pipx or pip installations, upgrade [bold]personal-model[/bold] with that "
+            "manager instead."
+        )
+        raise typer.Exit(1)
 
     updater.claim_legacy_foreground()
     launchagent_was_loaded = False

--- a/src/persome/doctor.py
+++ b/src/persome/doctor.py
@@ -269,7 +269,7 @@ def check_helpers(capture: config_mod.CaptureConfig | None = None) -> list[Check
                 Check(
                     name,
                     "fail",
-                    "binary and bundled Swift source not found — reinstall persome-core",
+                    "binary and bundled Swift source not found — reinstall Persome",
                 )
             )
     return out

--- a/src/persome/updater.py
+++ b/src/persome/updater.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import contextlib
 import ctypes
 import fcntl
+import importlib.metadata
 import json
 import os
 import shutil
@@ -161,6 +162,24 @@ def _runtime_binary() -> Path:
 
 def _runtime_python() -> Path:
     return _venv_dir() / "bin" / "python"
+
+
+def is_external_package_install() -> bool:
+    """Return whether the running CLI is the public package-manager install.
+
+    Source installs own ``<PERSOME_ROOT>/venv`` and can use the transactional
+    directory exchange. A PyPI tool/venv is owned by uv, pipx, or pip instead;
+    that package manager must replace it before onboarding re-proves Runtime
+    ownership and capture readiness.
+    """
+
+    if _venv_dir().is_dir():
+        return False
+    try:
+        importlib.metadata.distribution("personal-model")
+    except importlib.metadata.PackageNotFoundError:
+        return False
+    return True
 
 
 _LOCK_KEEPER_CODE = r"""

--- a/tests/test_build_pypi_dist.py
+++ b/tests/test_build_pypi_dist.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from persome import cli
+from scripts import build_pypi_dist
+
+
+def test_rewrite_distribution_name_keeps_runtime_package_and_changes_public_name(
+    tmp_path: Path,
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """[project]
+name = "persome-core"
+version = "0.3.1"
+
+[tool.persome.release]
+pypi-distribution = "personal-model"
+""",
+        encoding="utf-8",
+    )
+
+    assert build_pypi_dist._rewrite_distribution_name(pyproject) == (
+        "personal-model",
+        "0.3.1",
+    )
+    rewritten = pyproject.read_text(encoding="utf-8")
+    assert 'name = "personal-model"' in rewritten
+    assert 'pypi-distribution = "personal-model"' in rewritten
+
+
+def test_rewrite_distribution_name_rejects_unexpected_root_name(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """[project]
+name = "personal-model"
+version = "0.3.1"
+
+[tool.persome.release]
+pypi-distribution = "personal-model"
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError, match="unexpected root distribution"):
+        build_pypi_dist._rewrite_distribution_name(pyproject)
+
+
+def test_install_source_prefers_public_distribution(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[str] = []
+
+    def distribution(name: str) -> SimpleNamespace:
+        seen.append(name)
+        return SimpleNamespace(
+            read_text=lambda filename: (
+                '{"url":"file:///tmp/personal-model"}' if filename == "direct_url.json" else None
+            )
+        )
+
+    monkeypatch.setattr("importlib.metadata.distribution", distribution)
+    assert cli._install_source() == "/tmp/personal-model"
+    assert seen == ["personal-model"]
+
+
+def test_install_source_falls_back_to_compatibility_distribution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: list[str] = []
+
+    def distribution(name: str) -> SimpleNamespace:
+        seen.append(name)
+        if name == "personal-model":
+            raise LookupError(name)
+        return SimpleNamespace(
+            read_text=lambda filename: (
+                '{"url":"file:///tmp/persome-core"}' if filename == "direct_url.json" else None
+            )
+        )
+
+    monkeypatch.setattr("importlib.metadata.distribution", distribution)
+    assert cli._install_source() == "/tmp/persome-core"
+    assert seen == ["personal-model", "persome-core"]

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import fcntl
+import importlib.metadata
 import json
 import os
 import subprocess
@@ -26,6 +27,30 @@ def _source_tree(root: Path) -> Path:
     (root / "build-constraints.txt").write_text("", encoding="utf-8")
     (root / "install.sh").write_text("#!/bin/bash\n", encoding="utf-8")
     return root
+
+
+def test_external_package_install_requires_public_distribution_and_no_managed_venv(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        importlib.metadata,
+        "distribution",
+        lambda name: object() if name == "personal-model" else None,
+    )
+    assert updater.is_external_package_install() is True
+
+    (ac_root / "venv").mkdir()
+    assert updater.is_external_package_install() is False
+
+
+def test_root_distribution_without_managed_venv_is_not_external(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def missing(_name: str) -> object:
+        raise importlib.metadata.PackageNotFoundError
+
+    monkeypatch.setattr(importlib.metadata, "distribution", missing)
+    assert updater.is_external_package_install() is False
 
 
 def _begin_transaction(*, launchagent: bool = False) -> str:

--- a/uv.lock
+++ b/uv.lock
@@ -1167,7 +1167,7 @@ wheels = [
 
 [[package]]
 name = "persome-core"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- add the first personal-model PyPI distribution using the configured pending Trusted Publisher
- keep the root persome-core source identifier so v0.3.0 transactional updates remain compatible
- build, checksum, attest, smoke-test, and publish personal_model artifacts from the same tagged tree
- document PyPI install and package-manager upgrade behavior
- prepare v0.3.1 metadata and release notes

## Validation

- 1810 passed, 15 deselected
- ruff, formatting, shell, secret, PII, language, documentation, OpenAPI, and DB schema gates
- Twine metadata validation for personal_model wheel and sdist
- clean Python 3.11 install with Name: personal-model and no persome-core metadata
- PyPI install update guard and onboarding guidance
- synthetic MCP transport with 16 tools and receipt verification

This PR must be merged with a merge commit.