### PR TITLE
Open the personal model after onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ onboarding proof:
 ```bash
 uv tool install personal-model
 persome onboard
+persome model open --after 30
 ```
 
 The distribution is named `personal-model`; the installed CLI remains
@@ -104,6 +105,7 @@ same Runtime proof:
 ```bash
 uv tool upgrade personal-model
 persome onboard
+persome model open --after 30
 ```
 
 ```bash
@@ -112,6 +114,7 @@ cd personal-model
 bash install.sh
 
 persome status
+# Source installs schedule this automatically for 30 minutes after onboarding.
 persome model open
 
 # Repeat only to repair/recheck permissions and Runtime proof:
@@ -137,6 +140,13 @@ text for AX-poor apps such as WeChat and Feishu; pixels never enter an LLM
 prompt. The first OCR model load can take up to two minutes; repeated onboarding
 normally finishes in seconds without warming a second worker. Completion never
 waits on a hidden final dialog. Persome does not require Full Disk Access.
+
+After a successful interactive source install, Persome schedules a detached,
+one-shot `persome model open --after 30` reminder. The local viewer opens
+automatically after 30 minutes of real activity and the reminder process then
+exits; no permanent reminder LaunchAgent is installed. Package-manager installs
+can run the same command explicitly. Open the viewer sooner at any time with
+`persome model open`, and keep the Runtime running while Points and Lines form.
 
 OCR intent is durable in `[capture].ocr_policy`: `auto` is an unconfigured fresh
 install, while `enabled` and `disabled` record an explicit choice. Ordinary

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -204,6 +204,12 @@ same generation through owner-only `.runtime-state.json`; trusted ingest is
 rejected when its authenticated HTTP endpoint is disabled.
 Non-interactive packaging environments must run the command later from a
 logged-in macOS session.
+Interactive source installs also schedule the authenticated local model viewer
+to open once after 30 minutes. The detached reminder must survive the installer
+terminal, write only to the owner-private `logs/model-open-reminder.log`, and
+exit after invoking `persome model open`; it must not install another permanent
+LaunchAgent. Verify its CLI and installer contract with
+`tests/test_cli_local_access.py` and `tests/test_onboarding.py`.
 `persome ocr-selftest <image>` remains available for a known-image inference
 check.
 

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,7 @@ PYTHON_TARGET=""
 INSTALL_TRANSACTION_ACTIVE=0
 OLD_VENV_BACKUP=""
 ONBOARDING_COMPLETED=0
+MODEL_OPEN_SCHEDULED=0
 DEFER_UPDATE_COMMIT="${PERSOME_UPDATE_DEFER_COMMIT:-0}"
 UPDATE_REPLACEMENT="${PERSOME_UPDATE_REPLACEMENT:-}"
 UPDATE_TRANSACTION_ID="${PERSOME_UPDATE_TRANSACTION_ID:-}"
@@ -741,6 +742,26 @@ run_onboarding() {
   ONBOARDING_COMPLETED=1
 }
 
+schedule_model_open() {
+  if [[ ${UPDATE_MODE} -eq 1 || ! -t 0 ]]; then
+    return 0
+  fi
+
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  Your Personal Model Opens in 30 Minutes"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+  echo "Keep Persome running while it learns from real activity. In 30 minutes,"
+  echo "Persome will automatically open your local personal-model viewer."
+  echo ""
+  if PERSOME_ROOT="${INSTALL_HOME}" "${INSTALL_BIN_DIR}/persome" model open --after 30; then
+    MODEL_OPEN_SCHEDULED=1
+  else
+    warn "could not schedule the model viewer; open it manually with 'persome model open'"
+  fi
+}
+
 ensure_screenshot_key() {
   local env_path="${INSTALL_HOME}/env"
   local status
@@ -802,11 +823,17 @@ Install root : ${INSTALL_HOME}
 Virtualenv   : ${VENV_DIR}
 CLI shim     : ${INSTALL_BIN_DIR}/persome
 
-Next steps:
-  1. Check status:
-     persome status
-  2. Open the live personal-model viewer:
+YOUR NEXT STEP — OPEN YOUR PERSONAL MODEL:
+  Keep Persome running for about 30 minutes so it can learn from real activity.
+  Then open the live personal-model viewer:
+
      persome model open
+
+  You can run that command immediately at any time. Do not stop Persome to build
+  the model; Points and Lines are created while the Runtime keeps running.
+
+Other checks:
+  persome status
 
 Event memory can appear during a session's five-minute flushes. Points and Lines
 are modeled from each successful flush while the daemon keeps running. Face,
@@ -851,6 +878,25 @@ Onboarding pending:
   logged-in macOS session, run `persome onboard`; it will not report success
   until the configured mode's permissions, Runtime owner, OCR policy, and
   capture/readiness receipt all pass.
+EOF
+  fi
+
+  if [[ ${MODEL_OPEN_SCHEDULED} -eq 1 ]]; then
+    cat <<'EOF'
+
+MODEL CTA:
+  ✓ Your local personal-model viewer is scheduled to open automatically in
+    30 minutes. Keep Persome running. To open it sooner, run:
+
+      persome model open
+EOF
+  else
+    cat <<'EOF'
+
+MODEL CTA:
+  After about 30 minutes of real activity, open your personal model:
+
+      persome model open
 EOF
   fi
 
@@ -927,6 +973,7 @@ main() {
   inject_detected_clients
   maybe_configure_llm
   run_onboarding
+  schedule_model_open
   if [[ ${UPDATE_MODE} -eq 1 ]]; then
     commit_install
   fi

--- a/install.sh
+++ b/install.sh
@@ -748,13 +748,6 @@ schedule_model_open() {
   fi
 
   echo ""
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "  Your Personal Model Opens in 30 Minutes"
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo ""
-  echo "Keep Persome running while it learns from real activity. In 30 minutes,"
-  echo "Persome will automatically open your local personal-model viewer."
-  echo ""
   if PERSOME_ROOT="${INSTALL_HOME}" "${INSTALL_BIN_DIR}/persome" model open --after 30; then
     MODEL_OPEN_SCHEDULED=1
   else
@@ -823,16 +816,7 @@ Install root : ${INSTALL_HOME}
 Virtualenv   : ${VENV_DIR}
 CLI shim     : ${INSTALL_BIN_DIR}/persome
 
-YOUR NEXT STEP — OPEN YOUR PERSONAL MODEL:
-  Keep Persome running for about 30 minutes so it can learn from real activity.
-  Then open the live personal-model viewer:
-
-     persome model open
-
-  You can run that command immediately at any time. Do not stop Persome to build
-  the model; Points and Lines are created while the Runtime keeps running.
-
-Other checks:
+Check Runtime status:
   persome status
 
 Event memory can appear during a session's five-minute flushes. Points and Lines
@@ -884,17 +868,18 @@ EOF
   if [[ ${MODEL_OPEN_SCHEDULED} -eq 1 ]]; then
     cat <<'EOF'
 
-MODEL CTA:
+MODEL CTA — KEEP PERSOME RUNNING:
   ✓ Your local personal-model viewer is scheduled to open automatically in
-    30 minutes. Keep Persome running. To open it sooner, run:
+    30 minutes. This is your next step: let Persome learn from real activity,
+    then explore the model it forms. To open it sooner, run:
 
       persome model open
 EOF
   else
     cat <<'EOF'
 
-MODEL CTA:
-  After about 30 minutes of real activity, open your personal model:
+MODEL CTA — OPEN YOUR PERSONAL MODEL:
+  Keep Persome running for about 30 minutes, then explore the model it forms:
 
       persome model open
 EOF

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -2675,6 +2675,42 @@ app.add_typer(model_app, name="model")
 
 _MODEL_VIEWER_STARTUP_ATTEMPTS = 20
 _MODEL_VIEWER_STARTUP_RETRY_SECONDS = 0.25
+_MODEL_VIEWER_REMINDER_LOG = "model-open-reminder.log"
+
+
+def _model_open_command() -> list[str]:
+    """Return a relocation-safe command for a detached model-viewer reminder."""
+    if getattr(sys, "frozen", False):
+        return [sys.executable]
+    return [sys.executable, "-m", "persome"]
+
+
+def _schedule_model_open(after_seconds: float) -> tuple[int, Path]:
+    """Start one detached, one-shot process that opens the viewer after a delay."""
+    if after_seconds <= 0:
+        raise ValueError("the model viewer delay must be greater than zero")
+    paths.ensure_dirs()
+    log_path = paths.logs_dir() / _MODEL_VIEWER_REMINDER_LOG
+    env = os.environ.copy()
+    env["PERSOME_ROOT"] = str(paths.root())
+    command = [
+        *_model_open_command(),
+        "model",
+        "open",
+        "--scheduled-after-seconds",
+        str(after_seconds),
+    ]
+    with paths.open_private_append_text(log_path) as log_handle:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=log_handle,
+            stderr=subprocess.STDOUT,
+            close_fds=True,
+            start_new_session=True,
+            env=env,
+        )
+    return process.pid, log_path
 
 
 def _local_viewer_base_url(cfg: config_mod.Config) -> str:
@@ -2783,8 +2819,41 @@ def model_status_cmd() -> None:
 
 
 @model_app.command("open")
-def model_open() -> None:
+def model_open(
+    after: int = typer.Option(
+        0,
+        "--after",
+        min=0,
+        help="Open automatically after this many minutes; 0 opens now.",
+    ),
+    scheduled_after_seconds: float = typer.Option(
+        0.0,
+        "--scheduled-after-seconds",
+        min=0.0,
+        hidden=True,
+    ),
+) -> None:
     """Open the local model viewer through a short-lived browser capability."""
+    if after and scheduled_after_seconds:
+        console.print("[red]Choose either --after or the internal scheduled delay, not both.[/red]")
+        raise typer.Exit(2)
+    if after:
+        try:
+            _pid, log_path = _schedule_model_open(after * 60)
+        except (OSError, RuntimeError, ValueError) as exc:
+            console.print(f"[red]Could not schedule the model viewer:[/red] {exc}")
+            raise typer.Exit(1) from exc
+        unit = "minute" if after == 1 else "minutes"
+        console.print(
+            f"[bold green]✓ Your personal model will open automatically in {after} {unit}.[/bold green]"
+        )
+        console.print("  Keep Persome running so it can learn from real activity.")
+        console.print("  Open it now: [bold]persome model open[/bold]")
+        console.print(f"  Reminder log: {log_path}")
+        return
+    if scheduled_after_seconds:
+        time.sleep(scheduled_after_seconds)
+
     import webbrowser
 
     import httpx

--- a/tests/test_cli_local_access.py
+++ b/tests/test_cli_local_access.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import stat
 import subprocess
+import sys
 import webbrowser
 from pathlib import Path
 from types import SimpleNamespace
@@ -72,6 +73,74 @@ def test_model_open_exchanges_bearer_for_one_time_browser_url(ac_root: Path, mon
     ]
     assert token not in result.output
     assert token not in opened[0]
+
+
+def test_model_open_can_schedule_detached_one_shot_reminder(ac_root: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    launched: dict[str, object] = {}
+
+    class _ScheduledProcess:
+        pid = 7331
+
+    def fake_popen(command, **kwargs):  # type: ignore[no-untyped-def]
+        launched["command"] = command
+        launched.update(kwargs)
+        return _ScheduledProcess()
+
+    monkeypatch.setattr(cli.subprocess, "Popen", fake_popen)
+
+    result = CliRunner().invoke(cli.app, ["model", "open", "--after", "30"])
+
+    assert result.exit_code == 0, result.output
+    assert launched["command"] == [
+        sys.executable,
+        "-m",
+        "persome",
+        "model",
+        "open",
+        "--scheduled-after-seconds",
+        "1800",
+    ]
+    assert launched["stdin"] is subprocess.DEVNULL
+    assert launched["stderr"] is subprocess.STDOUT
+    assert launched["close_fds"] is True
+    assert launched["start_new_session"] is True
+    assert launched["env"]["PERSOME_ROOT"] == str(ac_root)
+    log_path = ac_root / "logs" / "model-open-reminder.log"
+    assert launched["stdout"] is not subprocess.DEVNULL
+    assert _mode(log_path) == 0o600
+    assert "open automatically in 30 minutes" in result.output
+    assert "persome model open" in result.output
+
+
+def test_scheduled_model_open_waits_before_requesting_browser_capability(
+    ac_root: Path, monkeypatch
+) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv(LOCAL_API_TOKEN_ENV, "t" * 48)
+    delays: list[float] = []
+    monkeypatch.setattr(cli.time, "sleep", delays.append)
+    monkeypatch.setattr(
+        httpx,
+        "post",
+        lambda url, **kwargs: httpx.Response(
+            200,
+            json={
+                "success": True,
+                "data": {"bootstrap_url": "/auth/browser-bootstrap?nonce=" + "n" * 43},
+            },
+            request=httpx.Request("POST", url),
+        ),
+    )
+    opened: list[str] = []
+    monkeypatch.setattr(webbrowser, "open", lambda url, new=0: opened.append(url) or True)
+
+    result = CliRunner().invoke(
+        cli.app,
+        ["model", "open", "--scheduled-after-seconds", "2.5"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert delays == [2.5]
+    assert len(opened) == 1
 
 
 def test_bare_model_command_opens_viewer(monkeypatch) -> None:  # type: ignore[no-untyped-def]

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -713,6 +713,18 @@ def test_installer_runs_strict_onboarding_gate() -> None:
     assert 'die "onboarding is incomplete' in script
 
 
+def test_installer_schedules_and_emphasizes_model_open_cta() -> None:
+    script = (Path(__file__).resolve().parents[1] / "install.sh").read_text(encoding="utf-8")
+
+    assert 'persome" model open --after 30' in script
+    assert "Your Personal Model Opens in 30 Minutes" in script
+    assert "YOUR NEXT STEP — OPEN YOUR PERSONAL MODEL" in script
+    assert "MODEL CTA:" in script
+    main = script.index("main()")
+    assert script.index("run_onboarding\n", main) < script.index("schedule_model_open\n", main)
+    assert script.index("schedule_model_open\n", main) < script.index("print_summary\n", main)
+
+
 def test_preserve_policy_keeps_explicit_ocr_disable(
     ac_root: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -717,9 +717,10 @@ def test_installer_schedules_and_emphasizes_model_open_cta() -> None:
     script = (Path(__file__).resolve().parents[1] / "install.sh").read_text(encoding="utf-8")
 
     assert 'persome" model open --after 30' in script
-    assert "Your Personal Model Opens in 30 Minutes" in script
-    assert "YOUR NEXT STEP — OPEN YOUR PERSONAL MODEL" in script
-    assert "MODEL CTA:" in script
+    assert "Your Personal Model Opens in 30 Minutes" not in script
+    assert "YOUR NEXT STEP — OPEN YOUR PERSONAL MODEL" not in script
+    assert "MODEL CTA — KEEP PERSOME RUNNING" in script
+    assert "MODEL CTA — OPEN YOUR PERSONAL MODEL" in script
     main = script.index("main()")
     assert script.index("run_onboarding\n", main) < script.index("schedule_model_open\n", main)
     assert script.index("schedule_model_open\n", main) < script.index("print_summary\n", main)


### PR DESCRIPTION
## What changed

- add `persome model open --after <minutes>` for a detached, one-shot viewer open
- schedule the authenticated personal-model viewer 30 minutes after a successful interactive source install
- keep exactly two model CTAs: the scheduling confirmation and the final installer summary
- preserve a manual CTA for non-interactive installs and document the package-manager path
- write reminder output to the owner-private `logs/model-open-reminder.log` without installing another permanent LaunchAgent

## Why

The first useful onboarding outcome is seeing the model formed from real activity. The installer now carries the user to that outcome automatically while keeping the copy focused instead of repeating the same instruction four times.

## Validation

- `PERSOME_LLM_MOCK=1 uv run pytest -m "not macos and not integration"` - 1820 passed, 15 deselected
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python scripts/secret_scan.py`
- `uv run python scripts/pii_scan.py`
- `uv run python scripts/language_scan.py`
- `bash -n install.sh`
