### PR TITLE
ci: publish releases to the Official MCP Registry

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,54 @@
+name: Publish MCP Registry
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          persist-credentials: false
+
+      - name: Verify the PyPI package is public
+        run: |
+          version="$(jq -r '.version' server.json)"
+          package="$(jq -r '.packages[0].identifier' server.json)"
+          marker="$(jq -r '.name' server.json)"
+          metadata="$(curl --fail --silent --show-error \
+            "https://pypi.org/pypi/${package}/${version}/json")"
+          test "$(jq -r '.info.version' <<<"$metadata")" = "$version"
+          grep --fixed-strings --quiet \
+            "<!-- mcp-name: ${marker} -->" <<<"$(jq -r '.info.description' <<<"$metadata")"
+
+      - name: Install pinned MCP publisher
+        run: |
+          curl --fail --location \
+            https://github.com/modelcontextprotocol/registry/releases/download/v1.7.9/mcp-publisher_linux_amd64.tar.gz \
+            --output mcp-publisher.tar.gz
+          echo "ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac  mcp-publisher.tar.gz" \
+            | sha256sum --check --strict
+          tar --extract --gzip --file mcp-publisher.tar.gz mcp-publisher
+
+      - name: Validate Registry metadata
+        run: ./mcp-publisher validate
+
+      - name: Authenticate with GitHub OIDC
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish Persome to the Official MCP Registry
+        run: ./mcp-publisher publish

--- a/MCP.md
+++ b/MCP.md
@@ -21,6 +21,14 @@ Stdio runs one server process for the client:
 persome mcp
 ```
 
+## Official MCP Registry
+
+The committed [`server.json`](server.json) publishes the stdio server as
+`io.github.Intuition-Lab/personal-model` and points Registry clients to the
+public `personal-model` PyPI package. A successful GitHub `Release` workflow
+automatically publishes the matching version through GitHub Actions OIDC; the
+`Publish MCP Registry` workflow can also be dispatched manually for recovery.
+
 The stdio server lives exactly as long as its client: it exits on stdin EOF,
 and a parent-death watchdog also exits it within seconds if the spawning
 client dies without closing the pipe, so orphaned servers never accumulate.


### PR DESCRIPTION
## Summary
- publish `server.json` through GitHub Actions OIDC after each successful Release
- provide a manual dispatch path for the initial v0.3.2 publication and recovery
- verify the exact PyPI version and ownership marker before publishing
- pin and checksum-verify `mcp-publisher` v1.7.9

## Verification
- `actionlint -color .github/workflows/publish-mcp.yml`
- `uv run --no-sync python scripts/check_doc_links.py`
- `uv run --no-sync ruff check .`
- `uv run --no-sync ruff format --check .`
- live PyPI 0.3.2 ownership marker check