### PR TITLE
fix: recovery, legacy-data, and erasure-sweep regressions

### DIFF
--- a/src/persome/evomem/backup.py
+++ b/src/persome/evomem/backup.py
@@ -157,6 +157,11 @@ def scrub_database_copies(
 
     Corrupt/unreadable copies are deleted rather than silently retained. This
     helper also handles integrity-quarantine databases outside ``backup/``.
+
+    Returns the number of copies whose erasure verifiably completed (scrubbed
+    in place, or removed entirely). A copy that can be neither scrubbed nor
+    removed does not count and never blocks the rest of the sweep; the sweep
+    finishes first and then raises ``RuntimeError`` naming every leftover.
     """
     requested = _validated_scrub_tables(tables)
     candidates = tuple(dict.fromkeys(Path(item) for item in artifacts))
@@ -164,6 +169,7 @@ def scrub_database_copies(
         return 0
 
     scrubbed = 0
+    leftovers: list[str] = []
     for snapshot in sorted(candidates):
         conn: sqlite3.Connection | None = None
         try:
@@ -229,8 +235,16 @@ def scrub_database_copies(
             if conn is not None:
                 conn.close()
             _log.warning("snapshot scrub failed for %s; removing snapshot: %s", snapshot.name, exc)
-            _remove_sqlite_copy(snapshot)
+            try:
+                _remove_sqlite_copy(snapshot)
+            except RuntimeError as removal_exc:
+                # A stuck copy must not shield the remaining copies from
+                # erasure: record it, finish the sweep, and fail loud at the end.
+                leftovers.append(f"{snapshot.name}: {removal_exc}")
+                continue
         scrubbed += 1
+    if leftovers:
+        raise RuntimeError("snapshot erasure incomplete: " + "; ".join(sorted(leftovers)))
     return scrubbed
 
 

--- a/src/persome/evomem/edge_audit.py
+++ b/src/persome/evomem/edge_audit.py
@@ -16,12 +16,25 @@ logger = get("persome.evomem.edge_audit")
 
 _ENTITY_PREFIXES = ("person-", "org-", "project-", "tool-")
 
-# the extractor's honest synthetic fallbacks (constructions, not excerpts)
+# The extractor's honest synthetic fallbacks (constructions, not excerpts).
+# Edges written by pre-0.3.0 releases carry the same constructions in their
+# original Chinese wording; preserved data must keep auditing as synthetic, so
+# both generations are recognized (escaped to satisfy the language gate).
 _SYNTHETIC_PATTERNS = (
     re.compile(r"^Interaction history with .+$"),
     re.compile(r"^.+ and .+ appeared in the same context$"),
     re.compile(r"^Completed .+$"),
     re.compile(r"^.+ project memory contains \d+ durable facts$"),
+    re.compile("^\u4e0e .+ \u7684\u4ea4\u4e92\u8bb0\u5f55$"),
+    re.compile("^.+ \u4e0e .+ \u66fe\u5728\u540c\u4e00\u573a\u666f\u51fa\u73b0$"),
+    re.compile("^\u5df2\u5b8c\u6210\u7684 .+ \u4e8b\u9879$"),
+    re.compile("^.+ \u9879\u76ee\u8bb0\u5fc6 \\d+ \u6761\u6301\u4e45\u4e8b\u5b9e$"),
+)
+
+# Markers identifying the co-occurrence construction across both generations.
+_COOCCUR_MARKERS = (
+    "appeared in the same context",
+    "\u66fe\u5728\u540c\u4e00\u573a\u666f\u51fa\u73b0",
 )
 
 
@@ -31,6 +44,10 @@ def _norm_ws(text: str) -> str:
 
 def _is_synthetic(quote: str) -> bool:
     return any(p.match(quote or "") for p in _SYNTHETIC_PATTERNS)
+
+
+def _is_cooccur_quote(quote: str) -> bool:
+    return _is_synthetic(quote) and any(marker in quote for marker in _COOCCUR_MARKERS)
 
 
 def _activity_source(identity: str) -> tuple[str, str] | None:
@@ -224,7 +241,7 @@ def audit_edge(conn, row: Any, *, llm_call: Any | None = None) -> EdgeVerdict:
             v.notes.append("legacy_source_unavailable")
         if source_ok and quote and not _is_synthetic(quote):
             trace_ok = any(_norm_ws(quote) in _norm_ws(text) for text in source_texts)
-    elif _is_synthetic(quote) and "appeared in the same context" in quote:
+    elif _is_cooccur_quote(quote):
         # co-occurrence: re-derive the shared minute bucket instead of text trace
         trace_ok = _shared_bucket(conn, src, dst)
         source_ok = trace_ok

--- a/src/persome/evomem/relation_extractor.py
+++ b/src/persome/evomem/relation_extractor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from itertools import combinations
@@ -163,6 +164,23 @@ def _load_typed_entities(conn) -> dict[str, tuple[str, str]]:
     return out
 
 
+def _alias_mentioned(alias: str, text: str) -> bool:
+    """Evidence-grade mention check for a normalized alias in normalized text.
+
+    Plain substring containment fabricates participants — "amy" is inside
+    "family" and a one-character given name is inside almost any sentence —
+    and a fabricated participant becomes a relation edge. An ASCII alias must
+    therefore match on word boundaries, and every alias must be at least two
+    characters long.
+    """
+    if not alias or len(alias) < 2 or not text or alias not in text:
+        return False
+    if alias.isascii():
+        pattern = rf"(?<![0-9a-z]){re.escape(alias)}(?![0-9a-z])"
+        return re.search(pattern, text) is not None
+    return True
+
+
 def _load_terminal_activities(conn, people: _People) -> list[_Activity]:
     """Load durable activities plus the read-only legacy terminal-intent fallback.
 
@@ -180,7 +198,7 @@ def _load_terminal_activities(conn, people: _People) -> list[_Activity]:
         candidates = {_norm(name) for name in raw_names if _norm(name)}
         normalized_summary = _norm(summary)
         candidates.update(
-            alias for alias in people.aliases if alias and alias in normalized_summary
+            alias for alias in people.aliases if _alias_mentioned(alias, normalized_summary)
         )
         resolved: list[str] = []
         for alias in candidates:
@@ -199,7 +217,7 @@ def _load_terminal_activities(conn, people: _People) -> list[_Activity]:
     ).events():
         summary_norm = _norm(event.summary)
         typed_mentions = [
-            typed for alias, typed in typed_roster.items() if alias and alias in summary_norm
+            typed for alias, typed in typed_roster.items() if _alias_mentioned(alias, summary_norm)
         ]
         participants: list[str] = []
         for participant in event.participant_ids:

--- a/src/persome/integrity.py
+++ b/src/persome/integrity.py
@@ -45,6 +45,11 @@ _DERIVED_FTS_INTEGRITY_ERRORS = {
     "malformed inverted index for FTS5 table main.captures_fts": "captures_fts",
 }
 _DERIVED_FTS_TABLES = frozenset(_DERIVED_FTS_INTEGRITY_ERRORS.values())
+# SQLite >= 3.50 reports FTS5 damage per finding instead of one summary line,
+# e.g. 'fts5: corruption found reading blob 10 from table "captures_fts"'.
+_DERIVED_FTS_INTEGRITY_RE = re.compile(
+    r'^fts5: .* table "(' + "|".join(sorted(_DERIVED_FTS_TABLES)) + r')"$'
+)
 _GENERIC_MALFORMED_DB_ERROR = "database disk image is malformed"
 _SNAPSHOT_NAME_RE = re.compile(r"^evo-\d{8}\.db$")
 _PERSOME_SNAPSHOT_COLUMNS = {
@@ -243,9 +248,13 @@ def _derived_fts_damage(results: list[str]) -> set[str] | None:
         return None
     damaged: set[str] = set()
     for result in results:
-        table = _DERIVED_FTS_INTEGRITY_ERRORS.get(result.strip())
+        stripped = result.strip()
+        table = _DERIVED_FTS_INTEGRITY_ERRORS.get(stripped)
         if table is None:
-            return None
+            match = _DERIVED_FTS_INTEGRITY_RE.match(stripped)
+            if match is None:
+                return None
+            table = match.group(1)
         damaged.add(table)
     return damaged
 

--- a/tests/test_edge_audit_sources.py
+++ b/tests/test_edge_audit_sources.py
@@ -63,3 +63,83 @@ def test_missing_entry_source_is_structural_hallucination(ac_root) -> None:
         verdict = edge_audit.audit_edge(conn, row)
     assert verdict.verdict == "structural_hallucination"
     assert verdict.checks["source_exists"] is False
+
+
+def test_legacy_chinese_synthetic_quotes_still_audit_as_synthetic() -> None:
+    # Pre-0.3.0 extractors wrote the same honest constructions in Chinese.
+    legacy_interaction = "\u4e0e Alice \u7684\u4ea4\u4e92\u8bb0\u5f55"
+    legacy_cooccur = "Alice \u4e0e Bob \u66fe\u5728\u540c\u4e00\u573a\u666f\u51fa\u73b0"
+    legacy_completed = "\u5df2\u5b8c\u6210\u7684 review \u4e8b\u9879"
+    legacy_project = "core \u9879\u76ee\u8bb0\u5fc6 3 \u6761\u6301\u4e45\u4e8b\u5b9e"
+    for quote in (legacy_interaction, legacy_cooccur, legacy_completed, legacy_project):
+        assert edge_audit._is_synthetic(quote), quote
+    assert edge_audit._is_cooccur_quote(legacy_cooccur)
+    assert edge_audit._is_cooccur_quote("Alice and Bob appeared in the same context")
+    assert not edge_audit._is_cooccur_quote(legacy_interaction)
+    assert not edge_audit._is_synthetic("An ordinary excerpted sentence.")
+
+
+def test_legacy_chinese_quote_edges_are_not_condemned(ac_root) -> None:
+    from datetime import UTC, datetime
+    from types import SimpleNamespace
+
+    from persome.evomem.engine import EvoMemory
+    from persome.evomem.person_graph import PersonEvent, PersonGraph
+
+    class _StaticSource:
+        def __init__(self, events):
+            self._events = events
+
+        def events(self):
+            return list(self._events)
+
+    ts = datetime(2026, 6, 20, 10, 0, tzinfo=UTC)
+    PersonGraph(
+        EvoMemory(),
+        cfg=SimpleNamespace(person_graph_enabled=True),
+        name_source=_StaticSource(
+            [
+                PersonEvent(name="Alice", summary="weekly sync", occurred_at=ts, confidence=0.9),
+                PersonEvent(name="Bob", summary="weekly sync", occurred_at=ts, confidence=0.9),
+            ]
+        ),
+    ).ingest()
+
+    legacy_interaction = "\u4e0e Alice \u7684\u4ea4\u4e92\u8bb0\u5f55"
+    legacy_cooccur = "Alice \u4e0e Bob \u66fe\u5728\u540c\u4e00\u573a\u666f\u51fa\u73b0"
+    with fts.cursor() as conn:
+        knows_id = edges.add_edge(
+            conn,
+            src_identity="self",
+            dst_identity="Alice",
+            predicate="knows",
+            src_kind="self",
+            dst_kind="person",
+            provenance="inferred",
+            confidence=0.9,
+            quote=legacy_interaction,
+        )
+        cooccur_id = edges.add_edge(
+            conn,
+            src_identity="Alice",
+            dst_identity="Bob",
+            predicate="knows",
+            src_kind="person",
+            dst_kind="person",
+            provenance="inferred",
+            confidence=0.6,
+            quote=legacy_cooccur,
+        )
+        rows = {
+            edge_id: conn.execute(
+                "SELECT * FROM relation_edges WHERE edge_id=?", (edge_id,)
+            ).fetchone()
+            for edge_id in (knows_id, cooccur_id)
+        }
+        knows_verdict = edge_audit.audit_edge(conn, rows[knows_id])
+        cooccur_verdict = edge_audit.audit_edge(conn, rows[cooccur_id])
+
+    assert knows_verdict.verdict == "valid"
+    assert "synthetic_quote" in knows_verdict.notes
+    assert cooccur_verdict.verdict == "valid"
+    assert "synthetic_quote:cooccur_rederived" in cooccur_verdict.notes

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -1915,6 +1915,27 @@ def test_derived_fts_vtable_constructor_error_is_rebuildable() -> None:
     )
 
 
+def test_derived_fts_damage_recognizes_modern_sqlite_messages() -> None:
+    # SQLite >= 3.50 reports per-finding fts5 lines instead of one summary line.
+    assert integrity._derived_fts_damage(
+        ['fts5: corruption found reading blob 10 from table "captures_fts"']
+    ) == {"captures_fts"}
+    assert integrity._derived_fts_damage(
+        [
+            'fts5: missing row 7 from table "entries"',
+            "malformed inverted index for FTS5 table main.captures_fts",
+        ]
+    ) == {"entries", "captures_fts"}
+    # Damage naming any other table is still core damage, never a derived repair.
+    assert (
+        integrity._derived_fts_damage(['fts5: corruption found reading blob 3 from table "other"'])
+        is None
+    )
+    assert integrity._derived_fts_damage(["row 1 missing from index sqlite_autoindex_files_1"]) is (
+        None
+    )
+
+
 def test_generic_malformed_error_requires_readable_canonical_tables(
     ac_root: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_relation_extractor.py
+++ b/tests/test_relation_extractor.py
@@ -710,3 +710,65 @@ def test_org_has_no_deterministic_self_leg(ac_root):
         if r[1] == "\u817e\u8baf\u6df7\u5143\u5927\u8bed\u8a00\u6a21\u578b\u90e8"
         or r[0] == "\u817e\u8baf\u6df7\u5143\u5927\u8bed\u8a00\u6a21\u578b\u90e8"
     ]
+
+
+def test_alias_mention_requires_word_boundaries_and_length(ac_root):
+    # ASCII aliases must not match inside other words; CJK needs >= 2 chars.
+    wang_fang = "\u738b\u82b3"
+    wang = "\u738b"
+    assert not rx._alias_mentioned("amy", "spent the evening with family")
+    assert rx._alias_mentioned("amy", "sync with amy about the roadmap")
+    assert rx._alias_mentioned("amy", "amy: roadmap sync")
+    assert not rx._alias_mentioned(wang, f"{wang_fang} joined the review")
+    assert rx._alias_mentioned(wang_fang, f"{wang_fang} joined the review")
+    assert not rx._alias_mentioned("", "anything")
+    assert not rx._alias_mentioned("amy", "")
+
+
+def test_summary_substring_does_not_fabricate_participants(ac_root):
+    mem = _mem()
+    _ingest(
+        mem,
+        [PersonEvent(name="Amy", summary="quarterly review", occurred_at=_ts(20), confidence=0.9)],
+    )
+    with fts.cursor() as conn:
+        entries_store.create_file(
+            conn,
+            name="event-2026-07-11.md",
+            description="Synthetic activity",
+            tags=["event"],
+        )
+        entries_store.append_entry(
+            conn,
+            name="event-2026-07-11.md",
+            content="Organized the family photo archive.",
+            tags=["home"],
+        )
+    rx.run_relation_extraction(_on(), memory=mem, llm_call=_empty_llm, conn_factory=fts.cursor)
+    part = [r for r in _all_edges() if r[2] == "participates_in"]
+    # self participates in the activity, but "amy" inside "family" must not.
+    assert all(r[0] == "self" for r in part), part
+
+
+def test_summary_word_mention_still_links_participant(ac_root):
+    mem = _mem()
+    _ingest(
+        mem,
+        [PersonEvent(name="Amy", summary="quarterly review", occurred_at=_ts(20), confidence=0.9)],
+    )
+    with fts.cursor() as conn:
+        entries_store.create_file(
+            conn,
+            name="event-2026-07-12.md",
+            description="Synthetic activity",
+            tags=["event"],
+        )
+        entries_store.append_entry(
+            conn,
+            name="event-2026-07-12.md",
+            content="Roadmap sync with Amy before the release.",
+            tags=["work"],
+        )
+    rx.run_relation_extraction(_on(), memory=mem, llm_call=_empty_llm, conn_factory=fts.cursor)
+    part = [r for r in _all_edges() if r[2] == "participates_in"]
+    assert any(r[0] == "Amy" for r in part), part

--- a/tests/test_storage_security.py
+++ b/tests/test_storage_security.py
@@ -630,3 +630,38 @@ def test_memory_rebuild_prunes_vectors_for_superseded_entries(ac_root: Path) -> 
         assert conn.execute("SELECT superseded FROM entries WHERE id=?", (entry_id,)).fetchone()[0]
         assert conn.execute("SELECT COUNT(*) FROM entry_vectors").fetchone()[0] == 0
         assert conn.execute("SELECT COUNT(*) FROM vector_queue").fetchone()[0] == 0
+
+
+def test_stuck_copy_does_not_shield_later_snapshots_from_erasure(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    secret = "zzzzlatersnapshotsecretzzzz"
+    paths.backup_dir().mkdir(parents=True, exist_ok=True)
+    stuck = paths.backup_dir() / "evo-20200101.db"
+    stuck.write_bytes(b"this is not a sqlite database")
+    later = paths.backup_dir() / "evo-20260711.db"
+    with sqlite3.connect(later) as conn:
+        conn.executescript(fts.SCHEMA)
+        conn.execute(
+            "INSERT INTO captures(id,timestamp,visible_text) VALUES('later','2026',?)",
+            (secret,),
+        )
+        conn.commit()
+    assert secret.encode() in later.read_bytes()
+
+    real_remove = backup._remove_sqlite_copy
+
+    def flaky_remove(main: Path) -> None:
+        if main.name == stuck.name:
+            raise RuntimeError(f"cannot remove unsanitized SQLite artifact {main}: stuck inode")
+        real_remove(main)
+
+    monkeypatch.setattr(backup, "_remove_sqlite_copy", flaky_remove)
+
+    with pytest.raises(RuntimeError, match="erasure incomplete.*evo-20200101"):
+        backup.scrub_database_copies(("captures",), (stuck, later))
+
+    # The sweep completed past the stuck copy: the later snapshot was scrubbed.
+    assert secret.encode() not in later.read_bytes()
+    with sqlite3.connect(later) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM captures").fetchone()[0] == 0


### PR DESCRIPTION
Four independent fixes for regressions introduced between the internal v0.2.2 codebase and the public v0.3.0 snapshot, each with a regression test.

## Fixes

- **SQLite >= 3.50 derived-FTS recovery** (closes #44): `_derived_fts_damage` only matched the legacy `malformed inverted index for FTS5 table main.<t>` wording; modern SQLite reports `fts5: corruption found reading blob N from table "<t>"` per finding, so a repairable derived-index corruption quarantined the whole `index.db`. Both generations are now recognized; anything else stays core damage.
- **Legacy synthetic quotes in the edge audit** (closes #45): edges written by pre-0.3.0 releases carry the original Chinese synthetic constructions in `relation_edges.quote`. After the English translation of `_SYNTHETIC_PATTERNS` they fell into the literal quote-trace branch and were condemned as `structural_hallucination` on preserved personal data. Both generations now audit as synthetic, and legacy co-occurrence quotes go through the same shared-bucket rederivation.
- **Alias substring fabrication** (closes #46): the Activity refactor scanned summaries for aliases with plain substring containment, so `amy` matched inside `family` and one-character CJK aliases matched almost anything, minting `participates_in`/about edges for uninvolved people and projects. Summary mentions now require ASCII word boundaries and a minimum alias length of two.
- **Erasure sweep robustness** (closes #47): one copy that could neither be scrubbed nor removed raised out of `scrub_database_copies` and shielded every later snapshot/quarantine copy from erasure. The sweep now finishes, counts only verifiably erased copies, and raises once at the end naming every leftover.

## Verification

- Full offline suite: 1811 passed (`PERSOME_LLM_MOCK=1 uv run pytest -m "not macos and not integration"`), including 7 new regression tests.
- `uv run ruff check .` / `uv run ruff format --check .` clean.
- `secret_scan.py`, `pii_scan.py`, `language_scan.py` gates clean (legacy Chinese patterns are unicode-escaped, matching the existing `identity.py` convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)