### PR TITLE
Learn owner identity without manual alias configuration

### DIFF
--- a/MODEL_FORMAT.md
+++ b/MODEL_FORMAT.md
@@ -70,7 +70,9 @@ receipts. Promotion requires stable repeated support.
 ### Volume
 
 A Volume is one active level-2 cross-domain schema. It relates behavior across
-otherwise separate topics and carries the same audit fields as a Face.
+otherwise separate owner-scoped topics and carries the same audit fields as a
+Face. Person schemas are excluded so evidence about a collaborator cannot be
+fused into the memory owner's behavior.
 
 ### Root
 

--- a/MODEL_FORMAT.md
+++ b/MODEL_FORMAT.md
@@ -48,6 +48,11 @@ file_name, tags, confidence, conflicted, receipt
 `is_latest` identifies a current chain head; historical Points remain available
 for audit and time travel.
 
+The memory owner is the reserved identity `self`, not a person Point. Names and
+handles learned from quoted owner-identity evidence resolve to `self`; if an
+owner alias was previously minted as a person, promotion retires that live
+projection while preserving its historical Point receipts.
+
 ### Line
 
 Lines have two forms:

--- a/docs/config.md
+++ b/docs/config.md
@@ -237,11 +237,17 @@ but stops it from changing the model and reactivates the classifier's legacy
 terminal write role. This switch is for diagnosis/migration, not a second
 normal operating mode.
 
-`owner_aliases` lists the local owner's names and handles (for example a full
-name and a GitHub handle). The runtime reserves them as aliases of `self`;
-they are excluded from the person roster and cannot become collaborator
-Points. This is especially important when those handles appear in repository,
-meeting, or chat UI.
+The runtime normally learns owner names and handles from evidence already
+produced by the windowed modeling pass. Explicit first-person identity evidence
+can activate an alias immediately; account-ownership evidence requires two
+independent sessions. Pending aliases enter a seven-day person-creation
+quarantine; active owner aliases remain excluded from the person roster. This
+prevents an uncertain first observation from becoming a self-reinforcing
+collaborator Point without suppressing an ordinary person forever.
+
+`owner_aliases` is an optional trusted override for deployments that already
+know the owner's identities. It is not required for ordinary onboarding or
+Day-1 modeling. Configured and learned aliases both resolve to reserved `self`.
 
 The pattern detector requires repeated evidence and writes observed behavioral
 memory under `memory/skills/skill-*.md`. It does not propose or execute

--- a/docs/config.md
+++ b/docs/config.md
@@ -216,6 +216,7 @@ incremental personal-model writes.
 enabled = true
 max_blocks = 120
 roster_max = 60
+owner_aliases = []
 min_confidence = 0.5
 apply_enabled = true
 apply_assertions = true
@@ -235,6 +236,12 @@ only catches the remaining tail. Disabling `apply_enabled` keeps the audit row
 but stops it from changing the model and reactivates the classifier's legacy
 terminal write role. This switch is for diagnosis/migration, not a second
 normal operating mode.
+
+`owner_aliases` lists the local owner's names and handles (for example a full
+name and a GitHub handle). The runtime reserves them as aliases of `self`;
+they are excluded from the person roster and cannot become collaborator
+Points. This is especially important when those handles appear in repository,
+meeting, or chat UI.
 
 The pattern detector requires repeated evidence and writes observed behavioral
 memory under `memory/skills/skill-*.md`. It does not propose or execute

--- a/docs/db-schema.sql
+++ b/docs/db-schema.sql
@@ -232,6 +232,38 @@ CREATE INDEX idx_memory_deltas_created ON memory_deltas(created_at DESC);
 
 CREATE INDEX idx_memory_deltas_session ON memory_deltas(session_id);
 
+-- ---- store/owner_aliases.py ----
+
+CREATE TABLE owner_alias_evidence (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    alias_key   TEXT NOT NULL,
+    alias       TEXT NOT NULL,
+    session_id  TEXT NOT NULL,
+    source_kind TEXT NOT NULL,
+    quote       TEXT NOT NULL,
+    confidence  REAL NOT NULL,
+    created_at  TEXT NOT NULL,
+    UNIQUE(alias_key, session_id),
+    FOREIGN KEY(alias_key) REFERENCES owner_aliases(alias_key)
+);
+
+CREATE TABLE owner_aliases (
+    alias_key      TEXT PRIMARY KEY,
+    alias          TEXT NOT NULL,
+    status         TEXT NOT NULL,
+    confidence     REAL NOT NULL,
+    evidence_count INTEGER NOT NULL DEFAULT 0,
+    first_seen_at  TEXT NOT NULL,
+    last_seen_at   TEXT NOT NULL,
+    activated_at   TEXT,
+    decision_source TEXT NOT NULL DEFAULT 'inferred'
+);
+
+CREATE INDEX ix_owner_alias_evidence_alias
+    ON owner_alias_evidence(alias_key, created_at);
+
+CREATE INDEX ix_owner_aliases_status ON owner_aliases(status);
+
 -- ---- store/parser_ticks.py ----
 
 CREATE TABLE parser_ticks (

--- a/docs/writer.md
+++ b/docs/writer.md
@@ -117,7 +117,9 @@ proposition, support summary, expected inferences, confidence, and source
 receipts. Low-confidence output is `forming` and excluded from the active model;
 stable output contributes a Face. Derived PersonGraph entity/event nodes are
 excluded from schema mining; only durable person facts can support a person
-Face. Re-mining supersedes the prior schema in place.
+Face. Owner-scoped Faces anchor to `self`; collaborators mentioned only in the
+supporting receipts are not added as hull identities. Re-mining supersedes the
+prior schema in place.
 
 ### Volumes
 

--- a/docs/writer.md
+++ b/docs/writer.md
@@ -10,13 +10,13 @@ Root.
 | Writer | Input | Output |
 |---|---|---|
 | session reducer | timeline blocks | `event-YYYY-MM-DD.md` |
-| memory delta + apply | one newly flushed session window | entities, assertions, events, relation Lines in evomem/FTS/Markdown projection |
+| memory delta + apply | one newly flushed session window | owner-alias evidence plus entities, assertions, events, and relation Lines in evomem/FTS/Markdown projection |
 | pattern detector | repeated event evidence | `memory/skills/skill-*.md` |
 | case extractor | error followed by supported resolution | reusable L5 knowledge Points |
 | schema miner | repeated durable facts | level-1 Face candidates |
 | cross-domain sweeper | stable topic-distinct Faces | level-2 Volumes |
 | root synthesis | active Face/Volume/profile evidence | at most one level-3 Root |
-| CLI/MCP correction | explicit user/agent request | audited append, supersede, retype, merge, or revoke |
+| CLI/MCP correction | explicit user/agent request | audited append, supersede, retype, merge, merge-into-self, reject-owner-alias, or revoke |
 
 No writer owns product tasks, notifications, actuation, or evaluation labels.
 
@@ -47,7 +47,8 @@ live Point/Line path is:
 ```text
 new timeline window + structured focus evidence
   -> one memory_delta LLM extraction
-  -> quote / roster / predicate / confidence gates
+  -> owner-alias evidence + quote / roster / predicate / confidence gates
+  -> repeated owner evidence resolves names and handles to reserved self
   -> append-only memory_deltas audit row
   -> deterministic delta_apply
   -> Points, assertions, events, and relation Lines
@@ -58,8 +59,17 @@ through the identity roster or appear explicitly in the session. Relations use
 a closed predicate set. Low-confidence or unsupported items are dropped and
 counted.
 
-The roster always includes the reserved `self` endpoint. Configured
-`memory_delta.owner_aliases` resolve to `self` and are never minted as people.
+The roster always includes the reserved `self` endpoint. The same LLM pass may
+propose `owner_alias_candidates` only when quoted session evidence identifies a
+proper name or handle as an explicit self-identification or owned account. One
+non-explicit observation stays `pending` and enters a bounded seven-day
+PersonGraph quarantine; two independent sessions promote it to an active alias
+of `self`. A quoted explicit
+first-person identity statement may promote immediately. Promotion retires an
+already-minted duplicate person projection without deleting its audit history.
+
+Configured `memory_delta.owner_aliases` remain a trusted override, but ordinary
+operation does not require users to discover or fill the setting themselves.
 Persome's own localhost `/model` output is removed from the delta evidence so a
 rendered Face, Volume, or Root cannot train the next model window on itself.
 

--- a/docs/writer.md
+++ b/docs/writer.md
@@ -58,6 +58,11 @@ through the identity roster or appear explicitly in the session. Relations use
 a closed predicate set. Low-confidence or unsupported items are dropped and
 counted.
 
+The roster always includes the reserved `self` endpoint. Configured
+`memory_delta.owner_aliases` resolve to `self` and are never minted as people.
+Persome's own localhost `/model` output is removed from the delta evidence so a
+rendered Face, Volume, or Root cannot train the next model window on itself.
+
 The deterministic `self engaged_with <entity>` attention floor is direct
 observational evidence, so it becomes an active Line on the first applied
 window. LLM semantic relations remain shadow candidates. Repeated deterministic
@@ -110,14 +115,18 @@ minted. Cards enter the public deterministic evomem write entrance.
 domain. Bundles smaller than four facts are skipped. A schema contains a central
 proposition, support summary, expected inferences, confidence, and source
 receipts. Low-confidence output is `forming` and excluded from the active model;
-stable output contributes a Face. Re-mining supersedes the prior schema in place.
+stable output contributes a Face. Derived PersonGraph entity/event nodes are
+excluded from schema mining; only durable person facts can support a person
+Face. Re-mining supersedes the prior schema in place.
 
 ### Volumes
 
 `cross_domain_sweeper` compares stable, topic-distinct schemas using a
 deterministic behavior signature before an LLM judge. Confirmed repeated
-cross-domain structure becomes a Volume. Forming candidates stay outside active
-snapshots. The LLM stage has a hard per-build probe budget (8 by default), with
+cross-domain structure becomes a Volume. Person schemas are not eligible inputs:
+collaborator behavior cannot be fused into the owner's project/tool/topic model.
+Forming candidates stay outside active snapshots. The LLM stage has a hard
+per-build probe budget (8 by default), with
 live shadow Volumes whose latest result is still stable/promotable ordered before
 unseen pairs so bounded builds can satisfy the unchanged two-observation
 promotion gate. A negative, failed, or low-confidence retry immediately lowers

--- a/src/persome/config.py
+++ b/src/persome/config.py
@@ -188,7 +188,8 @@ class PatternDetectorConfig:
 @dataclass
 class MemoryDeltaConfig:
     # One LLM reading of each newly flushed session window emits a structured
-    # ``memory_delta {entities, assertions, relations, events}`` persisted to
+    # ``memory_delta {owner_alias_candidates, entities, assertions, relations,
+    # events}`` persisted to
     # the ``memory_deltas`` table before deterministic application mints or
     # reinforces evomem Points and relation Lines.
     enabled: bool = True
@@ -198,8 +199,9 @@ class MemoryDeltaConfig:
     # entities are references into this roster or an explicit new_entity — the
     # LLM never emits bare strings that probe the store).
     roster_max: int = 60
-    # Explicit aliases for the one memory owner. They resolve to the reserved
-    # ``self`` endpoint and must never be minted as ordinary people.
+    # Optional trusted overrides for the one memory owner. Normal operation
+    # learns aliases from evidence; configured and learned values both resolve
+    # to reserved ``self`` and are never minted as ordinary people.
     owner_aliases: list[str] = field(default_factory=list)
     # Items whose confidence is below this floor are dropped at the
     # deterministic parse gate (§4.1: judgment belongs to the LLM, gating and
@@ -680,7 +682,7 @@ min_occurrences = 2        # minimum repetitions to flag as a candidate
 enabled = true             # one evidence-gated structured extraction per newly flushed session window
 max_blocks = 120
 roster_max = 60
-owner_aliases = []          # names/handles for the memory owner; all resolve to reserved identity "self"
+owner_aliases = []          # optional trusted overrides; owner aliases are normally learned from evidence
 min_confidence = 0.5
 apply_enabled = true       # deterministic Point/Line production after persist
 apply_assertions = true

--- a/src/persome/config.py
+++ b/src/persome/config.py
@@ -198,6 +198,9 @@ class MemoryDeltaConfig:
     # entities are references into this roster or an explicit new_entity — the
     # LLM never emits bare strings that probe the store).
     roster_max: int = 60
+    # Explicit aliases for the one memory owner. They resolve to the reserved
+    # ``self`` endpoint and must never be minted as ordinary people.
+    owner_aliases: list[str] = field(default_factory=list)
     # Items whose confidence is below this floor are dropped at the
     # deterministic parse gate (§4.1: judgment belongs to the LLM, gating and
     # identity to code).
@@ -677,6 +680,7 @@ min_occurrences = 2        # minimum repetitions to flag as a candidate
 enabled = true             # one evidence-gated structured extraction per newly flushed session window
 max_blocks = 120
 roster_max = 60
+owner_aliases = []          # names/handles for the memory owner; all resolve to reserved identity "self"
 min_confidence = 0.5
 apply_enabled = true       # deterministic Point/Line production after persist
 apply_assertions = true

--- a/src/persome/evomem/identity.py
+++ b/src/persome/evomem/identity.py
@@ -76,20 +76,37 @@ class Roster:
 def load_roster(cfg, *, memory=None, limit: int | None = None) -> Roster:
     """Build the roster from person_graph (the consolidated past layer).
 
-    Fail-open: any read error → empty roster (callers then mint candidates;
-    nothing breaks). ``memory`` is an injectable EvoMemory for tests — the
-    default reads the SAME default-user scope production writes.
+    The reserved owner identity is always first. Learned and configured owner
+    aliases resolve to ``self``; recent pending owner candidates are withheld
+    from the collaborator roster so one uncertain judgment cannot become
+    self-reinforcing PersonGraph evidence.
     """
+    return Roster.build(load_roster_entries(cfg, memory=memory, limit=limit))
+
+
+def load_roster_entries(
+    cfg, *, memory=None, limit: int | None = None
+) -> list[tuple[str, list[str]]]:
+    """Return the shared roster menu used by every identity consumer."""
     try:
+        from . import owner_identity
         from .engine import EvoMemory
         from .person_graph import PersonGraph
 
+        active_owner = owner_identity.active_aliases(cfg)
+        reserved_keys = {norm(alias) for alias in owner_identity.reserved_aliases(cfg)}
         persons = PersonGraph(memory or EvoMemory(), cfg=cfg).list_persons()
-        if limit is not None:
-            persons = persons[:limit]
-        return Roster.build([(p.canonical, list(getattr(p, "aliases", []))) for p in persons])
+        known: list[tuple[str, list[str]]] = []
+        for person in persons:
+            aliases = list(getattr(person, "aliases", []))
+            if any(norm(name) in reserved_keys for name in [person.canonical, *aliases]):
+                continue
+            known.append((person.canonical, aliases))
+            if limit is not None and len(known) >= limit:
+                break
+        return [("self", active_owner), *known]
     except Exception:  # noqa: BLE001 — the roster is best-effort by design
-        return Roster()
+        return [("self", [])]
 
 
 def _strip_honorific(mention: str) -> str | None:

--- a/src/persome/evomem/owner_identity.py
+++ b/src/persome/evomem/owner_identity.py
@@ -200,8 +200,9 @@ def accept_alias(
     *,
     source_id: str,
     quote: str,
+    decision_source: str = "user",
 ) -> alias_store.OwnerAliasState | None:
-    return record_candidate(
+    state = record_candidate(
         conn,
         alias=alias,
         session_id=source_id,
@@ -209,7 +210,15 @@ def accept_alias(
         quote=quote or alias,
         confidence=1.0,
     )
+    if state is not None:
+        conn.execute(
+            "UPDATE owner_aliases SET decision_source=? WHERE alias_key=?",
+            (decision_source, state.alias_key),
+        )
+    return state
 
 
-def reject_alias(conn: sqlite3.Connection, alias: str) -> alias_store.OwnerAliasState | None:
-    return alias_store.reject(conn, alias, source="user")
+def reject_alias(
+    conn: sqlite3.Connection, alias: str, *, decision_source: str = "user"
+) -> alias_store.OwnerAliasState | None:
+    return alias_store.reject(conn, alias, source=decision_source)

--- a/src/persome/evomem/owner_identity.py
+++ b/src/persome/evomem/owner_identity.py
@@ -1,0 +1,215 @@
+"""High-level owner identity resolver joining AI evidence to reserved ``self``."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import UTC, datetime
+from typing import Any
+
+from ..logger import get
+from ..store import fts
+from ..store import owner_aliases as alias_store
+
+logger = get("persome.evomem.owner_identity")
+
+
+def configured_aliases(cfg: Any) -> list[str]:
+    values = getattr(getattr(cfg, "memory_delta", None), "owner_aliases", [])
+    out: list[str] = []
+    seen: set[str] = set()
+    for raw in values:
+        value = alias_store.clean_alias(str(raw))
+        if value is None or (key := alias_store.norm(value)) in seen:
+            continue
+        seen.add(key)
+        out.append(value)
+    return out
+
+
+def _stored_aliases(conn: sqlite3.Connection | None, statuses: set[str]) -> list[str]:
+    if conn is not None:
+        return alias_store.list_aliases(conn, statuses=statuses)
+    try:
+        with fts.cursor() as owned:
+            return alias_store.list_aliases(owned, statuses=statuses)
+    except Exception:  # noqa: BLE001 - owner evidence is fail-safe
+        logger.debug("owner identity store read failed", exc_info=True)
+        return []
+
+
+def active_aliases(cfg: Any, *, conn: sqlite3.Connection | None = None) -> list[str]:
+    values = [
+        *configured_aliases(cfg),
+        *_stored_aliases(conn, {alias_store.STATUS_ACTIVE}),
+    ]
+    out: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        key = alias_store.norm(value)
+        if key and key not in seen:
+            seen.add(key)
+            out.append(value)
+    return out
+
+
+def reserved_aliases(cfg: Any, *, conn: sqlite3.Connection | None = None) -> list[str]:
+    values = [
+        *active_aliases(cfg, conn=conn),
+        *_stored_aliases(conn, {alias_store.STATUS_PENDING}),
+    ]
+    out: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        key = alias_store.norm(value)
+        if key and key not in seen:
+            seen.add(key)
+            out.append(value)
+    return out
+
+
+def _matching_person_files(conn: sqlite3.Connection, alias: str) -> set[str]:
+    key = alias_store.norm(alias)
+    files: set[str] = set()
+    try:
+        rows = conn.execute(
+            "SELECT file_name, content, schema_summary FROM evo_nodes"
+            " WHERE is_latest=1 AND status='active' AND file_name LIKE 'person-%'"
+        ).fetchall()
+    except sqlite3.Error:
+        return files
+    for row in rows:
+        file_name = str(row[0] or "")
+        names = [str(row[1] or "")]
+        try:
+            meta = json.loads(row[2] or "{}")
+            if isinstance(meta, dict):
+                names.append(str(meta.get("canonical") or ""))
+                names.extend(str(a) for a in (meta.get("aliases") or []))
+        except (TypeError, ValueError):
+            pass
+        if any(alias_store.norm(name) == key for name in names):
+            files.add(file_name)
+    return files
+
+
+def _retire_person_projection(conn: sqlite3.Connection, alias: str) -> None:
+    """Retire an already-minted owner Point without deleting its audit history."""
+    now = datetime.now(UTC).isoformat()
+    files = _matching_person_files(conn, alias)
+    if files:
+        derived_files: set[str] = set()
+        for file_name in files:
+            stem = file_name.removesuffix(".md")
+            derived_files.add(f"schema-{stem}.md")
+            try:
+                rows = conn.execute(
+                    "SELECT DISTINCT file_name FROM evo_nodes"
+                    " WHERE is_latest=1 AND status='active'"
+                    " AND (file_name LIKE ? OR file_name LIKE ?)",
+                    (f"schema-xdomain-{stem}__%", f"schema-xdomain-%__{stem}.md"),
+                ).fetchall()
+                derived_files.update(str(row[0]) for row in rows if row[0])
+            except sqlite3.Error:
+                pass
+        files.update(derived_files)
+        placeholders = ",".join("?" for _ in files)
+        conn.execute(
+            f"UPDATE evo_nodes SET status='shadow', is_latest=0,"
+            f" valid_until=COALESCE(valid_until, ?) WHERE file_name IN ({placeholders})"
+            " AND is_latest=1 AND status='active'",
+            (now, *sorted(files)),
+        )
+
+    key = alias_store.norm(alias)
+    try:
+        rows = conn.execute(
+            "SELECT edge_id, src_identity, dst_identity FROM relation_edges WHERE valid_to IS NULL"
+        ).fetchall()
+        edge_ids = [
+            str(row[0])
+            for row in rows
+            if alias_store.norm(str(row[1])) == key or alias_store.norm(str(row[2])) == key
+        ]
+        if edge_ids:
+            placeholders = ",".join("?" for _ in edge_ids)
+            conn.execute(
+                f"UPDATE relation_edges SET valid_to=?, status='archived'"
+                f" WHERE edge_id IN ({placeholders}) AND valid_to IS NULL",
+                (now, *edge_ids),
+            )
+    except sqlite3.Error:
+        pass
+
+    try:
+        rows = conn.execute(
+            "SELECT face_id, anchors FROM schema_faces WHERE valid_to IS NULL"
+        ).fetchall()
+        face_ids: list[str] = []
+        for row in rows:
+            try:
+                anchors = json.loads(row[1] or "[]")
+            except (TypeError, ValueError):
+                anchors = []
+            if any(alias_store.norm(str(anchor)) == key for anchor in anchors):
+                face_ids.append(str(row[0]))
+        if face_ids:
+            placeholders = ",".join("?" for _ in face_ids)
+            conn.execute(
+                f"UPDATE schema_faces SET valid_to=?, status='archived'"
+                f" WHERE face_id IN ({placeholders}) AND valid_to IS NULL",
+                (now, *face_ids),
+            )
+    except sqlite3.Error:
+        pass
+
+    if files:
+        try:
+            from ..session import store as session_store
+
+            session_store.increment_system_state(conn, "model_structure_dirty")
+        except Exception:  # noqa: BLE001 - projection retirement remains valid
+            logger.debug("could not mark model dirty after owner promotion", exc_info=True)
+
+
+def record_candidate(
+    conn: sqlite3.Connection,
+    *,
+    alias: str,
+    session_id: str,
+    source_kind: str,
+    quote: str,
+    confidence: float,
+) -> alias_store.OwnerAliasState | None:
+    state = alias_store.record_evidence(
+        conn,
+        alias=alias,
+        session_id=session_id,
+        source_kind=source_kind,
+        quote=quote,
+        confidence=confidence,
+    )
+    if state is not None and state.activated_now:
+        _retire_person_projection(conn, state.alias)
+    return state
+
+
+def accept_alias(
+    conn: sqlite3.Connection,
+    alias: str,
+    *,
+    source_id: str,
+    quote: str,
+) -> alias_store.OwnerAliasState | None:
+    return record_candidate(
+        conn,
+        alias=alias,
+        session_id=source_id,
+        source_kind=alias_store.SOURCE_USER_CORRECTION,
+        quote=quote or alias,
+        confidence=1.0,
+    )
+
+
+def reject_alias(conn: sqlite3.Connection, alias: str) -> alias_store.OwnerAliasState | None:
+    return alias_store.reject(conn, alias, source="user")

--- a/src/persome/evomem/person_graph.py
+++ b/src/persome/evomem/person_graph.py
@@ -124,10 +124,23 @@ class PersonGraph:
         self._cfg = cfg
         self._source = name_source or EmptyPersonNameSource()
         self._min_confidence = min_confidence
+        self._reserved_owner_keys: set[str] | None = None
 
     @property
     def enabled(self) -> bool:
         return bool(getattr(self._cfg, "person_graph_enabled", False))
+
+    def _owner_keys(self) -> set[str]:
+        if self._reserved_owner_keys is None:
+            try:
+                from . import owner_identity
+
+                self._reserved_owner_keys = {
+                    _norm(alias) for alias in owner_identity.reserved_aliases(self._cfg)
+                }
+            except Exception:  # noqa: BLE001 - identity protection is fail-safe
+                self._reserved_owner_keys = set()
+        return self._reserved_owner_keys
 
     def ingest(self) -> list[str]:
         if not self.enabled:
@@ -144,6 +157,10 @@ class PersonGraph:
             return None
         norm = _norm(event.name)
         if not norm:
+            return None
+        owner_keys = self._owner_keys()
+        if norm in owner_keys or any(_norm(alias) in owner_keys for alias in event.aliases):
+            _log.debug("person_graph: reserve owner identity %r", event.name)
             return None
 
         existing = self._find_entity(norm, event.aliases)
@@ -280,11 +297,22 @@ class PersonGraph:
         # the file taxonomy IS the kind axis's SSOT, so an adjudicated retype
 
         # roster (and out of knows-edge extraction) by construction.
-        return [
-            n
-            for n in self._mem.store.all_latest()
-            if _TAG_ENTITY in (n.tags or "").split() and (n.file_name or "").startswith("person-")
-        ]
+        owner_keys = self._owner_keys()
+        out: list[MemoryNode] = []
+        for node in self._mem.store.all_latest():
+            if _TAG_ENTITY not in (node.tags or "").split() or not (
+                node.file_name or ""
+            ).startswith("person-"):
+                continue
+            meta = _meta_of(node)
+            names = [
+                str(meta.get(_META_CANONICAL) or node.content),
+                *(str(alias) for alias in (meta.get(_META_ALIASES) or [])),
+            ]
+            if any(_norm(name) in owner_keys for name in names):
+                continue
+            out.append(node)
+        return out
 
     def _find_entity(self, norm_name: str, extra_aliases: Iterable[str]) -> PersonEntity | None:
         wanted = {norm_name, *(_norm(a) for a in extra_aliases)}

--- a/src/persome/evomem/person_graph.py
+++ b/src/persome/evomem/person_graph.py
@@ -55,6 +55,7 @@ class PersonEvent:
     category: str | None = None
     aliases: Sequence[str] = field(default_factory=tuple)
     confidence: float = 1.0
+    source_id: str | None = None
 
 
 @dataclass
@@ -146,6 +147,13 @@ class PersonGraph:
             return None
 
         existing = self._find_entity(norm, event.aliases)
+
+        if (
+            existing is not None
+            and event.source_id
+            and self._has_source_event(existing.canonical, event.source_id)
+        ):
+            return existing.canonical
 
         if existing is None and event.confidence < self._min_confidence:
             _log.debug("person_graph: skip low-confidence first sighting %r", event.name)
@@ -248,9 +256,24 @@ class PersonGraph:
             file_name=f"person-{_slug(entity_canonical)}.md",
             tags=_TAG_EVENT,
             occurred_at=(event.occurred_at or now).isoformat(),
-            schema_summary=json.dumps({_META_CANONICAL: entity_canonical}, ensure_ascii=False),
+            schema_summary=json.dumps(
+                {_META_CANONICAL: entity_canonical, "source_id": event.source_id},
+                ensure_ascii=False,
+            ),
         )
         return self._mem.commit_node(node)
+
+    def _has_source_event(self, canonical: str, source_id: str) -> bool:
+        wanted = _norm(canonical)
+        for node in self._mem.store.all_latest():
+            if _TAG_EVENT not in (node.tags or "").split():
+                continue
+            meta = _meta_of(node)
+            if _norm(str(meta.get(_META_CANONICAL, ""))) != wanted:
+                continue
+            if str(meta.get("source_id") or "") == source_id:
+                return True
+        return False
 
     def _entity_nodes(self) -> list[MemoryNode]:
 

--- a/src/persome/model/entity_source.py
+++ b/src/persome/model/entity_source.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 
 from ..capture.timestamps import parse_capture_timestamp
+from ..evomem.identity import norm as norm_identity
 
 _ENTITY_PREFIXES = {"person-": "person", "org-": "org", "project-": "project"}
 _DERIVED_PERSON_TAGS = ("person-entity", "person-event")
@@ -135,7 +136,7 @@ class EntitySource:
                         display_name=display_name,
                         kind=kind,
                         occurred_at=str(row[2]) if row[2] else None,
-                        summary=content,
+                        summary=_mention_excerpt(content, display_name, entity_id),
                         confidence=0.85,
                         source_kind="entry",
                         source_id=entry_id,
@@ -143,6 +144,17 @@ class EntitySource:
                     )
                 )
         return out
+
+
+def _mention_excerpt(content: str, *names: str) -> str:
+    """Keep person-specific lines instead of cloning an entire mixed session."""
+    keys = {name.casefold() for name in names if name}
+    lines = [
+        line.strip()
+        for line in content.splitlines()
+        if line.strip() and any(key in line.casefold() for key in keys)
+    ]
+    return "\n".join(lines[:8]) or content[:500]
 
 
 class MemoryPersonNameSource:
@@ -153,9 +165,11 @@ class MemoryPersonNameSource:
         *,
         conn_factory: Callable[[], object] | None = None,
         limit: int = 500,
+        cfg: object | None = None,
     ) -> None:
         self._conn_factory = conn_factory
         self._limit = limit
+        self._cfg = cfg
 
     def events(self):  # type: ignore[no-untyped-def]
         from ..evomem.person_graph import PersonEvent, _parse_ts
@@ -172,13 +186,21 @@ class MemoryPersonNameSource:
                 events = EntitySource(conn, limit=self._limit).events()
         except Exception:  # noqa: BLE001 — model enrichment is fail-safe
             return []
+        owner_aliases = {
+            norm_identity(str(alias))
+            for alias in getattr(getattr(self._cfg, "memory_delta", None), "owner_aliases", [])
+            if str(alias).strip()
+        }
         return [
             PersonEvent(
                 name=event.display_name,
                 summary=event.summary,
                 occurred_at=_parse_ts(event.occurred_at),
                 confidence=event.confidence,
+                source_id=event.stable_id,
             )
             for event in events
             if event.kind == "person"
+            and norm_identity(event.display_name) not in owner_aliases
+            and norm_identity(event.entity_id) not in owner_aliases
         ]

--- a/src/persome/model/entity_source.py
+++ b/src/persome/model/entity_source.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 
 from ..capture.timestamps import parse_capture_timestamp
+from ..evomem import owner_identity
 from ..evomem.identity import norm as norm_identity
 
 _ENTITY_PREFIXES = {"person-": "person", "org-": "org", "project-": "project"}
@@ -187,9 +188,7 @@ class MemoryPersonNameSource:
         except Exception:  # noqa: BLE001 — model enrichment is fail-safe
             return []
         owner_aliases = {
-            norm_identity(str(alias))
-            for alias in getattr(getattr(self._cfg, "memory_delta", None), "owner_aliases", [])
-            if str(alias).strip()
+            norm_identity(alias) for alias in owner_identity.reserved_aliases(self._cfg)
         }
         return [
             PersonEvent(

--- a/src/persome/prompts/cross_domain_sweeper.md
+++ b/src/persome/prompts/cross_domain_sweeper.md
@@ -22,6 +22,8 @@ predictive, and falsifiable schema that explains both source observations.
 
 When uncertain, return `detected: false`.
 
+Both schemas must describe the same modeled subject. Never fuse schemas about two different people, or a collaborator's person schema with the memory owner's project/tool/topic schema.
+
 ## Output
 
 Return strict JSON with no other text:

--- a/src/persome/prompts/memory_delta.md
+++ b/src/persome/prompts/memory_delta.md
@@ -14,6 +14,8 @@ An entity must denote ONE concrete individual (a specific person, a specific gro
 
 The **memory owner** — the first-person speaker whose screen and activity this is — is NEVER an entity. This applies to first-person pronouns in every language. Never emit the owner, their own login name, or their handle as a person. Reference the owner as `self` (the roster's own identity) when they are one endpoint of a relation.
 
+Persome's own localhost `/model` viewer, including its Point/Line/Face/Volume/Root prose, is a model output rather than independent evidence. Never use a claim merely because that viewer displayed it; it requires separate non-model evidence in the session.
+
 **Kind discipline.** A `person` is a human being. Coding assistants and CLI agents the owner operates (claude, codex, cc, opencode, cursor, or "the agent" in any language), and apps, files, repos, branches, builds, DMGs, and documents, are `artifact` — never `person`. An organization, team, company, or group is `org`. A named body of ongoing work is `project`. When unsure between `artifact` and `project`, a shippable named undertaking is a `project`; a concrete file, tool, or build is an `artifact`.
 
 ## Evidence rule (critical)

--- a/src/persome/prompts/memory_delta.md
+++ b/src/persome/prompts/memory_delta.md
@@ -14,6 +14,13 @@ An entity must denote ONE concrete individual (a specific person, a specific gro
 
 The **memory owner** — the first-person speaker whose screen and activity this is — is NEVER an entity. This applies to first-person pronouns in every language. Never emit the owner, their own login name, or their handle as a person. Reference the owner as `self` (the roster's own identity) when they are one endpoint of a relation.
 
+When the session itself provides evidence that a visible proper name or handle identifies the memory owner, emit it under `owner_alias_candidates`; continue to use `self` in relations/events and do NOT also emit that alias as an entity. This is evidence collection, not a guess based on frequency:
+
+- `explicit_self_identification`: quoted authored text explicitly says the owner is or owns the named identity, such as "I am Alex", "my name is Alex", or "my GitHub is alex". Apply the same rule in every language.
+- `owned_account`: quoted activity explicitly labels a profile/account/repository page as the user's own/current account and contains the name or handle. A commit author, meeting participant, message sender, document owner, group member, or frequently seen collaborator is not ownership evidence.
+
+If the evidence is ambiguous, emit no owner alias candidate. A missed alias can be learned from a later session; a false owner merge is expensive.
+
 Persome's own localhost `/model` viewer, including its Point/Line/Face/Volume/Root prose, is a model output rather than independent evidence. Never use a claim merely because that viewer displayed it; it requires separate non-model evidence in the session.
 
 **Kind discipline.** A `person` is a human being. Coding assistants and CLI agents the owner operates (claude, codex, cc, opencode, cursor, or "the agent" in any language), and apps, files, repos, branches, builds, DMGs, and documents, are `artifact` — never `person`. An organization, team, company, or group is `org`. A named body of ongoing work is `project`. When unsure between `artifact` and `project`, a shippable named undertaking is a `project`; a concrete file, tool, or build is an `artifact`.
@@ -24,11 +31,12 @@ Every item carries a `quote`: a short verbatim excerpt copied character-for-char
 
 ## Output
 
-Return ONLY a JSON object with exactly these four arrays (any may be empty):
+Return ONLY a JSON object with exactly these five arrays (any may be empty):
 
+- `owner_alias_candidates`: names or handles evidenced as belonging to the memory owner. Each: `{"alias": "<verbatim proper name or handle>", "source_kind": "<explicit_self_identification|owned_account>", "quote": "<verbatim evidence containing the alias>", "confidence": <0-1>}`. Never emit generic values such as "user", "me", "owner", or `self`.
 - `entities`: people/orgs/projects/artifacts that materially appeared. Each: `{"ref": "<roster canonical>"}` OR `{"new_entity": "<verbatim name>"}`, plus `"kind"` (one of `person|org|project|artifact`), `"ended"` (true ONLY when the quote states this entity's validity ended — left the company, project wrapped up), `"quote"`, `"confidence"` (0-1).
 - `assertions`: durable facts about an entity learned this session (state changes, completed outcomes, stated preferences). Each: `{"subject": <ref-or-new_entity object>, "text": "<one-sentence past-tense fact>", "quote": ..., "confidence": ...}`.
 - `relations`: relations between entities evidenced this session. Each: `{"src": <ref-or-new_entity object>, "dst": <ref-or-new_entity object>, "predicate": "<participates_in|part_of|reports_to|knows|about|depends_on>", "label": "<free-text nuance>", "polarity": "<+|-|0>", "ended": false, "quote": ..., "confidence": ...}`. Only emit a relation the quoted text actually evidences — co-presence in one message is `knows` at most. `polarity` is `"0"` unless the quote itself carries clear valence (praise/conflict → `"+"`/`"-"`). `ended` is `true` ONLY when the quote states the relation has ENDED (quit, handed over, project closed) — the quote must contain the ending language.
 - `events`: discrete completed happenings worth remembering as episodes (a meeting held, a decision made, a deliverable shipped). Each: `{"title": "<past-tense one-liner>", "participants": [<ref-or-new_entity objects>], "quote": ..., "confidence": ...}`.
 
-Set `confidence` honestly: 0.9+ only when the quote states it outright; 0.5-0.7 for reasonable readings. Uncertain hedges below 0.5 are better omitted. When the session contains nothing durable, return `{"entities": [], "assertions": [], "relations": [], "events": []}` — an empty delta is a correct answer, not a failure.
+Set `confidence` honestly: 0.9+ only when the quote states it outright; 0.5-0.7 for reasonable readings. Uncertain hedges below 0.5 are better omitted. When the session contains nothing durable, return `{"owner_alias_candidates": [], "entities": [], "assertions": [], "relations": [], "events": []}` — an empty delta is a correct answer, not a failure.

--- a/src/persome/prompts/update_memory.md
+++ b/src/persome/prompts/update_memory.md
@@ -24,6 +24,8 @@ An update contains **supersede operations** and an optional entity operation.
   - `{"op":"retype","entity":"Research Team","kind":"org"}` when an entity exists but has the wrong kind.
   - `{"op":"shadow","entity":"customer"}` when a generic class or role should not be an entity.
   - `{"op":"merge","entity":"Alex J.","keeper":"Alex Jones"}` when two names identify the same entity.
+  - `{"op":"merge_into_self","entity":"Alex"}` when the user authoritatively says Alex is their own name or handle. This registers Alex as an alias of reserved `self`; never merge the owner into an ordinary person keeper.
+  - `{"op":"reject_owner_alias","entity":"Kevin"}` when the user says Kevin is another person, not the memory owner. This prevents future automatic owner promotion without deleting Kevin's legitimate person history.
 
 ## Rules
 

--- a/src/persome/session/tick.py
+++ b/src/persome/session/tick.py
@@ -633,7 +633,7 @@ def _run_evomem_enrichment_once(
     if getattr(cfg, "person_graph_enabled", False):
         try:
             touched = PersonGraph(
-                EvoMemory(), cfg=cfg, name_source=MemoryPersonNameSource()
+                EvoMemory(), cfg=cfg, name_source=MemoryPersonNameSource(cfg=cfg)
             ).ingest()
             report["person_updates"] = len(touched)
             logger.info("evomem enrichment: person graph ingested %d update(s)", len(touched))

--- a/src/persome/store/memory_deltas.py
+++ b/src/persome/store/memory_deltas.py
@@ -1,7 +1,8 @@
 """DAO for windowed structured memory deltas and their apply audit.
 
 One LLM reading of each newly flushed window emits a structured
-``memory_delta {entities, assertions, relations, events}``. The post-gate
+``memory_delta {owner_alias_candidates, entities, assertions, relations, events}``.
+The post-gate
 payload is persisted here before deterministic application mints Points and
 Lines. ``apply_status`` makes interrupted application retryable without
 spending another LLM call or reinforcing an edge twice.
@@ -175,7 +176,13 @@ def stats(conn: sqlite3.Connection) -> dict:
         " WHERE session_id=m.session_id AND window_start=m.window_start"
         " AND window_end=m.window_end)"
     ).fetchall()
-    heads = {"entities": 0, "assertions": 0, "relations": 0, "events": 0}
+    heads = {
+        "owner_alias_candidates": 0,
+        "entities": 0,
+        "assertions": 0,
+        "relations": 0,
+        "events": 0,
+    }
     dropped = 0
     for _sid, payload, drop in rows:
         dropped += int(drop or 0)

--- a/src/persome/store/owner_aliases.py
+++ b/src/persome/store/owner_aliases.py
@@ -1,0 +1,291 @@
+"""Auditable evidence and decisions for the reserved memory-owner identity.
+
+The LLM may recognize that a visible name or handle belongs to the person whose
+screen Persome observes.  That probabilistic judgment lands here as evidence;
+it never writes directly into PersonGraph.  A deterministic promotion rule
+turns repeated, independent evidence into an active alias of ``self``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import unicodedata
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+STATUS_PENDING = "pending"
+STATUS_ACTIVE = "active"
+STATUS_REJECTED = "rejected"
+STATUSES = frozenset({STATUS_PENDING, STATUS_ACTIVE, STATUS_REJECTED})
+
+SOURCE_OWNED_ACCOUNT = "owned_account"
+SOURCE_EXPLICIT_SELF = "explicit_self_identification"
+SOURCE_USER_CORRECTION = "user_correction"
+SOURCE_KINDS = frozenset({SOURCE_OWNED_ACCOUNT, SOURCE_EXPLICIT_SELF, SOURCE_USER_CORRECTION})
+
+MIN_CANDIDATE_CONFIDENCE = 0.8
+PROMOTION_SESSIONS = 2
+PENDING_RESERVATION_DAYS = 7
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS owner_aliases (
+    alias_key      TEXT PRIMARY KEY,
+    alias          TEXT NOT NULL,
+    status         TEXT NOT NULL,
+    confidence     REAL NOT NULL,
+    evidence_count INTEGER NOT NULL DEFAULT 0,
+    first_seen_at  TEXT NOT NULL,
+    last_seen_at   TEXT NOT NULL,
+    activated_at   TEXT,
+    decision_source TEXT NOT NULL DEFAULT 'inferred'
+);
+CREATE INDEX IF NOT EXISTS ix_owner_aliases_status ON owner_aliases(status);
+
+CREATE TABLE IF NOT EXISTS owner_alias_evidence (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    alias_key   TEXT NOT NULL,
+    alias       TEXT NOT NULL,
+    session_id  TEXT NOT NULL,
+    source_kind TEXT NOT NULL,
+    quote       TEXT NOT NULL,
+    confidence  REAL NOT NULL,
+    created_at  TEXT NOT NULL,
+    UNIQUE(alias_key, session_id),
+    FOREIGN KEY(alias_key) REFERENCES owner_aliases(alias_key)
+);
+CREATE INDEX IF NOT EXISTS ix_owner_alias_evidence_alias
+    ON owner_alias_evidence(alias_key, created_at);
+"""
+
+_GENERIC_ALIASES = frozenset(
+    {
+        "self",
+        "user",
+        "the user",
+        "owner",
+        "memory owner",
+        "me",
+        "i",
+        "\u6211",
+        "\u672c\u4eba",
+        "\u7528\u6237",
+    }
+)
+
+
+@dataclass(frozen=True)
+class OwnerAliasState:
+    alias: str
+    alias_key: str
+    status: str
+    confidence: float
+    evidence_count: int
+    activated_now: bool = False
+
+
+def ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(SCHEMA)
+
+
+def norm(alias: str) -> str:
+    folded = unicodedata.normalize("NFKC", alias or "").strip()
+    return " ".join(folded.split()).casefold()
+
+
+def clean_alias(alias: str) -> str | None:
+    value = unicodedata.normalize("NFKC", str(alias or "")).strip()
+    value = " ".join(value.split())
+    key = norm(value)
+    if not value or key in _GENERIC_ALIASES or len(value) > 160:
+        return None
+    if not any(ch.isalnum() for ch in value):
+        return None
+    return value
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _row_state(row: sqlite3.Row | tuple, *, activated_now: bool = False) -> OwnerAliasState:
+    return OwnerAliasState(
+        alias=str(row[1]),
+        alias_key=str(row[0]),
+        status=str(row[2]),
+        confidence=float(row[3]),
+        evidence_count=int(row[4]),
+        activated_now=activated_now,
+    )
+
+
+def get(conn: sqlite3.Connection, alias: str) -> OwnerAliasState | None:
+    ensure_schema(conn)
+    row = conn.execute(
+        "SELECT alias_key, alias, status, confidence, evidence_count "
+        "FROM owner_aliases WHERE alias_key=?",
+        (norm(alias),),
+    ).fetchone()
+    return _row_state(row) if row else None
+
+
+def list_aliases(conn: sqlite3.Connection, *, statuses: set[str]) -> list[str]:
+    ensure_schema(conn)
+    wanted = sorted(statuses & STATUSES)
+    if not wanted:
+        return []
+    placeholders = ",".join("?" for _ in wanted)
+    params: list[str] = list(wanted)
+    recent = ""
+    if statuses == {STATUS_PENDING}:
+        recent = " AND last_seen_at>=?"
+        params.append((datetime.now(UTC) - timedelta(days=PENDING_RESERVATION_DAYS)).isoformat())
+    rows = conn.execute(
+        f"SELECT alias FROM owner_aliases WHERE status IN ({placeholders}){recent} "
+        "ORDER BY first_seen_at, alias_key",
+        params,
+    ).fetchall()
+    return [str(row[0]) for row in rows]
+
+
+def _explicit_self_quote(alias: str, quote: str) -> bool:
+    key = norm(alias)
+    hay = norm(quote)
+    if not key or key not in hay:
+        return False
+    prefixes = (
+        "i am ",
+        "i'm ",
+        "i’m ",
+        "my name is ",
+        "my github is ",
+        "my account is ",
+        "my handle is ",
+        "\u6211\u662f",
+        "\u6211\u53eb",
+        "\u672c\u4eba\u662f",
+        "\u6211\u7684github\u662f",
+        "\u6211\u7684\u8d26\u53f7\u662f",
+        "\u6211\u7684\u8d26\u6237\u662f",
+        "\u6211\u7684\u7528\u6237\u540d\u662f",
+        "\u6211\u7684\u6635\u79f0\u662f",
+    )
+    terminators = frozenset(
+        " \t\r\n,.;:!?)]}\u3002\uff0c\uff1b\uff1a\uff01\uff1f\uff09\u3011\u300b"
+    )
+    for prefix in prefixes:
+        candidate = prefix + key
+        start = hay.find(candidate)
+        if start < 0:
+            continue
+        end = start + len(candidate)
+        if end == len(hay) or hay[end] in terminators:
+            return True
+    return False
+
+
+def record_evidence(
+    conn: sqlite3.Connection,
+    *,
+    alias: str,
+    session_id: str,
+    source_kind: str,
+    quote: str,
+    confidence: float,
+) -> OwnerAliasState | None:
+    """Record one independent-session observation and apply the promotion rule."""
+    ensure_schema(conn)
+    value = clean_alias(alias)
+    source = str(source_kind or "")
+    sid = str(session_id or "").strip()
+    evidence = str(quote or "").strip()
+    try:
+        conf = float(confidence)
+    except (TypeError, ValueError):
+        return None
+    if (
+        value is None
+        or not sid
+        or not evidence
+        or source not in SOURCE_KINDS
+        or not 0.0 <= conf <= 1.0
+        or conf < MIN_CANDIDATE_CONFIDENCE
+    ):
+        return None
+
+    key = norm(value)
+    now = _now()
+    existing = get(conn, value)
+    if existing is not None and existing.status == STATUS_REJECTED:
+        return existing
+
+    if existing is None:
+        conn.execute(
+            "INSERT INTO owner_aliases"
+            " (alias_key, alias, status, confidence, evidence_count, first_seen_at,"
+            " last_seen_at, activated_at, decision_source)"
+            " VALUES (?, ?, ?, ?, 0, ?, ?, NULL, 'inferred')",
+            (key, value, STATUS_PENDING, conf, now, now),
+        )
+
+    conn.execute(
+        "INSERT INTO owner_alias_evidence"
+        " (alias_key, alias, session_id, source_kind, quote, confidence, created_at)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?)"
+        " ON CONFLICT(alias_key, session_id) DO UPDATE SET"
+        " alias=CASE WHEN excluded.confidence > confidence THEN excluded.alias ELSE alias END,"
+        " source_kind=CASE WHEN excluded.confidence > confidence THEN excluded.source_kind"
+        " ELSE source_kind END,"
+        " quote=CASE WHEN excluded.confidence > confidence THEN excluded.quote ELSE quote END,"
+        " confidence=MAX(confidence, excluded.confidence)",
+        (key, value, sid, source, evidence, conf, now),
+    )
+    count, max_conf = conn.execute(
+        "SELECT COUNT(*), MAX(confidence) FROM owner_alias_evidence WHERE alias_key=?",
+        (key,),
+    ).fetchone()
+    current = get(conn, value)
+    assert current is not None
+    explicit = source == SOURCE_USER_CORRECTION or (
+        source == SOURCE_EXPLICIT_SELF and conf >= 0.9 and _explicit_self_quote(value, evidence)
+    )
+    active = current.status == STATUS_ACTIVE or explicit or int(count) >= PROMOTION_SESSIONS
+    activated_now = active and current.status != STATUS_ACTIVE
+    conn.execute(
+        "UPDATE owner_aliases SET alias=?, status=?, confidence=?, evidence_count=?,"
+        " last_seen_at=?, activated_at=CASE WHEN ? THEN COALESCE(activated_at, ?)"
+        " ELSE activated_at END, decision_source=CASE WHEN ? THEN ? ELSE decision_source END"
+        " WHERE alias_key=?",
+        (
+            value,
+            STATUS_ACTIVE if active else STATUS_PENDING,
+            float(max_conf or conf),
+            int(count),
+            now,
+            1 if active else 0,
+            now,
+            1 if activated_now else 0,
+            "user" if source == SOURCE_USER_CORRECTION else "inferred",
+            key,
+        ),
+    )
+    updated = get(conn, value)
+    assert updated is not None
+    return OwnerAliasState(**{**updated.__dict__, "activated_now": activated_now})
+
+
+def reject(conn: sqlite3.Connection, alias: str, *, source: str = "user") -> OwnerAliasState | None:
+    ensure_schema(conn)
+    value = clean_alias(alias)
+    if value is None:
+        return None
+    key = norm(value)
+    now = _now()
+    conn.execute(
+        "INSERT INTO owner_aliases"
+        " (alias_key, alias, status, confidence, evidence_count, first_seen_at, last_seen_at,"
+        " activated_at, decision_source) VALUES (?, ?, ?, 1.0, 0, ?, ?, NULL, ?)"
+        " ON CONFLICT(alias_key) DO UPDATE SET status=excluded.status,"
+        " last_seen_at=excluded.last_seen_at, decision_source=excluded.decision_source",
+        (key, value, STATUS_REJECTED, now, now, source),
+    )
+    return get(conn, value)

--- a/src/persome/store/schema_dump.py
+++ b/src/persome/store/schema_dump.py
@@ -92,6 +92,7 @@ def _index_db_steps() -> list[tuple[str, Callable[[sqlite3.Connection], None]]]:
     from . import (
         contradictions,
         memory_deltas,
+        owner_aliases,
         parser_ticks,
         relation_edges,
         schema_faces,
@@ -105,6 +106,7 @@ def _index_db_steps() -> list[tuple[str, Callable[[sqlite3.Connection], None]]]:
         ("store/relation_edges.py", relation_edges.ensure_schema),
         ("store/contradictions.py", contradictions.ensure_schema),
         ("store/memory_deltas.py", memory_deltas.ensure_schema),
+        ("store/owner_aliases.py", owner_aliases.ensure_schema),
         ("store/parser_ticks.py", parser_ticks.ensure_schema),
         ("store/schema_faces.py", schema_faces.ensure_schema),
         ("evomem/store.py", _evomem),

--- a/src/persome/writer/correct.py
+++ b/src/persome/writer/correct.py
@@ -143,7 +143,12 @@ def _plan(supersede: list[dict], entity_op: dict | None) -> list[str]:
 
 
 def _apply_entity_op(
-    entity_op: dict, cfg: Any, conn: sqlite3.Connection, *, signal: str
+    entity_op: dict,
+    cfg: Any,
+    conn: sqlite3.Connection,
+    *,
+    signal: str,
+    source: str,
 ) -> list[str]:
     from ..evomem import retype as retype_mod
 
@@ -156,10 +161,16 @@ def _apply_entity_op(
             from ..evomem import owner_identity
 
             if op == "reject_owner_alias":
-                state = owner_identity.reject_alias(conn, ent)
+                state = owner_identity.reject_alias(conn, ent, decision_source=source)
                 return [f"rejected owner alias {ent}"] if state is not None else []
             source_id = "correction:" + hashlib.sha1(signal.encode()).hexdigest()[:16]  # noqa: S324
-            state = owner_identity.accept_alias(conn, ent, source_id=source_id, quote=signal or ent)
+            state = owner_identity.accept_alias(
+                conn,
+                ent,
+                source_id=source_id,
+                quote=signal or ent,
+                decision_source=source,
+            )
             return [f"merged {ent} → self"] if state is not None else []
         if op == "retype":
             retype_mod.retype_entity(ent, str(entity_op.get("kind", "")).strip())
@@ -261,7 +272,7 @@ def update_memory(
             if r.errors:
                 applied.append(f"errors: {r.errors}")
         if entity_op and entity_op.get("op") in _ENTITY_OPS:  # entity layer → retype verbs
-            applied += _apply_entity_op(entity_op, cfg, conn, signal=signal)
+            applied += _apply_entity_op(entity_op, cfg, conn, signal=signal, source=source)
             kind = "entity_update" if not supersede else "update"
 
         # Closed loop: weight update (backward) → re-run the forward pass on the affected path so

--- a/src/persome/writer/correct.py
+++ b/src/persome/writer/correct.py
@@ -19,6 +19,7 @@ The update is logged as a feedback signal — a user's "this is wrong" is the mo
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sqlite3
 from collections.abc import Callable
@@ -38,7 +39,7 @@ from ..writer import llm as llm_mod
 logger = get("persome.writer.correct")
 
 _PROMPT_PATH = Path(__file__).parent.parent / "prompts" / "update_memory.md"
-_ENTITY_OPS = {"retype", "shadow", "merge"}
+_ENTITY_OPS = {"retype", "shadow", "merge", "merge_into_self", "reject_owner_alias"}
 
 
 @dataclass
@@ -141,7 +142,9 @@ def _plan(supersede: list[dict], entity_op: dict | None) -> list[str]:
     return out
 
 
-def _apply_entity_op(entity_op: dict, cfg: Any) -> list[str]:
+def _apply_entity_op(
+    entity_op: dict, cfg: Any, conn: sqlite3.Connection, *, signal: str
+) -> list[str]:
     from ..evomem import retype as retype_mod
 
     op = entity_op.get("op")
@@ -149,6 +152,15 @@ def _apply_entity_op(entity_op: dict, cfg: Any) -> list[str]:
     if not ent or op not in _ENTITY_OPS:
         return []
     try:
+        if op in {"merge_into_self", "reject_owner_alias"}:
+            from ..evomem import owner_identity
+
+            if op == "reject_owner_alias":
+                state = owner_identity.reject_alias(conn, ent)
+                return [f"rejected owner alias {ent}"] if state is not None else []
+            source_id = "correction:" + hashlib.sha1(signal.encode()).hexdigest()[:16]  # noqa: S324
+            state = owner_identity.accept_alias(conn, ent, source_id=source_id, quote=signal or ent)
+            return [f"merged {ent} → self"] if state is not None else []
         if op == "retype":
             retype_mod.retype_entity(ent, str(entity_op.get("kind", "")).strip())
             return [f"retyped {ent} → {entity_op.get('kind')}"]
@@ -249,7 +261,7 @@ def update_memory(
             if r.errors:
                 applied.append(f"errors: {r.errors}")
         if entity_op and entity_op.get("op") in _ENTITY_OPS:  # entity layer → retype verbs
-            applied += _apply_entity_op(entity_op, cfg)
+            applied += _apply_entity_op(entity_op, cfg, conn, signal=signal)
             kind = "entity_update" if not supersede else "update"
 
         # Closed loop: weight update (backward) → re-run the forward pass on the affected path so

--- a/src/persome/writer/cross_domain_sweeper.py
+++ b/src/persome/writer/cross_domain_sweeper.py
@@ -259,6 +259,12 @@ def _load_stable_schemas(conn: sqlite3.Connection) -> list[_StableSchema]:
         name = r["path"]
         if name.startswith("schema-xdomain-"):
             continue
+        source_path = _source_of(name)
+        # person-* schemas describe collaborators. Cross-domain synthesis is
+        # owner-scoped; fusing across subjects turns another person's behavior
+        # into an owner belief.
+        if source_path.startswith("person-"):
+            continue
         tags = (r["tags"] or "").split()
         if "stable" not in tags:
             continue
@@ -269,7 +275,7 @@ def _load_stable_schemas(conn: sqlite3.Connection) -> list[_StableSchema]:
         out.append(
             _StableSchema(
                 name=name,
-                source_path=_source_of(name),
+                source_path=source_path,
                 central=central,
                 inferences=stage.parse_expected_inferences(body),
                 confidence=_confidence_of(tags),

--- a/src/persome/writer/memory_delta.py
+++ b/src/persome/writer/memory_delta.py
@@ -49,6 +49,10 @@ _HEADS = ("entities", "assertions", "relations", "events")
 _ENTITY_KINDS = frozenset({"person", "org", "project", "artifact"})
 _PREDICATES = frozenset(p.value for p in edges_store.Predicate)
 _POLARITIES = frozenset({"+", "-", "0"})
+_SELF_IDENTITY = "self"
+_LOCAL_MODEL_URL_RE = re.compile(
+    r"https?://(?:127\.0\.0\.1|localhost)(?::\d+)?/model(?:[/?#]|\b)", re.IGNORECASE
+)
 
 
 def _norm_polarity(item: dict) -> str:
@@ -100,16 +104,30 @@ def _load_roster(cfg: Any) -> list[tuple[str, list[str]]]:
     Fail-open: any read error → empty roster (the delta then only carries
     ``new_entity`` items; nothing breaks).
     """
+    owner_aliases = [
+        str(alias).strip()
+        for alias in getattr(cfg.memory_delta, "owner_aliases", [])
+        if str(alias).strip()
+    ]
+    owner_keys = {identity_mod.norm(alias) for alias in owner_aliases}
     try:
         from ..evomem.engine import EvoMemory
         from ..evomem.person_graph import PersonGraph
 
         persons = PersonGraph(EvoMemory(), cfg=cfg).list_persons()
         limit = int(getattr(cfg.memory_delta, "roster_max", 60))
-        return [(p.canonical, list(getattr(p, "aliases", []))) for p in persons[:limit]]
+        known: list[tuple[str, list[str]]] = []
+        for person in persons:
+            aliases = list(getattr(person, "aliases", []))
+            if any(identity_mod.norm(name) in owner_keys for name in [person.canonical, *aliases]):
+                continue
+            known.append((person.canonical, aliases))
+            if len(known) >= limit:
+                break
+        return [(_SELF_IDENTITY, owner_aliases), *known]
     except Exception:  # noqa: BLE001 — roster is best-effort
         logger.debug("memory_delta: roster load failed, empty", exc_info=True)
-        return []
+        return [(_SELF_IDENTITY, owner_aliases)]
 
 
 def _render_roster(roster: list[tuple[str, list[str]]]) -> str:
@@ -118,8 +136,19 @@ def _render_roster(roster: list[tuple[str, list[str]]]) -> str:
     lines = []
     for canonical, aliases in roster:
         alias_part = f" (aliases: {', '.join(aliases)})" if aliases else ""
-        lines.append(f"- {canonical}{alias_part}")
+        owner_part = (
+            " (memory owner; relation endpoint only)" if canonical == _SELF_IDENTITY else ""
+        )
+        lines.append(f"- {canonical}{alias_part}{owner_part}")
     return "\n".join(lines)
+
+
+def _is_local_model_output(entry: str) -> bool:
+    """Match Persome's rendered model, not a typed mention of its URL."""
+    text = str(entry or "")
+    return bool(_LOCAL_MODEL_URL_RE.search(text)) and (
+        "Persome Personal Model" in text or "[Google Chrome]" in text or "[Chrome]" in text
+    )
 
 
 def _render_blocks(blocks: list[tl_store.TimelineBlock]) -> str:
@@ -132,11 +161,15 @@ def _render_blocks(blocks: list[tl_store.TimelineBlock]) -> str:
     """
     parts: list[str] = []
     for b in blocks:
+        raw_entries = list(b.entries or [])
+        entries = [entry for entry in raw_entries if not _is_local_model_output(entry)]
+        if not entries:
+            continue
         window = f"[{b.start_time:%H:%M}-{b.end_time:%H:%M}] apps: {', '.join(b.apps_used)}"
         lines = [window]
-        lines.extend(f"  - {e}" for e in b.entries)
+        lines.extend(f"  - {e}" for e in entries)
         focus = (b.focus_structured or b.focus_excerpt or "").strip()
-        if focus:
+        if focus and len(entries) == len(raw_entries):
             lines.append("  focus:")
             lines.extend(f"    {ln}" for ln in focus.splitlines())
         parts.append("\n".join(lines))
@@ -221,6 +254,7 @@ def gate_delta(
             isinstance(item, dict)
             and item.get("kind") in _ENTITY_KINDS
             and who is not None
+            and who.get("ref") != _SELF_IDENTITY
             and _quote_ok(item, text_norm)
             and conf_ok(item)
         ):
@@ -363,6 +397,9 @@ def run_after_session(
     roster_entries = _load_roster(cfg)
     roster = identity_mod.Roster.build(roster_entries)
     session_text = _render_blocks(blocks)
+    if not session_text.strip():
+        result.skipped_reason = "model_output_only"
+        return result
 
     _cache = {"type": "ephemeral"}
     messages: list[dict[str, Any]] = [

--- a/src/persome/writer/memory_delta.py
+++ b/src/persome/writer/memory_delta.py
@@ -1,7 +1,8 @@
 """Windowed structured modeling: observations to auditable Points and Lines.
 
 One LLM reading of each newly flushed session window, multiple structured heads —
-``memory_delta {entities, assertions, relations, events}``. The gated delta is
+``memory_delta {owner_alias_candidates, entities, assertions, relations, events}``.
+The gated delta is
 persisted first, then ``delta_apply`` deterministically mints or reinforces
 evomem Points and relation Lines. Persist-before-apply makes the windowed path
 auditable and retryable.
@@ -34,9 +35,11 @@ from typing import Any
 
 from .. import prompts
 from ..evomem import identity as identity_mod
+from ..evomem import owner_identity
 from ..logger import get
 from ..store import fts
 from ..store import memory_deltas as deltas_store
+from ..store import owner_aliases as owner_alias_store
 from ..store import relation_edges as edges_store
 from ..timeline import store as tl_store
 from . import llm as llm_mod
@@ -45,7 +48,7 @@ logger = get("persome.writer.memory_delta")
 
 STAGE = "memory_delta"
 
-_HEADS = ("entities", "assertions", "relations", "events")
+_HEADS = ("owner_alias_candidates", "entities", "assertions", "relations", "events")
 _ENTITY_KINDS = frozenset({"person", "org", "project", "artifact"})
 _PREDICATES = frozenset(p.value for p in edges_store.Predicate)
 _POLARITIES = frozenset({"+", "-", "0"})
@@ -104,30 +107,12 @@ def _load_roster(cfg: Any) -> list[tuple[str, list[str]]]:
     Fail-open: any read error → empty roster (the delta then only carries
     ``new_entity`` items; nothing breaks).
     """
-    owner_aliases = [
-        str(alias).strip()
-        for alias in getattr(cfg.memory_delta, "owner_aliases", [])
-        if str(alias).strip()
-    ]
-    owner_keys = {identity_mod.norm(alias) for alias in owner_aliases}
     try:
-        from ..evomem.engine import EvoMemory
-        from ..evomem.person_graph import PersonGraph
-
-        persons = PersonGraph(EvoMemory(), cfg=cfg).list_persons()
         limit = int(getattr(cfg.memory_delta, "roster_max", 60))
-        known: list[tuple[str, list[str]]] = []
-        for person in persons:
-            aliases = list(getattr(person, "aliases", []))
-            if any(identity_mod.norm(name) in owner_keys for name in [person.canonical, *aliases]):
-                continue
-            known.append((person.canonical, aliases))
-            if len(known) >= limit:
-                break
-        return [(_SELF_IDENTITY, owner_aliases), *known]
+        return identity_mod.load_roster_entries(cfg, limit=limit)
     except Exception:  # noqa: BLE001 — roster is best-effort
         logger.debug("memory_delta: roster load failed, empty", exc_info=True)
-        return [(_SELF_IDENTITY, owner_aliases)]
+        return [(_SELF_IDENTITY, [])]
 
 
 def _render_roster(roster: list[tuple[str, list[str]]]) -> str:
@@ -220,6 +205,50 @@ def _canonicalize(
     return None
 
 
+def gate_owner_alias_candidates(
+    raw: dict,
+    *,
+    session_text: str,
+) -> tuple[list[dict], int]:
+    """Validate probabilistic owner recognition before it reaches the identity store."""
+    text_norm = _norm_ws(session_text)
+    clean: list[dict] = []
+    dropped = 0
+    for item in raw.get("owner_alias_candidates") or []:
+        if not isinstance(item, dict):
+            dropped += 1
+            continue
+        alias = owner_alias_store.clean_alias(str(item.get("alias") or ""))
+        quote = str(item.get("quote") or "").strip()
+        source_kind = str(item.get("source_kind") or "")
+        try:
+            confidence = float(item.get("confidence", 0.0))
+        except (TypeError, ValueError):
+            confidence = 0.0
+        if (
+            alias is None
+            or source_kind
+            not in {
+                owner_alias_store.SOURCE_OWNED_ACCOUNT,
+                owner_alias_store.SOURCE_EXPLICIT_SELF,
+            }
+            or confidence < owner_alias_store.MIN_CANDIDATE_CONFIDENCE
+            or _norm_ws(quote) not in text_norm
+            or identity_mod.norm(alias) not in identity_mod.norm(quote)
+        ):
+            dropped += 1
+            continue
+        clean.append(
+            {
+                "alias": alias,
+                "source_kind": source_kind,
+                "quote": quote,
+                "confidence": confidence,
+            }
+        )
+    return clean, dropped
+
+
 def gate_delta(
     raw: dict,
     *,
@@ -227,6 +256,8 @@ def gate_delta(
     session_text: str,
     min_confidence: float,
     cooccurrence: bool = True,
+    owner_candidates: list[dict] | None = None,
+    protected_owner_aliases: list[str] | None = None,
 ) -> tuple[dict, int]:
     """Deterministic gates over the LLM's delta. Returns (clean, dropped).
 
@@ -237,7 +268,11 @@ def gate_delta(
     """
     text_norm = _norm_ws(session_text)
     clean: dict[str, list[dict]] = {h: [] for h in _HEADS}
+    clean["owner_alias_candidates"] = list(owner_candidates or [])
     dropped = 0
+    protected_owner_keys = {
+        identity_mod.norm(alias) for alias in (protected_owner_aliases or []) if alias
+    }
 
     def conf_ok(item: dict) -> bool:
         try:
@@ -246,7 +281,13 @@ def gate_delta(
             return False
 
     def ident(obj: Any) -> dict[str, str] | None:
-        return _canonicalize(obj, roster, text_norm)
+        canonical = _canonicalize(obj, roster, text_norm)
+        if canonical is None:
+            return None
+        unresolved = canonical.get("new_entity")
+        if unresolved and identity_mod.norm(unresolved) in protected_owner_keys:
+            return None
+        return canonical
 
     for item in raw.get("entities") or []:
         who = ident(item) if isinstance(item, dict) else None
@@ -395,7 +436,6 @@ def run_after_session(
         return result
 
     roster_entries = _load_roster(cfg)
-    roster = identity_mod.Roster.build(roster_entries)
     session_text = _render_blocks(blocks)
     if not session_text.strip():
         result.skipped_reason = "model_output_only"
@@ -435,15 +475,35 @@ def run_after_session(
         result.skipped_reason = "unparseable"
         return result
 
-    clean, dropped = gate_delta(
-        raw,
-        roster=roster,
-        session_text=session_text,
-        min_confidence=float(getattr(cfg.memory_delta, "min_confidence", 0.5)),
-        cooccurrence=bool(getattr(cfg.memory_delta, "cooccurrence_knows", True)),
+    owner_candidates, candidate_dropped = gate_owner_alias_candidates(
+        raw, session_text=session_text
     )
     try:
         with fts.cursor() as conn:
+            for candidate in owner_candidates:
+                owner_identity.record_candidate(
+                    conn,
+                    alias=candidate["alias"],
+                    session_id=session_id,
+                    source_kind=candidate["source_kind"],
+                    quote=candidate["quote"],
+                    confidence=candidate["confidence"],
+                )
+
+            # Rebuild after recording: a second independent session can promote
+            # the alias during this very window, so its relation endpoints must
+            # canonicalize to self immediately.
+            roster = identity_mod.load_roster(cfg)
+            clean, gated_dropped = gate_delta(
+                raw,
+                roster=roster,
+                session_text=session_text,
+                min_confidence=float(getattr(cfg.memory_delta, "min_confidence", 0.5)),
+                cooccurrence=bool(getattr(cfg.memory_delta, "cooccurrence_knows", True)),
+                owner_candidates=owner_candidates,
+                protected_owner_aliases=owner_identity.reserved_aliases(cfg, conn=conn),
+            )
+            dropped = candidate_dropped + gated_dropped
             delta_id = deltas_store.insert(
                 conn,
                 session_id=session_id,

--- a/src/persome/writer/schema_miner_stage.py
+++ b/src/persome/writer/schema_miner_stage.py
@@ -313,9 +313,9 @@ def _face_anchors(
     - the source file's own entity (a Face mined from ``person-alex.md`` is
       about Alex; a ``user-*`` Face anchors to ``self``);
     - every roster identity named in the signature OR in the footprint fact
-      BODIES — the cluster emerged from those facts, so the people they name
-      ARE the points it spans (signature-only anchors leave person faces with
-      one anchor forever and every face degenerates to a halo/plate);
+      BODIES when the schema is not explicitly about the owner. Owner-scoped
+      schemas anchor to ``self`` instead of every collaborator mentioned in
+      their evidence;
     - the same ``scan_mentions`` knife the read path uses (§4.3 one funnel).
 
     Best-effort: an empty list just means the face renders as a tower plate."""
@@ -333,17 +333,20 @@ def _face_anchors(
 
         # it is ABOUT the user, so it belongs on the USER hub (§1.5 same-component invariant).
         sig = (signature or "").strip()
-        if (
+        owner_scoped = (
             stem.startswith("user-")
             or sig.startswith("\u7528\u6237")
-            or sig.lower().startswith("user")
-        ):
+            or sig.startswith("\u8be5\u7528\u6237")
+            or sig.lower().startswith(("user", "the user", "this person"))
+        )
+        if owner_scoped:
             anchors.add("self")
         from ..evomem import identity as identity_mod
 
         roster = identity_mod.load_roster(cfg)
         hay = "\n".join([signature, *(facts or [])])
-        anchors.update(identity_mod.scan_mentions(hay, roster))
+        if not owner_scoped:
+            anchors.update(identity_mod.scan_mentions(hay, roster))
     except Exception:  # noqa: BLE001 — anchors decorate, never block the mine
         logger.debug("face anchor derivation failed for %s", source_path, exc_info=True)
     return sorted(anchors)

--- a/src/persome/writer/schema_miner_stage.py
+++ b/src/persome/writer/schema_miner_stage.py
@@ -160,6 +160,8 @@ def collect_fact_bundles(
             rows = conn.execute(
                 f"SELECT file_name AS path, content FROM evo_nodes "
                 f"WHERE is_latest = 1 AND status = 'active' AND ({like}) "
+                "AND tags NOT LIKE '%person-event%' "
+                "AND tags NOT LIKE '%person-entity%' "
                 f"ORDER BY file_name, gmt_created"
             ).fetchall()
         except Exception:  # noqa: BLE001 — evo_nodes

--- a/tests/test_cross_domain_sweeper.py
+++ b/tests/test_cross_domain_sweeper.py
@@ -523,3 +523,16 @@ def test_xdomain_schemas_are_not_re_fused(ac_root):
         names = {s.name for s in bases}
         assert "schema-project-a.md" in names
         assert "schema-xdomain-x__y.md" not in names
+
+
+def test_person_schemas_are_not_cross_domain_inputs(ac_root):
+    """Collaborator schemas cannot be fused into the owner's project model."""
+    from persome.store import fts
+
+    with fts.cursor() as conn:
+        _seed_schema(conn, "schema-person-kevin.md", "Kevin iterates with a fixed prompt", ["x"])
+        _seed_schema(conn, "schema-project-persome.md", "The owner iterates on Persome", ["y"])
+
+        bases = sweeper._load_stable_schemas(conn)
+
+    assert [schema.name for schema in bases] == ["schema-project-persome.md"]

--- a/tests/test_entity_source.py
+++ b/tests/test_entity_source.py
@@ -7,11 +7,13 @@ import time
 from datetime import UTC, datetime
 from types import SimpleNamespace
 
+from persome.evomem import owner_identity
 from persome.evomem.models import MemoryLayer, MemoryNode
 from persome.evomem.store import NodeStore
 from persome.model.entity_source import EntitySource, MemoryPersonNameSource
 from persome.store import entries as entries_store
 from persome.store import fts
+from persome.store import owner_aliases as owner_alias_store
 
 
 def _seed_person_memory() -> str:
@@ -109,6 +111,31 @@ def test_memory_person_source_filters_configured_owner_alias(ac_root) -> None:
         )
     )
     cfg = SimpleNamespace(memory_delta=SimpleNamespace(owner_aliases=["Singularity-tian"]))
+
+    assert MemoryPersonNameSource(cfg=cfg).events() == []
+
+
+def test_memory_person_source_filters_learned_owner_alias(ac_root) -> None:
+    NodeStore().save(
+        MemoryNode(
+            node_id="point-person-learned-owner",
+            content="Singularity-tian opened a pull request.",
+            layer=MemoryLayer.L2_FACT,
+            file_name="person-singularity-tian.md",
+            confidence="high",
+        )
+    )
+    with fts.cursor() as conn:
+        for session_id in ("owner-1", "owner-2"):
+            owner_identity.record_candidate(
+                conn,
+                alias="Singularity-tian",
+                session_id=session_id,
+                source_kind=owner_alias_store.SOURCE_OWNED_ACCOUNT,
+                quote="own account Singularity-tian",
+                confidence=0.9,
+            )
+    cfg = SimpleNamespace(memory_delta=SimpleNamespace(owner_aliases=[]))
 
     assert MemoryPersonNameSource(cfg=cfg).events() == []
 

--- a/tests/test_entity_source.py
+++ b/tests/test_entity_source.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import time
 from datetime import UTC, datetime
+from types import SimpleNamespace
 
 from persome.evomem.models import MemoryLayer, MemoryNode
 from persome.evomem.store import NodeStore
@@ -59,6 +60,57 @@ def test_memory_person_source_implements_person_graph_seam(ac_root) -> None:
     assert [event.name for event in events] == ["alex"]
     assert events[0].summary == "Alex reviews architecture decisions with the user."
     assert events[0].confidence == 0.95
+
+
+def test_event_mentions_keep_only_person_specific_lines(ac_root) -> None:
+    NodeStore().save(
+        MemoryNode(
+            node_id="point-person-kevin",
+            content="Kevin is a launch collaborator.",
+            layer=MemoryLayer.L2_FACT,
+            file_name="person-kevin.md",
+            confidence="high",
+        )
+    )
+    with fts.cursor() as conn:
+        entries_store.create_file(
+            conn,
+            name="event-2026-07-10.md",
+            description="Synthetic mixed activity",
+            tags=["event"],
+        )
+        entries_store.append_entry(
+            conn,
+            name="event-2026-07-10.md",
+            content=(
+                "The user adjusted a private investment portfolio.\n"
+                "- [Feishu] Kevin reviewed the launch checklist.\n"
+                "- [Chrome] The user opened a banking dashboard."
+            ),
+            tags=["work"],
+        )
+        mention = next(
+            event for event in EntitySource(conn).events() if event.source_kind == "entry"
+        )
+
+    assert mention.summary == "- [Feishu] Kevin reviewed the launch checklist."
+    assert "investment" not in mention.summary
+
+
+def test_memory_person_source_filters_configured_owner_alias(ac_root) -> None:
+    node_id = "point-person-owner"
+    NodeStore().save(
+        MemoryNode(
+            node_id=node_id,
+            content="Singularity-tian opened a pull request.",
+            layer=MemoryLayer.L2_FACT,
+            file_name="person-singularity-tian.md",
+            confidence="high",
+        )
+    )
+    cfg = SimpleNamespace(memory_delta=SimpleNamespace(owner_aliases=["Singularity-tian"]))
+
+    assert MemoryPersonNameSource(cfg=cfg).events() == []
 
 
 def test_entity_source_limit_uses_actual_instant_across_offsets(ac_root) -> None:

--- a/tests/test_memory_delta.py
+++ b/tests/test_memory_delta.py
@@ -48,6 +48,7 @@ def _ref(name: str) -> dict:
 
 def _payload(**overrides) -> str:
     base = {
+        "owner_alias_candidates": [],
         "entities": [
             {
                 "new_entity": "\u5f20\u4e09",
@@ -155,6 +156,83 @@ def test_owner_alias_canonicalizes_to_self_but_never_mints_person(ac_root) -> No
     assert [entity["ref"] for entity in clean["entities"]] == ["Kevin"]
     assert clean["relations"][0]["src"] == {"ref": "self"}
     assert clean["relations"][0]["dst"] == {"ref": "Kevin"}
+
+
+def test_ai_owner_alias_evidence_promotes_without_user_config(ac_root, fake_llm) -> None:
+    quote = "Opened the user's own GitHub account Singularity-tian with Kevin"
+    start, end = _seed_session_blocks([f"[Chrome] {quote}"])
+    fake_llm.set_default(
+        delta_mod.STAGE,
+        _payload(
+            owner_alias_candidates=[
+                {
+                    "alias": "Singularity-tian",
+                    "source_kind": "owned_account",
+                    "quote": quote,
+                    "confidence": 0.94,
+                }
+            ],
+            entities=[
+                {
+                    "new_entity": "Singularity-tian",
+                    "kind": "person",
+                    "quote": quote,
+                    "confidence": 0.94,
+                },
+                {
+                    "new_entity": "Kevin",
+                    "kind": "person",
+                    "quote": quote,
+                    "confidence": 0.9,
+                },
+            ],
+            assertions=[],
+            relations=[
+                {
+                    "src": {"new_entity": "Singularity-tian"},
+                    "dst": {"new_entity": "Kevin"},
+                    "predicate": "knows",
+                    "label": "collaborators",
+                    "quote": quote,
+                    "confidence": 0.9,
+                }
+            ],
+        ),
+    )
+    cfg = _cfg()
+
+    first = delta_mod.run_after_session(
+        cfg, session_id="owner-session-1", start_time=start, end_time=end
+    )
+    assert first.counts["owner_alias_candidates"] == 1
+    with fts.cursor() as conn:
+        assert (
+            conn.execute(
+                "SELECT status FROM owner_aliases WHERE alias_key='singularity-tian'"
+            ).fetchone()[0]
+            == "pending"
+        )
+        payload = json.loads(deltas_store.latest_for_session(conn, "owner-session-1")["payload"])
+    assert all(entity.get("new_entity") != "Singularity-tian" for entity in payload["entities"])
+    assert payload["relations"] == []
+
+    second = delta_mod.run_after_session(
+        cfg, session_id="owner-session-2", start_time=start, end_time=end
+    )
+    assert second.counts["owner_alias_candidates"] == 1
+    with fts.cursor() as conn:
+        row = conn.execute(
+            "SELECT status, evidence_count FROM owner_aliases WHERE alias_key='singularity-tian'"
+        ).fetchone()
+        payload = json.loads(deltas_store.latest_for_session(conn, "owner-session-2")["payload"])
+        owner_points = conn.execute(
+            "SELECT COUNT(*) FROM evo_nodes WHERE file_name='person-singularity-tian.md'"
+            " AND is_latest=1 AND status='active'"
+        ).fetchone()[0]
+    assert tuple(row) == ("active", 2)
+    assert payload["relations"][0]["src"] == {"ref": "self"}
+    assert owner_points == 0
+    assert delta_mod._load_roster(cfg)[0] == ("self", ["Singularity-tian"])
 
 
 def test_render_blocks_excludes_local_model_output_and_mixed_focus(ac_root) -> None:

--- a/tests/test_memory_delta.py
+++ b/tests/test_memory_delta.py
@@ -105,6 +105,80 @@ def test_delta_persisted_shadow_with_counts(ac_root, fake_llm) -> None:
     assert blocks[0].get("cache_control") == {"type": "ephemeral"}
 
 
+def test_roster_reserves_self_and_owner_aliases(ac_root) -> None:
+    cfg = _cfg()
+    cfg.memory_delta.owner_aliases = [
+        "Tianyi Zhang",
+        "\u5f20\u5929\u7fca",
+        "Singularity-tian",
+    ]
+
+    roster = delta_mod._load_roster(cfg)
+
+    assert roster[0] == (
+        "self",
+        ["Tianyi Zhang", "\u5f20\u5929\u7fca", "Singularity-tian"],
+    )
+    rendered = delta_mod._render_roster(roster)
+    assert "self" in rendered and "memory owner" in rendered
+
+
+def test_owner_alias_canonicalizes_to_self_but_never_mints_person(ac_root) -> None:
+    from persome.evomem import identity as identity_mod
+
+    roster = identity_mod.Roster.build([("self", ["Singularity-tian"]), ("Kevin", [])])
+    quote = "Singularity-tian reviewed the launch plan with Kevin"
+    raw = {
+        "entities": [
+            {"ref": "Singularity-tian", "kind": "person", "quote": quote, "confidence": 0.9},
+            {"ref": "Kevin", "kind": "person", "quote": quote, "confidence": 0.9},
+        ],
+        "assertions": [],
+        "relations": [
+            {
+                "src": {"ref": "Singularity-tian"},
+                "dst": {"ref": "Kevin"},
+                "predicate": "knows",
+                "label": "teammates",
+                "quote": quote,
+                "confidence": 0.9,
+            }
+        ],
+        "events": [],
+    }
+
+    clean, dropped = delta_mod.gate_delta(
+        raw, roster=roster, session_text=quote, min_confidence=0.5
+    )
+
+    assert dropped == 1
+    assert [entity["ref"] for entity in clean["entities"]] == ["Kevin"]
+    assert clean["relations"][0]["src"] == {"ref": "self"}
+    assert clean["relations"][0]["dst"] == {"ref": "Kevin"}
+
+
+def test_render_blocks_excludes_local_model_output_and_mixed_focus(ac_root) -> None:
+    start = datetime(2026, 7, 12, 9, 0).astimezone()
+    block = TimelineBlock(
+        start_time=start,
+        end_time=start + timedelta(minutes=1),
+        entries=[
+            "[Google Chrome] Persome Personal Model (http://127.0.0.1:8742/model): "
+            "read Root claiming Kevin is the owner.",
+            "[Feishu] Project chat: Kevin said the release is ready.",
+        ],
+        apps_used=["Google Chrome", "Feishu"],
+        capture_count=2,
+        focus_excerpt="Root: Kevin is the owner",
+    )
+
+    rendered = delta_mod._render_blocks([block])
+
+    assert "release is ready" in rendered
+    assert "127.0.0.1:8742/model" not in rendered
+    assert "Root: Kevin is the owner" not in rendered
+
+
 def test_quote_evidence_gate_drops_unquoted_items(ac_root, fake_llm) -> None:
     """No verbatim quote from the session text → the item never lands (§4.1)."""
     start, end = _seed_session_blocks([SESSION_ENTRY])

--- a/tests/test_owner_identity.py
+++ b/tests/test_owner_identity.py
@@ -1,0 +1,154 @@
+"""Owner identity evidence accumulates safely into the reserved self identity."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from persome.evomem import owner_identity
+from persome.evomem.engine import EvoMemory
+from persome.evomem.models import MemoryLayer
+from persome.store import fts
+from persome.store import owner_aliases as alias_store
+
+
+def _cfg():
+    return SimpleNamespace(memory_delta=SimpleNamespace(owner_aliases=[]))
+
+
+def test_owned_account_requires_two_independent_sessions(ac_root) -> None:
+    with fts.cursor() as conn:
+        first = owner_identity.record_candidate(
+            conn,
+            alias="Singularity-tian",
+            session_id="session-1",
+            source_kind=alias_store.SOURCE_OWNED_ACCOUNT,
+            quote="Opened the user's own GitHub account Singularity-tian",
+            confidence=0.91,
+        )
+        duplicate = owner_identity.record_candidate(
+            conn,
+            alias="Singularity-tian",
+            session_id="session-1",
+            source_kind=alias_store.SOURCE_OWNED_ACCOUNT,
+            quote="Opened the user's own GitHub account Singularity-tian",
+            confidence=0.94,
+        )
+        assert first is not None and first.status == alias_store.STATUS_PENDING
+        assert duplicate is not None and duplicate.evidence_count == 1
+
+        second = owner_identity.record_candidate(
+            conn,
+            alias="Singularity-tian",
+            session_id="session-2",
+            source_kind=alias_store.SOURCE_OWNED_ACCOUNT,
+            quote="Returned to own repositories for Singularity-tian",
+            confidence=0.9,
+        )
+
+    assert second is not None and second.status == alias_store.STATUS_ACTIVE
+    assert second.evidence_count == 2 and second.activated_now
+    assert owner_identity.active_aliases(_cfg()) == ["Singularity-tian"]
+
+
+def test_explicit_authored_identity_promotes_immediately(ac_root) -> None:
+    with fts.cursor() as conn:
+        state = owner_identity.record_candidate(
+            conn,
+            alias="\u5f20\u5929\u7fca",
+            session_id="session-explicit",
+            source_kind=alias_store.SOURCE_EXPLICIT_SELF,
+            quote="\u6211\u53eb\u5f20\u5929\u7fca",
+            confidence=0.96,
+        )
+
+    assert state is not None and state.status == alias_store.STATUS_ACTIVE
+    assert state.evidence_count == 1
+
+
+def test_explicit_kind_does_not_promote_unrelated_first_person_sentence(ac_root) -> None:
+    with fts.cursor() as conn:
+        state = owner_identity.record_candidate(
+            conn,
+            alias="Kevin",
+            session_id="session-ambiguous",
+            source_kind=alias_store.SOURCE_EXPLICIT_SELF,
+            quote="I am reviewing the launch plan with Kevin",
+            confidence=0.99,
+        )
+
+    assert state is not None and state.status == alias_store.STATUS_PENDING
+    assert not alias_store._explicit_self_quote("Alex", "I am Alexander")
+    assert not alias_store._explicit_self_quote("Alex", "I am Alex's manager")
+
+
+def test_rejected_alias_does_not_reactivate_from_inference(ac_root) -> None:
+    with fts.cursor() as conn:
+        owner_identity.reject_alias(conn, "Kevin")
+        state = owner_identity.record_candidate(
+            conn,
+            alias="Kevin",
+            session_id="session-1",
+            source_kind=alias_store.SOURCE_OWNED_ACCOUNT,
+            quote="own account Kevin",
+            confidence=0.99,
+        )
+
+    assert state is not None and state.status == alias_store.STATUS_REJECTED
+    assert "Kevin" not in owner_identity.reserved_aliases(_cfg())
+
+
+def test_stale_pending_alias_no_longer_blocks_person_graph(ac_root) -> None:
+    with fts.cursor() as conn:
+        owner_identity.record_candidate(
+            conn,
+            alias="Kevin",
+            session_id="session-1",
+            source_kind=alias_store.SOURCE_OWNED_ACCOUNT,
+            quote="own account Kevin",
+            confidence=0.9,
+        )
+        conn.execute(
+            "UPDATE owner_aliases SET last_seen_at='2000-01-01T00:00:00+00:00'"
+            " WHERE alias_key='kevin'"
+        )
+
+    assert "Kevin" not in owner_identity.reserved_aliases(_cfg())
+
+
+def test_promotion_retires_existing_person_and_derived_schema(ac_root) -> None:
+    memory = EvoMemory()
+    memory.add_direct(
+        "Singularity-tian",
+        layer=MemoryLayer.L5_KNOWLEDGE,
+        file_name="person-singularity-tian",
+        tags="person-entity",
+    )
+    memory.add_direct(
+        "The person iterates on pull requests.",
+        layer=MemoryLayer.L6_SCHEMA,
+        file_name="schema-person-singularity-tian",
+        tags="schema stable",
+    )
+
+    with fts.cursor() as conn:
+        for session_id in ("session-1", "session-2"):
+            owner_identity.record_candidate(
+                conn,
+                alias="Singularity-tian",
+                session_id=session_id,
+                source_kind=alias_store.SOURCE_OWNED_ACCOUNT,
+                quote="own GitHub account Singularity-tian",
+                confidence=0.91,
+            )
+        active = conn.execute(
+            "SELECT file_name FROM evo_nodes WHERE is_latest=1 AND status='active'"
+            " AND file_name IN ('person-singularity-tian.md',"
+            " 'schema-person-singularity-tian.md')"
+        ).fetchall()
+        retired = conn.execute(
+            "SELECT COUNT(*) FROM evo_nodes WHERE status='shadow' AND is_latest=0"
+            " AND file_name IN ('person-singularity-tian.md',"
+            " 'schema-person-singularity-tian.md')"
+        ).fetchone()[0]
+
+    assert active == [] and retired == 2

--- a/tests/test_person_graph.py
+++ b/tests/test_person_graph.py
@@ -9,6 +9,8 @@ from persome.evomem.engine import EvoMemory
 from persome.evomem.models import MemoryLayer, MemoryStatus
 from persome.evomem.person_graph import PersonEvent, PersonGraph
 from persome.evomem.reconciler import Reconciler
+from persome.store import fts
+from persome.store import owner_aliases as owner_alias_store
 
 
 def _no_llm(messages):
@@ -139,6 +141,22 @@ def test_same_source_event_is_idempotent_across_enrichment_ticks(ac_root):
     person = graph.list_persons()[0]
     assert person.sightings == 1
     assert len(graph.person_timeline("Kevin")) == 1
+
+
+def test_pending_owner_alias_never_mints_person(ac_root):
+    with fts.cursor() as conn:
+        owner_alias_store.record_evidence(
+            conn,
+            alias="Singularity-tian",
+            session_id="owner-session-1",
+            source_kind=owner_alias_store.SOURCE_OWNED_ACCOUNT,
+            quote="own GitHub account Singularity-tian",
+            confidence=0.9,
+        )
+
+    graph = PersonGraph(_mem(), cfg=_on(), name_source=_StaticSource([]))
+    assert graph.record(PersonEvent(name="Singularity-tian", summary="opened a PR")) is None
+    assert graph.list_persons() == []
 
 
 def test_shared_alias_distinct_people_do_not_merge(ac_root):

--- a/tests/test_person_graph.py
+++ b/tests/test_person_graph.py
@@ -124,6 +124,23 @@ def test_distinct_people_stay_separate(ac_root):
     assert len(graph.list_persons()) == 2
 
 
+def test_same_source_event_is_idempotent_across_enrichment_ticks(ac_root):
+    graph = PersonGraph(_mem(), cfg=_on(), name_source=_StaticSource([]))
+    event = PersonEvent(
+        name="Kevin",
+        summary="Kevin reviewed the launch plan.",
+        occurred_at=_ts(18),
+        source_id="entity:entry:event-1:person:kevin",
+    )
+
+    graph.record(event)
+    graph.record(event)
+
+    person = graph.list_persons()[0]
+    assert person.sightings == 1
+    assert len(graph.person_timeline("Kevin")) == 1
+
+
 def test_shared_alias_distinct_people_do_not_merge(ac_root):
     graph = PersonGraph(_mem(), cfg=_on(), name_source=_StaticSource([]))
     graph.record(PersonEvent(name="Alex Chen", aliases=["Alex"], occurred_at=_ts(18), summary="a"))

--- a/tests/test_schema_faces.py
+++ b/tests/test_schema_faces.py
@@ -417,3 +417,13 @@ class TestAnchors:
         )
 
         assert got == ["Bob", "x", "\u5f20\u4f1f"]
+
+        # When the mined proposition is explicitly about the owner, people
+        # mentioned in supporting receipts are context, not hull identities.
+        owner = stage._face_anchors(
+            cfg,
+            "project-x.md",
+            "The user systematically diagnoses integration bugs",
+            ["Kevin reported the failing build"],
+        )
+        assert owner == ["self", "x"]

--- a/tests/test_schema_miner_stage.py
+++ b/tests/test_schema_miner_stage.py
@@ -13,6 +13,7 @@ The fake-llm injection mirrors ``tests/test_evomem/test_schema_miner.py``.
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime
 from types import SimpleNamespace
 
 from persome import config as config_mod
@@ -326,3 +327,26 @@ def test_collect_fact_bundles_from_evomem_reads_evo_nodes(ac_root):
 
     assert "person-\u674e\u56db.md" in legacy and "person-\u5f20\u4f1f.md" not in legacy
     assert "person-\u5f20\u4f1f.md" in evo and "person-\u674e\u56db.md" not in evo
+
+
+def test_evomem_schema_miner_excludes_derived_person_graph_nodes(ac_root):
+    from persome.evomem.models import MemoryLayer, MemoryNode
+    from persome.evomem.store import NodeStore
+
+    store = NodeStore()
+    for i in range(4):
+        store.save(
+            MemoryNode(
+                node_id=f"person-event-{i}",
+                content=f"Mixed session summary {i} mentioning Kevin and the owner",
+                layer=MemoryLayer.L5_KNOWLEDGE,
+                file_name="person-kevin.md",
+                tags="person-event",
+                memory_at=datetime(2026, 7, 12, 9, i, tzinfo=UTC),
+            )
+        )
+
+    with fts.cursor() as conn:
+        bundles = stage.collect_fact_bundles(conn, from_evomem=True, min_facts=1)
+
+    assert all(bundle.source_path != "person-kevin.md" for bundle in bundles)

--- a/tests/test_update_memory.py
+++ b/tests/test_update_memory.py
@@ -180,6 +180,28 @@ def test_entity_op_can_reject_false_owner_alias(ac_root):
     assert res.ok and status == "rejected"
 
 
+def test_owner_alias_correction_preserves_agent_provenance(ac_root):
+    with fts.cursor() as conn:
+        res = C.update_memory(
+            _cfg(),
+            conn,
+            "Singularity-tian is the owner's GitHub handle",
+            source="agent",
+            llm_call=_llm(
+                {
+                    "supersede": [],
+                    "entity_op": {"op": "merge_into_self", "entity": "Singularity-tian"},
+                    "reason": "owner handle",
+                }
+            ),
+        )
+        source = conn.execute(
+            "SELECT decision_source FROM owner_aliases WHERE alias_key='singularity-tian'"
+        ).fetchone()[0]
+
+    assert res.ok and source == "agent"
+
+
 def test_noop_when_nothing_to_update(ac_root):
     with fts.cursor() as conn:
         res = C.update_memory(

--- a/tests/test_update_memory.py
+++ b/tests/test_update_memory.py
@@ -137,6 +137,49 @@ def test_entity_op_routes_to_retype(ac_root, monkeypatch):
     assert res.ok and calls.get("merge") == ("\u5c0f\u5f20", "\u5f20\u4e09")
 
 
+def test_entity_op_can_merge_identity_into_reserved_self(ac_root):
+    with fts.cursor() as conn:
+        res = C.update_memory(
+            _cfg(),
+            conn,
+            "Singularity-tian is my GitHub handle",
+            llm_call=_llm(
+                {
+                    "supersede": [],
+                    "entity_op": {"op": "merge_into_self", "entity": "Singularity-tian"},
+                    "reason": "owner handle",
+                }
+            ),
+        )
+        row = conn.execute(
+            "SELECT status, decision_source FROM owner_aliases WHERE alias_key='singularity-tian'"
+        ).fetchone()
+
+    assert res.ok and "merged Singularity-tian → self" in res.applied
+    assert tuple(row) == ("active", "user")
+
+
+def test_entity_op_can_reject_false_owner_alias(ac_root):
+    with fts.cursor() as conn:
+        res = C.update_memory(
+            _cfg(),
+            conn,
+            "Kevin is my teammate, not me",
+            llm_call=_llm(
+                {
+                    "supersede": [],
+                    "entity_op": {"op": "reject_owner_alias", "entity": "Kevin"},
+                    "reason": "collaborator",
+                }
+            ),
+        )
+        status = conn.execute(
+            "SELECT status FROM owner_aliases WHERE alias_key='kevin'"
+        ).fetchone()[0]
+
+    assert res.ok and status == "rejected"
+
+
 def test_noop_when_nothing_to_update(ac_root):
     with fts.cursor() as conn:
         res = C.update_memory(


### PR DESCRIPTION
## What changed

- reserve `self` across the shared identity roster and keep collaborators separate
- let `memory_delta` propose evidence-backed owner alias candidates
- accumulate independent owner evidence, quarantine pending candidates, and promote confirmed aliases automatically
- prevent PersonGraph, schema mining, cross-domain synthesis, and Face anchors from amplifying owner/collaborator contamination
- filter local `/model` output from future evidence
- support audited `merge_into_self` and `reject_owner_alias` corrections

## Root cause

The prompt understood the screen operator as the memory owner, but the deterministic roster did not previously register `self`. Correct owner references could be rejected, while a visible owner name or handle could be minted as a normal person and then reinforced through PersonGraph and structural modeling.

## Impact

New installs learn owner aliases from existing session evidence instead of requiring users to fill `owner_aliases`. One account-ownership observation remains pending; two independent sessions promote it. Explicit first-person identity evidence can promote immediately. Manual aliases remain an optional trusted override.

## Validation

- `PERSOME_LLM_MOCK=1 uv run pytest -m "not macos and not integration" -q` — 1837 passed, 15 deselected
- `uv run ruff check .`
- `uv run ruff format --check .`
- secret, PII, and language scans clean
- generated DB schema drift test passed
- local Runtime update and capture proof passed