### PR TITLE
fix: speed up stdio MCP and isolate daily reducer windows

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -16,7 +16,10 @@ persome mcp
 
 The daemon endpoint requires `Authorization: Bearer <PERSOME_LOCAL_API_TOKEN>`.
 The token is provisioned in the owner-only Runtime env file. Stdio does not
-need or copy that bearer.
+need or copy that bearer. Stdio also skips construction of the daemon-only
+REST/Chat application and never runs database recovery, keeping per-client cold
+starts bounded to MCP tools. Integrity recovery remains a daemon-start and
+maintenance responsibility.
 
 Example stdio client configuration:
 

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -111,7 +111,7 @@ SELECT * FROM timeline_blocks
  ORDER BY start_time ASC
 ```
 
-Where `:start_bound` is `flush_end` (or `session.start` on the first flush) and `:end_bound` is `now` (flush) or `session.end` (terminal). All overlapping blocks are fed to the reducer LLM along with the window's wall-clock range. The reducer emits per-window-range sub_tasks like `[13:25-13:30, Cursor] edited tick.py; "fixed _stem_to_dt for negative offsets"; involving persome/timeline/aggregator.py`.
+Where `:start_bound` is `flush_end` (or `session.start` on the first flush) and `:end_bound` is `now` (flush) or `session.end` (terminal). All overlapping blocks are fed to the reducer LLM along with the window's wall-clock range. Earlier entries from the same daily file are deliberately not included: `flush_end` already prevents overlap, while replaying old task bodies biases later same-day summaries toward stale work. The reducer emits per-window-range sub_tasks like `[13:25-13:30, Cursor] edited tick.py; "fixed _stem_to_dt for negative offsets"; involving persome/timeline/aggregator.py`.
 
 ## Tuning
 

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -1099,7 +1099,10 @@ def mcp() -> None:
     # current PID/lock receipts and could be writing while a newer stdio client
     # decides the database is offline. Daemon startup and explicit maintenance
     # commands retain the recovery path.
-    _init(recover_integrity=False)
+    # Stdio stdout is the JSON-RPC transport. Keep first-run config notices and
+    # lifecycle diagnostics visible on stderr without corrupting the protocol.
+    with contextlib.redirect_stdout(sys.stderr):
+        _init(recover_integrity=False)
     from .mcp import server as mcp_server
 
     mcp_server.run_stdio()

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -96,7 +96,11 @@ def _daemon_lock_is_held() -> bool:
         handle.close()
 
 
-def _init(*, starting_runtime: bool = False) -> config_mod.Config:
+def _init(
+    *,
+    starting_runtime: bool = False,
+    recover_integrity: bool = True,
+) -> config_mod.Config:
     paths.ensure_dirs()
     # Every initialized CLI command gets the same owner-only Runtime secrets as
     # the daemon. In particular, one-shot commands such as `model build` run
@@ -111,7 +115,7 @@ def _init(*, starting_runtime: bool = False) -> config_mod.Config:
     # The daemon owns active SQLite writes. A status/MCP/second-start invocation
     # must never quarantine or rebuild an index while that process has it open.
     # When stopped, this remains the first database-touching operation.
-    if not _read_pid() and (starting_runtime or not _daemon_lock_is_held()):
+    if recover_integrity and not _read_pid() and (starting_runtime or not _daemon_lock_is_held()):
         recovered = integrity.check_and_recover()
         if paths.integrity_recovery_pending().exists():
             console.print(
@@ -1090,12 +1094,12 @@ def _format_ping(res) -> str:  # type: ignore[no-untyped-def]
 @app.command()
 def mcp() -> None:
     """Run the MCP server (stdio). For LLM client config."""
-    _init()
-
-    # env file (OPENAI_* embeddings creds live there) exactly like `persome start`,
-    # else the stdio server's read path can never activate hybrid dense and an
-    # LLM client silently gets a weaker memory than the in-daemon server.
-    env_file_mod.load_env_file(paths.env_file())
+    # Per-client MCP startup must never run database recovery. Besides adding a
+    # full SQLite scan to every handshake, an older daemon may not publish the
+    # current PID/lock receipts and could be writing while a newer stdio client
+    # decides the database is offline. Daemon startup and explicit maintenance
+    # commands retain the recovery path.
+    _init(recover_integrity=False)
     from .mcp import server as mcp_server
 
     mcp_server.run_stdio()

--- a/src/persome/mcp/server.py
+++ b/src/persome/mcp/server.py
@@ -29,16 +29,6 @@ from ..config import Config
 from ..config import load as load_config
 from ..logger import get
 from ..prompts import load as load_prompt
-from ..security.auth import (
-    add_local_api_auth_middleware,
-    loopback_http_url,
-    reset_browser_auth_state,
-    validate_bind_host,
-)
-from ..security.body_limit import (
-    RequestBodyLimitMiddleware,
-    RequestConcurrencyLimitMiddleware,
-)
 from ..store import files as files_mod
 from ..store import fts
 from ..timeline import attention_trajectory as attention_traj
@@ -765,6 +755,12 @@ def _protect_http_app(app: Any, *, host: str, auth_enabled: bool) -> Any:
     therefore the single outer boundary for MCP, REST, and future custom
     routes.  Keep this helper composable with other outer ASGI limits.
     """
+    from ..security.auth import add_local_api_auth_middleware, validate_bind_host
+    from ..security.body_limit import (
+        RequestBodyLimitMiddleware,
+        RequestConcurrencyLimitMiddleware,
+    )
+
     if auth_enabled:
         validate_bind_host(host)
     # Starlette applies middleware in reverse add order.  Add resource limits
@@ -779,11 +775,19 @@ def build_server(
     cfg: Config | None = None,
     *,
     auth_enabled: bool = True,
+    include_http_routes: bool = True,
 ):  # type: ignore[no-untyped-def]
-    """Construct and return a FastMCP server instance (not yet running)."""
+    """Construct and return a FastMCP server instance (not yet running).
+
+    ``include_http_routes`` mounts the REST/Chat application used by daemon
+    transports. A stdio client has no HTTP surface, so importing and building
+    that application would only add several seconds of cold-start work.
+    """
     from mcp.server.fastmcp import FastMCP  # lazy import
 
     if auth_enabled:
+        from ..security.auth import reset_browser_auth_state
+
         # HTTP cookies are not port-bound. Invalidate every capability whenever
         # a listener generation is rebuilt so a cookie captured during a crash
         # / port-rebind window cannot be replayed after the daemon recovers.
@@ -806,6 +810,8 @@ def build_server(
     from mcp.server.transport_security import TransportSecuritySettings
 
     if auth_enabled and cfg.mcp.transport != "stdio":
+        from ..security.auth import validate_bind_host
+
         validate_bind_host(cfg.mcp.host)
 
     class _ProtectedFastMCP(FastMCP):
@@ -1441,9 +1447,10 @@ def build_server(
                 ensure_ascii=False,
             )
 
-    from ..api import register_routes
+    if include_http_routes:
+        from ..api import register_routes
 
-    register_routes(server, cfg, auth_enabled=auth_enabled)
+        register_routes(server, cfg, auth_enabled=auth_enabled)
     return server
 
 
@@ -1514,7 +1521,7 @@ def run_stdio() -> None:
     _start_parent_watchdog()
     # Stdio has no HTTP request surface and therefore no bearer header.  Keep it
     # explicitly outside the local HTTP authentication boundary.
-    server = build_server(auth_enabled=False)
+    server = build_server(auth_enabled=False, include_http_routes=False)
     server.run()  # FastMCP.run() uses stdio by default
 
 
@@ -1524,8 +1531,14 @@ async def run_async(cfg: Config | None = None, *, transport: str | None = None) 
     transport = transport or cfg.mcp.transport
     auth_enabled = transport != "stdio"
     if auth_enabled:
+        from ..security.auth import validate_bind_host
+
         validate_bind_host(cfg.mcp.host)
-    server = build_server(cfg, auth_enabled=auth_enabled)
+    server = build_server(
+        cfg,
+        auth_enabled=auth_enabled,
+        include_http_routes=transport != "stdio",
+    )
     if transport == "stdio":
         await server.run_stdio_async()
     elif transport == "sse":
@@ -1540,6 +1553,8 @@ async def run_async(cfg: Config | None = None, *, transport: str | None = None) 
 
 def endpoint_url(cfg: Config) -> str:
     """Return the public URL where the daemon-hosted MCP server is reachable."""
+    from ..security.auth import loopback_http_url
+
     transport = cfg.mcp.transport
     if transport == "sse":
         return loopback_http_url(cfg.mcp.host, cfg.mcp.port, "/sse")

--- a/src/persome/prompts/session_reduce.preceding.md
+++ b/src/persome/prompts/session_reduce.preceding.md
@@ -1,7 +1,0 @@
-## Preceding entries in {event_daily_name}
-
-The file below already contains the most recent session/flush entries from today, written by earlier runs of this same reducer. Treat them as *context only* — do **not** rewrite, restate, or append content that merely rehashes what's already there. If the current window is a continuation of a task already logged in one of these entries, say so in `summary` (e.g. "continued the same Cursor refactor from 14:12–14:30") and only add sub_tasks whose time range is outside any earlier entry's range. If the current window has genuinely new activity, ignore the preceding entries.
-
----
-{preceding_text}
----

--- a/src/persome/prompts/session_reduce.system.md
+++ b/src/persome/prompts/session_reduce.system.md
@@ -1,6 +1,6 @@
 You are summarizing one user work window into a structured session entry. The window is presented as an ordered list of pre-computed timeline blocks; each block already contains a list of activity records in the format `[<app>] <context>: <what happened>. <verbatim authored text in quotes, if any>. Involving: <people/topics/files>`. The timeline stage was instructed to preserve authored text, URLs, and proper nouns *verbatim*, so the content inside quotes is the user's own typed text — you must carry it forward without paraphrasing.
 
-The user message that follows contains two sections: first, the preceding entries in the same event-daily file (context only — do not duplicate); then, the new window header and the timeline blocks for the window you must summarize.
+The user message that follows contains only the new window header and the timeline blocks for the window you must summarize. The caller advances a durable `flush_end`, so this window does not overlap earlier reductions.
 
 ## Rules
 
@@ -10,18 +10,18 @@ The user message that follows contains two sections: first, the preceding entrie
 
 **Authorship guard (chat apps).** Do not upgrade "read / checked" into "participated / discussed / replied" unless the source blocks clearly show composing (focused editable input counts). If the editable input looks like search/navigation (title includes keywords like "search", "find", "url", "address", "omnibox", or "command"), describe it as searching instead of participating. If the input title is missing, prefer "typing in an input field" over claiming a chat reply/message unless the UI clearly indicates authorship.
 
-**No duplication with preceding entries.** Do not emit a sub_task whose `[HH:MM-HH:MM, app]` range overlaps the range of a preceding entry for the same activity. This window's sub_tasks should describe *new* activity in the window's stated start/end range only.
+**Current-window isolation — critical.** Describe only activity supported by the supplied window. Do not infer that work continues an earlier task merely because it happened on the same day, and do not import people, projects, framing, or conclusions from prior windows. If the supplied blocks themselves show a continuation, describe it using only evidence in those blocks. Every sub_task must stay inside the stated start/end range.
 
 **Observed-regularity surfacing.** A separate terminal modeling stage decides what long-term preference / habit / style facts are worth persisting. It is forbidden from inventing claims the evidence does not support, so it depends on *you* to flag behavioral regularities in concrete, quotable form.
 
-Fire this rule when the current window exhibits, or continues, a clearly repeated behavior:
+Fire this rule only when the supplied blocks in the current window exhibit a clearly repeated behavior:
 
 - the same tool is being used for the same kind of task in a way that could generalize (e.g. commit messages all in present tense; Notion for drafts vs Apple Notes for quick captures; always routes work meetings to Google Calendar)
 - a stable working style is directly observable (e.g. 90-minute focus blocks; always opens a terminal with `tmux` before coding; writes all shell scripts with `set -euo pipefail`)
 - a repeated authored-text pattern (e.g. commit messages consistently use `feat:` / `fix:` / `docs:` prefix; PR titles always in English)
 - a declarative statement the user has *typed* in this window stating a preference (e.g. typed "I prefer uv over pip" into Claude or a doc)
 
-When fired, append **one** extra sentence to `summary` beginning with the literal phrase `Observed regularity:` (one per window max; skip if nothing qualifies). Be concrete and groundable — name the behavior, the app(s), and either a count or an explicit "continues X from earlier" reference. Example: `Observed regularity: commit messages in Cursor's git panel were written in present tense in all 3 commits this window ("add mermaid code…", "add contributors", "initial project setup"), matching the same pattern in today's earlier entries.`
+When fired, append **one** extra sentence to `summary` beginning with the literal phrase `Observed regularity:` (one per window max; skip if nothing qualifies). Be concrete and groundable — name the behavior, the app(s), and a count from the supplied blocks. Example: `Observed regularity: commit messages in Cursor's git panel were written in present tense in all 3 commits this window ("add mermaid code…", "add contributors", "initial project setup").`
 
 Do NOT fire this rule for:
 
@@ -36,7 +36,7 @@ If nothing qualifies, omit the sentence. The modeling stage's default is silence
 
 Return a JSON object with exactly these fields:
 
-- `summary`: 2-4 sentences describing this window's core tasks, progress, and any clear task switches. Every named person / project / file / topic must be stated next to the app or channel it appeared in. If this window continues a task that the preceding entries already cover, lead with a one-clause acknowledgement ("continued …") before describing new progress.
+- `summary`: 2-4 sentences describing this window's core tasks, progress, and any clear task switches. Every named person / project / file / topic must be stated next to the app or channel it appeared in. Use "continued" only when the supplied blocks explicitly establish continuity; never infer it from earlier same-day activity.
 - `sub_tasks`: ordered, de-duplicated array of sub-task lines in the format
   `[HH:MM-HH:MM, <app name>] <action>; <verbatim authored text or quoted evidence, if present>; involving <people/topics/files>`
   Group consecutive blocks that describe the same activity into one sub-task; split when the user switches app, switches subject, or starts a clearly new task. At least one entry. Use `involving —` if there is nothing notable. Multi-sentence sub_tasks are allowed when a verbatim quote is long — do NOT force everything into one short line at the cost of losing the user's typed content.

--- a/src/persome/writer/session_reducer.py
+++ b/src/persome/writer/session_reducer.py
@@ -42,12 +42,6 @@ from ..timeline import store as timeline_store
 from ..timeline.attention_trajectory import build_attention_trajectory
 from . import llm as llm_mod
 
-# Number of preceding entries from the same event-YYYY-MM-DD.md file to show
-# the reducer as context. Lets a new session summary align with / avoid
-# duplicating entries that earlier sessions (or earlier flushes of this same
-# session) already wrote for the same day.
-_PRECEDING_ENTRY_LIMIT = 6
-
 logger = get("persome.writer")
 
 # Matches Einsia. The index into this tuple is the attempt counter
@@ -223,13 +217,11 @@ def _reduce_window_locked(
             is_final=is_final,
         )
 
-    event_daily_name = _event_daily_name(session_start)
     payload = _call_reducer_llm(
         cfg,
         blocks,
         window_start,
         window_end,
-        event_daily_name=event_daily_name,
     )
 
     if payload is None:
@@ -530,43 +522,12 @@ def _attach_drill_down_breadcrumb(sub_task: str) -> str:
     return sub_task.rstrip() + breadcrumb
 
 
-def _load_preceding_entries(file_name: str, limit: int) -> str:
-    """Return the last ``limit`` entries of ``file_name`` as a single string.
-
-    Used to give the reducer context about what's already been written to
-    today's event-daily file — both from earlier sessions and from earlier
-    flushes of the current session — so the new summary can align with or
-    explicitly supersede them instead of silently duplicating.
-    """
-    path = files_mod.memory_path(file_name)
-    if not path.exists():
-        return "(no prior entries today)"
-    try:
-        parsed = files_mod.read_file(path)
-    except Exception:  # noqa: BLE001
-        return "(prior entries unavailable)"
-    if not parsed.entries:
-        return "(no prior entries today)"
-    tail = parsed.entries[-limit:]
-    out: list[str] = []
-    for e in tail:
-        out.append(f"### [{e.timestamp}] {{id: {e.id}}}")
-        body = e.body.strip()
-        if body:
-            out.append(body)
-        out.append("")
-    return "\n".join(out).strip()
-
-
 def _call_reducer_llm(
     cfg: Config,
     blocks: list[timeline_store.TimelineBlock],
     start_time: datetime,
     end_time: datetime,
-    *,
-    event_daily_name: str,
 ) -> dict[str, Any] | None:
-    preceding_text = _load_preceding_entries(event_daily_name, _PRECEDING_ENTRY_LIMIT)
     system_text = load_prompt("session_reduce.system.md")
     window_text = load_prompt("session_reduce.window.md").format(
         start_time=_format_time(start_time),
@@ -576,21 +537,6 @@ def _call_reducer_llm(
         blocks_text=_format_blocks(blocks),
         attention_text=_format_attention_trajectory(blocks),
     )
-
-    user_blocks: list[dict[str, Any]] = []
-    if preceding_text.strip():
-        # The preceding entries section is a prefix-growth corpus across flush
-        # ticks — call N+1's preceding_text starts with call N's content plus
-        # a few new entries. Marking it with cache_control yields high hit
-        # rates across same-day flush invocations.
-        preceding = load_prompt("session_reduce.preceding.md").format(
-            preceding_text=preceding_text,
-            event_daily_name=event_daily_name,
-        )
-        user_blocks.append(
-            {"type": "text", "text": preceding, "cache_control": {"type": "ephemeral"}}
-        )
-    user_blocks.append({"type": "text", "text": window_text})
 
     try:
         resp = llm_mod.call_llm(
@@ -607,7 +553,7 @@ def _call_reducer_llm(
                         }
                     ],
                 },
-                {"role": "user", "content": user_blocks},
+                {"role": "user", "content": [{"type": "text", "text": window_text}]},
             ],
             json_mode=True,
         )

--- a/tests/test_cli_lifecycle.py
+++ b/tests/test_cli_lifecycle.py
@@ -161,6 +161,23 @@ def test_mcp_uses_non_recovering_initialization(monkeypatch: pytest.MonkeyPatch)
     assert started == [True]
 
 
+def test_mcp_keeps_initialization_notices_off_protocol_stdout(
+    ac_root,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    cli.paths.config_file().unlink(missing_ok=True)
+
+    from persome.mcp import server as mcp_server
+
+    monkeypatch.setattr(mcp_server, "run_stdio", lambda: None)
+    cli.mcp()
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "Created default config" in captured.err
+
+
 def test_cli_surfaces_database_recovery_and_model_rebuild_next_step(
     ac_root, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_cli_lifecycle.py
+++ b/tests/test_cli_lifecycle.py
@@ -129,6 +129,38 @@ def test_non_starting_client_skips_integrity_during_pid_publication_window(
         lock.close()
 
 
+def test_non_recovering_init_never_inspects_or_repairs_database(
+    ac_root, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(cli, "_fail_if_runtime_state_is_ambiguous", lambda: None)
+    monkeypatch.setattr(
+        cli,
+        "_read_pid",
+        lambda: pytest.fail("non-recovering init inspected the daemon PID"),
+    )
+    monkeypatch.setattr(
+        cli.integrity,
+        "check_and_recover",
+        lambda: pytest.fail("non-recovering init touched SQLite"),
+    )
+
+    assert cli._init(recover_integrity=False) is not None
+
+
+def test_mcp_uses_non_recovering_initialization(monkeypatch: pytest.MonkeyPatch) -> None:
+    init_kwargs: list[dict[str, bool]] = []
+    started: list[bool] = []
+    monkeypatch.setattr(cli, "_init", lambda **kwargs: init_kwargs.append(kwargs))
+
+    from persome.mcp import server as mcp_server
+
+    monkeypatch.setattr(mcp_server, "run_stdio", lambda: started.append(True))
+    cli.mcp()
+
+    assert init_kwargs == [{"recover_integrity": False}]
+    assert started == [True]
+
+
 def test_cli_surfaces_database_recovery_and_model_rebuild_next_step(
     ac_root, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_mcp_parent_watchdog.py
+++ b/tests/test_mcp_parent_watchdog.py
@@ -111,12 +111,18 @@ def test_watchdog_arms_a_daemon_thread_when_a_client_is_watchable(
 
 def test_run_stdio_starts_the_watchdog(monkeypatch: pytest.MonkeyPatch) -> None:
     started: list[bool] = []
+    build_args: list[dict[str, bool]] = []
     monkeypatch.setattr(mcp_server, "_start_parent_watchdog", lambda: started.append(True))
 
     class _FakeServer:
         def run(self) -> None:  # pragma: no cover - trivial
             pass
 
-    monkeypatch.setattr(mcp_server, "build_server", lambda auth_enabled: _FakeServer())
+    def _build_server(**kwargs: bool) -> _FakeServer:
+        build_args.append(kwargs)
+        return _FakeServer()
+
+    monkeypatch.setattr(mcp_server, "build_server", _build_server)
     mcp_server.run_stdio()
     assert started == [True]
+    assert build_args == [{"auth_enabled": False, "include_http_routes": False}]

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -159,6 +159,11 @@ def test_server_reports_runtime_version(ac_root: Path) -> None:
     assert server._mcp_server.version == __version__
 
 
+def test_stdio_server_skips_daemon_http_routes(ac_root: Path) -> None:
+    server = mcp_server.build_server(auth_enabled=False, include_http_routes=False)
+    assert server._custom_starlette_routes == []
+
+
 # ─── search_captures + current_context ────────────────────────────────────
 
 

--- a/tests/test_session_reducer.py
+++ b/tests/test_session_reducer.py
@@ -111,6 +111,57 @@ def test_reducer_happy_path_writes_event_daily(ac_root: Path, fake_llm) -> None:
     assert row.status == "reduced"
 
 
+def test_reducer_prompt_does_not_replay_earlier_same_day_tasks(ac_root: Path, fake_llm) -> None:
+    day = datetime(2026, 4, 21, 9, 0, tzinfo=_TZ)
+    with fts.cursor() as conn:
+        session_reducer._append_event_entry(
+            conn,
+            session_id="sess_old_task",
+            start_time=day,
+            end_time=day + timedelta(minutes=30),
+            summary="Prepared the launch campaign in Feishu.",
+            sub_tasks=["[09:00-09:30, Feishu] drafted launch copy, involving campaign"],
+            heuristic=False,
+            is_final=True,
+        )
+
+    current = day + timedelta(hours=5)
+    blocks = [
+        timeline_store.TimelineBlock(
+            start_time=current,
+            end_time=current + timedelta(minutes=5),
+            timezone="+08:00",
+            entries=["[Cursor] fixed an MCP startup test, involving server.py"],
+            apps_used=["Cursor"],
+            capture_count=3,
+        )
+    ]
+    fake_llm.set_default(
+        "reducer",
+        json.dumps(
+            {
+                "summary": "Fixed an MCP startup test.",
+                "sub_tasks": ["[14:00-14:05, Cursor] fixed test, involving server.py"],
+            }
+        ),
+    )
+
+    cfg = config_mod.load(ac_root / "config.toml")
+    payload = session_reducer._call_reducer_llm(
+        cfg,
+        blocks,
+        current,
+        current + timedelta(minutes=5),
+    )
+
+    assert payload is not None
+    user_content = fake_llm.calls[-1]["messages"][1]["content"]
+    rendered = "\n".join(block["text"] for block in user_content)
+    assert "fixed an MCP startup test" in rendered
+    assert "Prepared the launch campaign" not in rendered
+    assert "drafted launch copy" not in rendered
+
+
 def test_reducer_no_blocks_marks_reduced_no_write(ac_root: Path) -> None:
     start = datetime(2026, 4, 21, 11, 0, tzinfo=_TZ)
     end = start + timedelta(minutes=5)


### PR DESCRIPTION
## What changed

- keep stdio MCP startup on the MCP-only path
  - skip daemon-only REST/Chat route construction
  - lazy-load HTTP security dependencies
  - never run database recovery from a per-client stdio process
- isolate session-reducer prompts to the current `flush_end -> window_end` range
  - stop replaying the previous six same-day entries
  - remove the obsolete preceding-entry prompt
  - require evidence from the supplied window before saying work "continued"
- add regression coverage and update MCP/timeline documentation

## Root cause

The stdio server shared the daemon builder, so every client spawn eagerly built the full HTTP/Chat application and OpenAPI surface. It could also run a full SQLite integrity scan when a newer client could not recognize an older daemon's PID/lock receipts. Both happen before the MCP initialize response.

The reducer already advances a durable `flush_end`, making each reduction window non-overlapping. Replaying complete earlier entries was therefore unnecessary and biased later same-day summaries toward stale tasks.

## Impact

- stdio clients no longer pay daemon-only initialization costs or race database recovery against another runtime
- later tasks on a busy day are summarized from their own evidence instead of inheriting earlier task framing
- HTTP/SSE behavior and integrity recovery during daemon startup remain unchanged

## Validation

- `97 passed` across MCP, lifecycle, reducer, local-auth, transport-security, and input-limit tests
- `36 passed` across additional reducer, session-tick, recall, MCP-limit, and OpenAPI-drift tests
- `ruff check .`
- `ruff format --check .`
- secret, PII, and English-language scans
- real MCP SDK initialize handshake returned `persome 0.3.2`
