### PR TITLE
release: publish Persome to the Official MCP Registry

### DIFF
--- a/.github/releases/v0.3.2.md
+++ b/.github/releases/v0.3.2.md
@@ -1,0 +1,19 @@
+# Persome Runtime v0.3.2
+
+Persome v0.3.2 adds the metadata and executable entry point required for the
+Official MCP Registry. The Runtime remains local-first: Registry clients launch
+the same `persome mcp` stdio server from the public `personal-model` PyPI
+package, and personal data stays on the owner's Mac.
+
+## Install or upgrade
+
+```bash
+uv tool install personal-model
+# Existing installs:
+uv tool upgrade personal-model
+
+persome onboard
+```
+
+The `personal-model` executable is an alias for `persome`, allowing MCP
+Registry installers to launch `personal-model mcp` directly.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Persome
 
+<!-- mcp-name: io.github.Intuition-Lab/personal-model -->
+
 **The local-first Personal Model Runtime for macOS.** Persome observes the apps
 you already use, turns cross-app activity into an inspectable model of a real
 person, and serves that model to MCP agents.

--- a/openapi.json
+++ b/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Persome API",
     "description": "Local-first screen-context memory and personal-model REST API.",
-    "version": "0.3.1"
+    "version": "0.3.2"
   },
   "paths": {
     "/health": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "persome-core"
-version = "0.3.1"
+version = "0.3.2"
 description = "Local-first macOS Runtime for screen-context memory, personal modeling, and MCP."
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -54,6 +54,7 @@ dependencies = [
 
 [project.scripts]
 persome = "persome.cli:app"
+personal-model = "persome.cli:app"
 
 [project.urls]
 Homepage = "https://github.com/Intuition-Lab/personal-model"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.Intuition-Lab/personal-model",
+  "title": "Persome",
+  "description": "Local-first personal memory and model server for trusted MCP agents on macOS.",
+  "repository": {
+    "url": "https://github.com/Intuition-Lab/personal-model",
+    "source": "github"
+  },
+  "version": "0.3.2",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "personal-model",
+      "version": "0.3.2",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        }
+      ]
+    }
+  ]
+}

--- a/src/persome/__init__.py
+++ b/src/persome/__init__.py
@@ -1,3 +1,3 @@
 """Persome Runtime: local screen-context memory and personal modeling."""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/uv.lock
+++ b/uv.lock
@@ -1167,7 +1167,7 @@ wheels = [
 
 [[package]]
 name = "persome-core"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- add Official MCP Registry metadata for the public `personal-model` PyPI package
- add the Registry ownership marker required in the PyPI README
- add a `personal-model` executable alias so Registry installers can launch `personal-model mcp`
- prepare patch release v0.3.2

## Verification
- `uv lock --check`
- `uv run --no-sync pytest tests/test_build_pypi_dist.py tests/test_supply_chain_security.py -q`
- `uv run --no-sync ruff check .`
- `uv run --no-sync ruff format --check .`
- Official 2025-12-11 `server.json` schema validation
- built PyPI wheel contains the ownership marker and both console entry points