### PR TITLE
fix: exclude AX placeholders from authored text

### DIFF
--- a/docs/capture.md
+++ b/docs/capture.md
@@ -179,6 +179,21 @@ Ported from Einsia-Partner's `s1_collector`. These are what downstream LLM stage
 - **`visible_text`** — a length-capped markdown rendering of the AX tree (up to ~10 k chars). What the user is currently reading on screen.
 - **`url`** — regex-extracted from `visible_text` when present; `null` otherwise.
 
+Editable values are placeholder-cleaned before they enter S1. The native AX
+helper's focused-element projection first uses `AXPlaceholderValue`, then a
+bounded fallback for Chromium's exact `.placeholder` descendant shape. The raw
+tree retains that evidence; the Python S1 projection applies the same structural
+check to the tree, older helpers, watcher triggers, and trusted-ingest
+producers. An exact placeholder descendant is removed only inside its owning
+editable subtree and only when its text is locally paired with that control.
+Matching text is then cleared from the parent projection. Ordinary page text
+and broad CSS classes that merely contain the word `placeholder` remain intact.
+Historical timeline/MCP
+reads and `rebuild-captures-index` apply the same sanitizer, so replaying an old
+buffer cannot turn input hints into authored text; index rebuilds also preserve
+DB-only OCR backfills. Explicit `--raw` native captures retain the diagnostic AX
+structure.
+
 Persisted screenshots are **not** passed to timeline, reducer, memory-delta, or
 schema prompts. They support optional local provenance drill-down and debugging.
 When `encrypt_screenshots=true`, `PERSOME_SCREENSHOT_KEY` seals them with

--- a/docs/capture.md
+++ b/docs/capture.md
@@ -188,10 +188,10 @@ producers. An exact placeholder descendant is removed only inside its owning
 editable subtree and only when its text is locally paired with that control.
 Matching text is then cleared from the parent projection. Ordinary page text
 and broad CSS classes that merely contain the word `placeholder` remain intact.
-Historical timeline/MCP
-reads and `rebuild-captures-index` apply the same sanitizer, so replaying an old
-buffer cannot turn input hints into authored text; index rebuilds also preserve
-DB-only OCR backfills. When an AX-empty surface falls back to screenshot OCR,
+Historical timeline, MCP, and classifier chat-drill reads plus
+`rebuild-captures-index` apply the same sanitizer, so replaying an old buffer
+cannot turn input hints into authored text; index rebuilds also preserve DB-only
+OCR backfills. When an AX-empty surface falls back to screenshot OCR,
 the same frontmost/focused-window evidence removes exact OCR lines/fields only
 for controls whose placeholder can currently be visible (the control is empty
 or exposes that same hint as its value). It never performs substring

--- a/docs/capture.md
+++ b/docs/capture.md
@@ -191,8 +191,13 @@ and broad CSS classes that merely contain the word `placeholder` remain intact.
 Historical timeline/MCP
 reads and `rebuild-captures-index` apply the same sanitizer, so replaying an old
 buffer cannot turn input hints into authored text; index rebuilds also preserve
-DB-only OCR backfills. Explicit `--raw` native captures retain the diagnostic AX
-structure.
+DB-only OCR backfills. When an AX-empty surface falls back to screenshot OCR,
+the same frontmost/focused-window evidence removes exact OCR lines/fields only
+for controls whose placeholder can currently be visible (the control is empty
+or exposes that same hint as its value). It never performs substring
+replacement. If identical OCR units outnumber the proven placeholder controls,
+the value is ambiguous and every occurrence is preserved. Explicit `--raw`
+native captures retain the diagnostic AX structure.
 
 Persisted screenshots are **not** passed to timeline, reducer, memory-delta, or
 schema prompts. They support optional local provenance drill-down and debugging.

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -37,7 +37,7 @@ Only closed windows are produced. The current half-formed window sits as "traili
 `timeline/aggregator.py` reads each capture's S1 fields (`focused_element`, `visible_text`, `url`, `window_meta`) — **not** the raw AX tree during normal operation. This keeps the prompt tractable:
 
 - `visible_text` is a pre-rendered, length-capped markdown view of the AX tree (capped at 10 KB per capture by S1, then capped at 4 KB per capture by the timeline prompt).
-- `focused_element` carries the user's current cursor / input context (role, title, value, editable flag). When `is_editable=true` and `value_length > 0`, the value is the user's own typed content — the prompt treats this as the highest-priority signal to preserve verbatim.
+- `focused_element` carries the user's current cursor / input context (role, title, value, editable flag). Before this boundary, S1 removes standard AX placeholders and locally matched Chromium `.placeholder` descendants. Therefore, when `is_editable=true` and `value_length > 0`, the remaining value is user-authored content and the prompt treats it as the highest-priority signal to preserve verbatim.
 - `url` is regex-extracted from visible text when present.
 - When capture JSON has no AX text and `ocr_submitted=true`, the aggregator
   consults the OCR backfill in `captures` FTS before declaring the window empty.

--- a/resources/mac-ax-helper.swift
+++ b/resources/mac-ax-helper.swift
@@ -118,6 +118,76 @@ func axChildren(_ element: AXUIElement) -> [AXUIElement] {
     return children
 }
 
+private let editableTextRoles: Set<String> = [
+    "AXTextField", "AXTextArea", "AXComboBox", "AXSearchField",
+]
+private let placeholderScanNodeLimit = 256
+private let placeholderScanDepthLimit = 12
+
+func normalizedAXText(_ value: String?) -> String {
+    return (value ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+/// Exact DOM class token only. CSS utilities such as
+/// `placeholder:text-token-input-placeholder-foreground` are ordinary style
+/// classes and must not make real content disappear.
+func hasPlaceholderDOMClass(_ element: AXUIElement) -> Bool {
+    return axStringList(element, "AXDOMClassList").contains {
+        $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "placeholder"
+    }
+}
+
+/// Text exposed by a `.placeholder` descendant of this editable element.
+/// Chromium sometimes advertises `AXPlaceholderValue` but returns nil, so the
+/// bounded structural fallback is required for Codex and other Electron apps.
+func placeholderDescendantTexts(_ element: AXUIElement) -> Set<String> {
+    var result: Set<String> = []
+    var pending: [(AXUIElement, Int, Bool)] = axChildren(element).reversed().map {
+        ($0, 1, false)
+    }
+    var scanned = 0
+    while let (current, depth, inheritedPlaceholder) = pending.popLast() {
+        if scanned >= placeholderScanNodeLimit { break }
+        scanned += 1
+        // A nested editable owns its own placeholder semantics. Do not let
+        // its hint propagate into an outer control.
+        if editableTextRoles.contains(axString(current, kAXRoleAttribute as String) ?? "") {
+            continue
+        }
+        let inPlaceholder = inheritedPlaceholder || hasPlaceholderDOMClass(current)
+        if inPlaceholder {
+            for attribute in [
+                kAXValueAttribute as String,
+                kAXTitleAttribute as String,
+                kAXDescriptionAttribute as String,
+            ] {
+                let text = normalizedAXText(axString(current, attribute))
+                if !text.isEmpty { result.insert(text) }
+            }
+        }
+        if depth >= placeholderScanDepthLimit { continue }
+        for child in axChildren(current).reversed() {
+            pending.append((child, depth + 1, inPlaceholder))
+        }
+    }
+    return result
+}
+
+func confirmedPlaceholderTexts(
+    _ element: AXUIElement, role: String?
+) -> Set<String> {
+    guard let role, editableTextRoles.contains(role) else { return [] }
+    let standard = normalizedAXText(axString(element, "AXPlaceholderValue"))
+    var evidence = placeholderDescendantTexts(element)
+    if !standard.isEmpty { evidence.insert(standard) }
+    let ownText = Set([
+        normalizedAXText(axString(element, kAXValueAttribute as String)),
+        normalizedAXText(axString(element, kAXTitleAttribute as String)),
+        normalizedAXText(axString(element, kAXDescriptionAttribute as String)),
+    ].filter { !$0.isEmpty })
+    return Set(evidence.filter { $0 == standard || ownText.contains($0) })
+}
+
 /// Ask an app to populate its accessibility tree by setting the private `AXManualAccessibility`
 /// attribute (the same toggle VoiceOver/assistive tech use). Electron/Chromium apps gate AX behind
 /// this for performance; setting it true makes a previously-empty tree readable. Best-effort: the
@@ -402,20 +472,25 @@ func focusedUIElementDict(_ appRef: AXUIElement, config: Config) -> [String: Any
     let subrole = axString(el, kAXSubroleAttribute as String)
     let isSecure = role == "AXTextField" && subrole == "AXSecureTextField"
 
+    let placeholderTexts = config.raw ? [] : confirmedPlaceholderTexts(el, role: role)
     var value = ""
     if isSecure {
         value = "[REDACTED]"
     } else if let raw = axString(el, kAXValueAttribute as String)?
-        .trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty
+        .trimmingCharacters(in: .whitespacesAndNewlines),
+        !raw.isEmpty,
+        config.raw || !placeholderTexts.contains(raw)
     {
         value = raw.count > config.maxValueLength
             ? String(raw.prefix(config.maxValueLength)) + "..."
             : raw
     }
-    let title = (axString(el, kAXTitleAttribute as String) ?? "")
+    var title = (axString(el, kAXTitleAttribute as String) ?? "")
         .trimmingCharacters(in: .whitespacesAndNewlines)
-    let desc = (axString(el, kAXDescriptionAttribute as String) ?? "")
+    var desc = (axString(el, kAXDescriptionAttribute as String) ?? "")
         .trimmingCharacters(in: .whitespacesAndNewlines)
+    if !config.raw && placeholderTexts.contains(title) { title = "" }
+    if !config.raw && placeholderTexts.contains(desc) { desc = "" }
 
     // Editable = a text-entry role, OR the element exposes a selected-text range
     // (only text-editing controls do). A present range == the caret is here ==

--- a/resources/mac-ax-helper.swift
+++ b/resources/mac-ax-helper.swift
@@ -211,6 +211,7 @@ struct AXNode {
     var title: String?
     var description: String?
     var value: String?
+    var placeholderValue: String?
     var identifier: String?
     var domIdentifier: String?
     var domClassList: [String]
@@ -222,6 +223,7 @@ struct AXNode {
             && title == nil
             && description == nil
             && value == nil
+            && placeholderValue == nil
             && identifier == nil
             && domIdentifier == nil
             && domClassList.isEmpty
@@ -238,6 +240,7 @@ struct AXNode {
         if let t = title { dict["title"] = t }
         if let d = description { dict["description"] = d }
         if let v = value { dict["value"] = v }
+        if let p = placeholderValue { dict["AXPlaceholderValue"] = p }
         if let id = identifier { dict["identifier"] = id }
         if let domID = domIdentifier { dict["domIdentifier"] = domID }
         if !domClassList.isEmpty { dict["domClassList"] = domClassList }
@@ -279,6 +282,10 @@ func traverseElement(
         .trimmingCharacters(in: .whitespacesAndNewlines)
     let domClassList = axStringList(element, "AXDOMClassList")
     let attributeNames = config.raw ? axAttributeNames(element) : []
+    let rawPlaceholderValue = editableTextRoles.contains(role ?? "")
+        ? normalizedAXText(axString(element, "AXPlaceholderValue"))
+        : ""
+    let placeholderValue = rawPlaceholderValue.isEmpty ? nil : rawPlaceholderValue
 
     // Get text content
     var title = axString(element, kAXTitleAttribute as String)?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -327,19 +334,21 @@ func traverseElement(
     let hasText = title != nil || value != nil
     let hasMetadata = subrole != nil
         || description != nil
+        || placeholderValue != nil
         || identifier != nil
         || domIdentifier != nil
         || !domClassList.isEmpty
 
     // For text-bearing roles: keep if they have text or meaningful children
     if let role = role, textBearingRoles.contains(role) {
-        if hasText || description != nil || !childNodes.isEmpty {
+        if hasText || description != nil || placeholderValue != nil || !childNodes.isEmpty {
             return AXNode(
                 role: role,
                 subrole: subrole,
                 title: title,
                 description: description,
                 value: value,
+                placeholderValue: placeholderValue,
                 identifier: identifier,
                 domIdentifier: domIdentifier,
                 domClassList: domClassList,
@@ -369,6 +378,7 @@ func traverseElement(
             title: title,
             description: description,
             value: value,
+            placeholderValue: placeholderValue,
             identifier: identifier,
             domIdentifier: domIdentifier,
             domClassList: domClassList,
@@ -385,6 +395,7 @@ func traverseElement(
             title: title,
             description: description,
             value: value,
+            placeholderValue: placeholderValue,
             identifier: identifier,
             domIdentifier: domIdentifier,
             domClassList: domClassList,
@@ -401,6 +412,7 @@ func traverseElement(
             title: title,
             description: description,
             value: value,
+            placeholderValue: placeholderValue,
             identifier: identifier,
             domIdentifier: domIdentifier,
             domClassList: domClassList,
@@ -473,6 +485,7 @@ func focusedUIElementDict(_ appRef: AXUIElement, config: Config) -> [String: Any
     let isSecure = role == "AXTextField" && subrole == "AXSecureTextField"
 
     let placeholderTexts = config.raw ? [] : confirmedPlaceholderTexts(el, role: role)
+    let standardPlaceholder = normalizedAXText(axString(el, "AXPlaceholderValue"))
     var value = ""
     if isSecure {
         value = "[REDACTED]"
@@ -502,6 +515,7 @@ func focusedUIElementDict(_ appRef: AXUIElement, config: Config) -> [String: Any
 
     var dict: [String: Any] = ["role": role]
     if let sr = subrole, !sr.isEmpty { dict["subrole"] = sr }
+    if !standardPlaceholder.isEmpty { dict["AXPlaceholderValue"] = standardPlaceholder }
     if !title.isEmpty { dict["title"] = title }
     if !desc.isEmpty { dict["description"] = desc }
     if !value.isEmpty {

--- a/resources/mac-ax-watcher.swift
+++ b/resources/mac-ax-watcher.swift
@@ -55,6 +55,20 @@ func axSubrole(_ element: AXUIElement) -> String? {
     return axString(element, kAXSubroleAttribute as String)
 }
 
+private let editableTextRoles: Set<String> = [
+    "AXTextField", "AXTextArea", "AXComboBox", "AXSearchField",
+]
+
+func normalizedAXText(_ value: String?) -> String {
+    return (value ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+func directPlaceholderTexts(_ element: AXUIElement, role: String) -> Set<String> {
+    guard editableTextRoles.contains(role) else { return [] }
+    let standard = normalizedAXText(axString(element, "AXPlaceholderValue"))
+    return standard.isEmpty ? [] : [standard]
+}
+
 /// True if the element itself is a secure text field.
 func isSecureElement(_ el: AXUIElement) -> Bool {
     return axRole(el) == "AXTextField" && axSubrole(el) == "AXSecureTextField"
@@ -96,10 +110,19 @@ func truncate(_ s: String, _ maxLen: Int) -> String {
 func describeElement(_ el: AXUIElement) -> [String: Any] {
     let role = axRole(el) ?? ""
     let subrole = axSubrole(el) ?? ""
-    let title = truncate(axString(el, kAXTitleAttribute as String) ?? "", 200)
+    let placeholderTexts = directPlaceholderTexts(el, role: role)
+    let rawTitle = normalizedAXText(axString(el, kAXTitleAttribute as String))
+    let title = placeholderTexts.contains(rawTitle) ? "" : truncate(rawTitle, 200)
     let identifier = truncate(axString(el, kAXIdentifierAttribute as String) ?? "", 200)
     let rawValue = axString(el, kAXValueAttribute as String) ?? ""
-    let value = isSecureElement(el) ? "[REDACTED]" : truncate(rawValue, 2000)
+    let value: String
+    if isSecureElement(el) {
+        value = "[REDACTED]"
+    } else if placeholderTexts.contains(normalizedAXText(rawValue)) {
+        value = ""
+    } else {
+        value = truncate(rawValue, 2000)
+    }
     return [
         "role": role,
         "subrole": subrole,
@@ -511,7 +534,8 @@ final class InteractionTapper {
 /// C callback for the CGEventTap. Keep this fast — the system will disable
 /// the tap if callbacks take too long. We do the minimum inline (unpacking
 /// the userInfo pointer and dispatching by event type); the real work in
-/// ``handleMouseDown`` / ``handleKeyDown`` is still synchronous but cheap.
+/// ``handleMouseDown`` / ``handleKeyDown`` remains the established synchronous
+/// path and only reads direct AX attributes.
 func interactionTapCallback(
     proxy: CGEventTapProxy,
     type: CGEventType,

--- a/src/persome/capture/placeholder.py
+++ b/src/persome/capture/placeholder.py
@@ -1,0 +1,365 @@
+"""Remove accessibility placeholders from authored-text signals.
+
+Chromium can expose an empty editable control's placeholder as ``AXValue``.
+The same control also exposes a descendant whose exact DOM class token is
+``placeholder``.  Treat that local pairing as UI chrome, not user-authored
+text.  The sanitizer is deliberately structural: it never hard-codes product
+copy and never matches broad CSS class substrings.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+EDITABLE_ROLES = frozenset({"AXTextField", "AXTextArea", "AXComboBox", "AXSearchField"})
+
+_PLACEHOLDER_CLASS = "placeholder"
+_PLACEHOLDER_VALUE_KEYS = (
+    "AXPlaceholderValue",
+    "placeholder_value",
+    "placeholderValue",
+)
+_TEXT_KEYS = ("value", "title", "description")
+_MAX_PLACEHOLDER_SCAN_NODES = 256
+_MAX_PLACEHOLDER_SCAN_DEPTH = 12
+
+
+def _normalized(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _class_tokens(element: dict[str, Any]) -> tuple[str, ...]:
+    raw = element.get("domClassList")
+    if isinstance(raw, str):
+        values = raw.split()
+    elif isinstance(raw, list):
+        values = [value for value in raw if isinstance(value, str)]
+    else:
+        values = []
+    return tuple(value.strip().casefold() for value in values if value.strip())
+
+
+def _is_placeholder_node(element: dict[str, Any]) -> bool:
+    # Exact token only. Tailwind and other CSS utilities legitimately contain
+    # substrings such as ``placeholder:text-token-…`` and must stay visible.
+    return _PLACEHOLDER_CLASS in _class_tokens(element)
+
+
+def _direct_placeholder_values(element: dict[str, Any]) -> set[str]:
+    return {
+        normalized
+        for key in _PLACEHOLDER_VALUE_KEYS
+        if (normalized := _normalized(element.get(key)))
+    }
+
+
+def _subtree_text(element: dict[str, Any]) -> set[str]:
+    """Collect bounded text from one already-identified placeholder subtree."""
+    values: set[str] = set()
+    stack: list[tuple[dict[str, Any], int]] = [(element, 0)]
+    seen = 0
+    while stack and seen < _MAX_PLACEHOLDER_SCAN_NODES:
+        current, depth = stack.pop()
+        seen += 1
+        if depth > 0 and str(current.get("role") or "") in EDITABLE_ROLES:
+            continue
+        for key in _TEXT_KEYS:
+            if text := _normalized(current.get(key)):
+                values.add(text)
+        if depth >= _MAX_PLACEHOLDER_SCAN_DEPTH:
+            continue
+        stack.extend(
+            (child, depth + 1)
+            for child in reversed(current.get("children") or [])
+            if isinstance(child, dict)
+        )
+    return values
+
+
+def _local_placeholder_values(element: dict[str, Any]) -> set[str]:
+    """Return placeholder text found inside this editable control only."""
+    values = _direct_placeholder_values(element)
+    stack: list[tuple[dict[str, Any], int]] = [
+        (child, 1) for child in reversed(element.get("children") or []) if isinstance(child, dict)
+    ]
+    seen = 0
+    while stack and seen < _MAX_PLACEHOLDER_SCAN_NODES:
+        current, depth = stack.pop()
+        seen += 1
+        if str(current.get("role") or "") in EDITABLE_ROLES:
+            continue
+        if _is_placeholder_node(current):
+            values.update(_subtree_text(current))
+            continue
+        if depth >= _MAX_PLACEHOLDER_SCAN_DEPTH:
+            continue
+        stack.extend(
+            (child, depth + 1)
+            for child in reversed(current.get("children") or [])
+            if isinstance(child, dict)
+        )
+    return values
+
+
+def _confirmed_placeholder_values(element: dict[str, Any]) -> set[str]:
+    """Return placeholder text locally paired with this editable control.
+
+    A ``.placeholder`` class alone is not enough: an application can use that
+    class name for ordinary page content.  Chromium's broken empty-composer
+    shape has both pieces of evidence on the *same* editable subtree: the
+    control exposes the hint as one of its text fields and a descendant marks
+    the same text with the exact class token.  The standard AX placeholder
+    attribute is authoritative on its own.
+    """
+    if str(element.get("role") or "") not in EDITABLE_ROLES:
+        return set()
+    standard = _direct_placeholder_values(element)
+    own_text = {text for key in _TEXT_KEYS if (text := _normalized(element.get(key)))}
+    structural = _local_placeholder_values(element) - standard
+    return standard | (structural & own_text)
+
+
+def _sanitize_element(
+    element: dict[str, Any],
+    *,
+    inside_editable: bool,
+    placeholder_values: frozenset[str] = frozenset(),
+) -> tuple[dict[str, Any] | None, bool]:
+    """Return ``(node, changed)`` with structural sharing."""
+    role = str(element.get("role") or "")
+    is_editable = role in EDITABLE_ROLES
+    in_control = inside_editable or is_editable
+    # Nested editables own their placeholder evidence; never let an outer
+    # control's hint bleed into an inner control.
+    local_values = (
+        frozenset(_confirmed_placeholder_values(element)) if is_editable else placeholder_values
+    )
+
+    if (
+        inside_editable
+        and local_values
+        and _is_placeholder_node(element)
+        and bool(_subtree_text(element) & local_values)
+    ):
+        return None, True
+
+    children = element.get("children") or []
+    clean_children: list[Any] = []
+    changed = False
+    for child in children:
+        if not isinstance(child, dict):
+            clean_children.append(child)
+            continue
+        clean_child, child_changed = _sanitize_element(
+            child,
+            inside_editable=in_control,
+            placeholder_values=local_values,
+        )
+        changed = changed or child_changed
+        if clean_child is not None:
+            clean_children.append(clean_child)
+
+    clear_keys = {
+        key
+        for key in _TEXT_KEYS
+        if is_editable and (text := _normalized(element.get(key))) and text in local_values
+    }
+    changed = changed or bool(clear_keys)
+    if not changed:
+        return element, False
+
+    clean = dict(element)
+    if clean_children or "children" in clean:
+        clean["children"] = clean_children
+    for key in clear_keys:
+        clean.pop(key, None)
+    if "value" in clear_keys:
+        clean["has_value"] = False
+        clean["value_length"] = 0
+    return clean, True
+
+
+def _identities_compatible(reference: dict[str, Any], candidate: dict[str, Any]) -> bool:
+    for key in ("identifier", "domIdentifier"):
+        expected = _normalized(reference.get(key))
+        actual = _normalized(candidate.get(key))
+        if expected and actual and expected != actual:
+            return False
+    return True
+
+
+def _reference_text_is_placeholder(
+    app_data: dict[str, Any], reference: dict[str, Any], text: str
+) -> bool:
+    """Prove one compact AX reference points into a local placeholder.
+
+    Watcher event references do not retain AX identity or parent links.  Match
+    them back to the full tree by role/text (and stable identifiers when
+    available), and only classify the text when *every* compatible match lies
+    in a confirmed editable-placeholder region.  Ambiguity therefore fails
+    open and preserves authored text.
+    """
+    role = str(reference.get("role") or "")
+    if not role or not text:
+        return False
+
+    matches: list[bool] = []
+
+    def walk(
+        element: dict[str, Any],
+        *,
+        inside_editable: bool,
+        placeholder_values: frozenset[str],
+        inside_placeholder: bool,
+    ) -> None:
+        current_role = str(element.get("role") or "")
+        is_editable = current_role in EDITABLE_ROLES
+        local_values = (
+            frozenset(_confirmed_placeholder_values(element)) if is_editable else placeholder_values
+        )
+        in_control = inside_editable or is_editable
+        this_placeholder = (
+            False
+            if is_editable
+            else (
+                inside_placeholder
+                or (
+                    inside_editable
+                    and text in local_values
+                    and _is_placeholder_node(element)
+                    and text in _subtree_text(element)
+                )
+            )
+        )
+        element_text = {value for key in _TEXT_KEYS if (value := _normalized(element.get(key)))}
+        if (
+            current_role == role
+            and text in element_text
+            and _identities_compatible(reference, element)
+        ):
+            matches.append(this_placeholder or (is_editable and text in local_values))
+        for child in element.get("children") or []:
+            if isinstance(child, dict):
+                walk(
+                    child,
+                    inside_editable=in_control,
+                    placeholder_values=local_values,
+                    inside_placeholder=this_placeholder,
+                )
+
+    for window in app_data.get("windows") or []:
+        if not isinstance(window, dict):
+            continue
+        for element in window.get("elements") or []:
+            if isinstance(element, dict):
+                walk(
+                    element,
+                    inside_editable=False,
+                    placeholder_values=frozenset(),
+                    inside_placeholder=False,
+                )
+    return bool(matches) and all(matches)
+
+
+def sanitize_element_reference(
+    app_data: dict[str, Any], reference: dict[str, Any]
+) -> dict[str, Any]:
+    """Remove proven placeholder text from a focused/clicked AX reference."""
+    direct = _confirmed_placeholder_values(reference)
+    clear_keys = {
+        key
+        for key in _TEXT_KEYS
+        if (text := _normalized(reference.get(key)))
+        and (text in direct or _reference_text_is_placeholder(app_data, reference, text))
+    }
+    if not clear_keys:
+        return reference
+    clean = dict(reference)
+    for key in clear_keys:
+        clean.pop(key, None)
+    if "value" in clear_keys:
+        clean["has_value"] = False
+        clean["value_length"] = 0
+    return clean
+
+
+def sanitize_trigger(app_data: dict[str, Any], trigger: dict[str, Any]) -> dict[str, Any]:
+    """Sanitize the watcher's compact ``details.element`` projection."""
+    details = trigger.get("details")
+    if not isinstance(details, dict):
+        return trigger
+    element = details.get("element")
+    if not isinstance(element, dict):
+        return trigger
+    clean_element = sanitize_element_reference(app_data, element)
+    if clean_element is element:
+        return trigger
+    clean_details = dict(details)
+    clean_details["element"] = clean_element
+    clean_trigger = dict(trigger)
+    clean_trigger["details"] = clean_details
+    return clean_trigger
+
+
+def sanitize_app(app_data: dict[str, Any]) -> dict[str, Any]:
+    """Return an app projection with placeholder semantics removed.
+
+    The input object is returned unchanged when no repair is needed. This
+    structural sharing keeps the normal, already-clean capture path cheap.
+    """
+    changed = False
+    clean_windows: list[Any] = []
+    for window in app_data.get("windows") or []:
+        if not isinstance(window, dict):
+            clean_windows.append(window)
+            continue
+        clean_elements: list[Any] = []
+        window_changed = False
+        for element in window.get("elements") or []:
+            if not isinstance(element, dict):
+                clean_elements.append(element)
+                continue
+            clean_element, element_changed = _sanitize_element(element, inside_editable=False)
+            window_changed = window_changed or element_changed
+            if clean_element is not None:
+                clean_elements.append(clean_element)
+        if window_changed:
+            clean_window = dict(window)
+            clean_window["elements"] = clean_elements
+            clean_windows.append(clean_window)
+            changed = True
+        else:
+            clean_windows.append(window)
+
+    focused = app_data.get("focused_element")
+    clean_focused = focused
+    if isinstance(focused, dict):
+        clean_focused = sanitize_element_reference(app_data, focused)
+        changed = changed or clean_focused is not focused
+
+    if not changed:
+        return app_data
+    clean_app = dict(app_data)
+    clean_app["windows"] = clean_windows
+    if isinstance(clean_focused, dict):
+        clean_app["focused_element"] = clean_focused
+    return clean_app
+
+
+def sanitize_ax_tree(ax_tree: dict[str, Any]) -> dict[str, Any]:
+    """Return an AX tree whose app projections cannot emit placeholder text."""
+    apps = ax_tree.get("apps") or []
+    clean_apps: list[Any] = []
+    changed = False
+    for app in apps:
+        if not isinstance(app, dict):
+            clean_apps.append(app)
+            continue
+        clean_app = sanitize_app(app)
+        changed = changed or clean_app is not app
+        clean_apps.append(clean_app)
+    if not changed:
+        return ax_tree
+    clean_tree = dict(ax_tree)
+    clean_tree["apps"] = clean_apps
+    return clean_tree

--- a/src/persome/capture/placeholder.py
+++ b/src/persome/capture/placeholder.py
@@ -189,7 +189,11 @@ def _identities_compatible(reference: dict[str, Any], candidate: dict[str, Any])
 
 
 def _reference_text_is_placeholder(
-    app_data: dict[str, Any], reference: dict[str, Any], text: str
+    app_data: dict[str, Any],
+    reference: dict[str, Any],
+    text: str,
+    *,
+    any_confirmed_match: bool = False,
 ) -> bool:
     """Prove one compact AX reference points into a local placeholder.
 
@@ -258,11 +262,14 @@ def _reference_text_is_placeholder(
                     placeholder_values=frozenset(),
                     inside_placeholder=False,
                 )
-    return bool(matches) and all(matches)
+    return any(matches) if any_confirmed_match else bool(matches) and all(matches)
 
 
 def sanitize_element_reference(
-    app_data: dict[str, Any], reference: dict[str, Any]
+    app_data: dict[str, Any],
+    reference: dict[str, Any],
+    *,
+    any_confirmed_match: bool = False,
 ) -> dict[str, Any]:
     """Remove proven placeholder text from a focused/clicked AX reference."""
     direct = _confirmed_placeholder_values(reference)
@@ -270,7 +277,15 @@ def sanitize_element_reference(
         key
         for key in _TEXT_KEYS
         if (text := _normalized(reference.get(key)))
-        and (text in direct or _reference_text_is_placeholder(app_data, reference, text))
+        and (
+            text in direct
+            or _reference_text_is_placeholder(
+                app_data,
+                reference,
+                text,
+                any_confirmed_match=any_confirmed_match,
+            )
+        )
     }
     if not clear_keys:
         return reference
@@ -291,7 +306,16 @@ def sanitize_trigger(app_data: dict[str, Any], trigger: dict[str, Any]) -> dict[
     element = details.get("element")
     if not isinstance(element, dict):
         return trigger
-    clean_element = sanitize_element_reference(app_data, element)
+    # A click label is an attention hint, not authored content. If the compact
+    # hit-test reference is ambiguous with the same text elsewhere, prefer
+    # dropping the label once any local placeholder match is proven; raw AX and
+    # visible authored content remain untouched. Focused/input references keep
+    # the stricter all-matches fail-open policy.
+    clean_element = sanitize_element_reference(
+        app_data,
+        element,
+        any_confirmed_match=str(trigger.get("event_type") or "") == "UserMouseClick",
+    )
     if clean_element is element:
         return trigger
     clean_details = dict(details)

--- a/src/persome/capture/placeholder.py
+++ b/src/persome/capture/placeholder.py
@@ -9,6 +9,9 @@ copy and never matches broad CSS class substrings.
 
 from __future__ import annotations
 
+import re
+from collections import Counter
+from collections.abc import Collection
 from typing import Any
 
 EDITABLE_ROLES = frozenset({"AXTextField", "AXTextArea", "AXComboBox", "AXSearchField"})
@@ -22,6 +25,11 @@ _PLACEHOLDER_VALUE_KEYS = (
 _TEXT_KEYS = ("value", "title", "description")
 _MAX_PLACEHOLDER_SCAN_NODES = 256
 _MAX_PLACEHOLDER_SCAN_DEPTH = 12
+_MAX_PLACEHOLDER_TREE_NODES = 100_000
+
+_MARKDOWN_LIST_FIELD = re.compile(r"^\s*(?:[-*+]|\d+[.)])\s+(?P<value>.*)$")
+_MARKDOWN_TAGGED_FIELD = re.compile(r"^\[[^]\r\n]{1,40}\]\s+(?P<value>.*)$")
+_MARKDOWN_NAMED_FIELD = re.compile(r"^(?P<label>\s*#{1,6}\s+[^:\r\n]{1,120}:)\s*(?P<value>.*)$")
 
 
 def _normalized(value: Any) -> str:
@@ -117,6 +125,180 @@ def _confirmed_placeholder_values(element: dict[str, Any]) -> set[str]:
     own_text = {text for key in _TEXT_KEYS if (text := _normalized(element.get(key)))}
     structural = _local_placeholder_values(element) - standard
     return standard | (structural & own_text)
+
+
+def _ocr_visible_placeholder_values(element: dict[str, Any]) -> set[str]:
+    """Return placeholder evidence that can actually be visible in pixels.
+
+    ``AXPlaceholderValue`` describes a control even while that control contains
+    real text.  In that state the hint is hidden and must not authorize removal
+    of matching OCR elsewhere in the window.  An empty value can display any
+    confirmed hint; a non-empty value can only be the Chromium failure mode
+    where AX exposes the visible placeholder itself as the control value.
+    """
+    confirmed = _confirmed_placeholder_values(element)
+    current_value = _normalized(element.get("value"))
+    if not current_value:
+        return confirmed
+    return {value for value in confirmed if value == current_value}
+
+
+def confirmed_placeholder_values(ax_tree: Any) -> tuple[str, ...]:
+    """Collect placeholder strings proven in the screenshot's focused surface.
+
+    OCR pixels cover the frontmost app's focused window, not background apps.
+    Keep one value occurrence per proven editable control so one empty composer
+    can consume at most one matching OCR field.  The walk is globally bounded
+    in addition to the per-editable subtree bounds above.
+    """
+    if not isinstance(ax_tree, dict):
+        return ()
+    apps = [app for app in ax_tree.get("apps") or [] if isinstance(app, dict)]
+    if not apps:
+        return ()
+    app = next((candidate for candidate in apps if candidate.get("is_frontmost")), apps[0])
+    windows = [window for window in app.get("windows") or [] if isinstance(window, dict)]
+    focused_windows = [window for window in windows if window.get("focused")]
+    selected_windows = focused_windows[:1] or windows[:1]
+
+    values: list[str] = []
+    stack: list[Any] = [
+        element
+        for window in reversed(selected_windows)
+        for element in reversed(window.get("elements") or [])
+        if isinstance(element, dict)
+    ]
+    seen = 0
+    while stack and seen < _MAX_PLACEHOLDER_TREE_NODES:
+        current = stack.pop()
+        seen += 1
+        if isinstance(current, dict):
+            if str(current.get("role") or "") in EDITABLE_ROLES:
+                values.extend(sorted(_ocr_visible_placeholder_values(current)))
+            stack.extend(
+                reversed(
+                    [child for child in current.get("children") or [] if isinstance(child, dict)]
+                )
+            )
+
+    # The app-level focused reference can carry the standard AX placeholder
+    # attribute even when the bounded window tree omitted the control. Avoid
+    # double-counting the same control when its value was already found there.
+    focused = app.get("focused_element")
+    if isinstance(focused, dict):
+        for value in sorted(_ocr_visible_placeholder_values(focused)):
+            if value not in values:
+                values.append(value)
+    return tuple(values)
+
+
+def _ocr_field_value(line: str) -> str | None:
+    """Return a Markdown field payload only when the whole field is isolated."""
+    stripped = line.strip()
+    match = _MARKDOWN_LIST_FIELD.fullmatch(stripped)
+    value = match.group("value").strip() if match else stripped
+    tagged = _MARKDOWN_TAGGED_FIELD.fullmatch(value)
+    if tagged:
+        return tagged.group("value").strip()
+    if match:
+        return value
+    named = _MARKDOWN_NAMED_FIELD.fullmatch(stripped)
+    if named:
+        return named.group("value").strip()
+    return None
+
+
+def _consume_exact(remaining: Counter[str], value: str) -> bool:
+    if not value or remaining[value] <= 0:
+        return False
+    remaining[value] -= 1
+    return True
+
+
+def _ocr_removable_values(line: str, candidates: Collection[str]) -> tuple[str, ...]:
+    """Identify exact removable units without deciding whether removal is safe."""
+    stripped = line.strip()
+    if stripped in candidates:
+        return (stripped,)
+    if stripped.startswith("|") and stripped.endswith("|"):
+        return tuple(
+            value for cell in stripped[1:-1].split("|") if (value := cell.strip()) in candidates
+        )
+    field_value = _ocr_field_value(line)
+    return (field_value,) if field_value in candidates else ()
+
+
+def _sanitize_ocr_table_line(line: str, remaining: Counter[str]) -> str | None:
+    """Clear exact placeholder cells in one simple Markdown table row."""
+    stripped = line.strip()
+    if not (stripped.startswith("|") and stripped.endswith("|")):
+        return line
+    cells = stripped[1:-1].split("|")
+    substantive = [cell.strip() for cell in cells if cell.strip()]
+    if not substantive or not any(remaining[cell] > 0 for cell in substantive):
+        return line
+    kept: list[str] = []
+    for cell in cells:
+        value = cell.strip()
+        kept.append("" if _consume_exact(remaining, value) else value)
+    if not any(kept):
+        return None
+    indent = line[: len(line) - len(line.lstrip())]
+    return indent + "| " + " | ".join(kept) + " |"
+
+
+def sanitize_ocr_text(text: str, placeholder_values: Collection[str]) -> str:
+    """Remove only exact OCR lines or fields backed by AX placeholder proof.
+
+    OCR is flat visual text, so it cannot safely use substring replacement: the
+    same words may also occur in a real conversation.  This helper therefore
+    removes a plain line, Markdown list payload, tagged list payload, named
+    field value, or table cell only when that entire unit exactly equals a
+    structurally confirmed placeholder.  All other OCR content is preserved.
+    """
+    proven = Counter(_normalized(value) for value in placeholder_values if _normalized(value))
+    if not text or not proven:
+        return text
+
+    # OCR has no persisted geometry, so multiple identical fields cannot be
+    # mapped safely back to one placeholder control.  Count candidates first;
+    # if a value occurs more often than its structural AX proof, preserve every
+    # occurrence of that value rather than guessing which one is UI chrome.
+    candidate_counts: Counter[str] = Counter()
+    for raw_line in text.splitlines():
+        candidate_counts.update(_ocr_removable_values(raw_line, proven))
+    remaining = Counter(
+        {value: count for value, count in proven.items() if candidate_counts[value] <= count}
+    )
+
+    clean_lines: list[str] = []
+    for raw_line in text.splitlines(keepends=True):
+        if raw_line.endswith("\r\n"):
+            line, ending = raw_line[:-2], "\r\n"
+        elif raw_line.endswith(("\r", "\n")):
+            line, ending = raw_line[:-1], raw_line[-1:]
+        else:
+            line, ending = raw_line, ""
+        stripped = line.strip()
+        if _consume_exact(remaining, stripped):
+            continue
+        table_line = _sanitize_ocr_table_line(line, remaining)
+        if table_line is None:
+            continue
+        if table_line != line:
+            clean_lines.append(table_line + ending)
+            continue
+        field_value = _ocr_field_value(line)
+        if field_value is None or not _consume_exact(remaining, field_value):
+            clean_lines.append(raw_line)
+            continue
+        named = _MARKDOWN_NAMED_FIELD.fullmatch(stripped)
+        if named:
+            indent = line[: len(line) - len(line.lstrip())]
+            clean_lines.append(indent + named.group("label") + ending)
+        # List fields consist only of the placeholder payload, so drop the
+        # entire line instead of retaining a meaningless bullet/tag.
+    return "".join(clean_lines)
 
 
 def _sanitize_element(

--- a/src/persome/capture/s1_parser.py
+++ b/src/persome/capture/s1_parser.py
@@ -17,7 +17,7 @@ import re
 from dataclasses import asdict, dataclass
 from typing import Any
 
-from . import browser_detect, generic_render
+from . import browser_detect, generic_render, placeholder
 from .ax_models import ax_app_to_markdown, ax_tree_to_markdown
 
 _URL_RE = re.compile(r"https?://\S+")
@@ -41,6 +41,7 @@ _STATIC_ROLES = {"AXStaticText", "AXWebArea"}
 _VISIBLE_TEXT_MAX = 10_000
 _FOCUS_TITLE_MAX = 200
 _FOCUS_VALUE_MAX = 2_000
+_CMUX_TERMINAL_MARKER = "### [cmux terminal]"
 
 
 @dataclass
@@ -69,7 +70,14 @@ def enrich(capture: dict[str, Any]) -> None:
     if not isinstance(ax_tree, dict):
         return
 
-    app_data = _frontmost_app(ax_tree)
+    clean_ax_tree = placeholder.sanitize_ax_tree(ax_tree)
+    original_app = _frontmost_app(ax_tree)
+    trigger = capture.get("trigger")
+    if isinstance(trigger, dict):
+        clean_trigger = placeholder.sanitize_trigger(original_app or {}, trigger)
+        if clean_trigger is not trigger:
+            capture["trigger"] = clean_trigger
+    app_data = _frontmost_app(clean_ax_tree)
     if app_data is None:
         capture["focused_element"] = FocusedElement().to_dict()
         capture["visible_text"] = ""
@@ -79,6 +87,64 @@ def enrich(capture: dict[str, Any]) -> None:
     capture["focused_element"] = _extract_focused_element(app_data).to_dict()
     capture["visible_text"] = _render_visible_text(app_data, app_data.get("bundle_id") or "")
     capture["url"] = _extract_url(app_data)
+
+
+def sanitize_capture(capture: dict[str, Any], *, replace_ax_tree: bool = False) -> dict[str, Any]:
+    """Return a replay-safe capture without mutating the raw record.
+
+    Historical buffer JSON and trusted-ingest producers may predate the native
+    placeholder fix. Recompute their S1 projection from a sanitized AX tree so
+    timeline replay, MCP reads, and capture-index rebuilds cannot resurrect an
+    old placeholder as authored text. Already-clean captures are returned by
+    identity.
+    """
+    ax_tree = capture.get("ax_tree")
+    clean_ax_tree = placeholder.sanitize_ax_tree(ax_tree) if isinstance(ax_tree, dict) else ax_tree
+    original_app = _frontmost_app(ax_tree) if isinstance(ax_tree, dict) else None
+    trigger = capture.get("trigger")
+    clean_trigger = (
+        placeholder.sanitize_trigger(original_app or {}, trigger)
+        if isinstance(trigger, dict)
+        else trigger
+    )
+    projection_changed = clean_ax_tree is not ax_tree
+    trigger_changed = clean_trigger is not trigger
+    if not projection_changed and not trigger_changed:
+        return capture
+    clean = dict(capture)
+    if replace_ax_tree and projection_changed:
+        clean["ax_tree"] = clean_ax_tree
+    if trigger_changed:
+        clean["trigger"] = clean_trigger
+    if not projection_changed:
+        return clean
+    app_data = _frontmost_app(clean_ax_tree)
+    if app_data is None:
+        clean["focused_element"] = FocusedElement().to_dict()
+        clean["visible_text"] = ""
+        clean["url"] = None
+        return clean
+    clean["focused_element"] = _extract_focused_element(app_data).to_dict()
+    preserve_ocr_sentinel = bool(capture.get("ocr_submitted")) and not str(
+        capture.get("visible_text") or ""
+    )
+    visible_text = (
+        ""
+        if preserve_ocr_sentinel
+        else _render_visible_text(app_data, app_data.get("bundle_id") or "")
+    )
+    # cmux terminal text is injected *after* S1 enrichment because its GPU
+    # surface is absent from AX. Historical replay must preserve that suffix
+    # while recomputing only the AX-derived prefix.
+    if capture.get("cmux_text_injected"):
+        prior = str(capture.get("visible_text") or "")
+        marker_at = prior.find(_CMUX_TERMINAL_MARKER)
+        if marker_at >= 0:
+            suffix = prior[marker_at:].strip()
+            visible_text = f"{visible_text.rstrip()}\n\n{suffix}" if visible_text else suffix
+    clean["visible_text"] = visible_text
+    clean["url"] = _extract_url(app_data)
+    return clean
 
 
 def _frontmost_app(ax_tree: dict[str, Any]) -> dict[str, Any] | None:

--- a/src/persome/capture/s1_parser.py
+++ b/src/persome/capture/s1_parser.py
@@ -42,6 +42,7 @@ _VISIBLE_TEXT_MAX = 10_000
 _FOCUS_TITLE_MAX = 200
 _FOCUS_VALUE_MAX = 2_000
 _CMUX_TERMINAL_MARKER = "### [cmux terminal]"
+_OCR_PLACEHOLDER_VALUES = "_persome_ocr_placeholder_values"
 
 
 @dataclass
@@ -89,6 +90,21 @@ def enrich(capture: dict[str, Any]) -> None:
     capture["url"] = _extract_url(app_data)
 
 
+def ocr_placeholder_values(capture: dict[str, Any]) -> tuple[str, ...]:
+    """Return trusted placeholder evidence for this capture's OCR surface."""
+    cached = capture.get(_OCR_PLACEHOLDER_VALUES)
+    # JSON cannot encode tuples, so this type also distinguishes the internal
+    # replay cache below from an untrusted key in a persisted/ingested record.
+    if isinstance(cached, tuple) and all(isinstance(value, str) for value in cached):
+        return cached
+    return placeholder.confirmed_placeholder_values(capture.get("ax_tree"))
+
+
+def sanitize_ocr_text(capture: dict[str, Any], text: str) -> str:
+    """Filter OCR using only exact fields backed by this capture's raw AX."""
+    return placeholder.sanitize_ocr_text(text, ocr_placeholder_values(capture))
+
+
 def sanitize_capture(capture: dict[str, Any], *, replace_ax_tree: bool = False) -> dict[str, Any]:
     """Return a replay-safe capture without mutating the raw record.
 
@@ -99,6 +115,7 @@ def sanitize_capture(capture: dict[str, Any], *, replace_ax_tree: bool = False) 
     identity.
     """
     ax_tree = capture.get("ax_tree")
+    ocr_values = ocr_placeholder_values(capture) if replace_ax_tree else ()
     clean_ax_tree = placeholder.sanitize_ax_tree(ax_tree) if isinstance(ax_tree, dict) else ax_tree
     original_app = _frontmost_app(ax_tree) if isinstance(ax_tree, dict) else None
     trigger = capture.get("trigger")
@@ -109,11 +126,16 @@ def sanitize_capture(capture: dict[str, Any], *, replace_ax_tree: bool = False) 
     )
     projection_changed = clean_ax_tree is not ax_tree
     trigger_changed = clean_trigger is not trigger
-    if not projection_changed and not trigger_changed:
+    cache_changed = (
+        replace_ax_tree and bool(ocr_values) and ocr_values != capture.get(_OCR_PLACEHOLDER_VALUES)
+    )
+    if not projection_changed and not trigger_changed and not cache_changed:
         return capture
     clean = dict(capture)
     if replace_ax_tree and projection_changed:
         clean["ax_tree"] = clean_ax_tree
+    if replace_ax_tree and ocr_values:
+        clean[_OCR_PLACEHOLDER_VALUES] = ocr_values
     if trigger_changed:
         clean["trigger"] = clean_trigger
     if not projection_changed:

--- a/src/persome/capture/scheduler.py
+++ b/src/persome/capture/scheduler.py
@@ -521,21 +521,25 @@ def _index_capture(file_stem: str, out: dict[str, Any]) -> bool:
     ``persome rebuild-captures-index``; killing the capture worker
     over an indexing hiccup would lose the JSON too.
     """
-    meta = out.get("window_meta") or {}
-    focused = out.get("focused_element") or {}
+    # Rollback/recovery paths can feed historical JSON that predates native
+    # placeholder filtering. Index the repaired S1 projection without
+    # rewriting the forensic raw AX tree on disk.
+    indexed_out = s1_parser.sanitize_capture(out)
+    meta = indexed_out.get("window_meta") or {}
+    focused = indexed_out.get("focused_element") or {}
     try:
         with fts_store.cursor() as conn:
             fts_store.insert_capture(
                 conn,
                 id=file_stem,
-                timestamp=out.get("timestamp", ""),
+                timestamp=indexed_out.get("timestamp", ""),
                 app_name=meta.get("app_name") or "",
                 bundle_id=meta.get("bundle_id") or "",
                 window_title=meta.get("title") or "",
                 focused_role=focused.get("role") or "",
                 focused_value=focused.get("value") or "",
-                visible_text=out.get("visible_text") or "",
-                url=out.get("url") or "",
+                visible_text=indexed_out.get("visible_text") or "",
+                url=indexed_out.get("url") or "",
             )
     except Exception as exc:  # noqa: BLE001
         logger.warning("captures FTS insert failed for %s: %s", file_stem, exc)

--- a/src/persome/capture/scheduler.py
+++ b/src/persome/capture/scheduler.py
@@ -25,6 +25,7 @@ from . import (
     cmux_source,
     ocr_local,
     ocr_structure,
+    placeholder,
     s1_parser,
     screen_state,
     screenshot,
@@ -102,6 +103,7 @@ def _submit_ocr_async(
     tier: str,
     window_meta: dict[str, str] | None = None,
     structured: bool = False,
+    placeholder_values: tuple[str, ...] = (),
 ) -> None:
     """Fire-and-forget local OCR + geometry structuring. Runs on a daemon thread.
 
@@ -136,6 +138,7 @@ def _submit_ocr_async(
     backfill_text = ocr_structure.to_markdown(struct) if struct else ""
     if not backfill_text:
         backfill_text = raw
+    backfill_text = placeholder.sanitize_ocr_text(backfill_text, placeholder_values)
     if not backfill_text:
         return
 
@@ -483,6 +486,7 @@ def _write_capture(out: dict[str, Any]) -> Path:
     ocr_jpeg = out.pop("_ocr_pending_jpeg", None)
     ocr_tier = out.pop("_ocr_tier", "tiny")
     ocr_structured = out.pop("_ocr_structured", False)
+    ocr_placeholder_values = s1_parser.ocr_placeholder_values(out) if ocr_jpeg is not None else ()
     if ocr_jpeg is not None:
         out["ocr_submitted"] = True
 
@@ -505,7 +509,14 @@ def _write_capture(out: dict[str, Any]) -> Path:
     if ocr_jpeg is not None:
         thread = threading.Thread(
             target=_submit_ocr_async,
-            args=(ocr_jpeg, path.stem, ocr_tier, meta, ocr_structured),
+            args=(
+                ocr_jpeg,
+                path.stem,
+                ocr_tier,
+                meta,
+                ocr_structured,
+                ocr_placeholder_values,
+            ),
             name=f"ocr-submit-{path.stem}",
             daemon=True,
         )

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -3150,6 +3150,8 @@ def rebuild_captures_index(
     """
     import json
 
+    from .capture import s1_parser
+
     _init()
     buf = paths.capture_buffer_dir()
     files = sorted(p for p in buf.iterdir() if p.is_file() and p.suffix == ".json")
@@ -3157,6 +3159,16 @@ def rebuild_captures_index(
     indexed = 0
     skipped = 0
     with fts.cursor() as conn:
+        # OCR text is a DB-only backfill: raw JSON intentionally keeps an
+        # empty ``visible_text`` sentinel plus ``ocr_submitted=true``. Preserve
+        # those rows across both exact and merge rebuilds instead of silently
+        # replacing recognized text with the raw empty sentinel.
+        ocr_backfills = {
+            str(row["id"]): str(row["visible_text"] or "")
+            for row in conn.execute(
+                "SELECT id, visible_text FROM captures WHERE visible_text != ''"
+            ).fetchall()
+        }
         # Exact rebuild is reconciliation, not just an upsert pass. Recovery
         # merge intentionally preserves older snapshot rows whose source JSON
         # has already aged out of the bounded capture buffer.
@@ -3169,6 +3181,14 @@ def rebuild_captures_index(
                 skipped += 1
                 console.print(f"[yellow]skip {p.name}: {exc}[/yellow]")
                 continue
+            if not isinstance(data, dict):
+                skipped += 1
+                console.print(f"[yellow]skip {p.name}: capture is not a JSON object[/yellow]")
+                continue
+            preserve_ocr = bool(data.get("ocr_submitted")) and not str(
+                data.get("visible_text") or ""
+            )
+            data = s1_parser.sanitize_capture(data)
             meta = data.get("window_meta") or {}
             focused = data.get("focused_element") or {}
             try:
@@ -3181,7 +3201,11 @@ def rebuild_captures_index(
                     window_title=meta.get("title") or "",
                     focused_role=focused.get("role") or "",
                     focused_value=focused.get("value") or "",
-                    visible_text=data.get("visible_text") or "",
+                    visible_text=(
+                        ocr_backfills.get(p.stem, "")
+                        if preserve_ocr and not data.get("visible_text")
+                        else data.get("visible_text") or ""
+                    ),
                     url=data.get("url") or "",
                 )
                 indexed += 1

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -3258,6 +3258,10 @@ def rebuild_captures_index(
                 data.get("visible_text") or ""
             )
             data = s1_parser.sanitize_capture(data)
+            preserved_ocr = s1_parser.sanitize_ocr_text(
+                data,
+                ocr_backfills.get(p.stem, ""),
+            )
             meta = data.get("window_meta") or {}
             focused = data.get("focused_element") or {}
             try:
@@ -3271,7 +3275,7 @@ def rebuild_captures_index(
                     focused_role=focused.get("role") or "",
                     focused_value=focused.get("value") or "",
                     visible_text=(
-                        ocr_backfills.get(p.stem, "")
+                        preserved_ocr
                         if preserve_ocr and not data.get("visible_text")
                         else data.get("visible_text") or ""
                     ),

--- a/src/persome/mcp/captures.py
+++ b/src/persome/mcp/captures.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any
 
 from .. import paths
-from ..capture import screenshot_crypto
+from ..capture import s1_parser, screenshot_crypto
 from ..capture.timestamps import (
     parse_capture_path_timestamp,
     parse_capture_timestamp,
@@ -62,11 +62,23 @@ def _matches(
     return not (window_title_substring and window_title_substring.lower() not in title)
 
 
-def _load_capture(path: Path) -> dict[str, Any] | None:
+def _load_capture_projection(path: Path) -> dict[str, Any] | None:
+    """Return the safe S1 projection for one raw capture file."""
     try:
-        return json.loads(path.read_text())  # type: ignore[no-any-return]
+        data = json.loads(path.read_text())
     except (OSError, json.JSONDecodeError):
         return None
+    if not isinstance(data, dict):
+        return None
+    return s1_parser.sanitize_capture(data)
+
+
+def _load_capture(path: Path) -> dict[str, Any] | None:
+    return _load_capture_projection(path)
+
+
+def _buffer_projection(file_stem: str) -> dict[str, Any] | None:
+    return _load_capture_projection(paths.capture_buffer_dir() / f"{file_stem}.json")
 
 
 def _count_ax_nodes(ax_tree: Any) -> int:
@@ -308,22 +320,43 @@ def search_captures(
             app_name=app_name,
             limit=limit,
         )
-    return [
-        {
-            "provenance": CAPTURE_PROVENANCE,
-            "timestamp": h.timestamp,
-            "app_name": h.app_name,
-            "bundle_id": h.bundle_id,
-            "window_title": h.window_title,
-            "url": h.url,
-            "snippet": h.snippet,
-            "rank": h.rank,
-            "file_stem": h.id,
-            "focused_role": h.focused_role,
-            "focused_value_preview": (h.focused_value or "")[:200],
-        }
-        for h in hits
-    ]
+        indexed_text = {hit.id: fts_store.get_capture_visible_text(conn, hit.id) for hit in hits}
+    out: list[dict[str, Any]] = []
+    for h in hits:
+        projection = _buffer_projection(h.id)
+        data = projection or {}
+        meta = data.get("window_meta") or {}
+        focused = data.get("focused_element") or {}
+        safe_visible = str(data.get("visible_text") or "")
+        db_ocr_authoritative = bool(data.get("ocr_submitted")) and not safe_visible
+        stale_text = projection is not None and (
+            not db_ocr_authoritative and safe_visible != indexed_text.get(h.id, "")
+        )
+        # Preserve FTS highlighting for clean rows. A pre-upgrade row whose S1
+        # projection repairs differently is rendered only from the safe JSON
+        # projection so a stale index cannot echo placeholder text.
+        safe_snippet = h.snippet
+        if stale_text:
+            safe_snippet = " ".join(safe_visible.split())[:300]
+        out.append(
+            {
+                "provenance": CAPTURE_PROVENANCE,
+                "timestamp": h.timestamp,
+                "app_name": meta.get("app_name") or h.app_name,
+                "bundle_id": meta.get("bundle_id") or h.bundle_id,
+                "window_title": meta.get("title") or h.window_title,
+                "url": (data.get("url") if projection is not None else h.url) or "",
+                "snippet": safe_snippet,
+                "rank": h.rank,
+                "file_stem": h.id,
+                "focused_role": (focused.get("role") if projection is not None else h.focused_role)
+                or "",
+                "focused_value_preview": (
+                    (focused.get("value") if projection is not None else h.focused_value) or ""
+                )[:200],
+            }
+        )
+    return out
 
 
 def _dedupe_recent_captures(
@@ -407,15 +440,30 @@ def current_context(
         full_rows = _dedupe_recent_captures(rows, limit=fulltext_limit)
         full: list[dict[str, Any]] = []
         for r in full_rows:
-            visible = fts_store.get_capture_visible_text(conn, r.id)
+            projection = _buffer_projection(r.id)
+            data = projection or {}
+            focused = data.get("focused_element") or {}
+            safe_visible = str(data.get("visible_text") or "")
+            db_ocr_authoritative = bool(data.get("ocr_submitted")) and not safe_visible
+            visible = (
+                safe_visible
+                if projection is not None and not db_ocr_authoritative
+                else fts_store.get_capture_visible_text(conn, r.id)
+            )
             full.append(
                 {
                     "timestamp": r.timestamp,
                     "app_name": r.app_name,
                     "window_title": r.window_title,
-                    "url": r.url,
-                    "focused_role": r.focused_role,
-                    "focused_value": r.focused_value,
+                    "url": (data.get("url") if projection is not None else r.url) or "",
+                    "focused_role": (
+                        focused.get("role") if projection is not None else r.focused_role
+                    )
+                    or "",
+                    "focused_value": (
+                        focused.get("value") if projection is not None else r.focused_value
+                    )
+                    or "",
                     "visible_text": visible,
                     "file_stem": r.id,
                 }
@@ -424,10 +472,23 @@ def current_context(
         # Lightweight per-headline preview so a context list shows content
         # (incl. OCR-backfilled WeChat text) at a glance. One indexed SELECT per
         # headline (≤ headline_limit) — cheap; no JSON reads on this hot path.
-        head_text: dict[str, str] = {
-            r.id: (fts_store.get_capture_visible_text(conn, r.id) or "")
-            for r in rows[:headline_limit]
-        }
+        head_text: dict[str, str] = {}
+        headline_focus: dict[str, str] = {}
+        for r in rows[:headline_limit]:
+            projection = _buffer_projection(r.id)
+            data = projection or {}
+            safe_visible = str(data.get("visible_text") or "")
+            db_ocr_authoritative = bool(data.get("ocr_submitted")) and not safe_visible
+            if projection is not None and not db_ocr_authoritative:
+                head_text[r.id] = safe_visible
+                headline_focus[r.id] = str((data.get("focused_element") or {}).get("role") or "")
+            else:
+                head_text[r.id] = fts_store.get_capture_visible_text(conn, r.id) or ""
+                headline_focus[r.id] = (
+                    str((data.get("focused_element") or {}).get("role") or "")
+                    if projection is not None
+                    else r.focused_role
+                )
 
     headlines: list[dict[str, Any]] = []
     for r in rows[:headline_limit]:
@@ -444,7 +505,7 @@ def current_context(
                 "time": ts_short,
                 "app_name": r.app_name,
                 "window_title": r.window_title,
-                "focused_role": r.focused_role,
+                "focused_role": headline_focus.get(r.id, r.focused_role),
                 "file_stem": r.id,
                 "preview": preview,
                 "text_chars": len(vt),

--- a/src/persome/mcp/captures.py
+++ b/src/persome/mcp/captures.py
@@ -130,6 +130,7 @@ def _resolve_text(result: dict[str, Any], data: dict[str, Any], capture_id: str)
         try:
             with fts_store.cursor() as conn:
                 ocr_text = fts_store.get_ocr_result_for_capture(conn, capture_id) or ""
+                ocr_text = s1_parser.sanitize_ocr_text(data, ocr_text)
         except Exception:  # noqa: BLE001
             ocr_text = ""
 
@@ -328,16 +329,26 @@ def search_captures(
         meta = data.get("window_meta") or {}
         focused = data.get("focused_element") or {}
         safe_visible = str(data.get("visible_text") or "")
+        safe_focused_value = str(focused.get("value") or "")
         db_ocr_authoritative = bool(data.get("ocr_submitted")) and not safe_visible
-        stale_text = projection is not None and (
-            not db_ocr_authoritative and safe_visible != indexed_text.get(h.id, "")
+        indexed_visible = indexed_text.get(h.id, "")
+        safe_db_ocr = (
+            s1_parser.sanitize_ocr_text(data, indexed_visible) if db_ocr_authoritative else ""
+        )
+        stale_projection = projection is not None and (
+            (not db_ocr_authoritative and safe_visible != indexed_visible)
+            or (db_ocr_authoritative and safe_db_ocr != indexed_visible)
+            or safe_focused_value != h.focused_value
         )
         # Preserve FTS highlighting for clean rows. A pre-upgrade row whose S1
-        # projection repairs differently is rendered only from the safe JSON
-        # projection so a stale index cannot echo placeholder text.
+        # text or focused value repairs differently is rendered only from the
+        # safe JSON projection so a stale index cannot echo placeholder text.
         safe_snippet = h.snippet
-        if stale_text:
-            safe_snippet = " ".join(safe_visible.split())[:300]
+        if stale_projection:
+            # OCR backfills exist only in SQLite, not in the raw JSON. Keep
+            # that authoritative text while discarding a stale focused value.
+            snippet_source = safe_db_ocr if db_ocr_authoritative else safe_visible
+            safe_snippet = " ".join(snippet_source.split())[:300]
         out.append(
             {
                 "provenance": CAPTURE_PROVENANCE,
@@ -445,11 +456,13 @@ def current_context(
             focused = data.get("focused_element") or {}
             safe_visible = str(data.get("visible_text") or "")
             db_ocr_authoritative = bool(data.get("ocr_submitted")) and not safe_visible
-            visible = (
-                safe_visible
-                if projection is not None and not db_ocr_authoritative
-                else fts_store.get_capture_visible_text(conn, r.id)
-            )
+            indexed_visible = fts_store.get_capture_visible_text(conn, r.id)
+            if projection is not None and not db_ocr_authoritative:
+                visible = safe_visible
+            elif projection is not None:
+                visible = s1_parser.sanitize_ocr_text(data, indexed_visible)
+            else:
+                visible = indexed_visible
             full.append(
                 {
                     "timestamp": r.timestamp,
@@ -483,7 +496,12 @@ def current_context(
                 head_text[r.id] = safe_visible
                 headline_focus[r.id] = str((data.get("focused_element") or {}).get("role") or "")
             else:
-                head_text[r.id] = fts_store.get_capture_visible_text(conn, r.id) or ""
+                indexed_visible = fts_store.get_capture_visible_text(conn, r.id) or ""
+                head_text[r.id] = (
+                    s1_parser.sanitize_ocr_text(data, indexed_visible)
+                    if projection is not None
+                    else indexed_visible
+                )
                 headline_focus[r.id] = (
                     str((data.get("focused_element") or {}).get("role") or "")
                     if projection is not None

--- a/src/persome/timeline/aggregator.py
+++ b/src/persome/timeline/aggregator.py
@@ -18,6 +18,7 @@ from datetime import datetime, tzinfo
 from pathlib import Path
 
 from .. import paths
+from ..capture import s1_parser
 from ..capture.ax_models import ax_tree_to_markdown
 from ..capture.timestamps import parse_capture_path_timestamp
 from ..config import Config
@@ -245,7 +246,10 @@ def _load_captures(capture_files: list[Path]) -> list[tuple[Path, dict]]:
         if not isinstance(data, dict):
             logger.warning("timeline: capture %s is not a JSON object", p.name)
             continue
-        parsed.append((p, data))
+        # Sanitize once at the replay boundary so prompt rendering, heuristic
+        # fallback, focus_excerpt, and per-app structured parsers all consume
+        # the same placeholder-free projection.
+        parsed.append((p, s1_parser.sanitize_capture(data, replace_ax_tree=True)))
     return parsed
 
 
@@ -277,6 +281,9 @@ def _format_events(
 
     files = parsed[-_MAX_EVENTS_PER_WINDOW:]
     for i, (p, data) in enumerate(files, 1):
+        # Direct unit callers can pass pre-parsed captures without going
+        # through ``_load_captures``. Keep this idempotent boundary guard.
+        data = s1_parser.sanitize_capture(data, replace_ax_tree=True)
         ts_raw = str(data.get("timestamp", p.stem))
         ts = _short_time(ts_raw, display_tz=display_tz)
 

--- a/src/persome/timeline/aggregator.py
+++ b/src/persome/timeline/aggregator.py
@@ -352,7 +352,7 @@ def _format_events(
                 with fts_store.cursor() as conn:
                     ocr_text = fts_store.get_ocr_result_for_capture(conn, p.stem)
                     if ocr_text:
-                        visible_text = ocr_text.strip()
+                        visible_text = s1_parser.sanitize_ocr_text(data, ocr_text).strip()
             except Exception:  # noqa: BLE001
                 pass
 

--- a/src/persome/timeline/attention_locus.py
+++ b/src/persome/timeline/attention_locus.py
@@ -159,6 +159,8 @@ def focus_pane(visible_text: str) -> tuple[str, bool]:
 
 def _click_element(trigger: dict) -> dict:
     """The AX element the watcher hit-tested under the cursor, or {}."""
+    if str(trigger.get("event_type") or "") != "UserMouseClick":
+        return {}
     details = trigger.get("details") or {}
     el = details.get("element")
     return el if isinstance(el, dict) else {}

--- a/src/persome/writer/chat_extractor.py
+++ b/src/persome/writer/chat_extractor.py
@@ -2,8 +2,62 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from datetime import datetime
+from typing import Any
+
+from .. import paths
+from ..capture import s1_parser
+
+
+def _safe_visible_text(capture_id: str, indexed_text: Any) -> str:
+    """Return placeholder-safe text when the raw capture proves the repair.
+
+    The capture index can outlive the S1 projection that produced it.  Use the
+    raw AX tree to repair those legacy rows, but keep the indexed text as the
+    fail-open value when the matching JSON is unavailable, malformed, or lacks
+    structural placeholder evidence.  OCR backfills live only in SQLite, so an
+    OCR-submitted capture with an empty safe AX projection sanitizes (rather
+    than replaces) that DB-only text.
+    """
+    db_text = str(indexed_text or "")
+    path = paths.capture_buffer_dir() / f"{capture_id}.json"
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return db_text
+    if not isinstance(raw, dict):
+        return db_text
+
+    projection = s1_parser.sanitize_capture(raw)
+    safe_ax_text = str(projection.get("visible_text") or "")
+    if bool(raw.get("ocr_submitted")) and not safe_ax_text:
+        # OCR is a flat pixel projection.  Only evidence that the placeholder
+        # was actually visible can authorize removing an exact OCR field.
+        if not s1_parser.ocr_placeholder_values(raw):
+            return db_text
+        return s1_parser.sanitize_ocr_text(raw, db_text)
+
+    # Non-OCR S1 can be repaired from the local editable/placeholder pairing
+    # even when a filled control hides its standard hint from OCR.  Require a
+    # concrete change to an authored-text field before replacing the indexed
+    # value: tree-only metadata changes are not enough to trust a recomputed
+    # projection over SQLite.
+    raw_focus = raw.get("focused_element")
+    safe_focus = projection.get("focused_element")
+    visible_repaired = safe_ax_text != str(raw.get("visible_text") or "")
+    focus_repaired = (
+        isinstance(raw_focus, dict)
+        and isinstance(safe_focus, dict)
+        and any(
+            str(raw_focus.get(key) or "") != str(safe_focus.get(key) or "")
+            for key in ("title", "value")
+        )
+    )
+    if not visible_repaired and not focus_repaired:
+        return db_text
+    return safe_ax_text
 
 
 def extract_chat_messages(
@@ -22,7 +76,7 @@ def extract_chat_messages(
     the most recent content).
     """
     rows = conn.execute(
-        "SELECT timestamp, visible_text FROM captures "
+        "SELECT id, timestamp, visible_text FROM captures "
         " WHERE app_name = ? "
         "   AND persome_epoch(timestamp) >= persome_epoch(?) "
         "   AND persome_epoch(timestamp) <= persome_epoch(?) "
@@ -35,8 +89,8 @@ def extract_chat_messages(
 
     # Deduplicate consecutive identical visible_text snapshots.
     deduped: list[tuple[str, str]] = []
-    for ts, text in rows:
-        text = (text or "").strip()
+    for capture_id, ts, indexed_text in rows:
+        text = _safe_visible_text(str(capture_id), indexed_text).strip()
         if not text:
             continue
         if deduped and deduped[-1][1] == text:

--- a/tests/test_attention_locus.py
+++ b/tests/test_attention_locus.py
@@ -94,6 +94,20 @@ def test_editing_with_same_target_no_peripheral() -> None:
     assert loc.peripheral == ""
 
 
+def test_user_text_input_element_does_not_select_cursor_rung() -> None:
+    cap = _cap(
+        focused_element={"role": "", "is_editable": False},
+        trigger={
+            "event_type": "UserTextInput",
+            "details": {"element": {"role": "AXTextArea", "value": "typed text"}},
+        },
+        visible_text="ordinary window content",
+    )
+    loc = resolve_locus(cap, visible_text=cap["visible_text"])
+    assert loc.rung != "cursor"
+    assert loc.peripheral == ""
+
+
 # --- cmux resolver: narrow to the pane, drop chrome ------------------------
 
 

--- a/tests/test_ax_capture.py
+++ b/tests/test_ax_capture.py
@@ -191,6 +191,23 @@ def test_accessibility_request_targets_only_configured_principals(
     assert commands == [[str(helper), "--request-accessibility"]]
 
 
+def test_native_helper_filters_focused_placeholder_and_keeps_tree_evidence() -> None:
+    source = (Path(__file__).resolve().parents[1] / "resources" / "mac-ax-helper.swift").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'axString(element, "AXPlaceholderValue")' in source
+    assert 'lowercased() == "placeholder"' in source
+    assert "evidence = placeholderDescendantTexts(element)" in source
+    traverse = source.split("func traverseElement", 1)[1].split("func processWindow", 1)[0]
+    # Normal tree output retains the local pair as forensic evidence; Python
+    # S1 sanitizes its authored-text projection without mutating raw AX.
+    assert "confirmedPlaceholderTexts" not in traverse
+    focused = source.split("func focusedUIElementDict", 1)[1]
+    assert "config.raw || !placeholderTexts.contains(raw)" in focused
+    assert "placeholderTexts.contains(title)" in focused
+
+
 def test_stable_native_binary_is_reused_across_reinstall_sources(
     ac_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_ax_capture.py
+++ b/tests/test_ax_capture.py
@@ -203,9 +203,13 @@ def test_native_helper_filters_focused_placeholder_and_keeps_tree_evidence() -> 
     # Normal tree output retains the local pair as forensic evidence; Python
     # S1 sanitizes its authored-text projection without mutating raw AX.
     assert "confirmedPlaceholderTexts" not in traverse
+    assert 'dict["AXPlaceholderValue"] = p' in source
+    assert 'axString(element, "AXPlaceholderValue")' in traverse
+    assert "placeholderValue: placeholderValue" in traverse
     focused = source.split("func focusedUIElementDict", 1)[1]
     assert "config.raw || !placeholderTexts.contains(raw)" in focused
     assert "placeholderTexts.contains(title)" in focused
+    assert 'dict["AXPlaceholderValue"] = standardPlaceholder' in focused
 
 
 def test_stable_native_binary_is_reused_across_reinstall_sources(

--- a/tests/test_capture_scheduler_fts.py
+++ b/tests/test_capture_scheduler_fts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import time
 from contextlib import contextmanager
@@ -62,6 +63,119 @@ def test_write_capture_indexes_into_fts(ac_root: Path) -> None:
         assert len(hits) == 1
         assert hits[0].id == path.stem
         assert hits[0].app_name == "Cursor"
+
+
+def test_restore_capture_index_sanitizes_legacy_placeholder(ac_root: Path) -> None:
+    phrase = "Ask for follow-up changes"
+    out = _capture_dict(
+        ts="2026-07-12T23:00:00+08:00",
+        app="Chat",
+        title="Conversation",
+        value=phrase,
+        text=f"[TextArea] {phrase}",
+    )
+    out["ax_tree"] = {
+        "apps": [
+            {
+                "name": "Chat",
+                "bundle_id": "com.test.chat",
+                "is_frontmost": True,
+                "focused_element": {
+                    "role": "AXTextArea",
+                    "value": phrase,
+                    "is_editable": True,
+                },
+                "windows": [
+                    {
+                        "title": "Conversation",
+                        "elements": [
+                            {
+                                "role": "AXTextArea",
+                                "value": phrase,
+                                "children": [
+                                    {
+                                        "role": "AXGroup",
+                                        "domClassList": ["placeholder"],
+                                        "children": [{"role": "AXStaticText", "value": phrase}],
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+    target = paths.capture_buffer_dir() / "legacy-placeholder.json"
+    target.write_text(json.dumps(out), encoding="utf-8")
+
+    scheduler_mod._restore_capture_index(target)
+
+    with fts.cursor() as conn:
+        row = conn.execute(
+            "SELECT focused_value, visible_text FROM captures WHERE id=?",
+            (target.stem,),
+        ).fetchone()
+    assert row is not None
+    assert row["focused_value"] == ""
+    assert phrase not in row["visible_text"]
+
+
+def test_placeholder_repair_preserves_ocr_backfill_sentinel(ac_root: Path) -> None:
+    phrase = "Ask for follow-up changes"
+    out = _capture_dict(
+        ts="2026-07-12T23:01:00+08:00",
+        app="Chat",
+        title="Conversation",
+        value=phrase,
+        text="",
+    )
+    out["ocr_submitted"] = True
+    out["ax_tree"] = {
+        "apps": [
+            {
+                "name": "Chat",
+                "bundle_id": "com.test.chat",
+                "is_frontmost": True,
+                "focused_element": {
+                    "role": "AXTextArea",
+                    "value": phrase,
+                    "is_editable": True,
+                },
+                "windows": [
+                    {
+                        "title": "Conversation",
+                        "elements": [
+                            {
+                                "role": "AXTextArea",
+                                "value": phrase,
+                                "children": [
+                                    {
+                                        "role": "AXGroup",
+                                        "domClassList": ["placeholder"],
+                                        "children": [{"role": "AXStaticText", "value": phrase}],
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+
+    assert scheduler_mod._index_capture("ocr-placeholder", out) is True
+    with fts.cursor() as conn:
+        before = conn.execute(
+            "SELECT focused_value, visible_text FROM captures WHERE id='ocr-placeholder'"
+        ).fetchone()
+        assert before["focused_value"] == ""
+        assert before["visible_text"] == ""
+        fts.backfill_capture_ocr_text(conn, "ocr-placeholder", "recognized body")
+        after = conn.execute(
+            "SELECT visible_text FROM captures WHERE id='ocr-placeholder'"
+        ).fetchone()
+    assert after["visible_text"] == "recognized body"
 
 
 def test_cleanup_buffer_removes_fts_rows(ac_root: Path) -> None:

--- a/tests/test_captures_ingest_api.py
+++ b/tests/test_captures_ingest_api.py
@@ -135,6 +135,42 @@ def test_ingest_readable_via_recent(ac_root) -> None:
     assert rec["app_name"] == payload["window_meta"]["app_name"]
 
 
+def test_ingest_filters_empty_composer_placeholder(ac_root) -> None:
+    phrase = "Ask for follow-up changes"
+    _, payload = _payload()
+    payload["trigger"] = {
+        "event_type": "UserMouseClick",
+        "details": {"element": {"role": "AXStaticText", "value": phrase}},
+    }
+    app = payload["ax_tree"]["apps"][0]
+    app["focused_element"] = {
+        "role": "AXTextArea",
+        "value": phrase,
+        "is_editable": True,
+    }
+    app["windows"][0]["elements"] = [
+        {
+            "role": "AXTextArea",
+            "value": phrase,
+            "children": [
+                {
+                    "role": "AXGroup",
+                    "domClassList": ["placeholder"],
+                    "children": [{"role": "AXStaticText", "value": phrase}],
+                }
+            ],
+        }
+    ]
+
+    response = _client().post("/captures/ingest", json=payload)
+
+    assert response.status_code == 200, response.text
+    out = json.loads(next(paths.capture_buffer_dir().glob("*.json")).read_text())
+    assert out["focused_element"]["value"] == ""
+    assert phrase not in out["visible_text"]
+    assert out["trigger"]["details"]["element"].get("value", "") == ""
+
+
 def test_ingest_through_runner_fires_session_hook_and_dedups(ac_root) -> None:
     from persome.capture import scheduler
 

--- a/tests/test_chat_extractor.py
+++ b/tests/test_chat_extractor.py
@@ -1,0 +1,166 @@
+"""Safe classifier drill-down over legacy capture-index rows."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from persome import paths
+from persome.store import fts
+from persome.writer.chat_extractor import extract_chat_messages
+from persome.writer.tools import tool_drill_chat_captures
+
+_PHRASE = "Ask for follow-up changes"
+_START = "2026-07-12T22:59:00+08:00"
+_END = "2026-07-12T23:01:00+08:00"
+
+
+def _legacy_placeholder_capture(*, ocr_submitted: bool = False) -> dict[str, Any]:
+    return {
+        "timestamp": "2026-07-12T23:00:00+08:00",
+        "window_meta": {
+            "app_name": "Chat",
+            "title": "Conversation",
+            "bundle_id": "com.example.chat",
+        },
+        "ocr_submitted": ocr_submitted,
+        "focused_element": {
+            "role": "AXTextArea",
+            "value": _PHRASE,
+            "is_editable": True,
+        },
+        "visible_text": "" if ocr_submitted else f"[TextArea] {_PHRASE}",
+        "ax_tree": {
+            "apps": [
+                {
+                    "name": "Chat",
+                    "bundle_id": "com.example.chat",
+                    "is_frontmost": True,
+                    "focused_element": {
+                        "role": "AXTextArea",
+                        "value": _PHRASE,
+                        "is_editable": True,
+                    },
+                    "windows": [
+                        {
+                            "title": "Conversation",
+                            "elements": [
+                                {"role": "AXStaticText", "value": "Existing conversation"},
+                                {
+                                    "role": "AXTextArea",
+                                    "value": _PHRASE,
+                                    "children": [
+                                        {
+                                            "role": "AXGroup",
+                                            "domClassList": ["placeholder"],
+                                            "children": [
+                                                {"role": "AXStaticText", "value": _PHRASE}
+                                            ],
+                                        }
+                                    ],
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
+    }
+
+
+def _seed_legacy_row(raw: dict[str, Any], *, indexed_text: str) -> None:
+    capture_id = "2026-07-12T23-00-00p08-00"
+    (paths.capture_buffer_dir() / f"{capture_id}.json").write_text(
+        json.dumps(raw), encoding="utf-8"
+    )
+    with fts.cursor() as conn:
+        fts.insert_capture(
+            conn,
+            id=capture_id,
+            timestamp=str(raw["timestamp"]),
+            app_name="Chat",
+            bundle_id="com.example.chat",
+            window_title="Conversation",
+            focused_role="AXTextArea",
+            focused_value=_PHRASE,
+            visible_text=indexed_text,
+            url="",
+        )
+
+
+def test_legacy_placeholder_is_excluded_from_extractor_and_tool_drill(ac_root: Path) -> None:
+    raw = _legacy_placeholder_capture()
+    _seed_legacy_row(raw, indexed_text=f"[TextArea] {_PHRASE}")
+
+    with fts.cursor() as conn:
+        text, count, gaps = extract_chat_messages(conn, "Chat", _START, _END)
+        drilled = tool_drill_chat_captures(conn, app_name="Chat", start_ts=_START, end_ts=_END)
+
+    assert count == 1
+    assert gaps == 0
+    assert "Existing conversation" in text
+    assert _PHRASE not in text
+    assert drilled["ok"] is True
+    assert drilled["snapshot_count"] == 1
+    assert "Existing conversation" in drilled["content"]
+    assert _PHRASE not in drilled["content"]
+
+
+def test_tool_drill_sanitizes_placeholder_without_losing_db_only_ocr(ac_root: Path) -> None:
+    raw = _legacy_placeholder_capture(ocr_submitted=True)
+    _seed_legacy_row(raw, indexed_text=f"{_PHRASE}\nrecognized OCR body")
+
+    with fts.cursor() as conn:
+        drilled = tool_drill_chat_captures(conn, app_name="Chat", start_ts=_START, end_ts=_END)
+
+    assert drilled["ok"] is True
+    assert drilled["snapshot_count"] == 1
+    assert "recognized OCR body" in drilled["content"]
+    assert _PHRASE not in drilled["content"]
+
+
+def test_filled_control_still_repairs_stale_placeholder_title_and_description(
+    ac_root: Path,
+) -> None:
+    raw = _legacy_placeholder_capture()
+    textarea = raw["ax_tree"]["apps"][0]["windows"][0]["elements"][1]
+    textarea["value"] = "real draft"
+    textarea["title"] = _PHRASE
+    textarea["description"] = _PHRASE
+    textarea["AXPlaceholderValue"] = _PHRASE
+    focused = raw["ax_tree"]["apps"][0]["focused_element"]
+    focused["value"] = "real draft"
+    focused["title"] = _PHRASE
+    focused["description"] = _PHRASE
+    focused["AXPlaceholderValue"] = _PHRASE
+    raw["focused_element"] = {
+        "role": "AXTextArea",
+        "title": _PHRASE,
+        "value": "real draft",
+        "is_editable": True,
+    }
+    raw["visible_text"] = f"[TextArea] {_PHRASE}: real draft"
+    _seed_legacy_row(raw, indexed_text=raw["visible_text"])
+
+    with fts.cursor() as conn:
+        text, count, gaps = extract_chat_messages(conn, "Chat", _START, _END)
+
+    assert count == 1
+    assert gaps == 0
+    assert "real draft" in text
+    assert _PHRASE not in text
+
+
+def test_missing_or_unproven_raw_capture_fails_open_to_indexed_text(ac_root: Path) -> None:
+    raw = _legacy_placeholder_capture()
+    raw["ax_tree"] = {"apps": []}
+    raw["visible_text"] = "raw projection without AX proof"
+    _seed_legacy_row(raw, indexed_text="DB text remains authoritative")
+
+    with fts.cursor() as conn:
+        text, count, _ = extract_chat_messages(conn, "Chat", _START, _END)
+
+    assert count == 1
+    assert "DB text remains authoritative" in text
+    assert "raw projection without AX proof" not in text

--- a/tests/test_cli_capture_rebuild.py
+++ b/tests/test_cli_capture_rebuild.py
@@ -76,3 +76,115 @@ def test_rebuild_captures_default_remains_exact_buffer_reconciliation(ac_root: P
     with fts.cursor() as conn:
         ids = {row[0] for row in conn.execute("SELECT id FROM captures").fetchall()}
     assert ids == {"buffer-new"}
+
+
+def test_rebuild_captures_sanitizes_historical_placeholder_projection(ac_root: Path) -> None:
+    phrase = "Ask for follow-up changes"
+    target = paths.capture_buffer_dir() / "placeholder-old.json"
+    target.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-07-12T00:00:00+00:00",
+                "window_meta": {
+                    "app_name": "Chat",
+                    "bundle_id": "com.example.chat",
+                    "title": "Conversation",
+                },
+                "focused_element": {
+                    "role": "AXTextArea",
+                    "value": phrase,
+                    "is_editable": True,
+                    "value_length": len(phrase),
+                },
+                "visible_text": f"[TextArea] {phrase}",
+                "ax_tree": {
+                    "apps": [
+                        {
+                            "name": "Chat",
+                            "bundle_id": "com.example.chat",
+                            "is_frontmost": True,
+                            "focused_element": {
+                                "role": "AXTextArea",
+                                "value": phrase,
+                                "is_editable": True,
+                            },
+                            "windows": [
+                                {
+                                    "title": "Conversation",
+                                    "focused": True,
+                                    "elements": [
+                                        {
+                                            "role": "AXTextArea",
+                                            "value": phrase,
+                                            "children": [
+                                                {
+                                                    "role": "AXGroup",
+                                                    "domClassList": ["placeholder"],
+                                                    "children": [
+                                                        {"role": "AXStaticText", "value": phrase}
+                                                    ],
+                                                }
+                                            ],
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(cli.app, ["rebuild-captures-index"])
+
+    assert result.exit_code == 0, result.output
+    with fts.cursor() as conn:
+        row = conn.execute(
+            "SELECT focused_value, visible_text FROM captures WHERE id='placeholder-old'"
+        ).fetchone()
+    assert row is not None
+    assert row["focused_value"] == ""
+    assert phrase not in row["visible_text"]
+
+
+def test_rebuild_captures_preserves_db_only_ocr_backfill(ac_root: Path) -> None:
+    target = paths.capture_buffer_dir() / "ocr-only.json"
+    target.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-07-12T00:01:00+00:00",
+                "window_meta": {
+                    "app_name": "WeChat",
+                    "bundle_id": "com.tencent.xinWeChat",
+                    "title": "Conversation",
+                },
+                "focused_element": {},
+                "visible_text": "",
+                "ocr_submitted": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    with fts.cursor() as conn:
+        fts.insert_capture(
+            conn,
+            id=target.stem,
+            timestamp="2026-07-12T00:01:00+00:00",
+            app_name="WeChat",
+            bundle_id="com.tencent.xinWeChat",
+            window_title="Conversation",
+            focused_role="",
+            focused_value="",
+            visible_text="recognized OCR body",
+            url="",
+        )
+
+    result = CliRunner().invoke(cli.app, ["rebuild-captures-index"])
+
+    assert result.exit_code == 0, result.output
+    with fts.cursor() as conn:
+        row = conn.execute("SELECT visible_text FROM captures WHERE id='ocr-only'").fetchone()
+    assert row is not None
+    assert row["visible_text"] == "recognized OCR body"

--- a/tests/test_cli_capture_rebuild.py
+++ b/tests/test_cli_capture_rebuild.py
@@ -188,3 +188,83 @@ def test_rebuild_captures_preserves_db_only_ocr_backfill(ac_root: Path) -> None:
         row = conn.execute("SELECT visible_text FROM captures WHERE id='ocr-only'").fetchone()
     assert row is not None
     assert row["visible_text"] == "recognized OCR body"
+
+
+def test_rebuild_captures_filters_placeholder_from_db_only_ocr_backfill(
+    ac_root: Path,
+) -> None:
+    phrase = "Ask for follow-up changes"
+    target = paths.capture_buffer_dir() / "ocr-placeholder.json"
+    target.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-07-12T00:02:00+00:00",
+                "window_meta": {
+                    "app_name": "Chat",
+                    "bundle_id": "com.example.chat",
+                    "title": "Conversation",
+                },
+                "focused_element": {"role": "AXTextArea", "value": phrase},
+                "visible_text": "",
+                "ocr_submitted": True,
+                "ax_tree": {
+                    "apps": [
+                        {
+                            "name": "Chat",
+                            "bundle_id": "com.example.chat",
+                            "is_frontmost": True,
+                            "windows": [
+                                {
+                                    "title": "Conversation",
+                                    "focused": True,
+                                    "elements": [
+                                        {
+                                            "role": "AXTextArea",
+                                            "value": phrase,
+                                            "children": [
+                                                {
+                                                    "role": "AXGroup",
+                                                    "domClassList": ["placeholder"],
+                                                    "children": [
+                                                        {
+                                                            "role": "AXStaticText",
+                                                            "value": phrase,
+                                                        }
+                                                    ],
+                                                }
+                                            ],
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    with fts.cursor() as conn:
+        fts.insert_capture(
+            conn,
+            id=target.stem,
+            timestamp="2026-07-12T00:02:00+00:00",
+            app_name="Chat",
+            bundle_id="com.example.chat",
+            window_title="Conversation",
+            focused_role="AXTextArea",
+            focused_value=phrase,
+            visible_text=f"{phrase}\nrecognized OCR body",
+            url="",
+        )
+
+    result = CliRunner().invoke(cli.app, ["rebuild-captures-index"])
+
+    assert result.exit_code == 0, result.output
+    with fts.cursor() as conn:
+        row = conn.execute(
+            "SELECT focused_value, visible_text FROM captures WHERE id='ocr-placeholder'"
+        ).fetchone()
+    assert row is not None
+    assert row["focused_value"] == ""
+    assert row["visible_text"] == "recognized OCR body"

--- a/tests/test_click_anchor.py
+++ b/tests/test_click_anchor.py
@@ -58,3 +58,16 @@ def test_empty_element_returns_empty() -> None:
 
 def test_non_click_trigger_with_no_details_is_empty() -> None:
     assert _click_anchor({"event_type": "UserTextInput"}) == ""
+
+
+def test_text_input_element_is_not_mislabeled_as_click() -> None:
+    trigger = {
+        "event_type": "UserTextInput",
+        "details": {
+            "element": {
+                "role": "AXTextArea",
+                "value": "draft from the keyboard event",
+            }
+        },
+    }
+    assert _click_anchor(trigger) == ""

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -177,6 +177,67 @@ def _seed_capture(conn, *, id, ts, app, title, value, text, url=""):
     )
 
 
+def _write_legacy_placeholder_capture(*, stem: str, phrase: str) -> dict:
+    data = {
+        "timestamp": "2026-07-12T23:00:00+08:00",
+        "window_meta": {
+            "app_name": "Chat",
+            "title": "Conversation",
+            "bundle_id": "com.example.chat",
+        },
+        "trigger": {
+            "event_type": "UserMouseClick",
+            "details": {"element": {"role": "AXStaticText", "value": phrase}},
+        },
+        "focused_element": {
+            "role": "AXTextArea",
+            "value": phrase,
+            "is_editable": True,
+            "value_length": len(phrase),
+        },
+        "visible_text": f"[TextArea] {phrase}",
+        "ax_tree": {
+            "apps": [
+                {
+                    "name": "Chat",
+                    "bundle_id": "com.example.chat",
+                    "is_frontmost": True,
+                    "focused_element": {
+                        "role": "AXTextArea",
+                        "value": phrase,
+                        "is_editable": True,
+                    },
+                    "windows": [
+                        {
+                            "title": "Conversation",
+                            "elements": [
+                                {
+                                    "role": "AXStaticText",
+                                    "value": "Existing conversation",
+                                },
+                                {
+                                    "role": "AXTextArea",
+                                    "value": phrase,
+                                    "children": [
+                                        {
+                                            "role": "AXGroup",
+                                            "domClassList": ["placeholder"],
+                                            "children": [{"role": "AXStaticText", "value": phrase}],
+                                        }
+                                    ],
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
+    }
+    target = paths.capture_buffer_dir() / f"{stem}.json"
+    target.write_text(json.dumps(data), encoding="utf-8")
+    return data
+
+
 def test_search_captures_returns_bm25_hits_with_snippet(ac_root: Path) -> None:
     with fts.cursor() as conn:
         _seed_capture(
@@ -206,6 +267,120 @@ def test_search_captures_returns_bm25_hits_with_snippet(ac_root: Path) -> None:
     assert "[rate]" in r["snippet"] and "[limiter]" in r["snippet"]
     # Agent-Native firewall: captured screen content is tagged observed (DATA, not instructions).
     assert r["provenance"] == "observed"
+
+
+def test_capture_reads_repair_stale_fts_but_preserve_raw_ax(ac_root: Path) -> None:
+    phrase = "Ask for follow-up changes"
+    stem = "2026-07-12T23-00-00p08-00"
+    raw = _write_legacy_placeholder_capture(stem=stem, phrase=phrase)
+    with fts.cursor() as conn:
+        _seed_capture(
+            conn,
+            id=stem,
+            ts=raw["timestamp"],
+            app="Chat",
+            title="Conversation",
+            value=phrase,
+            text=f"[TextArea] {phrase}",
+        )
+
+    hits = captures_mod.search_captures(query='"Ask for follow-up changes"')
+    context = captures_mod.current_context(headline_limit=1, fulltext_limit=1)
+    recent = captures_mod.read_recent_capture(at=stem, include_ax_tree=True)
+
+    assert hits and phrase not in json.dumps(hits)
+    assert phrase not in json.dumps(context["recent_captures_headline"])
+    assert phrase not in json.dumps(context["recent_captures_fulltext"])
+    assert recent is not None
+    assert recent["focused_element"]["value"] == ""
+    assert phrase not in recent["visible_text"]
+    # The opt-in expansion is forensic evidence, not the authored-text
+    # projection, so it stays byte-for-byte equivalent to the disk record.
+    assert recent["ax_tree"] == raw["ax_tree"]
+
+
+def test_capture_reads_prefer_clean_raw_projection_over_stale_fts(ac_root: Path) -> None:
+    phrase = "Ask for follow-up changes"
+    stem = "2026-07-12T23-01-00p08-00"
+    raw = _write_legacy_placeholder_capture(stem=stem, phrase=phrase)
+    raw["timestamp"] = "2026-07-12T23:01:00+08:00"
+    raw["focused_element"] = {
+        "role": "AXTextArea",
+        "is_editable": True,
+        "has_value": False,
+        "value_length": 0,
+    }
+    raw["visible_text"] = "Existing conversation"
+    raw["ax_tree"] = {
+        "apps": [
+            {
+                "name": "Chat",
+                "bundle_id": "com.example.chat",
+                "is_frontmost": True,
+                "focused_element": {"role": "AXTextArea", "is_editable": True},
+                "windows": [
+                    {
+                        "title": "Conversation",
+                        "elements": [{"role": "AXStaticText", "value": "Existing conversation"}],
+                    }
+                ],
+            }
+        ]
+    }
+    (paths.capture_buffer_dir() / f"{stem}.json").write_text(json.dumps(raw), encoding="utf-8")
+    with fts.cursor() as conn:
+        _seed_capture(
+            conn,
+            id=stem,
+            ts=raw["timestamp"],
+            app="Chat",
+            title="Conversation",
+            value=phrase,
+            text=f"[TextArea] {phrase}",
+        )
+
+    hits = captures_mod.search_captures(query='"Ask for follow-up changes"')
+    context = captures_mod.current_context(headline_limit=1, fulltext_limit=1)
+    recent = captures_mod.read_recent_capture(at=stem)
+
+    assert hits and phrase not in json.dumps(hits)
+    assert phrase not in json.dumps(context["recent_captures_headline"])
+    assert phrase not in json.dumps(context["recent_captures_fulltext"])
+    assert recent is not None
+    assert recent["focused_element"]["value"] == ""
+    assert recent["visible_text"] == "Existing conversation"
+
+
+def test_placeholder_projection_keeps_db_ocr_visible_to_all_mcp_reads(ac_root: Path) -> None:
+    phrase = "Ask for follow-up changes"
+    stem = "2026-07-12T23-02-00p08-00"
+    raw = _write_legacy_placeholder_capture(stem=stem, phrase=phrase)
+    raw["timestamp"] = "2026-07-12T23:02:00+08:00"
+    raw["visible_text"] = ""
+    raw["ocr_submitted"] = True
+    (paths.capture_buffer_dir() / f"{stem}.json").write_text(json.dumps(raw), encoding="utf-8")
+    with fts.cursor() as conn:
+        _seed_capture(
+            conn,
+            id=stem,
+            ts=raw["timestamp"],
+            app="Chat",
+            title="Conversation",
+            value="",
+            text="recognized OCR body",
+        )
+
+    hits = captures_mod.search_captures(query="recognized OCR body")
+    context = captures_mod.current_context(headline_limit=1, fulltext_limit=1)
+    recent = captures_mod.read_recent_capture(at=stem)
+
+    assert hits and "recognized" in hits[0]["snippet"]
+    assert context["recent_captures_headline"][0]["preview"] == "recognized OCR body"
+    assert context["recent_captures_fulltext"][0]["visible_text"] == "recognized OCR body"
+    assert context["recent_captures_fulltext"][0]["focused_value"] == ""
+    assert recent is not None
+    assert recent["visible_text"] == "recognized OCR body"
+    assert recent["focused_element"]["value"] == ""
 
 
 def test_capture_tools_tag_observed_provenance(ac_root: Path) -> None:

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from persome import __version__, paths
 from persome import model as model_mod
+from persome.capture import s1_parser
 from persome.mcp import captures as captures_mod
 from persome.mcp import server as mcp_server
 from persome.model import ModelBuildCoordinator, create_build_manifest
@@ -351,6 +352,36 @@ def test_capture_reads_prefer_clean_raw_projection_over_stale_fts(ac_root: Path)
     assert recent["visible_text"] == "Existing conversation"
 
 
+def test_search_captures_repairs_stale_focused_value_when_visible_text_matches(
+    ac_root: Path,
+) -> None:
+    phrase = "Ask for follow-up changes"
+    stem = "2026-07-12T23-01-30p08-00"
+    raw = _write_legacy_placeholder_capture(stem=stem, phrase=phrase)
+    raw["timestamp"] = "2026-07-12T23:01:30+08:00"
+    # Model a partially repaired index: the persisted/indexed visible text is
+    # already identical to the safe projection, but focused_value is stale.
+    raw["visible_text"] = s1_parser.sanitize_capture(raw)["visible_text"]
+    (paths.capture_buffer_dir() / f"{stem}.json").write_text(json.dumps(raw), encoding="utf-8")
+    with fts.cursor() as conn:
+        _seed_capture(
+            conn,
+            id=stem,
+            ts=raw["timestamp"],
+            app="Chat",
+            title="Conversation",
+            value=phrase,
+            text=raw["visible_text"],
+        )
+
+    hits = captures_mod.search_captures(query='"Ask for follow-up changes"')
+
+    assert hits
+    assert phrase not in json.dumps(hits)
+    assert hits[0]["focused_value_preview"] == ""
+    assert hits[0]["snippet"] == " ".join(raw["visible_text"].split())[:300]
+
+
 def test_placeholder_projection_keeps_db_ocr_visible_to_all_mcp_reads(ac_root: Path) -> None:
     phrase = "Ask for follow-up changes"
     stem = "2026-07-12T23-02-00p08-00"
@@ -366,15 +397,18 @@ def test_placeholder_projection_keeps_db_ocr_visible_to_all_mcp_reads(ac_root: P
             ts=raw["timestamp"],
             app="Chat",
             title="Conversation",
-            value="",
-            text="recognized OCR body",
+            value=phrase,
+            text=f"{phrase}\nrecognized OCR body",
         )
 
     hits = captures_mod.search_captures(query="recognized OCR body")
+    placeholder_hits = captures_mod.search_captures(query='"Ask for follow-up changes"')
     context = captures_mod.current_context(headline_limit=1, fulltext_limit=1)
     recent = captures_mod.read_recent_capture(at=stem)
 
     assert hits and "recognized" in hits[0]["snippet"]
+    assert placeholder_hits and phrase not in json.dumps(placeholder_hits)
+    assert placeholder_hits[0]["snippet"] == "recognized OCR body"
     assert context["recent_captures_headline"][0]["preview"] == "recognized OCR body"
     assert context["recent_captures_fulltext"][0]["visible_text"] == "recognized OCR body"
     assert context["recent_captures_fulltext"][0]["focused_value"] == ""

--- a/tests/test_ocr_backfill.py
+++ b/tests/test_ocr_backfill.py
@@ -53,6 +53,37 @@ def _write_capture_json(buf: Path, stem: str, visible_text: str = "") -> None:
     (buf / f"{stem}.json").write_text(json.dumps(data))
 
 
+def _placeholder_ax_tree(phrase: str) -> dict[str, Any]:
+    return {
+        "apps": [
+            {
+                "name": "Chat",
+                "bundle_id": "com.example.chat",
+                "is_frontmost": True,
+                "windows": [
+                    {
+                        "title": "Conversation",
+                        "focused": True,
+                        "elements": [
+                            {
+                                "role": "AXTextArea",
+                                "value": phrase,
+                                "children": [
+                                    {
+                                        "role": "AXGroup",
+                                        "domClassList": ["placeholder"],
+                                        "children": [{"role": "AXStaticText", "value": phrase}],
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+
+
 # ─── store/fts.py: backfill_capture_ocr_text ──────────────────────────────────
 
 
@@ -286,6 +317,44 @@ class TestWriteCaptureDefersOcr:
         assert "_ocr_tier" not in on_disk
         assert "_ocr_structured" not in on_disk
         assert on_disk.get("ocr_submitted") is True  # but the marker is kept
+
+    def test_deferred_ocr_filters_proven_placeholder_but_keeps_other_lines(
+        self, monkeypatch: pytest.MonkeyPatch, ac_root: Path
+    ) -> None:
+        from persome.capture import scheduler as sched_mod
+
+        phrase = "Ask for follow-up changes"
+        monkeypatch.setattr(
+            sched_mod.ocr_local,
+            "recognize_detailed",
+            lambda *a, **k: (
+                [phrase, "legitimate OCR body"],
+                [[0, 0, 100, 20], [0, 30, 100, 50]],
+                [0.99, 0.99],
+            ),
+        )
+        monkeypatch.setattr(sched_mod.threading, "Thread", _InlineThread)
+        ts = "2026-07-12T23:02:00+08:00"
+        out = {
+            "timestamp": ts,
+            "window_meta": {
+                "app_name": "Chat",
+                "title": "Conversation",
+                "bundle_id": "com.example.chat",
+            },
+            "focused_element": {},
+            "visible_text": "",
+            "url": "",
+            "ax_tree": _placeholder_ax_tree(phrase),
+            "_ocr_pending_jpeg": b"jpeg",
+            "_ocr_tier": "tiny",
+        }
+
+        path = sched_mod._write_capture(out)
+
+        with fts_store.cursor() as conn:
+            text = fts_store.get_capture_visible_text(conn, path.stem)
+        assert text == "legitimate OCR body"
 
 
 # ─── mcp/captures.py: OCR enrichment in read_recent_capture ──────────────────

--- a/tests/test_s1_parser.py
+++ b/tests/test_s1_parser.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import copy
+
 from persome.capture import s1_parser
 
 
@@ -362,3 +364,230 @@ def test_enrich_focused_element_falls_back_to_scan_without_helper() -> None:
     s1_parser.enrich(capture)
     assert capture["focused_element"]["role"] == "AXTextArea"
     assert capture["focused_element"]["value"] == "legacy-scanned focus"
+
+
+_COMPOSER_PLACEHOLDER = "Ask for follow-up changes"
+
+
+def _chromium_composer(
+    value: str,
+    *,
+    placeholder_class: str = "placeholder",
+    standard_placeholder: str = "",
+) -> dict:
+    textarea = {
+        "role": "AXTextArea",
+        "value": value,
+        "domClassList": ["ProseMirror"],
+        "children": [
+            {
+                "role": "AXGroup",
+                "domClassList": [placeholder_class],
+                "children": [{"role": "AXStaticText", "value": _COMPOSER_PLACEHOLDER}],
+            }
+        ],
+    }
+    if standard_placeholder:
+        textarea["AXPlaceholderValue"] = standard_placeholder
+    return textarea
+
+
+def _composer_capture(textarea: dict, *, focused_value: str | None = None) -> dict:
+    focused_value = textarea.get("value", "") if focused_value is None else focused_value
+    return {
+        "ax_tree": _ax_tree(
+            {
+                "name": "Chat",
+                "bundle_id": "com.example.chromium-chat",
+                "is_frontmost": True,
+                "focused_element": {
+                    "role": "AXTextArea",
+                    "value": focused_value,
+                    "is_editable": True,
+                    "value_length": len(focused_value),
+                },
+                "windows": [
+                    {
+                        "title": "Conversation",
+                        "focused": True,
+                        "elements": [
+                            {
+                                "role": "AXStaticText",
+                                "value": "Existing conversation content long enough to render.",
+                            },
+                            textarea,
+                        ],
+                    }
+                ],
+            }
+        )
+    }
+
+
+def test_enrich_filters_chromium_placeholder_without_mutating_raw_ax() -> None:
+    capture = _composer_capture(_chromium_composer(f"\n{_COMPOSER_PLACEHOLDER}"))
+    raw = copy.deepcopy(capture["ax_tree"])
+
+    s1_parser.enrich(capture)
+
+    focused = capture["focused_element"]
+    assert focused["role"] == "AXTextArea"
+    assert focused["value"] == ""
+    assert focused["has_value"] is False
+    assert focused["value_length"] == 0
+    assert _COMPOSER_PLACEHOLDER not in capture["visible_text"]
+    assert capture["ax_tree"] == raw
+
+
+def test_enrich_keeps_typed_value_and_unmatched_class_child() -> None:
+    typed = "Please fix the capture bug"
+    capture = _composer_capture(_chromium_composer(typed))
+
+    s1_parser.enrich(capture)
+
+    assert capture["focused_element"]["value"] == typed
+    assert typed in capture["visible_text"]
+    # Exact class alone is insufficient to delete subtree content. The real
+    # empty-composer bug also exposes the same text on the owning control.
+    assert _COMPOSER_PLACEHOLDER in capture["visible_text"]
+
+
+def test_enrich_does_not_globally_remove_same_text_outside_editable_control() -> None:
+    textarea = _chromium_composer(_COMPOSER_PLACEHOLDER)
+    capture = _composer_capture(textarea)
+    capture["ax_tree"]["apps"][0]["windows"][0]["elements"].insert(
+        0, {"role": "AXStaticText", "value": _COMPOSER_PLACEHOLDER}
+    )
+
+    s1_parser.enrich(capture)
+
+    assert capture["focused_element"]["value"] == ""
+    assert _COMPOSER_PLACEHOLDER in capture["visible_text"]
+
+
+def test_enrich_requires_exact_placeholder_dom_class_token() -> None:
+    styled = "placeholder:text-token-input-placeholder-foreground"
+    capture = _composer_capture(_chromium_composer(_COMPOSER_PLACEHOLDER, placeholder_class=styled))
+
+    s1_parser.enrich(capture)
+
+    assert capture["focused_element"]["value"] == _COMPOSER_PLACEHOLDER
+    assert _COMPOSER_PLACEHOLDER in capture["visible_text"]
+
+
+def test_enrich_filters_standard_ax_placeholder_value_without_dom_marker() -> None:
+    textarea = {
+        "role": "AXTextArea",
+        "value": _COMPOSER_PLACEHOLDER,
+        "AXPlaceholderValue": _COMPOSER_PLACEHOLDER,
+    }
+    capture = _composer_capture(textarea)
+
+    s1_parser.enrich(capture)
+
+    assert capture["focused_element"]["value"] == ""
+    assert _COMPOSER_PLACEHOLDER not in capture["visible_text"]
+
+
+def test_enrich_keeps_matching_text_without_placeholder_evidence() -> None:
+    capture = _composer_capture({"role": "AXTextArea", "value": _COMPOSER_PLACEHOLDER})
+
+    s1_parser.enrich(capture)
+
+    assert capture["focused_element"]["value"] == _COMPOSER_PLACEHOLDER
+
+
+def test_sanitize_capture_repairs_historical_s1_projection() -> None:
+    capture = _composer_capture(_chromium_composer(_COMPOSER_PLACEHOLDER))
+    capture["focused_element"] = {
+        "role": "AXTextArea",
+        "value": _COMPOSER_PLACEHOLDER,
+        "is_editable": True,
+        "has_value": True,
+        "value_length": len(_COMPOSER_PLACEHOLDER),
+    }
+    capture["visible_text"] = f"[TextArea] {_COMPOSER_PLACEHOLDER}"
+
+    clean = s1_parser.sanitize_capture(capture)
+
+    assert clean is not capture
+    assert clean["focused_element"]["value"] == ""
+    assert _COMPOSER_PLACEHOLDER not in clean["visible_text"]
+    assert capture["focused_element"]["value"] == _COMPOSER_PLACEHOLDER
+
+
+def test_enrich_filters_matching_placeholder_title_and_description() -> None:
+    textarea = _chromium_composer(_COMPOSER_PLACEHOLDER)
+    textarea["title"] = _COMPOSER_PLACEHOLDER
+    textarea["description"] = _COMPOSER_PLACEHOLDER
+    capture = _composer_capture(textarea)
+    focused = capture["ax_tree"]["apps"][0]["focused_element"]
+    focused["title"] = _COMPOSER_PLACEHOLDER
+    focused["description"] = _COMPOSER_PLACEHOLDER
+
+    s1_parser.enrich(capture)
+
+    assert capture["focused_element"]["title"] == ""
+    assert capture["focused_element"]["value"] == ""
+    assert _COMPOSER_PLACEHOLDER not in capture["visible_text"]
+
+
+def test_enrich_preserves_ambiguous_same_role_authored_value() -> None:
+    placeholder = _chromium_composer(_COMPOSER_PLACEHOLDER)
+    authored = {"role": "AXTextArea", "value": _COMPOSER_PLACEHOLDER}
+    capture = _composer_capture(placeholder)
+    app = capture["ax_tree"]["apps"][0]
+    app["windows"][0]["elements"].append(authored)
+
+    s1_parser.enrich(capture)
+
+    # The compact focused reference has no stable identity. Since one
+    # compatible TextArea is authored, ambiguity fails open.
+    assert capture["focused_element"]["value"] == _COMPOSER_PLACEHOLDER
+    assert _COMPOSER_PLACEHOLDER in capture["visible_text"]
+
+
+def test_sanitize_capture_repairs_historical_static_placeholder_click() -> None:
+    capture = _composer_capture(_chromium_composer(_COMPOSER_PLACEHOLDER))
+    capture["trigger"] = {
+        "event_type": "UserMouseClick",
+        "details": {"element": {"role": "AXStaticText", "value": _COMPOSER_PLACEHOLDER}},
+    }
+    raw_ax = capture["ax_tree"]
+
+    clean = s1_parser.sanitize_capture(capture)
+
+    click = clean["trigger"]["details"]["element"]
+    assert click.get("value", "") == ""
+    # MCP/debug readers retain the raw evidence unless a caller explicitly
+    # requests a cleaned structural projection.
+    assert clean["ax_tree"] is raw_ax
+    assert capture["trigger"]["details"]["element"]["value"] == _COMPOSER_PLACEHOLDER
+
+
+def test_sanitize_capture_preserves_cmux_post_s1_injection() -> None:
+    capture = _composer_capture(_chromium_composer(_COMPOSER_PLACEHOLDER))
+    terminal = "### [cmux terminal] tests\n42 passed"
+    capture["visible_text"] = f"[TextArea] {_COMPOSER_PLACEHOLDER}\n\n{terminal}"
+    capture["cmux_text_injected"] = True
+
+    clean = s1_parser.sanitize_capture(capture)
+
+    assert _COMPOSER_PLACEHOLDER not in clean["visible_text"]
+    assert terminal in clean["visible_text"]
+
+
+def test_sanitize_capture_preserves_empty_ocr_backfill_sentinel() -> None:
+    capture = _composer_capture(_chromium_composer(_COMPOSER_PLACEHOLDER))
+    capture["focused_element"] = {
+        "role": "AXTextArea",
+        "value": _COMPOSER_PLACEHOLDER,
+        "is_editable": True,
+    }
+    capture["visible_text"] = ""
+    capture["ocr_submitted"] = True
+
+    clean = s1_parser.sanitize_capture(capture)
+
+    assert clean["focused_element"]["value"] == ""
+    assert clean["visible_text"] == ""

--- a/tests/test_s1_parser.py
+++ b/tests/test_s1_parser.py
@@ -458,11 +458,16 @@ def test_enrich_does_not_globally_remove_same_text_outside_editable_control() ->
     capture["ax_tree"]["apps"][0]["windows"][0]["elements"].insert(
         0, {"role": "AXStaticText", "value": _COMPOSER_PLACEHOLDER}
     )
+    capture["trigger"] = {
+        "event_type": "UserMouseClick",
+        "details": {"element": {"role": "AXStaticText", "value": _COMPOSER_PLACEHOLDER}},
+    }
 
     s1_parser.enrich(capture)
 
     assert capture["focused_element"]["value"] == ""
     assert _COMPOSER_PLACEHOLDER in capture["visible_text"]
+    assert capture["trigger"]["details"]["element"].get("value", "") == ""
 
 
 def test_enrich_requires_exact_placeholder_dom_class_token() -> None:

--- a/tests/test_s1_parser.py
+++ b/tests/test_s1_parser.py
@@ -470,6 +470,87 @@ def test_enrich_does_not_globally_remove_same_text_outside_editable_control() ->
     assert capture["trigger"]["details"]["element"].get("value", "") == ""
 
 
+def test_ocr_placeholder_filter_fails_open_for_ambiguous_exact_occurrences() -> None:
+    capture = _composer_capture(_chromium_composer(_COMPOSER_PLACEHOLDER))
+    assert s1_parser.sanitize_ocr_text(capture, _COMPOSER_PLACEHOLDER) == ""
+
+    ocr = "\n".join(
+        (
+            _COMPOSER_PLACEHOLDER,
+            _COMPOSER_PLACEHOLDER,
+            f"Conversation quoted: {_COMPOSER_PLACEHOLDER}",
+        )
+    )
+
+    clean = s1_parser.sanitize_ocr_text(capture, ocr)
+
+    assert clean.splitlines() == [
+        _COMPOSER_PLACEHOLDER,
+        _COMPOSER_PLACEHOLDER,
+        f"Conversation quoted: {_COMPOSER_PLACEHOLDER}",
+    ]
+
+
+def test_ocr_placeholder_filter_removes_exact_field_and_keeps_mixed_content() -> None:
+    capture = _composer_capture(_chromium_composer(_COMPOSER_PLACEHOLDER))
+    ocr = "\n".join(
+        (
+            "## [Message pane]",
+            f"- [self] {_COMPOSER_PLACEHOLDER}",
+            "- [self] legitimate OCR body",
+        )
+    )
+
+    clean = s1_parser.sanitize_ocr_text(capture, ocr)
+
+    assert _COMPOSER_PLACEHOLDER not in clean
+    assert clean.splitlines() == ["## [Message pane]", "- [self] legitimate OCR body"]
+
+
+def test_ocr_placeholder_filter_keeps_phrase_inside_normal_sentence() -> None:
+    capture = _composer_capture(_chromium_composer(_COMPOSER_PLACEHOLDER))
+    sentence = f"Alice said: {_COMPOSER_PLACEHOLDER}"
+
+    assert s1_parser.sanitize_ocr_text(capture, sentence) == sentence
+
+
+def test_ocr_placeholder_evidence_is_scoped_to_frontmost_focused_window() -> None:
+    background = _composer_capture(_chromium_composer(_COMPOSER_PLACEHOLDER))["ax_tree"]["apps"][0]
+    background["is_frontmost"] = False
+    unfocused_placeholder_window = copy.deepcopy(background["windows"][0])
+    unfocused_placeholder_window["focused"] = False
+    foreground = {
+        "name": "Foreground",
+        "bundle_id": "com.example.foreground",
+        "is_frontmost": True,
+        "windows": [
+            unfocused_placeholder_window,
+            {
+                "title": "Focused",
+                "focused": True,
+                "elements": [{"role": "AXStaticText", "value": "real content"}],
+            },
+        ],
+    }
+    capture = {"ax_tree": _ax_tree(background, foreground)}
+
+    assert s1_parser.sanitize_ocr_text(capture, _COMPOSER_PLACEHOLDER) == _COMPOSER_PLACEHOLDER
+
+
+def test_ocr_placeholder_filter_ignores_hidden_standard_hint_on_filled_control() -> None:
+    hint = "Search"
+    textarea = {
+        "role": "AXTextField",
+        "value": "typed query",
+        "AXPlaceholderValue": hint,
+    }
+    capture = _composer_capture(textarea)
+    ocr = f"{hint}\nlegitimate OCR body"
+
+    assert s1_parser.ocr_placeholder_values(capture) == ()
+    assert s1_parser.sanitize_ocr_text(capture, ocr) == ocr
+
+
 def test_enrich_requires_exact_placeholder_dom_class_token() -> None:
     styled = "placeholder:text-token-input-placeholder-foreground"
     capture = _composer_capture(_chromium_composer(_COMPOSER_PLACEHOLDER, placeholder_class=styled))

--- a/tests/test_s1_parser.py
+++ b/tests/test_s1_parser.py
@@ -575,6 +575,26 @@ def test_enrich_filters_standard_ax_placeholder_value_without_dom_marker() -> No
     assert _COMPOSER_PLACEHOLDER not in capture["visible_text"]
 
 
+def test_enrich_filters_helper_tree_standard_placeholder_after_native_focus_cleanup() -> None:
+    textarea = {
+        "role": "AXTextArea",
+        "value": _COMPOSER_PLACEHOLDER,
+        "AXPlaceholderValue": _COMPOSER_PLACEHOLDER,
+    }
+    # The native helper already removes the placeholder from its compact
+    # focused projection. Its window tree deliberately keeps the raw value and
+    # now carries AXPlaceholderValue so Python can clean the visible S1 view.
+    capture = _composer_capture(textarea, focused_value="")
+    capture["ax_tree"]["apps"][0]["focused_element"]["AXPlaceholderValue"] = _COMPOSER_PLACEHOLDER
+    raw = copy.deepcopy(capture["ax_tree"])
+
+    s1_parser.enrich(capture)
+
+    assert capture["focused_element"]["value"] == ""
+    assert _COMPOSER_PLACEHOLDER not in capture["visible_text"]
+    assert capture["ax_tree"] == raw
+
+
 def test_enrich_keeps_matching_text_without_placeholder_evidence() -> None:
     capture = _composer_capture({"role": "AXTextArea", "value": _COMPOSER_PLACEHOLDER})
 

--- a/tests/test_timeline_blocks.py
+++ b/tests/test_timeline_blocks.py
@@ -578,6 +578,225 @@ def test_format_events_generic_app_not_narrowed() -> None:
     assert loc is not None and loc.rung in {"focus", "fallback"}
 
 
+def test_format_events_replays_placeholder_capture_without_authored_text() -> None:
+    phrase = "Ask for follow-up changes"
+    ts = datetime(2026, 7, 12, 23, 0, tzinfo=_TZ)
+    data = {
+        "timestamp": ts.isoformat(),
+        "window_meta": {
+            "app_name": "Chat",
+            "title": "Conversation",
+            "bundle_id": "com.example.chat",
+        },
+        "trigger": {
+            "event_type": "UserMouseClick",
+            "details": {"element": {"role": "AXStaticText", "value": phrase}},
+        },
+        "focused_element": {
+            "role": "AXTextArea",
+            "value": phrase,
+            "is_editable": True,
+            "value_length": len(phrase),
+        },
+        "visible_text": f"[TextArea] {phrase}",
+        "ax_tree": {
+            "apps": [
+                {
+                    "name": "Chat",
+                    "bundle_id": "com.example.chat",
+                    "is_frontmost": True,
+                    "focused_element": {
+                        "role": "AXTextArea",
+                        "value": phrase,
+                        "is_editable": True,
+                    },
+                    "windows": [
+                        {
+                            "title": "Conversation",
+                            "focused": True,
+                            "elements": [
+                                {
+                                    "role": "AXTextArea",
+                                    "value": phrase,
+                                    "children": [
+                                        {
+                                            "role": "AXGroup",
+                                            "domClassList": ["placeholder"],
+                                            "children": [{"role": "AXStaticText", "value": phrase}],
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
+    }
+
+    events_text, _apps, loc = aggregator._format_events(
+        [(Path(f"{_stem(ts)}.json"), data)], locus_enabled=True
+    )
+
+    assert phrase not in events_text
+    assert f'"{phrase}"' not in events_text
+    assert loc is None or loc.rung != "editing"
+
+
+def test_produce_block_replays_placeholder_without_focus_evidence(ac_root: Path, fake_llm) -> None:
+    phrase = "Ask for follow-up changes"
+    start = datetime(2026, 7, 12, 23, 10, tzinfo=_TZ)
+    capture_path = paths.capture_buffer_dir() / f"{_stem(start + timedelta(seconds=10))}.json"
+    capture_path.write_text(
+        json.dumps(
+            {
+                "timestamp": (start + timedelta(seconds=10)).isoformat(),
+                "window_meta": {
+                    "app_name": "Chat",
+                    "title": "Conversation",
+                    "bundle_id": "com.example.chat",
+                },
+                "trigger": {
+                    "event_type": "UserMouseClick",
+                    "details": {"element": {"role": "AXStaticText", "value": phrase}},
+                },
+                "focused_element": {
+                    "role": "AXTextArea",
+                    "value": phrase,
+                    "is_editable": True,
+                    "value_length": len(phrase),
+                },
+                "visible_text": f"[TextArea] {phrase}",
+                "ax_tree": {
+                    "apps": [
+                        {
+                            "name": "Chat",
+                            "bundle_id": "com.example.chat",
+                            "is_frontmost": True,
+                            "focused_element": {
+                                "role": "AXTextArea",
+                                "value": phrase,
+                                "is_editable": True,
+                            },
+                            "windows": [
+                                {
+                                    "title": "Conversation",
+                                    "elements": [
+                                        {
+                                            "role": "AXTextArea",
+                                            "value": phrase,
+                                            "children": [
+                                                {
+                                                    "role": "AXGroup",
+                                                    "domClassList": ["placeholder"],
+                                                    "children": [
+                                                        {
+                                                            "role": "AXStaticText",
+                                                            "value": phrase,
+                                                        }
+                                                    ],
+                                                }
+                                            ],
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    fake_llm.set_default("timeline", json.dumps({"entries": ["[Chat] composer opened"]}))
+
+    block = aggregator.produce_block_for_window(
+        config_mod.load(ac_root / "config.toml"),
+        start=start,
+        end=start + timedelta(minutes=1),
+    )
+
+    assert block is not None
+    assert phrase not in "\n".join(block.entries)
+    assert phrase not in block.focus_excerpt
+    assert phrase not in block.focus_structured
+
+
+def test_placeholder_replay_keeps_ocr_fallback_available(ac_root: Path) -> None:
+    phrase = "Ask for follow-up changes"
+    ts = datetime(2026, 7, 12, 23, 12, tzinfo=_TZ)
+    stem = _stem(ts)
+    path = paths.capture_buffer_dir() / f"{stem}.json"
+    data = {
+        "timestamp": ts.isoformat(),
+        "window_meta": {
+            "app_name": "Chat",
+            "title": "Conversation",
+            "bundle_id": "com.example.chat",
+        },
+        "focused_element": {
+            "role": "AXTextArea",
+            "value": phrase,
+            "is_editable": True,
+        },
+        "visible_text": "",
+        "ocr_submitted": True,
+        "ax_tree": {
+            "apps": [
+                {
+                    "name": "Chat",
+                    "bundle_id": "com.example.chat",
+                    "is_frontmost": True,
+                    "focused_element": {
+                        "role": "AXTextArea",
+                        "value": phrase,
+                        "is_editable": True,
+                    },
+                    "windows": [
+                        {
+                            "title": "Conversation",
+                            "elements": [
+                                {
+                                    "role": "AXTextArea",
+                                    "value": phrase,
+                                    "children": [
+                                        {
+                                            "role": "AXGroup",
+                                            "domClassList": ["placeholder"],
+                                            "children": [{"role": "AXStaticText", "value": phrase}],
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        },
+    }
+    path.write_text(json.dumps(data), encoding="utf-8")
+    with fts.cursor() as conn:
+        fts.insert_capture(
+            conn,
+            id=stem,
+            timestamp=data["timestamp"],
+            app_name="Chat",
+            bundle_id="com.example.chat",
+            window_title="Conversation",
+            focused_role="AXTextArea",
+            focused_value="",
+            visible_text="recognized body",
+            url="",
+        )
+
+    parsed = aggregator._load_captures([path])
+    events_text, _apps, loc = aggregator._format_events(parsed, locus_enabled=True)
+
+    assert "recognized body" in events_text
+    assert phrase not in events_text
+    assert loc is None or loc.rung != "editing"
+
+
 def test_produce_block_persists_attention_locus(ac_root: Path, fake_llm) -> None:
     """End-to-end: the editing rung of a WeChat composer capture lands on the
     block and round-trips through the DB."""

--- a/tests/test_timeline_blocks.py
+++ b/tests/test_timeline_blocks.py
@@ -785,7 +785,7 @@ def test_placeholder_replay_keeps_ocr_fallback_available(ac_root: Path) -> None:
             window_title="Conversation",
             focused_role="AXTextArea",
             focused_value="",
-            visible_text="recognized body",
+            visible_text=f"{phrase}\nrecognized body",
             url="",
         )
 

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -238,3 +238,21 @@ def test_normal_watcher_start_uses_pure_accessibility_check() -> None:
 
     assert "let trusted = AXIsProcessTrusted()" in normal_start
     assert "AXIsProcessTrustedWithOptions" not in normal_start
+
+
+def test_native_watcher_filters_standard_placeholder_without_descendant_scan() -> None:
+    source = (Path(__file__).resolve().parents[1] / "resources" / "mac-ax-watcher.swift").read_text(
+        encoding="utf-8"
+    )
+    describe = source.split("func describeElement", 1)[1].split("func appInfoForElement", 1)[0]
+
+    assert 'axString(element, "AXPlaceholderValue")' in source
+    assert "directPlaceholderTexts(el, role: role)" in describe
+    assert "placeholderTexts.contains(normalizedAXText(rawValue))" in describe
+    assert "placeholderTexts.contains(rawTitle)" in describe
+    assert "placeholderDescendantTexts" not in source
+    callback = source.split("func interactionTapCallback", 1)[1].split(
+        "let interaction = InteractionTapper", 1
+    )[0]
+    assert "handleMouseDown(event, type: type)" in callback
+    assert "handleKeyDown(event)" in callback


### PR DESCRIPTION
## Summary

- remove structurally proven input placeholders from the authored-text S1 projection while preserving raw AX evidence
- apply the same repair at native capture, trusted ingest, historical replay, capture-index rebuild, timeline, and MCP boundaries
- prevent screenshot OCR from reintroducing a proven placeholder, with conservative exact-unit matching and ambiguity fail-open behavior
- preserve DB-only OCR backfills and add regression coverage for click events, stale FTS rows, mixed OCR, filled controls, and duplicate text

## Root cause

Chromium can expose an empty composer's placeholder as `AXValue`. The old pipeline treated that value as user-authored focused text, so it could be indexed, summarized, and eventually modeled as a repeated prompt. Historical rows could also be resurrected during replay or rebuild, and screenshot OCR could recognize the same visible hint after AX cleaning.

The fix requires local structural evidence: a standard AX placeholder on an empty control, or an exact `.placeholder` descendant paired with its owning editable. Raw AX remains available for diagnostics. OCR filtering removes only exact lines/fields and preserves all occurrences when the flat OCR output is ambiguous.

## Validation

- `PERSOME_LLM_MOCK=1 uv run pytest -m "not macos and not integration"` — 1875 passed, 15 deselected
- `uv run ruff check .`
- `uv run ruff format --check .`
- secret, PII, and language scans clean
- Swift typecheck passed for helper and watcher on arm64 and x86_64 macOS 12 targets
- transactional local update completed; Runtime health and isolated OCR worker are ready
