### PR TITLE
Speed up owner-local model graph loading

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -63,6 +63,12 @@ inspect the real person model. `persome model export` and MCP
 `get_model_snapshot` apply deterministic redaction by default; `/model/graph`
 is not a publication endpoint.
 
+The authenticated viewer polls for model changes, but the Runtime keeps one
+owner-local graph payload in memory for at most 15 seconds and makes refresh
+single-flight. This bounds repeated snapshot work across polling tabs without
+writing raw graph content to another file. The browser also coalesces overlapping
+polls and turns a request that exceeds 45 seconds into an explicit retry state.
+
 ## Security boundary
 
 - The server is restricted to loopback and defaults to `127.0.0.1`; wildcard

--- a/openapi.json
+++ b/openapi.json
@@ -187,7 +187,7 @@
           "model"
         ],
         "summary": "Model Graph",
-        "description": "Return the canonical versioned Point/Line/Face/Volume/Root snapshot.",
+        "description": "Return the canonical owner-local Point/Line/Face/Volume/Root snapshot.",
         "operationId": "model_graph_model_graph_get",
         "responses": {
           "200": {

--- a/resources/model_assets/viewer.css
+++ b/resources/model_assets/viewer.css
@@ -814,6 +814,24 @@ button {
   color: #ff9cae;
 }
 
+.error p {
+  margin: 0;
+}
+
+.error button {
+  margin-top: 14px;
+  padding: 8px 15px;
+  border: 1px solid rgba(255, 156, 174, 0.34);
+  border-radius: 999px;
+  background: rgba(255, 156, 174, 0.1);
+  color: #ffd4dc;
+  cursor: pointer;
+}
+
+.error button:hover {
+  background: rgba(255, 156, 174, 0.18);
+}
+
 .share-notice {
   position: absolute;
   z-index: 18;

--- a/resources/model_assets/viewer.js
+++ b/resources/model_assets/viewer.js
@@ -113,6 +113,7 @@ let zoomGoalDistance = null;
 let lastZoomPercent = null;
 let lastFrameTime = performance.now();
 let shareReady = false;
+let modelLoadPromise = null;
 const layerVisible = { points: true, lines: true, faces: true, volumes: true, root: true };
 const kindLayers = { point: "points", context: "points", face: "faces", volume: "volumes", root: "root" };
 const raycaster = new THREE.Raycaster();
@@ -121,6 +122,7 @@ const zoomDirection = new THREE.Vector3();
 const ZOOM_MIN_PERCENT = 50;
 const ZOOM_MAX_PERCENT = 400;
 const ZOOM_STEP_PERCENT = 25;
+const MODEL_GRAPH_TIMEOUT_MS = 45_000;
 const REDUCED_MOTION = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
 function freshLayerObjects() {
@@ -915,14 +917,33 @@ function fingerprint(nextModel) {
   });
 }
 
-async function loadModel(force = false) {
+function showModelLoadError(error) {
+  const message = document.createElement("p");
+  message.textContent = error?.name === "AbortError"
+    ? "The model is taking too long to load. The Runtime may still be building it."
+    : `Unable to load the personal model. ${error?.message || error}`;
+  const retry = document.createElement("button");
+  retry.type = "button";
+  retry.textContent = "Retry";
+  retry.addEventListener("click", () => loadModel(true));
+  errorEl.replaceChildren(message, retry);
+  errorEl.hidden = false;
+}
+
+async function loadModelOnce(force) {
+  const controller = new AbortController();
+  const timeout = window.setTimeout(() => controller.abort(), MODEL_GRAPH_TIMEOUT_MS);
   try {
-    const response = await fetch("./graph", { cache: "no-store" });
+    const response = await fetch("./graph", {
+      cache: "no-store",
+      signal: controller.signal,
+    });
     if (!response.ok) throw new Error(`Model endpoint returned HTTP ${response.status}`);
     const payload = await response.json();
     if (!payload.model || !Array.isArray(payload.model.points)) {
       throw new Error("Model endpoint returned an invalid snapshot");
     }
+    errorEl.hidden = true;
     const nextFingerprint = fingerprint(payload.model);
     if (!force && nextFingerprint === modelFingerprint) return;
     model = payload.model;
@@ -934,13 +955,21 @@ async function loadModel(force = false) {
     setShareBusy(false);
     updateTimelineBounds();
     buildScene();
-    errorEl.hidden = true;
   } catch (error) {
     shareReady = false;
     setShareBusy(false);
-    errorEl.textContent = `Unable to load the personal model. ${error.message || error}`;
-    errorEl.hidden = false;
+    showModelLoadError(error);
+  } finally {
+    window.clearTimeout(timeout);
   }
+}
+
+function loadModel(force = false) {
+  if (modelLoadPromise) return modelLoadPromise;
+  modelLoadPromise = loadModelOnce(force).finally(() => {
+    modelLoadPromise = null;
+  });
+  return modelLoadPromise;
 }
 
 function frameLayout(force) {

--- a/src/persome/api/routes.py
+++ b/src/persome/api/routes.py
@@ -50,6 +50,14 @@ _model_ping_cache: dict[
     tuple[float, dict[str, ModelPing]],
 ] = {}
 
+# The authenticated owner-local viewer polls every five seconds. Building a
+# large live snapshot is intentionally transactionally stable, but can take
+# longer than one poll interval. Reuse one raw viewer payload briefly and make
+# refresh single-flight so polling/browser tabs cannot multiply that work.
+_MODEL_GRAPH_CACHE_TTL_SECONDS = 15.0
+_model_graph_cache_lock = threading.Lock()
+_model_graph_cache: tuple[str, float, dict[str, Any]] | None = None
+
 # Re-export config so it can be overridden during tests
 _cfg: Config | None = None
 
@@ -57,10 +65,27 @@ _cfg: Config | None = None
 def set_config(cfg: Config | None) -> None:
     global _cfg
     _cfg = cfg
+    _clear_model_graph_cache()
 
 
 def _get_cfg() -> Config:
     return _cfg or load_config()
+
+
+def _clear_model_graph_cache() -> None:
+    global _model_graph_cache
+    with _model_graph_cache_lock:
+        _model_graph_cache = None
+
+
+def _cached_model_graph(root_key: str, now: float) -> dict[str, Any] | None:
+    cached = _model_graph_cache
+    if cached is None:
+        return None
+    cached_root, created_at, payload = cached
+    if cached_root != root_key or now - created_at >= _MODEL_GRAPH_CACHE_TTL_SECONDS:
+        return None
+    return payload
 
 
 def _read_pid() -> int | None:
@@ -459,15 +484,32 @@ def model_asset(asset_path: str) -> Response:
 
 @router.get("/model/graph", tags=["model"])
 def model_graph() -> dict[str, Any]:
-    """Return the canonical versioned Point/Line/Face/Volume/Root snapshot."""
+    """Return the canonical owner-local Point/Line/Face/Volume/Root snapshot."""
     from ..store import fts as fts_store
 
-    with fts_store.cursor() as conn:
-        snapshot = build_live_snapshot(conn)
-    return {
-        "generated_at": datetime.now().astimezone().isoformat(),
-        "model": snapshot,
-    }
+    global _model_graph_cache
+    root_key = str(paths.root())
+    now = time.monotonic()
+    cached = _cached_model_graph(root_key, now)
+    if cached is not None:
+        return cached
+
+    with _model_graph_cache_lock:
+        now = time.monotonic()
+        cached = _cached_model_graph(root_key, now)
+        if cached is not None:
+            return cached
+
+        with fts_store.cursor() as conn:
+            # This bearer/capability-protected loopback route is the owner's raw
+            # inspection surface. MCP and CLI exports retain redaction by default.
+            snapshot = build_live_snapshot(conn, redact=False)
+        payload = {
+            "generated_at": datetime.now().astimezone().isoformat(),
+            "model": snapshot,
+        }
+        _model_graph_cache = (root_key, time.monotonic(), payload)
+        return payload
 
 
 @router.get("/model/node", tags=["model"])

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 
 import pytest
@@ -33,6 +35,13 @@ BUILD_KEYS = {
 }
 
 
+@pytest.fixture(autouse=True)
+def _reset_model_graph_cache():
+    routes._clear_model_graph_cache()
+    yield
+    routes._clear_model_graph_cache()
+
+
 def _save_point(
     *,
     node_id: str,
@@ -55,8 +64,9 @@ class TestGraphJson:
         sentinel = {"schema_version": 1, "source": "live-reader"}
         calls = []
 
-        def fake_live_snapshot(conn):  # type: ignore[no-untyped-def]
+        def fake_live_snapshot(conn, *, redact=True):  # type: ignore[no-untyped-def]
             calls.append(conn)
+            assert redact is False
             return sentinel
 
         monkeypatch.setattr(routes, "build_live_snapshot", fake_live_snapshot)
@@ -65,6 +75,75 @@ class TestGraphJson:
 
         assert graph["model"] is sentinel
         assert len(calls) == 1
+
+    def test_graph_reuses_recent_owner_local_snapshot(self, ac_root, monkeypatch):
+        calls = []
+
+        def fake_live_snapshot(conn, *, redact=True):  # type: ignore[no-untyped-def]
+            calls.append(conn)
+            assert redact is False
+            return {"schema_version": 1, "call": len(calls)}
+
+        monkeypatch.setattr(routes, "build_live_snapshot", fake_live_snapshot)
+
+        first = routes.model_graph()
+        second = routes.model_graph()
+
+        assert first is second
+        assert first["model"]["call"] == 1
+        assert len(calls) == 1
+
+    def test_graph_cache_expires_after_bounded_ttl(self, ac_root, monkeypatch):
+        calls = []
+        clock = [100.0]
+
+        def fake_live_snapshot(conn, *, redact=True):  # type: ignore[no-untyped-def]
+            calls.append(conn)
+            return {"schema_version": 1, "call": len(calls)}
+
+        monkeypatch.setattr(routes, "build_live_snapshot", fake_live_snapshot)
+        monkeypatch.setattr(routes.time, "monotonic", lambda: clock[0])
+
+        first = routes.model_graph()
+        clock[0] += routes._MODEL_GRAPH_CACHE_TTL_SECONDS + 0.1
+        second = routes.model_graph()
+
+        assert first["model"]["call"] == 1
+        assert second["model"]["call"] == 2
+        assert len(calls) == 2
+
+    def test_graph_refresh_is_single_flight(self, ac_root, monkeypatch):
+        calls = []
+        started = threading.Event()
+        release = threading.Event()
+
+        def fake_live_snapshot(conn, *, redact=True):  # type: ignore[no-untyped-def]
+            calls.append(conn)
+            started.set()
+            assert release.wait(timeout=2)
+            return {"schema_version": 1, "call": len(calls)}
+
+        monkeypatch.setattr(routes, "build_live_snapshot", fake_live_snapshot)
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            first = pool.submit(routes.model_graph)
+            assert started.wait(timeout=2)
+            second = pool.submit(routes.model_graph)
+            release.set()
+            first_payload = first.result(timeout=2)
+            second_payload = second.result(timeout=2)
+
+        assert first_payload is second_payload
+        assert len(calls) == 1
+
+    def test_graph_preserves_raw_owner_local_content(self, ac_root):
+        content = "/" + "Users" + "/synthetic-owner/private-note"
+        _save_point(node_id="point-private", content=content)
+
+        graph = routes.model_graph()
+
+        assert graph["model"]["points"][0]["content"] == content
+        assert graph["model"]["stats"]["redactions"] == {}
 
     def test_graph_is_the_canonical_snapshot(self, ac_root):
         _save_point(node_id="point-runtime", content="The runtime stores local context.")
@@ -194,6 +273,10 @@ class TestViewPage:
         assert b"model.volumes" in viewer.body
         assert b"model.root" in viewer.body
         assert b'fetch("./graph"' in viewer.body
+        assert b"MODEL_GRAPH_TIMEOUT_MS = 45_000" in viewer.body
+        assert b"modelLoadPromise" in viewer.body
+        assert b"controller.abort()" in viewer.body
+        assert b'retry.textContent = "Retry"' in viewer.body
         assert b"fetch(`./node" in viewer.body
         assert b'fetch("/model' not in viewer.body
         assert b"ACESFilmicToneMapping" in viewer.body
@@ -227,6 +310,7 @@ class TestViewPage:
         assert b".zoom-controls" in css.body
         assert b".share-button" in css.body
         assert b".share-notice" in css.body
+        assert b".error button" in css.body
         assert b"(min-width: 1181px) and (max-width: 1360px)" in css.body
         assert b"top: 116px" in css.body
         assert b"prefers-reduced-motion" in css.body


### PR DESCRIPTION
## What changed

- serve the authenticated owner-local model graph without export-oriented redaction
- cache the raw graph payload for 15 seconds and make refresh single-flight across polling tabs
- coalesce overlapping browser polls and abort a graph request after 45 seconds
- show an explicit retry action when loading fails or times out
- document the behavior and add cache, concurrency, raw-content, and viewer regression coverage

## Why

The viewer polls every five seconds, while building a large live snapshot can take longer than one polling interval. The route also used the snapshot builder's default redaction even though `/model/graph` is the authenticated owner's raw local inspection surface. That added repeated PII scanning and allowed polling tabs to multiply expensive snapshot work.

## Impact

The first viewer load avoids unnecessary publication redaction, and repeated requests within the polling window reuse the same in-memory payload. MCP and CLI exports keep their existing deterministic redaction defaults. No raw graph content is written to a new file.

On a read-only copy of a real local store, the first graph build took about 15.4 seconds; immediate cached requests completed in about 31 ms and 0.1 ms.

## Validation

- `uv run pytest tests/test_model_routes.py -q` — 21 passed
- `node --test tests/js/model_layout.test.mjs tests/js/model_share.test.mjs` — 7 passed
- remaining offline suite continuation — 1538 passed; environment-restricted cases were isolated
- environment-sensitive socket/process cases rerun outside the sandbox — 15 passed
- `uv run pytest tests/test_openapi_drift.py -q` — passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- secret, PII, language, and documentation-link scans
