### PR TITLE
feat(model): add evidence drill-down

### DIFF
--- a/MCP.md
+++ b/MCP.md
@@ -54,6 +54,7 @@ Example client configuration:
 | `read_memory` | Read a memory file with time, tag, and tail filters. |
 | `search` | Search durable memory with lexical and optional dense retrieval. |
 | `read_receipt` | Resolve an entry ID to local provenance. |
+| `resolve_evidence` | Resolve any model ID or receipt one layer down; separates direct sources from nearby context. |
 | `recent_activity` | Read recent durable event entries. |
 | `behavior_patterns` | Read modeled patterns and supporting evidence. |
 | `get_model_snapshot` | Return the versioned Point/Line/Face/Volume/Root model. |

--- a/MCP.md
+++ b/MCP.md
@@ -54,7 +54,7 @@ Example client configuration:
 | `read_memory` | Read a memory file with time, tag, and tail filters. |
 | `search` | Search durable memory with lexical and optional dense retrieval. |
 | `read_receipt` | Resolve an entry ID to local provenance. |
-| `resolve_evidence` | Resolve any model ID or receipt one layer down; separates direct sources from nearby context. |
+| `resolve_evidence` | Resolve any model ID or receipt one layer down with human labels; separates direct sources, nearby context, and Point history. |
 | `recent_activity` | Read recent durable event entries. |
 | `behavior_patterns` | Read modeled patterns and supporting evidence. |
 | `get_model_snapshot` | Return the versioned Point/Line/Face/Volume/Root model. |
@@ -80,6 +80,11 @@ Example client configuration:
 
 The server exposes no computer-use, meeting, notification, product dashboard,
 or task-lifecycle tools.
+
+`resolve_evidence` returns a human-readable `label` for display, keeps the
+stable technical handle in `reference`, and separates `sources`, `context`, and
+Point predecessor/successor `history`. Consumers must not present nearby
+`context` as direct proof.
 
 ## Transport configuration
 

--- a/MODEL_FORMAT.md
+++ b/MODEL_FORMAT.md
@@ -89,8 +89,12 @@ summary can be expanded back to Points.
 
 Receipts are stable evidence handles rather than embedded raw capture payloads.
 Each Point has a receipt; sourced relations and aggregate geometry preserve or
-collect those handles. The MCP `read_receipt` tool resolves a handle to current
-local evidence.
+collect those handles. The MCP `resolve_evidence` tool and authenticated
+`GET /model/evidence?ref=...` route resolve model, memory, activity, and capture
+references through one progressive contract. Explicit lineage is returned as
+`sources`; time-adjacent capture clues are returned separately as `context` and
+must not be described as direct proof. `read_receipt` remains the focused,
+backward-compatible memory-entry resolver.
 
 ## Build record
 

--- a/MODEL_FORMAT.md
+++ b/MODEL_FORMAT.md
@@ -93,7 +93,10 @@ collect those handles. The MCP `resolve_evidence` tool and authenticated
 `GET /model/evidence?ref=...` route resolve model, memory, activity, and capture
 references through one progressive contract. Explicit lineage is returned as
 `sources`; time-adjacent capture clues are returned separately as `context` and
-must not be described as direct proof. `read_receipt` remains the focused,
+must not be described as direct proof. Resolved nodes and links include a
+human-readable `label`; Point predecessor/successor links are returned in
+`history`, separate from derivation sources. Raw receipts remain stable
+technical handles. `read_receipt` remains the focused,
 backward-compatible memory-entry resolver.
 
 ## Build record

--- a/README.md
+++ b/README.md
@@ -260,8 +260,8 @@ capture and session pipeline. OCR is a fallback, not a parallel cloud recorder.
 - Authenticated streamable HTTP MCP: `http://127.0.0.1:8742/mcp`
 - stdio MCP: `persome mcp`
 - Stable model contract: `persome model export` and `GET /model/graph`
-- Evidence tools: `search`, `read_receipt`, `verify_fact`, and
-  `get_model_snapshot`
+- Evidence tools: `search`, `read_receipt`, `resolve_evidence`, `verify_fact`,
+  and `get_model_snapshot`
 
 ## Connect an MCP client
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -25,12 +25,18 @@ runtime schema.
 | POST | `/captures/ingest` | Ingest one bearer-authenticated capture from a trusted local producer. |
 | GET | `/model` | Open the offline Point/Line/Face/Volume/Root explorer. |
 | GET | `/model/graph` | Read the canonical versioned model snapshot. |
+| GET | `/model/evidence?ref=...` | Resolve a model ID or receipt into direct sources and separately labeled nearby context. |
 | GET | `/model/node?id=...` | Resolve a snapshot Point ID or relation endpoint to receipts and its relation tree. |
 
 The model page renders snapshot Points and Lines directly, then derives the
 Face, Volume, and Root hierarchy from their declared `members`. It loads its
 pinned Three.js modules from `/model/assets/*`; those package resources are
 intentionally omitted from OpenAPI.
+
+Receipt buttons in the viewer call `/model/evidence`. The response is a
+progressive-disclosure node with `sources` for explicit stored lineage and
+`context` for time-adjacent captures. An unknown or retention-expired payload
+returns `status=missing` while preserving the original receipt for audit.
 
 `/status.data.llm_profile` reports the effective provider, protocol, model,
 endpoint, key variable name, credential presence, and legacy-migration state.

--- a/docs/api.md
+++ b/docs/api.md
@@ -35,8 +35,12 @@ intentionally omitted from OpenAPI.
 
 Receipt buttons in the viewer call `/model/evidence`. The response is a
 progressive-disclosure node with `sources` for explicit stored lineage and
-`context` for time-adjacent captures. An unknown or retention-expired payload
-returns `status=missing` while preserving the original receipt for audit.
+`context` for time-adjacent captures. Human-readable `label` values let clients
+present evidence without exposing internal IDs; Point version links are kept in
+`history`. The local viewer organizes this as Overview, Evidence, and History,
+with drill-down breadcrumbs and raw receipts under technical details. An unknown
+or retention-expired payload returns `status=missing` while preserving the
+original receipt for audit.
 
 `/status.data.llm_profile` reports the effective provider, protocol, model,
 endpoint, key variable name, credential presence, and legacy-migration state.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -39,6 +39,7 @@ Example stdio client configuration:
 | `read_memory` | Read one memory file with time, tag, and tail filters. |
 | `search` | Search durable memory with BM25 and optional dense retrieval. |
 | `read_receipt` | Resolve a memory entry to its provenance. |
+| `resolve_evidence` | Resolve model, memory, activity, and capture references through one progressive evidence contract. |
 | `recent_activity` | Read recent durable event entries. |
 | `behavior_patterns` | Read modeled behavioral patterns and their support. |
 | `get_model_snapshot` | Return the versioned Point/Line/Face/Volume/Root model snapshot. |
@@ -56,6 +57,11 @@ Example stdio client configuration:
 | `read_recent_capture` | Read an exact returned `file_stem` or nearest recent capture, with screenshot opt-in. |
 | `attention_trajectory` | Read the derived attention path used by state formation. |
 | `get_schema` | Return the Markdown memory schema. |
+
+`resolve_evidence` returns explicit stored lineage in `sources` and
+time-adjacent capture clues in `context`. Consumers must not present `context`
+as direct proof. Follow each returned `reference` to move down one layer; a
+retained receipt whose payload is no longer available returns `status=missing`.
 
 ## Transport
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -60,8 +60,11 @@ Example stdio client configuration:
 
 `resolve_evidence` returns explicit stored lineage in `sources` and
 time-adjacent capture clues in `context`. Consumers must not present `context`
-as direct proof. Follow each returned `reference` to move down one layer; a
-retained receipt whose payload is no longer available returns `status=missing`.
+as direct proof. Display `label` as the human-readable card title and keep
+`reference` as the stable technical handle. Point predecessor/successor links
+are returned separately in `history`. Follow each returned `reference` to move
+down one layer; a retained receipt whose payload is no longer available returns
+`status=missing`.
 
 ## Transport
 

--- a/docs/model-contract.md
+++ b/docs/model-contract.md
@@ -84,8 +84,11 @@ Point labels, receipts, source names, timestamps, and viewer credentials are exc
 artifact; the owner attaches the downloaded image and confirms the post in X.
 
 Visible node labels and their Point, Face, Volume, Root, or context meshes open the same provenance
-detail panel. Labels are keyboard-focusable; Escape closes the selection. Lines remain visual
-evidence of evolution, relation, and hierarchy and are intentionally excluded from pointer picking.
+detail panel. Overview summarizes the evidence footprint, Evidence presents human-readable source
+cards with drill-down breadcrumbs, and History keeps Point predecessor/successor versions separate
+from derivation sources. Raw IDs, paths, and receipts stay collapsed under technical details. Labels
+and tabs are keyboard-focusable; Escape closes the selection. Lines remain visual evidence of
+evolution, relation, and hierarchy and are intentionally excluded from pointer picking.
 `window.__persomeInteractionState` exposes aggregate interaction counts for local smoke tests.
 
 Zoom is relative to the fitted model: the visible minus, percentage, and plus controls cover 50%
@@ -99,6 +102,11 @@ Relation edges may carry the nullable triplet `source_kind`, `source_id`, and `s
 The triplet is atomic: callers either provide all three fields or none. Activity-derived edges use
 new stable IDs `event:entry:<id>` or `event:session:<id>`. `event:intent:<id>`
 is read-only compatibility for an old store.
+
+The read-only `resolve_evidence` MCP tool and authenticated `GET /model/evidence?ref=...` endpoint
+return `label` for human display and retain `reference` as the stable technical handle. Explicit
+derivation edges are in `sources`, time-adjacent investigation clues in `context`, and Point version
+edges in `history`. A missing retained payload stays inspectable as `status=missing`.
 
 ## Privacy and reproducibility
 

--- a/openapi.json
+++ b/openapi.json
@@ -205,6 +205,53 @@
         }
       }
     },
+    "/model/evidence": {
+      "get": {
+        "tags": [
+          "model"
+        ],
+        "summary": "Model Evidence",
+        "description": "Resolve one model receipt or object id into its evidence and nearby context.\n\nExplicit stored lineage is returned in ``sources``. Time-adjacent captures\nare returned separately in ``context`` and are never presented as direct\nprovenance. Unknown or expired references fail open with ``status=missing``\nso a historical receipt remains inspectable even after raw retention ends.",
+        "operationId": "model_evidence_model_evidence_get",
+        "parameters": [
+          {
+            "name": "ref",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 1024,
+              "title": "Ref"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Model Evidence Model Evidence Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/model/node": {
       "get": {
         "tags": [

--- a/openapi.json
+++ b/openapi.json
@@ -211,7 +211,7 @@
           "model"
         ],
         "summary": "Model Evidence",
-        "description": "Resolve one model receipt or object id into its evidence and nearby context.\n\nExplicit stored lineage is returned in ``sources``. Time-adjacent captures\nare returned separately in ``context`` and are never presented as direct\nprovenance. Unknown or expired references fail open with ``status=missing``\nso a historical receipt remains inspectable even after raw retention ends.",
+        "description": "Resolve one model receipt or object id into its evidence and nearby context.\n\nExplicit stored lineage is returned in ``sources``. Time-adjacent captures\nare returned separately in ``context`` and are never presented as direct\nprovenance. ``label`` is the human-readable display title; Point version\nlinks are returned separately in ``history``. Unknown or expired references\nfail open with ``status=missing`` so a historical receipt remains inspectable\neven after raw retention ends.",
         "operationId": "model_evidence_model_evidence_get",
         "parameters": [
           {

--- a/resources/model_assets/evidence.mjs
+++ b/resources/model_assets/evidence.mjs
@@ -1,0 +1,119 @@
+function compactText(value, fallback = "Evidence", limit = 140) {
+  const text = String(value || "").replace(/\s+/g, " ").trim();
+  return (text || fallback).slice(0, limit);
+}
+
+function parseReceipt(reference) {
+  const value = String(reference || "").trim();
+  if (!value.startsWith("⟨") || !value.endsWith("⟩")) {
+    return { id: value, path: "" };
+  }
+  const inner = value.slice(1, -1);
+  const separator = inner.lastIndexOf(":");
+  if (separator < 1) return { id: inner, path: "" };
+  return { id: inner.slice(0, separator), path: inner.slice(separator + 1) };
+}
+
+function humanizePath(path) {
+  const name = String(path || "").split("/").pop().replace(/\.(md|json)$/i, "");
+  return name
+    .replaceAll("_", "-")
+    .split("-")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function relationLabel(relation) {
+  const labels = {
+    direct_evidence: "Direct evidence",
+    direct_lineage: "Derived from",
+    direct_source: "Direct source",
+    nearby_context: "Nearby context",
+    previous_version: "Previous version",
+    next_version: "Next version",
+  };
+  return labels[relation] || compactText(String(relation || "Evidence").replaceAll("_", " "));
+}
+
+export function receiptIndex(model) {
+  const byReference = new Map();
+  (model?.points || []).forEach((point) => {
+    if (!point.receipt) return;
+    byReference.set(point.receipt, {
+      id: point.id,
+      kind: "point",
+      reference: point.receipt,
+      relation: "direct_evidence",
+      label: compactText(point.content, humanizePath(point.file_name) || "Observed fact"),
+      timestamp: point.occurred_at || point.valid_from || point.created_at || null,
+      status: point.status || null,
+    });
+  });
+  return byReference;
+}
+
+export function nodeEvidenceCards(item, model) {
+  const references = [
+    item?.receipt,
+    item?.source_evidence?.receipt,
+    ...(item?.member_receipts || []),
+    ...(item?.source_receipts || []),
+  ].filter(Boolean);
+  const index = receiptIndex(model);
+  return [...new Set(references)].map((reference) => {
+    const known = index.get(reference);
+    if (known) return known;
+    const parsed = parseReceipt(reference);
+    return {
+      id: parsed.id,
+      kind: "receipt",
+      reference,
+      relation: "direct_evidence",
+      label: humanizePath(parsed.path) || "Recorded evidence",
+      timestamp: null,
+      status: null,
+    };
+  });
+}
+
+export function nodeHistoryCards(item, model) {
+  const byId = new Map((model?.points || []).map((point) => [point.id, point]));
+  const links = [];
+  [
+    ["previous_version", item?.supersedes || []],
+    ["next_version", item?.superseded_by || []],
+  ].forEach(([relation, ids]) => {
+    ids.forEach((id) => {
+      const point = byId.get(id);
+      links.push({
+        id,
+        kind: "point",
+        reference: point?.receipt || id,
+        relation,
+        label: compactText(point?.content, "Recorded version"),
+        timestamp: point?.occurred_at || point?.valid_from || point?.created_at || null,
+        status: point?.status || null,
+      });
+    });
+  });
+  return links;
+}
+
+export function evidenceOverview(kind, item, model) {
+  const cards = nodeEvidenceCards(item, model);
+  const noun = cards.length === 1 ? "source observation" : "source observations";
+  return {
+    title: cards.length ? `${cards.length} ${noun}` : "No direct evidence receipts",
+    copy: kind === "face" || kind === "volume" || kind === "root"
+      ? "This model shape is summarized from the evidence below."
+      : "Inspect the stored source and its provenance without changing the model.",
+    highlights: cards.slice(0, 3),
+  };
+}
+
+export function evidenceBreadcrumb(data) {
+  return compactText(data?.label || data?.summary, humanizePath(data?.path) || data?.kind || "Evidence", 72);
+}
+
+export const evidenceText = { compactText, humanizePath, parseReceipt };

--- a/resources/model_assets/viewer.css
+++ b/resources/model_assets/viewer.css
@@ -715,6 +715,89 @@ button {
   margin-top: 5px;
 }
 
+.evidence-link,
+.evidence-back {
+  width: 100%;
+  margin-top: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 9px;
+  background: rgba(255, 255, 255, 0.035);
+  color: var(--muted);
+  cursor: pointer;
+  text-align: left;
+}
+
+.evidence-link {
+  display: grid;
+  gap: 3px;
+  padding: 8px 9px;
+}
+
+.evidence-link span {
+  color: var(--dim);
+  font: 7px/1.2 -apple-system, BlinkMacSystemFont, "SF Pro Display", sans-serif;
+  font-weight: 750;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.evidence-link b {
+  overflow-wrap: anywhere;
+  color: #d8d4e1;
+  font: 9px/1.45 ui-monospace, "SFMono-Regular", Menlo, monospace;
+  font-weight: 500;
+}
+
+.evidence-link:hover,
+.evidence-link:focus-visible,
+.evidence-back:hover,
+.evidence-back:focus-visible {
+  border-color: var(--detail-accent, var(--root));
+  background: rgba(255, 255, 255, 0.075);
+  color: var(--text);
+  outline: none;
+}
+
+.evidence-back {
+  margin: 0 0 12px;
+  padding: 7px 9px;
+  font: 8px/1.3 -apple-system, BlinkMacSystemFont, "SF Pro Display", sans-serif;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.evidence-summary,
+.evidence-note {
+  margin: 7px 0 9px;
+  color: #b8b3c4;
+  font: 10px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Display", sans-serif;
+  white-space: pre-wrap;
+}
+
+.evidence-note {
+  color: var(--dim);
+  font-size: 9px;
+}
+
+.evidence-missing {
+  color: #ff9cae;
+}
+
+.evidence-fact,
+.evidence-preview,
+.evidence-loading {
+  margin-top: 5px;
+  color: #858091;
+  font: 9px/1.55 ui-monospace, "SFMono-Regular", Menlo, monospace;
+  overflow-wrap: anywhere;
+}
+
+.evidence-preview {
+  padding: 7px 0 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.055);
+  color: #a7a1b2;
+}
+
 .timeline {
   position: absolute;
   z-index: 11;

--- a/resources/model_assets/viewer.css
+++ b/resources/model_assets/viewer.css
@@ -663,6 +663,62 @@ button {
   line-height: 1.3;
 }
 
+.detail-tabs {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 3px;
+  margin-bottom: 14px;
+  padding: 3px;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.detail-tabs button {
+  padding: 7px 6px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--dim);
+  cursor: pointer;
+  font: 8px/1.2 -apple-system, BlinkMacSystemFont, "SF Pro Display", sans-serif;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.detail-tabs button[aria-selected="true"] {
+  background: color-mix(in srgb, var(--detail-accent, var(--root)) 16%, rgba(255, 255, 255, 0.04));
+  color: var(--text);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--detail-accent, var(--root)) 35%, transparent);
+}
+
+.detail-tabs button:focus-visible {
+  outline: 2px solid var(--detail-accent, var(--root));
+  outline-offset: 1px;
+}
+
+.detail-panel[hidden] {
+  display: none;
+}
+
+.detail-summary {
+  margin-bottom: 12px;
+}
+
+.detail-summary > strong {
+  color: var(--text);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.detail-summary > p {
+  margin: 4px 0 10px;
+  color: var(--muted);
+  font-size: 10px;
+  line-height: 1.5;
+}
+
 .detail-meta {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -693,9 +749,7 @@ button {
 }
 
 .detail-receipts {
-  margin-top: 14px;
-  padding-top: 12px;
-  border-top: 1px solid var(--border);
+  margin-top: 10px;
   color: #858091;
   font: 9px/1.55 ui-monospace, "SFMono-Regular", Menlo, monospace;
   overflow-wrap: anywhere;
@@ -715,8 +769,45 @@ button {
   margin-top: 5px;
 }
 
-.evidence-link,
-.evidence-back {
+.evidence-breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  color: var(--dim);
+  font: 8px/1.4 -apple-system, BlinkMacSystemFont, "SF Pro Display", sans-serif;
+}
+
+.evidence-breadcrumbs button,
+.evidence-breadcrumbs strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.evidence-breadcrumbs button {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--detail-accent, var(--root));
+  cursor: pointer;
+}
+
+.evidence-breadcrumbs strong {
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.evidence-card {
+  margin-top: 7px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.evidence-link {
   width: 100%;
   margin-top: 6px;
   border: 1px solid rgba(255, 255, 255, 0.09);
@@ -730,7 +821,11 @@ button {
 .evidence-link {
   display: grid;
   gap: 3px;
+  margin: 0;
   padding: 8px 9px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
 }
 
 .evidence-link span {
@@ -748,22 +843,39 @@ button {
   font-weight: 500;
 }
 
+.evidence-link small {
+  color: var(--dim);
+  font: 8px/1.35 ui-monospace, "SFMono-Regular", Menlo, monospace;
+}
+
 .evidence-link:hover,
-.evidence-link:focus-visible,
-.evidence-back:hover,
-.evidence-back:focus-visible {
+.evidence-link:focus-visible {
   border-color: var(--detail-accent, var(--root));
   background: rgba(255, 255, 255, 0.075);
   color: var(--text);
   outline: none;
 }
 
-.evidence-back {
-  margin: 0 0 12px;
-  padding: 7px 9px;
-  font: 8px/1.3 -apple-system, BlinkMacSystemFont, "SF Pro Display", sans-serif;
-  font-weight: 700;
-  letter-spacing: 0.04em;
+.evidence-technical {
+  border-top: 1px solid rgba(255, 255, 255, 0.055);
+  color: var(--dim);
+}
+
+.evidence-technical summary {
+  padding: 6px 9px;
+  cursor: pointer;
+  font: 7px/1.3 -apple-system, BlinkMacSystemFont, "SF Pro Display", sans-serif;
+  letter-spacing: 0.08em;
+  list-style-position: inside;
+  text-transform: uppercase;
+}
+
+.evidence-technical div {
+  padding: 0 9px 8px;
+  color: #777181;
+  font: 8px/1.5 ui-monospace, "SFMono-Regular", Menlo, monospace;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
 }
 
 .evidence-summary,

--- a/resources/model_assets/viewer.js
+++ b/resources/model_assets/viewer.js
@@ -97,6 +97,9 @@ let pointerDown = null;
 let hoverPointer = null;
 let hoverDirty = false;
 let selected = null;
+let selectedItem = null;
+let detailMode = "node";
+let evidenceRequest = 0;
 let portraitMode = null;
 let labels = [];
 let pickables = [];
@@ -783,7 +786,10 @@ function syncSelectionState() {
 }
 
 function clearSelection() {
+  evidenceRequest += 1;
   selected = null;
+  selectedItem = null;
+  detailMode = "node";
   detailEl.hidden = true;
   delete detailEl.dataset.kind;
   syncSelectionState();
@@ -829,15 +835,151 @@ function receiptValues(item) {
   return [...new Set(values)];
 }
 
+function evidenceButton(reference, label = reference, relation = "") {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "evidence-link";
+  const relationEl = document.createElement("span");
+  relationEl.textContent = relation ? relation.replaceAll("_", " ") : "Evidence";
+  const labelEl = document.createElement("b");
+  labelEl.textContent = label || reference;
+  button.append(relationEl, labelEl);
+  button.addEventListener("click", () => loadEvidence(reference));
+  return button;
+}
+
+function appendEvidenceGroup(title, links, note = "") {
+  if (!links?.length) return;
+  const heading = document.createElement("strong");
+  heading.textContent = title;
+  detailReceiptsEl.appendChild(heading);
+  if (note) {
+    const copy = document.createElement("p");
+    copy.className = "evidence-note";
+    copy.textContent = note;
+    detailReceiptsEl.appendChild(copy);
+  }
+  links.forEach((link) => {
+    const label = link.label || link.reference || link.id;
+    detailReceiptsEl.appendChild(
+      evidenceButton(link.reference || link.id, label, link.relation),
+    );
+  });
+}
+
+function renderEvidence(data) {
+  detailReceiptsEl.replaceChildren();
+  const back = document.createElement("button");
+  back.type = "button";
+  back.className = "evidence-back";
+  back.textContent = "← Back to node evidence";
+  back.addEventListener("click", () => {
+    if (selected && selectedItem) renderNodeEvidence(selected.kind, selectedItem);
+  });
+  detailReceiptsEl.appendChild(back);
+
+  const heading = document.createElement("strong");
+  heading.textContent = `${data.kind || "unknown"} · ${data.status || "unknown"}`;
+  detailReceiptsEl.appendChild(heading);
+  if (data.summary) {
+    const summary = document.createElement("p");
+    summary.className = "evidence-summary";
+    summary.textContent = data.summary;
+    detailReceiptsEl.appendChild(summary);
+  }
+  const facts = [
+    data.timestamp ? `Time: ${data.timestamp}` : "",
+    data.path ? `Path: ${data.path}` : "",
+    data.canonical_reference ? `Receipt: ${data.canonical_reference}` : "",
+  ].filter(Boolean);
+  facts.forEach((fact) => {
+    const row = document.createElement("div");
+    row.className = "evidence-fact";
+    row.textContent = fact;
+    detailReceiptsEl.appendChild(row);
+  });
+  appendEvidenceGroup("Direct sources", data.sources);
+  appendEvidenceGroup(
+    "Nearby context",
+    data.context,
+    "These captures are close in time. They are investigation clues, not claimed direct proof.",
+  );
+  if (data.status === "missing") {
+    const missing = document.createElement("p");
+    missing.className = "evidence-note evidence-missing";
+    missing.textContent = "The receipt is retained, but its local payload was not found or has expired.";
+    detailReceiptsEl.appendChild(missing);
+  }
+}
+
+async function loadEvidence(reference) {
+  if (!selected || !reference) return;
+  detailMode = "evidence";
+  const request = ++evidenceRequest;
+  detailReceiptsEl.replaceChildren();
+  const loading = document.createElement("div");
+  loading.className = "evidence-loading";
+  loading.textContent = "Resolving evidence…";
+  detailReceiptsEl.appendChild(loading);
+  try {
+    const response = await fetch(`./evidence?ref=${encodeURIComponent(reference)}`, {
+      cache: "no-store",
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const data = await response.json();
+    if (!selected || request !== evidenceRequest || detailMode !== "evidence") return;
+    renderEvidence(data);
+  } catch (error) {
+    if (!selected || request !== evidenceRequest || detailMode !== "evidence") return;
+    detailReceiptsEl.replaceChildren();
+    const message = document.createElement("p");
+    message.className = "evidence-note evidence-missing";
+    message.textContent = `Unable to resolve evidence. ${error.message || error}`;
+    detailReceiptsEl.appendChild(message);
+  }
+}
+
+function renderNodeEvidence(kind, item) {
+  detailMode = "node";
+  evidenceRequest += 1;
+  detailReceiptsEl.replaceChildren();
+
+  const receipts = receiptValues(item);
+  if (receipts.length) {
+    const heading = document.createElement("strong");
+    heading.textContent = "Evidence receipts";
+    detailReceiptsEl.appendChild(heading);
+    receipts.slice(0, 12).forEach((receipt) => {
+      detailReceiptsEl.appendChild(evidenceButton(receipt, receipt, "direct_evidence"));
+    });
+  }
+
+  if (kind === "point") {
+    fetch(`./node?id=${encodeURIComponent(item.id)}`)
+      .then((response) => response.ok ? response.json() : null)
+      .then((data) => {
+        if (!data || !selected || detailMode !== "node"
+          || selected.kind !== kind || selected.id !== item.id) return;
+        (data.raw || []).slice(0, 3).forEach((raw) => {
+          const row = document.createElement("div");
+          row.className = "evidence-preview";
+          row.textContent = `${raw.ts ? `${String(raw.ts).slice(0, 16)}  ` : ""}${raw.text || ""}`;
+          detailReceiptsEl.appendChild(row);
+        });
+      })
+      .catch(() => {});
+  }
+}
+
 function showDetails(kind, item) {
   selected = { kind, id: item.id };
+  selectedItem = item;
   pauseAutoRotate();
   syncSelectionState();
   detailEl.dataset.kind = kind;
   detailKindEl.textContent = kind;
   detailTitleEl.textContent = item.content || item.signature || item.label || item.id;
   detailMetaEl.replaceChildren();
-  detailReceiptsEl.replaceChildren();
   appendMeta("ID", item.id);
   appendMeta("Layer", item.layer || item.level);
   appendMeta("Status", item.status);
@@ -846,33 +988,8 @@ function showDetails(kind, item) {
   appendMeta("Observations", item.observations);
   appendMeta("Valid from", item.valid_from);
   appendMeta("Members", item.members?.length);
-
-  const receipts = receiptValues(item);
-  if (receipts.length) {
-    const heading = document.createElement("strong");
-    heading.textContent = "Receipts";
-    detailReceiptsEl.appendChild(heading);
-    receipts.slice(0, 12).forEach((receipt) => {
-      const row = document.createElement("div");
-      row.textContent = receipt;
-      detailReceiptsEl.appendChild(row);
-    });
-  }
+  renderNodeEvidence(kind, item);
   detailEl.hidden = false;
-
-  if (kind === "point") {
-    fetch(`./node?id=${encodeURIComponent(item.id)}`)
-      .then((response) => response.ok ? response.json() : null)
-      .then((data) => {
-        if (!data || !selected || selected.kind !== kind || selected.id !== item.id) return;
-        (data.raw || []).slice(0, 3).forEach((raw) => {
-          const row = document.createElement("div");
-          row.textContent = `${raw.ts ? `${String(raw.ts).slice(0, 16)}  ` : ""}${raw.text || ""}`;
-          detailReceiptsEl.appendChild(row);
-        });
-      })
-      .catch(() => {});
-  }
 }
 
 function updateTimelineBounds() {

--- a/resources/model_assets/viewer.js
+++ b/resources/model_assets/viewer.js
@@ -3,6 +3,13 @@ import { OrbitControls } from "three/addons/controls/OrbitControls.js";
 import { CSS2DObject, CSS2DRenderer } from "three/addons/renderers/CSS2DRenderer.js";
 import { computeClusterLayout, zoomMath } from "./layout.mjs";
 import {
+  evidenceBreadcrumb,
+  evidenceOverview,
+  nodeEvidenceCards,
+  nodeHistoryCards,
+  relationLabel,
+} from "./evidence.mjs";
+import {
   SHARE_CARD_HEIGHT,
   SHARE_CARD_WIDTH,
   SHARE_FILE_NAME,
@@ -26,8 +33,13 @@ const statusEl = document.getElementById("status");
 const detailEl = document.getElementById("detail");
 const detailKindEl = document.getElementById("detail-kind");
 const detailTitleEl = document.getElementById("detail-title");
+const detailSummaryEl = document.getElementById("detail-summary");
 const detailMetaEl = document.getElementById("detail-meta");
 const detailReceiptsEl = document.getElementById("detail-receipts");
+const detailHistoryEl = document.getElementById("detail-history-list");
+const evidenceBreadcrumbsEl = document.getElementById("evidence-breadcrumbs");
+const detailTabEls = [...document.querySelectorAll("[data-detail-tab]")];
+const detailPanelEls = [...document.querySelectorAll(".detail-panel")];
 const emptyEl = document.getElementById("empty");
 const errorEl = document.getElementById("error");
 const modelIdentityEl = document.getElementById("model-identity");
@@ -99,6 +111,7 @@ let hoverDirty = false;
 let selected = null;
 let selectedItem = null;
 let detailMode = "node";
+let evidenceTrail = [];
 let evidenceRequest = 0;
 let portraitMode = null;
 let labels = [];
@@ -790,6 +803,7 @@ function clearSelection() {
   selected = null;
   selectedItem = null;
   detailMode = "node";
+  evidenceTrail = [];
   detailEl.hidden = true;
   delete detailEl.dataset.kind;
   syncSelectionState();
@@ -825,27 +839,59 @@ function appendMeta(label, value) {
   detailMetaEl.appendChild(row);
 }
 
-function receiptValues(item) {
-  const values = [
-    item.receipt,
-    item.source_evidence?.receipt,
-    ...(item.member_receipts || []),
-    ...(item.source_receipts || []),
-  ].filter(Boolean);
-  return [...new Set(values)];
+function setDetailTab(tab, focus = false) {
+  detailTabEls.forEach((button) => {
+    const active = button.dataset.detailTab === tab;
+    button.setAttribute("aria-selected", String(active));
+    button.tabIndex = active ? 0 : -1;
+    if (active && focus) button.focus();
+  });
+  detailPanelEls.forEach((panel) => {
+    panel.hidden = panel.id !== `detail-${tab}`;
+  });
 }
 
-function evidenceButton(reference, label = reference, relation = "") {
+function technicalDetails(link) {
+  const details = document.createElement("details");
+  details.className = "evidence-technical";
+  const summary = document.createElement("summary");
+  summary.textContent = "Technical details";
+  const values = [
+    link.id ? `ID: ${link.id}` : "",
+    link.reference ? `Receipt: ${link.reference}` : "",
+  ].filter(Boolean);
+  const body = document.createElement("div");
+  body.textContent = values.join("\n");
+  details.append(summary, body);
+  return details;
+}
+
+function evidenceCard(link, { drill = true } = {}) {
+  const card = document.createElement("article");
+  card.className = "evidence-card";
   const button = document.createElement("button");
   button.type = "button";
   button.className = "evidence-link";
   const relationEl = document.createElement("span");
-  relationEl.textContent = relation ? relation.replaceAll("_", " ") : "Evidence";
+  relationEl.textContent = relationLabel(link.relation);
   const labelEl = document.createElement("b");
-  labelEl.textContent = label || reference;
+  labelEl.textContent = link.label || "Recorded evidence";
   button.append(relationEl, labelEl);
-  button.addEventListener("click", () => loadEvidence(reference));
-  return button;
+  if (link.timestamp || link.status) {
+    const meta = document.createElement("small");
+    meta.textContent = [link.status, link.timestamp].filter(Boolean).join(" · ");
+    button.appendChild(meta);
+  }
+  if (drill && (link.reference || link.id)) {
+    button.addEventListener("click", () => {
+      setDetailTab("evidence");
+      loadEvidence(link.reference || link.id);
+    });
+  } else {
+    button.disabled = true;
+  }
+  card.append(button, technicalDetails(link));
+  return card;
 }
 
 function appendEvidenceGroup(title, links, note = "") {
@@ -860,26 +906,44 @@ function appendEvidenceGroup(title, links, note = "") {
     detailReceiptsEl.appendChild(copy);
   }
   links.forEach((link) => {
-    const label = link.label || link.reference || link.id;
-    detailReceiptsEl.appendChild(
-      evidenceButton(link.reference || link.id, label, link.relation),
-    );
+    detailReceiptsEl.appendChild(evidenceCard(link));
+  });
+}
+
+function renderBreadcrumbs() {
+  evidenceBreadcrumbsEl.replaceChildren();
+  evidenceTrail.forEach((crumb, index) => {
+    if (index) {
+      const separator = document.createElement("span");
+      separator.textContent = "/";
+      separator.setAttribute("aria-hidden", "true");
+      evidenceBreadcrumbsEl.appendChild(separator);
+    }
+    if (index === evidenceTrail.length - 1) {
+      const current = document.createElement("strong");
+      current.textContent = crumb.label;
+      current.setAttribute("aria-current", "page");
+      evidenceBreadcrumbsEl.appendChild(current);
+      return;
+    }
+    const button = document.createElement("button");
+    button.type = "button";
+    button.textContent = crumb.label;
+    button.addEventListener("click", () => {
+      evidenceTrail = evidenceTrail.slice(0, index + 1);
+      if (crumb.data) renderEvidence(crumb.data);
+      else renderNodeEvidence(selected.kind, selectedItem);
+    });
+    evidenceBreadcrumbsEl.appendChild(button);
   });
 }
 
 function renderEvidence(data) {
   detailReceiptsEl.replaceChildren();
-  const back = document.createElement("button");
-  back.type = "button";
-  back.className = "evidence-back";
-  back.textContent = "← Back to node evidence";
-  back.addEventListener("click", () => {
-    if (selected && selectedItem) renderNodeEvidence(selected.kind, selectedItem);
-  });
-  detailReceiptsEl.appendChild(back);
+  renderBreadcrumbs();
 
   const heading = document.createElement("strong");
-  heading.textContent = `${data.kind || "unknown"} · ${data.status || "unknown"}`;
+  heading.textContent = evidenceBreadcrumb(data);
   detailReceiptsEl.appendChild(heading);
   if (data.summary) {
     const summary = document.createElement("p");
@@ -888,9 +952,9 @@ function renderEvidence(data) {
     detailReceiptsEl.appendChild(summary);
   }
   const facts = [
+    data.kind ? `Kind: ${data.kind}` : "",
+    data.status ? `Status: ${data.status}` : "",
     data.timestamp ? `Time: ${data.timestamp}` : "",
-    data.path ? `Path: ${data.path}` : "",
-    data.canonical_reference ? `Receipt: ${data.canonical_reference}` : "",
   ].filter(Boolean);
   facts.forEach((fact) => {
     const row = document.createElement("div");
@@ -899,6 +963,7 @@ function renderEvidence(data) {
     detailReceiptsEl.appendChild(row);
   });
   appendEvidenceGroup("Direct sources", data.sources);
+  appendEvidenceGroup("Version history", data.history);
   appendEvidenceGroup(
     "Nearby context",
     data.context,
@@ -910,6 +975,15 @@ function renderEvidence(data) {
     missing.textContent = "The receipt is retained, but its local payload was not found or has expired.";
     detailReceiptsEl.appendChild(missing);
   }
+  const technical = technicalDetails({
+    id: data.id,
+    reference: data.canonical_reference || data.reference,
+  });
+  if (data.path) {
+    const body = technical.querySelector("div");
+    body.textContent += `${body.textContent ? "\n" : ""}Path: ${data.path}`;
+  }
+  detailReceiptsEl.appendChild(technical);
 }
 
 async function loadEvidence(reference) {
@@ -928,10 +1002,12 @@ async function loadEvidence(reference) {
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
     const data = await response.json();
     if (!selected || request !== evidenceRequest || detailMode !== "evidence") return;
+    evidenceTrail.push({ label: evidenceBreadcrumb(data), data });
     renderEvidence(data);
   } catch (error) {
     if (!selected || request !== evidenceRequest || detailMode !== "evidence") return;
     detailReceiptsEl.replaceChildren();
+    renderBreadcrumbs();
     const message = document.createElement("p");
     message.className = "evidence-note evidence-missing";
     message.textContent = `Unable to resolve evidence. ${error.message || error}`;
@@ -943,15 +1019,21 @@ function renderNodeEvidence(kind, item) {
   detailMode = "node";
   evidenceRequest += 1;
   detailReceiptsEl.replaceChildren();
+  renderBreadcrumbs();
 
-  const receipts = receiptValues(item);
-  if (receipts.length) {
+  const cards = nodeEvidenceCards(item, model);
+  if (cards.length) {
     const heading = document.createElement("strong");
-    heading.textContent = "Evidence receipts";
+    heading.textContent = "Direct evidence";
     detailReceiptsEl.appendChild(heading);
-    receipts.slice(0, 12).forEach((receipt) => {
-      detailReceiptsEl.appendChild(evidenceButton(receipt, receipt, "direct_evidence"));
+    cards.slice(0, 12).forEach((card) => {
+      detailReceiptsEl.appendChild(evidenceCard(card));
     });
+  } else {
+    const empty = document.createElement("p");
+    empty.className = "evidence-note";
+    empty.textContent = "No direct evidence receipts are attached to this object.";
+    detailReceiptsEl.appendChild(empty);
   }
 
   if (kind === "point") {
@@ -971,6 +1053,35 @@ function renderNodeEvidence(kind, item) {
   }
 }
 
+function renderOverview(kind, item) {
+  detailSummaryEl.replaceChildren();
+  const overview = evidenceOverview(kind, item, model);
+  const heading = document.createElement("strong");
+  heading.textContent = overview.title;
+  const copy = document.createElement("p");
+  copy.textContent = overview.copy;
+  detailSummaryEl.append(heading, copy);
+  overview.highlights.forEach((card) => {
+    detailSummaryEl.appendChild(evidenceCard(card));
+  });
+}
+
+function renderNodeHistory(item) {
+  detailHistoryEl.replaceChildren();
+  const history = nodeHistoryCards(item, model);
+  if (!history.length) {
+    const empty = document.createElement("p");
+    empty.className = "evidence-note";
+    empty.textContent = "No previous or next version is recorded for this object.";
+    detailHistoryEl.appendChild(empty);
+    return;
+  }
+  const heading = document.createElement("strong");
+  heading.textContent = "Version trail";
+  detailHistoryEl.appendChild(heading);
+  history.forEach((link) => detailHistoryEl.appendChild(evidenceCard(link)));
+}
+
 function showDetails(kind, item) {
   selected = { kind, id: item.id };
   selectedItem = item;
@@ -979,8 +1090,8 @@ function showDetails(kind, item) {
   detailEl.dataset.kind = kind;
   detailKindEl.textContent = kind;
   detailTitleEl.textContent = item.content || item.signature || item.label || item.id;
+  evidenceTrail = [{ label: detailTitleEl.textContent, data: null }];
   detailMetaEl.replaceChildren();
-  appendMeta("ID", item.id);
   appendMeta("Layer", item.layer || item.level);
   appendMeta("Status", item.status);
   appendMeta("Predicate", item.label || item.predicate);
@@ -988,7 +1099,10 @@ function showDetails(kind, item) {
   appendMeta("Observations", item.observations);
   appendMeta("Valid from", item.valid_from);
   appendMeta("Members", item.members?.length);
+  renderOverview(kind, item);
   renderNodeEvidence(kind, item);
+  renderNodeHistory(item);
+  setDetailTab("overview");
   detailEl.hidden = false;
 }
 
@@ -1235,6 +1349,17 @@ document.querySelectorAll("[data-layer]").forEach((button) => {
     layerVisible[layer] = !layerVisible[layer];
     applyLayerVisibility();
     if (window.__persomeViewerState) window.__persomeViewerState.layers = { ...layerVisible };
+  });
+});
+
+detailTabEls.forEach((button, index) => {
+  button.addEventListener("click", () => setDetailTab(button.dataset.detailTab));
+  button.addEventListener("keydown", (event) => {
+    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+    event.preventDefault();
+    const direction = event.key === "ArrowRight" ? 1 : -1;
+    const next = (index + direction + detailTabEls.length) % detailTabEls.length;
+    setDetailTab(detailTabEls[next].dataset.detailTab, true);
   });
 });
 

--- a/src/persome/api/model_view.py
+++ b/src/persome/api/model_view.py
@@ -80,8 +80,22 @@ _MEMORY_VIEW_TEMPLATE = """<!doctype html>
       <button id="close-detail" class="icon-button close" type="button" aria-label="Close details" title="Close details">×</button>
       <p class="detail-eyebrow"><span id="detail-kind" class="detail-kind"></span><span>Evidence-backed</span></p>
       <h1 id="detail-title"></h1>
-      <div id="detail-meta" class="detail-meta"></div>
-      <div id="detail-receipts" class="detail-receipts"></div>
+      <nav id="detail-tabs" class="detail-tabs" role="tablist" aria-label="Detail views">
+        <button id="detail-tab-overview" type="button" role="tab" data-detail-tab="overview" aria-controls="detail-overview" aria-selected="true">Overview</button>
+        <button id="detail-tab-evidence" type="button" role="tab" data-detail-tab="evidence" aria-controls="detail-evidence" aria-selected="false" tabindex="-1">Evidence</button>
+        <button id="detail-tab-history" type="button" role="tab" data-detail-tab="history" aria-controls="detail-history" aria-selected="false" tabindex="-1">History</button>
+      </nav>
+      <section id="detail-overview" class="detail-panel" role="tabpanel" aria-labelledby="detail-tab-overview">
+        <div id="detail-summary" class="detail-summary"></div>
+        <div id="detail-meta" class="detail-meta"></div>
+      </section>
+      <section id="detail-evidence" class="detail-panel" role="tabpanel" aria-labelledby="detail-tab-evidence" hidden>
+        <nav id="evidence-breadcrumbs" class="evidence-breadcrumbs" aria-label="Evidence drill-down"></nav>
+        <div id="detail-receipts" class="detail-receipts"></div>
+      </section>
+      <section id="detail-history" class="detail-panel" role="tabpanel" aria-labelledby="detail-tab-history" hidden>
+        <div id="detail-history-list" class="detail-receipts"></div>
+      </section>
     </aside>
 
     <div id="empty" class="empty" hidden>

--- a/src/persome/api/routes.py
+++ b/src/persome/api/routes.py
@@ -470,6 +470,24 @@ def model_graph() -> dict[str, Any]:
     }
 
 
+@router.get("/model/evidence", tags=["model"])
+def model_evidence(
+    ref: str = Query(..., min_length=1, max_length=1024),
+) -> dict[str, Any]:
+    """Resolve one model receipt or object id into its evidence and nearby context.
+
+    Explicit stored lineage is returned in ``sources``. Time-adjacent captures
+    are returned separately in ``context`` and are never presented as direct
+    provenance. Unknown or expired references fail open with ``status=missing``
+    so a historical receipt remains inspectable even after raw retention ends.
+    """
+    from ..evidence import resolve_evidence
+    from ..store import fts as fts_store
+
+    with fts_store.cursor() as conn:
+        return resolve_evidence(conn, ref)
+
+
 @router.get("/model/node", tags=["model"])
 def model_node(
     id: str = Query(..., min_length=1, max_length=512),

--- a/src/persome/api/routes.py
+++ b/src/persome/api/routes.py
@@ -423,6 +423,7 @@ def model_view(request: Request) -> HTMLResponse:
 
 
 _MODEL_ASSETS = {
+    "evidence.mjs",
     "three.module.js",
     "layout.mjs",
     "share.mjs",
@@ -478,8 +479,10 @@ def model_evidence(
 
     Explicit stored lineage is returned in ``sources``. Time-adjacent captures
     are returned separately in ``context`` and are never presented as direct
-    provenance. Unknown or expired references fail open with ``status=missing``
-    so a historical receipt remains inspectable even after raw retention ends.
+    provenance. ``label`` is the human-readable display title; Point version
+    links are returned separately in ``history``. Unknown or expired references
+    fail open with ``status=missing`` so a historical receipt remains inspectable
+    even after raw retention ends.
     """
     from ..evidence import resolve_evidence
     from ..store import fts as fts_store

--- a/src/persome/evidence.py
+++ b/src/persome/evidence.py
@@ -1,0 +1,488 @@
+"""Unified, read-only evidence resolution for MCP and the local model viewer.
+
+Receipts are stable pointers, not embedded payloads.  This module resolves the
+pointer formats already emitted by memory, evomem, activities, and model
+snapshots into one small response contract.  It deliberately labels
+time-adjacent captures as context rather than claiming they are direct sources.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+_SUMMARY_LIMIT = 4_000
+_NEARBY_CAPTURE_LIMIT = 3
+_NEARBY_CAPTURE_SECONDS = 30 * 60
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    return (
+        conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'view') AND name=?",
+            (table,),
+        ).fetchone()
+        is not None
+    )
+
+
+def _json_list(value: Any) -> list[str]:
+    if not value:
+        return []
+    try:
+        parsed = json.loads(value) if isinstance(value, str) else value
+    except (TypeError, ValueError):
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [str(item) for item in parsed if item is not None and str(item).strip()]
+
+
+def _trim(value: Any, limit: int = _SUMMARY_LIMIT) -> str:
+    return str(value or "").strip()[:limit]
+
+
+def parse_reference(reference: str) -> tuple[str, str | None, str | None]:
+    """Return ``(identifier, path_hint, canonical_receipt)``.
+
+    Receipt identifiers can themselves contain colons, so the path separator
+    is the final colon inside ``⟨identifier:path⟩``.
+    """
+    value = str(reference or "").strip()
+    if value.startswith("⟨") and value.endswith("⟩"):
+        inner = value[1:-1]
+        identifier, separator, path_hint = inner.rpartition(":")
+        if separator and identifier.strip() and path_hint.strip():
+            return identifier.strip(), path_hint.strip(), value
+    return value, None, None
+
+
+def _link(
+    *,
+    relation: str,
+    kind: str,
+    identifier: str,
+    reference: str | None = None,
+    label: str = "",
+    timestamp: str | None = None,
+    status: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "relation": relation,
+        "kind": kind,
+        "id": identifier,
+        "reference": reference or identifier,
+        "label": label,
+        "timestamp": timestamp,
+        "status": status,
+        "resolvable": True,
+    }
+
+
+def _base(
+    *,
+    reference: str,
+    canonical_reference: str,
+    kind: str,
+    identifier: str,
+    status: str,
+    summary: str = "",
+    timestamp: str | None = None,
+    path: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    sources: list[dict[str, Any]] | None = None,
+    context: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "reference": reference,
+        "canonical_reference": canonical_reference,
+        "kind": kind,
+        "id": identifier,
+        "status": status,
+        "summary": summary,
+        "timestamp": timestamp,
+        "path": path,
+        "metadata": metadata or {},
+        "sources": sources or [],
+        "context": context or [],
+    }
+
+
+def _nearby_capture_links(
+    conn: sqlite3.Connection, timestamp: str | None
+) -> list[dict[str, Any]]:
+    if not timestamp or not _table_exists(conn, "captures"):
+        return []
+    try:
+        rows = conn.execute(
+            "SELECT id, timestamp, app_name, window_title FROM captures"
+            " WHERE abs(persome_epoch(timestamp) - persome_epoch(?)) <= ?"
+            " ORDER BY abs(persome_epoch(timestamp) - persome_epoch(?)) LIMIT ?",
+            (timestamp, _NEARBY_CAPTURE_SECONDS, timestamp, _NEARBY_CAPTURE_LIMIT),
+        ).fetchall()
+    except sqlite3.Error:
+        return []
+    return [
+        _link(
+            relation="nearby_context",
+            kind="capture",
+            identifier=str(row[0]),
+            label=" · ".join(part for part in (str(row[2] or ""), str(row[3] or "")) if part),
+            timestamp=str(row[1]) if row[1] else None,
+        )
+        for row in rows
+    ]
+
+
+def _resolve_entry(
+    conn: sqlite3.Connection,
+    *,
+    original: str,
+    identifier: str,
+    receipt: str | None,
+) -> dict[str, Any] | None:
+    if not _table_exists(conn, "entries"):
+        return None
+    try:
+        row = conn.execute(
+            "SELECT id, path, timestamp, tags, content, superseded FROM entries WHERE id=?",
+            (identifier,),
+        ).fetchone()
+    except sqlite3.Error:
+        return None
+    if row is None:
+        return None
+
+    metadata: dict[str, Any] = {
+        "tags": str(row[3] or "").split(),
+        "superseded": bool(row[5]),
+    }
+    if _table_exists(conn, "entry_metadata"):
+        meta = conn.execute(
+            "SELECT confidence, conflicted, occurred_at FROM entry_metadata WHERE entry_id=?",
+            (identifier,),
+        ).fetchone()
+        if meta is not None:
+            metadata.update(
+                confidence=meta[0],
+                conflicted=bool(meta[1]),
+                occurred_at=meta[2],
+            )
+    if _table_exists(conn, "entry_temporal"):
+        temporal = conn.execute(
+            "SELECT valid_from, valid_until FROM entry_temporal WHERE entry_id=?",
+            (identifier,),
+        ).fetchone()
+        if temporal is not None:
+            metadata.update(valid_from=temporal[0], valid_until=temporal[1])
+
+    path = str(row[1] or "")
+    canonical = receipt or f"⟨{identifier}:{path}⟩"
+    timestamp = str(row[2]) if row[2] else None
+    return _base(
+        reference=original,
+        canonical_reference=canonical,
+        kind="memory",
+        identifier=identifier,
+        status="superseded" if row[5] else "active",
+        summary=_trim(row[4]),
+        timestamp=timestamp,
+        path=path,
+        metadata=metadata,
+        context=_nearby_capture_links(conn, timestamp),
+    )
+
+
+def _evo_receipt(conn: sqlite3.Connection, node_id: str) -> str:
+    row = conn.execute(
+        "SELECT file_name FROM evo_nodes WHERE node_id=? ORDER BY is_latest DESC LIMIT 1",
+        (node_id,),
+    ).fetchone()
+    return f"⟨{node_id}:{str(row[0] or '')}⟩" if row is not None else node_id
+
+
+def _resolve_evo_node(
+    conn: sqlite3.Connection,
+    *,
+    original: str,
+    identifier: str,
+    receipt: str | None,
+) -> dict[str, Any] | None:
+    if not _table_exists(conn, "evo_nodes"):
+        return None
+    try:
+        row = conn.execute(
+            "SELECT node_id, content, layer, supersedes, is_latest, status, memory_at,"
+            " gmt_created, file_name, tags, refined_from, abstracted_from, confidence,"
+            " conflicted, occurred_at, valid_from, valid_until"
+            " FROM evo_nodes WHERE node_id=? ORDER BY is_latest DESC LIMIT 1",
+            (identifier,),
+        ).fetchone()
+    except sqlite3.Error:
+        return None
+    if row is None:
+        return None
+
+    parent_ids = list(dict.fromkeys([*_json_list(row[3]), *_json_list(row[11])]))
+    if row[10] and str(row[10]) not in parent_ids:
+        parent_ids.append(str(row[10]))
+    sources = [
+        _link(
+            relation="direct_lineage",
+            kind="point",
+            identifier=parent_id,
+            reference=_evo_receipt(conn, parent_id),
+            label="Earlier evidence used to derive this point",
+        )
+        for parent_id in parent_ids
+    ]
+
+    path = str(row[8] or "")
+    canonical = receipt or f"⟨{identifier}:{path}⟩"
+    timestamp = str(row[6] or row[7]) if row[6] or row[7] else None
+    return _base(
+        reference=original,
+        canonical_reference=canonical,
+        kind="point",
+        identifier=identifier,
+        status=str(row[5] or ("active" if row[4] else "superseded")),
+        summary=_trim(row[1]),
+        timestamp=timestamp,
+        path=path,
+        metadata={
+            "layer": row[2],
+            "is_latest": bool(row[4]),
+            "tags": str(row[9] or "").split(),
+            "confidence": row[12],
+            "conflicted": bool(row[13]),
+            "occurred_at": row[14],
+            "valid_from": row[15],
+            "valid_until": row[16],
+        },
+        sources=sources,
+        context=_nearby_capture_links(conn, timestamp),
+    )
+
+
+def _resolve_capture(
+    conn: sqlite3.Connection,
+    *,
+    original: str,
+    identifier: str,
+) -> dict[str, Any] | None:
+    if not _table_exists(conn, "captures"):
+        return None
+    try:
+        row = conn.execute(
+            "SELECT id, timestamp, app_name, bundle_id, window_title, focused_role,"
+            " focused_value, visible_text, url FROM captures WHERE id=?",
+            (identifier,),
+        ).fetchone()
+    except sqlite3.Error:
+        return None
+    if row is None:
+        return None
+
+    from . import paths
+
+    buffer_available = (paths.capture_buffer_dir() / f"{identifier}.json").is_file()
+    summary = _trim(row[7] or row[6])
+    return _base(
+        reference=original,
+        canonical_reference=identifier,
+        kind="capture",
+        identifier=identifier,
+        status="available" if buffer_available else "metadata_only",
+        summary=summary,
+        timestamp=str(row[1]) if row[1] else None,
+        metadata={
+            "provenance": "observed",
+            "app_name": row[2],
+            "bundle_id": row[3],
+            "window_title": row[4],
+            "focused_role": row[5],
+            "focused_value": _trim(row[6], 1_000),
+            "url": row[8],
+            "raw_capture_available": buffer_available,
+        },
+    )
+
+
+def _resolve_activity(
+    conn: sqlite3.Connection,
+    *,
+    original: str,
+    identifier: str,
+    receipt: str | None,
+) -> dict[str, Any] | None:
+    from .model.activity_source import ActivitySource, normalize_activity_identity
+
+    normalized = normalize_activity_identity(identifier)
+    try:
+        event = next(
+            (
+                item
+                for item in ActivitySource(conn).events()
+                if item.stable_id == normalized
+                or item.source_receipt == original
+                or item.source_receipt == receipt
+            ),
+            None,
+        )
+    except sqlite3.Error:
+        return None
+    if event is None:
+        return None
+
+    sources: list[dict[str, Any]] = []
+    if event.source_kind == "entry" and event.source_receipt != original:
+        sources.append(
+            _link(
+                relation="direct_source",
+                kind="memory",
+                identifier=event.source_id,
+                reference=event.source_receipt,
+                label="Memory entry that records this activity",
+                timestamp=event.occurred_at,
+            )
+        )
+    return _base(
+        reference=original,
+        canonical_reference=receipt or event.source_receipt,
+        kind="activity",
+        identifier=event.stable_id,
+        status="historical",
+        summary=_trim(event.summary),
+        timestamp=event.occurred_at,
+        path=event.source_receipt,
+        metadata={
+            "source_kind": event.source_kind,
+            "source_id": event.source_id,
+            "participant_ids": event.participant_ids,
+        },
+        sources=sources,
+        context=_nearby_capture_links(conn, event.occurred_at),
+    )
+
+
+def _receipt_values(item: dict[str, Any]) -> list[str]:
+    values = [item.get("receipt")]
+    source_evidence = item.get("source_evidence")
+    if isinstance(source_evidence, dict):
+        values.append(source_evidence.get("receipt"))
+    values.extend(item.get("member_receipts") or [])
+    values.extend(item.get("source_receipts") or [])
+    return list(dict.fromkeys(str(value) for value in values if value))
+
+
+def _resolve_geometry(
+    conn: sqlite3.Connection,
+    *,
+    original: str,
+    identifier: str,
+) -> dict[str, Any] | None:
+    from .model.snapshot import build_snapshot
+
+    try:
+        snapshot = build_snapshot(conn, redact=False)
+    except (sqlite3.Error, RuntimeError, TypeError, ValueError):
+        # Evidence decoration must stay available even when an old or corrupt
+        # model cannot satisfy the current snapshot contract.
+        return None
+    candidates: list[tuple[str, dict[str, Any]]] = []
+    candidates.extend(("point", item) for item in snapshot["points"])
+    candidates.extend(("line", item) for item in snapshot["lines"])
+    candidates.extend(("face", item) for item in snapshot["faces"])
+    candidates.extend(("volume", item) for item in snapshot["volumes"])
+    if snapshot["root"] is not None:
+        candidates.append(("root", snapshot["root"]))
+    match = next(((kind, item) for kind, item in candidates if item.get("id") == identifier), None)
+    if match is None:
+        return None
+    kind, item = match
+    references = _receipt_values(item)
+    sources = [
+        _link(
+            relation="direct_evidence",
+            kind="receipt",
+            identifier=parse_reference(value)[0],
+            reference=value,
+            label="Evidence receipt inherited by this model object",
+        )
+        for value in references
+    ]
+    summary = item.get("content") or item.get("signature") or item.get("label") or identifier
+    timestamp = item.get("occurred_at") or item.get("valid_from") or item.get("created_at")
+    return _base(
+        reference=original,
+        canonical_reference=identifier,
+        kind=kind,
+        identifier=identifier,
+        status=str(item.get("status") or "active"),
+        summary=_trim(summary),
+        timestamp=str(timestamp) if timestamp else None,
+        metadata={
+            key: item.get(key)
+            for key in ("confidence", "observations", "provenance", "valid_from", "members")
+            if item.get(key) is not None
+        },
+        sources=sources,
+    )
+
+
+def resolve_evidence(conn: sqlite3.Connection, reference: str) -> dict[str, Any]:
+    """Resolve one receipt or object id into a progressive-disclosure node.
+
+    ``sources`` are explicit lineage already stored by Persome. ``context`` is
+    deliberately separate: it contains time-adjacent captures that may help an
+    owner investigate, but are not claimed as the inputs that produced the
+    derived object.
+    """
+    original = str(reference or "").strip()
+    identifier, path_hint, receipt = parse_reference(original)
+    if not identifier:
+        return _base(
+            reference=original,
+            canonical_reference=original,
+            kind="unknown",
+            identifier="",
+            status="missing",
+            metadata={"reason": "empty_reference"},
+        )
+
+    # A receipt path is a strong type hint. Memory and evomem receipts are
+    # checked before generic activities; bare ids use the same deterministic
+    # order and then fall through to captures/model geometry.
+    resolvers = (
+        lambda: _resolve_entry(
+            conn, original=original, identifier=identifier, receipt=receipt
+        ),
+        lambda: _resolve_evo_node(
+            conn, original=original, identifier=identifier, receipt=receipt
+        ),
+        lambda: _resolve_activity(
+            conn, original=original, identifier=identifier, receipt=receipt
+        ),
+        lambda: _resolve_capture(conn, original=original, identifier=identifier),
+        lambda: _resolve_geometry(conn, original=original, identifier=identifier),
+    )
+    for resolver in resolvers:
+        result = resolver()
+        if result is not None:
+            if path_hint and not result.get("path"):
+                result["path"] = path_hint
+            return result
+
+    return _base(
+        reference=original,
+        canonical_reference=receipt or identifier,
+        kind="unknown",
+        identifier=identifier,
+        status="missing",
+        path=path_hint,
+        metadata={
+            "reason": "source_not_found_or_retained",
+            "receipt_preserved": receipt is not None,
+        },
+    )

--- a/src/persome/evidence.py
+++ b/src/persome/evidence.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import stat
+from pathlib import Path
 from typing import Any
 
 _SUMMARY_LIMIT = 4_000
@@ -229,8 +231,9 @@ def _resolve_entry(
             metadata.update(valid_from=temporal[0], valid_until=temporal[1])
 
     path = str(row[1] or "")
-    canonical = receipt or f"⟨{identifier}:{path}⟩"
+    canonical = f"⟨{identifier}:{path}⟩" if path else receipt or identifier
     timestamp = str(row[2]) if row[2] else None
+    context_timestamp = str(metadata.get("occurred_at") or timestamp or "") or None
     return _base(
         reference=original,
         canonical_reference=canonical,
@@ -242,7 +245,7 @@ def _resolve_entry(
         timestamp=timestamp,
         path=path,
         metadata=metadata,
-        context=_nearby_capture_links(conn, timestamp),
+        context=_nearby_capture_links(conn, context_timestamp),
     )
 
 
@@ -305,8 +308,8 @@ def _resolve_evo_node(
             )
 
     path = str(row[8] or "")
-    canonical = receipt or f"⟨{identifier}:{path}⟩"
-    timestamp = str(row[6] or row[7]) if row[6] or row[7] else None
+    canonical = f"⟨{identifier}:{path}⟩" if path else receipt or identifier
+    timestamp = str(row[14] or row[6] or row[7]) if row[14] or row[6] or row[7] else None
     return _base(
         reference=original,
         canonical_reference=canonical,
@@ -354,7 +357,17 @@ def _resolve_capture(
 
     from . import paths
 
-    buffer_available = (paths.capture_buffer_dir() / f"{identifier}.json").is_file()
+    # Capture IDs are file stems.  Even if an imported/corrupt database contains
+    # a hostile absolute or nested ID, evidence lookup must not turn it into an
+    # existence probe outside the capture buffer.
+    capture_name = f"{identifier}.json"
+    buffer_available = False
+    if Path(capture_name).name == capture_name:
+        try:
+            retained = (paths.capture_buffer_dir() / capture_name).lstat()
+            buffer_available = stat.S_ISREG(retained.st_mode) and retained.st_nlink == 1
+        except OSError:
+            pass
     summary = _trim(row[7] or row[6])
     return _base(
         reference=original,
@@ -388,20 +401,17 @@ def _resolve_activity(
     identifier: str,
     receipt: str | None,
 ) -> dict[str, Any] | None:
-    from .model.activity_source import ActivitySource, normalize_activity_identity
+    from .model.activity_source import ActivitySource, is_activity_identity
 
-    normalized = normalize_activity_identity(identifier)
+    _receipt_id, path_hint, _canonical = parse_reference(original)
+    if is_activity_identity(identifier):
+        activity_identity = identifier
+    elif path_hint in {"sessions", "intents"}:
+        activity_identity = f"event:{path_hint.removesuffix('s')}:{identifier}"
+    else:
+        return None
     try:
-        event = next(
-            (
-                item
-                for item in ActivitySource(conn).events()
-                if item.stable_id == normalized
-                or item.source_receipt == original
-                or item.source_receipt == receipt
-            ),
-            None,
-        )
+        event = ActivitySource(conn).event(activity_identity)
     except sqlite3.Error:
         return None
     if event is None:
@@ -421,7 +431,7 @@ def _resolve_activity(
         )
     return _base(
         reference=original,
-        canonical_reference=receipt or event.source_receipt,
+        canonical_reference=event.source_receipt,
         kind="activity",
         identifier=event.stable_id,
         status="historical",
@@ -449,12 +459,32 @@ def _receipt_values(item: dict[str, Any]) -> list[str]:
     return list(dict.fromkeys(str(value) for value in values if value))
 
 
+def _has_geometry_identity(conn: sqlite3.Connection, identifier: str) -> bool:
+    """Cheaply reject arbitrary IDs before building the full model snapshot."""
+    if identifier.startswith("evolution:"):
+        return True
+    for table, column in (("relation_edges", "edge_id"), ("schema_faces", "face_id")):
+        if not _table_exists(conn, table):
+            continue
+        try:
+            if conn.execute(
+                f"SELECT 1 FROM {table} WHERE {column}=? LIMIT 1", (identifier,)
+            ).fetchone():
+                return True
+        except sqlite3.Error:
+            continue
+    return False
+
+
 def _resolve_geometry(
     conn: sqlite3.Connection,
     *,
     original: str,
     identifier: str,
 ) -> dict[str, Any] | None:
+    if not _has_geometry_identity(conn, identifier):
+        return None
+
     from .model.snapshot import build_snapshot
 
     try:

--- a/src/persome/evidence.py
+++ b/src/persome/evidence.py
@@ -475,13 +475,21 @@ def _resolve_geometry(
         return None
     kind, item = match
     references = _receipt_values(item)
+    point_labels = {
+        str(point["receipt"]): _short_label(
+            point.get("content"),
+            _humanize_path(str(point.get("file_name") or "")) or str(point.get("id") or "Point"),
+        )
+        for point in snapshot["points"]
+        if point.get("receipt")
+    }
     sources = [
         _link(
             relation="direct_evidence",
             kind="receipt",
             identifier=parse_reference(value)[0],
             reference=value,
-            label=_reference_label(conn, value),
+            label=point_labels.get(value) or _reference_label(conn, value),
         )
         for value in references
     ]

--- a/src/persome/evidence.py
+++ b/src/persome/evidence.py
@@ -109,9 +109,7 @@ def _base(
     }
 
 
-def _nearby_capture_links(
-    conn: sqlite3.Connection, timestamp: str | None
-) -> list[dict[str, Any]]:
+def _nearby_capture_links(conn: sqlite3.Connection, timestamp: str | None) -> list[dict[str, Any]]:
     if not timestamp or not _table_exists(conn, "captures"):
         return []
     try:
@@ -455,15 +453,9 @@ def resolve_evidence(conn: sqlite3.Connection, reference: str) -> dict[str, Any]
     # checked before generic activities; bare ids use the same deterministic
     # order and then fall through to captures/model geometry.
     resolvers = (
-        lambda: _resolve_entry(
-            conn, original=original, identifier=identifier, receipt=receipt
-        ),
-        lambda: _resolve_evo_node(
-            conn, original=original, identifier=identifier, receipt=receipt
-        ),
-        lambda: _resolve_activity(
-            conn, original=original, identifier=identifier, receipt=receipt
-        ),
+        lambda: _resolve_entry(conn, original=original, identifier=identifier, receipt=receipt),
+        lambda: _resolve_evo_node(conn, original=original, identifier=identifier, receipt=receipt),
+        lambda: _resolve_activity(conn, original=original, identifier=identifier, receipt=receipt),
         lambda: _resolve_capture(conn, original=original, identifier=identifier),
         lambda: _resolve_geometry(conn, original=original, identifier=identifier),
     )

--- a/src/persome/evidence.py
+++ b/src/persome/evidence.py
@@ -462,7 +462,22 @@ def _receipt_values(item: dict[str, Any]) -> list[str]:
 def _has_geometry_identity(conn: sqlite3.Connection, identifier: str) -> bool:
     """Cheaply reject arbitrary IDs before building the full model snapshot."""
     if identifier.startswith("evolution:"):
-        return True
+        old_id, separator, new_id = identifier.removeprefix("evolution:").rpartition(":")
+        if (
+            not separator
+            or not old_id.strip()
+            or not new_id.strip()
+            or not _table_exists(conn, "evo_nodes")
+        ):
+            return False
+        try:
+            rows = conn.execute(
+                "SELECT supersedes FROM evo_nodes WHERE node_id=? AND status != 'archived'",
+                (new_id,),
+            ).fetchall()
+        except sqlite3.Error:
+            return False
+        return any(old_id in _json_list(row[0]) for row in rows)
     for table, column in (("relation_edges", "edge_id"), ("schema_faces", "face_id")):
         if not _table_exists(conn, table):
             continue

--- a/src/persome/evidence.py
+++ b/src/persome/evidence.py
@@ -43,6 +43,16 @@ def _trim(value: Any, limit: int = _SUMMARY_LIMIT) -> str:
     return str(value or "").strip()[:limit]
 
 
+def _humanize_path(value: str | None) -> str:
+    name = str(value or "").rsplit("/", 1)[-1].removesuffix(".md").removesuffix(".json")
+    return " ".join(part.capitalize() for part in name.replace("_", "-").split("-") if part)
+
+
+def _short_label(value: Any, fallback: str, limit: int = 140) -> str:
+    text = " ".join(str(value or "").split())
+    return text[:limit] if text else fallback
+
+
 def parse_reference(reference: str) -> tuple[str, str | None, str | None]:
     """Return ``(identifier, path_hint, canonical_receipt)``.
 
@@ -87,12 +97,14 @@ def _base(
     kind: str,
     identifier: str,
     status: str,
+    label: str = "",
     summary: str = "",
     timestamp: str | None = None,
     path: str | None = None,
     metadata: dict[str, Any] | None = None,
     sources: list[dict[str, Any]] | None = None,
     context: list[dict[str, Any]] | None = None,
+    history: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     return {
         "reference": reference,
@@ -100,13 +112,54 @@ def _base(
         "kind": kind,
         "id": identifier,
         "status": status,
+        "label": label or identifier,
         "summary": summary,
         "timestamp": timestamp,
         "path": path,
         "metadata": metadata or {},
         "sources": sources or [],
         "context": context or [],
+        "history": history or [],
     }
+
+
+def _evo_reference(conn: sqlite3.Connection, node_id: str) -> tuple[str, str]:
+    try:
+        row = conn.execute(
+            "SELECT file_name, content FROM evo_nodes"
+            " WHERE node_id=? ORDER BY is_latest DESC LIMIT 1",
+            (node_id,),
+        ).fetchone()
+    except sqlite3.Error:
+        row = None
+    if row is None:
+        return node_id, node_id
+    path = str(row[0] or "")
+    label = _short_label(row[1], _humanize_path(path) or node_id)
+    return f"⟨{node_id}:{path}⟩", label
+
+
+def _reference_label(conn: sqlite3.Connection, reference: str) -> str:
+    identifier, path_hint, _receipt = parse_reference(reference)
+    if _table_exists(conn, "entries"):
+        row = conn.execute("SELECT content, path FROM entries WHERE id=?", (identifier,)).fetchone()
+        if row is not None:
+            return _short_label(row[0], _humanize_path(str(row[1] or "")) or identifier)
+    if _table_exists(conn, "evo_nodes"):
+        row = conn.execute(
+            "SELECT content, file_name FROM evo_nodes"
+            " WHERE node_id=? ORDER BY is_latest DESC LIMIT 1",
+            (identifier,),
+        ).fetchone()
+        if row is not None:
+            return _short_label(row[0], _humanize_path(str(row[1] or "")) or identifier)
+    if _table_exists(conn, "captures"):
+        row = conn.execute(
+            "SELECT app_name, window_title FROM captures WHERE id=?", (identifier,)
+        ).fetchone()
+        if row is not None:
+            return " · ".join(str(value) for value in row if value) or identifier
+    return _humanize_path(path_hint) or identifier
 
 
 def _nearby_capture_links(conn: sqlite3.Connection, timestamp: str | None) -> list[dict[str, Any]]:
@@ -184,20 +237,13 @@ def _resolve_entry(
         kind="memory",
         identifier=identifier,
         status="superseded" if row[5] else "active",
+        label=_short_label(row[4], _humanize_path(path) or identifier),
         summary=_trim(row[4]),
         timestamp=timestamp,
         path=path,
         metadata=metadata,
         context=_nearby_capture_links(conn, timestamp),
     )
-
-
-def _evo_receipt(conn: sqlite3.Connection, node_id: str) -> str:
-    row = conn.execute(
-        "SELECT file_name FROM evo_nodes WHERE node_id=? ORDER BY is_latest DESC LIMIT 1",
-        (node_id,),
-    ).fetchone()
-    return f"⟨{node_id}:{str(row[0] or '')}⟩" if row is not None else node_id
 
 
 def _resolve_evo_node(
@@ -213,7 +259,7 @@ def _resolve_evo_node(
         row = conn.execute(
             "SELECT node_id, content, layer, supersedes, is_latest, status, memory_at,"
             " gmt_created, file_name, tags, refined_from, abstracted_from, confidence,"
-            " conflicted, occurred_at, valid_from, valid_until"
+            " conflicted, occurred_at, valid_from, valid_until, superseded_by"
             " FROM evo_nodes WHERE node_id=? ORDER BY is_latest DESC LIMIT 1",
             (identifier,),
         ).fetchone()
@@ -222,19 +268,41 @@ def _resolve_evo_node(
     if row is None:
         return None
 
-    parent_ids = list(dict.fromkeys([*_json_list(row[3]), *_json_list(row[11])]))
+    # Version-chain edges belong in ``history`` below. Direct sources are only
+    # derivation inputs (abstraction/refinement), so clients do not present an
+    # earlier wording as independent proof for the current wording.
+    parent_ids = list(dict.fromkeys(_json_list(row[11])))
     if row[10] and str(row[10]) not in parent_ids:
         parent_ids.append(str(row[10]))
-    sources = [
-        _link(
-            relation="direct_lineage",
-            kind="point",
-            identifier=parent_id,
-            reference=_evo_receipt(conn, parent_id),
-            label="Earlier evidence used to derive this point",
+    sources = []
+    for parent_id in parent_ids:
+        parent_reference, parent_label = _evo_reference(conn, parent_id)
+        sources.append(
+            _link(
+                relation="direct_lineage",
+                kind="point",
+                identifier=parent_id,
+                reference=parent_reference,
+                label=parent_label,
+            )
         )
-        for parent_id in parent_ids
-    ]
+
+    history: list[dict[str, Any]] = []
+    for relation, related_ids in (
+        ("previous_version", _json_list(row[3])),
+        ("next_version", _json_list(row[17])),
+    ):
+        for related_id in related_ids:
+            related_reference, related_label = _evo_reference(conn, related_id)
+            history.append(
+                _link(
+                    relation=relation,
+                    kind="point",
+                    identifier=related_id,
+                    reference=related_reference,
+                    label=related_label,
+                )
+            )
 
     path = str(row[8] or "")
     canonical = receipt or f"⟨{identifier}:{path}⟩"
@@ -245,6 +313,7 @@ def _resolve_evo_node(
         kind="point",
         identifier=identifier,
         status=str(row[5] or ("active" if row[4] else "superseded")),
+        label=_short_label(row[1], _humanize_path(path) or identifier),
         summary=_trim(row[1]),
         timestamp=timestamp,
         path=path,
@@ -260,6 +329,7 @@ def _resolve_evo_node(
         },
         sources=sources,
         context=_nearby_capture_links(conn, timestamp),
+        history=history,
     )
 
 
@@ -292,6 +362,10 @@ def _resolve_capture(
         kind="capture",
         identifier=identifier,
         status="available" if buffer_available else "metadata_only",
+        label=(
+            " · ".join(part for part in (str(row[2] or ""), str(row[4] or "")) if part)
+            or identifier
+        ),
         summary=summary,
         timestamp=str(row[1]) if row[1] else None,
         metadata={
@@ -341,7 +415,7 @@ def _resolve_activity(
                 kind="memory",
                 identifier=event.source_id,
                 reference=event.source_receipt,
-                label="Memory entry that records this activity",
+                label=_reference_label(conn, event.source_receipt),
                 timestamp=event.occurred_at,
             )
         )
@@ -351,6 +425,7 @@ def _resolve_activity(
         kind="activity",
         identifier=event.stable_id,
         status="historical",
+        label=_short_label(event.summary, "Activity"),
         summary=_trim(event.summary),
         timestamp=event.occurred_at,
         path=event.source_receipt,
@@ -406,7 +481,7 @@ def _resolve_geometry(
             kind="receipt",
             identifier=parse_reference(value)[0],
             reference=value,
-            label="Evidence receipt inherited by this model object",
+            label=_reference_label(conn, value),
         )
         for value in references
     ]
@@ -418,6 +493,7 @@ def _resolve_geometry(
         kind=kind,
         identifier=identifier,
         status=str(item.get("status") or "active"),
+        label=_short_label(summary, kind.capitalize()),
         summary=_trim(summary),
         timestamp=str(timestamp) if timestamp else None,
         metadata={
@@ -446,6 +522,7 @@ def resolve_evidence(conn: sqlite3.Connection, reference: str) -> dict[str, Any]
             kind="unknown",
             identifier="",
             status="missing",
+            label="Unknown evidence",
             metadata={"reason": "empty_reference"},
         )
 
@@ -472,6 +549,7 @@ def resolve_evidence(conn: sqlite3.Connection, reference: str) -> dict[str, Any]
         kind="unknown",
         identifier=identifier,
         status="missing",
+        label=_humanize_path(path_hint) or identifier,
         path=path_hint,
         metadata={
             "reason": "source_not_found_or_retained",

--- a/src/persome/mcp/server.py
+++ b/src/persome/mcp/server.py
@@ -6,7 +6,7 @@ depending on `[mcp] transport`. Exposes:
 
   Compressed memory (Markdown layer):
     list_memories, read_memory, search, verify_fact, behavior_patterns,
-    get_model_snapshot, entity_graph, read_receipt, recent_activity
+    get_model_snapshot, resolve_evidence, entity_graph, read_receipt, recent_activity
   Raw captures (S1 buffer):
     current_context, search_captures, read_recent_capture
   Reference:
@@ -676,6 +676,9 @@ top-down — who they are (resident), what happened (recall), what was on screen
 - `read_receipt(entry_id)` — dereference a `⟨entry_id:path⟩` receipt (from `chains`
   or any hit id) into the full entry + nearby-capture breadcrumbs. The audit trail
   from any memory down to the on-screen moment it came from.
+- `resolve_evidence(reference)` — one resolver for model ids, Point/Line/Face/Volume/
+  Root receipts, memory entries, activities, and captures. Its `sources` are explicit
+  stored lineage; `context` is only time-adjacent and must not be described as proof.
 - `recent_activity(since?, limit?, prefix_filter?)` — newest-first feed across
   memory files. Best for "what has the user been up to" and recency disambiguation.
 - `list_memories()` / `read_memory(path, …)` — file index + whole-file reads, for
@@ -1055,6 +1058,24 @@ def build_server(
         """
         with fts.cursor() as conn:
             return json.dumps(_get_model_snapshot(conn, redact=redact), ensure_ascii=False)
+
+    @server.tool()
+    def resolve_evidence(reference: str) -> str:
+        """Resolve one receipt or model object id through Persome's evidence graph.
+
+        Use this for a Point, Line, Face, Volume, Root, memory receipt, activity,
+        or capture when the user asks "why?" or "what is this based on?". The
+        response keeps ``sources`` (explicit stored lineage) separate from
+        ``context`` (nearby captures that may help investigation but are NOT
+        claimed as direct inputs). Follow returned ``reference`` values to drill
+        down one layer at a time. A retained receipt whose payload has expired
+        returns ``status=missing`` rather than fabricating evidence.
+        """
+        from ..evidence import resolve_evidence as resolve
+
+        reference = bounded_text("reference", reference, maximum=1024)
+        with fts.cursor() as conn:
+            return json.dumps(resolve(conn, reference), ensure_ascii=False)
 
     if getattr(cfg.mcp, "read_receipt_enabled", True):
 

--- a/src/persome/mcp/server.py
+++ b/src/persome/mcp/server.py
@@ -1067,9 +1067,11 @@ def build_server(
         or capture when the user asks "why?" or "what is this based on?". The
         response keeps ``sources`` (explicit stored lineage) separate from
         ``context`` (nearby captures that may help investigation but are NOT
-        claimed as direct inputs). Follow returned ``reference`` values to drill
-        down one layer at a time. A retained receipt whose payload has expired
-        returns ``status=missing`` rather than fabricating evidence.
+        claimed as direct inputs). Display ``label`` to people, keep ``reference``
+        as the technical handle, and read Point predecessor/successor links from
+        ``history``. Follow returned references to drill down one layer at a time.
+        A retained receipt whose payload has expired returns ``status=missing``
+        rather than fabricating evidence.
         """
         from ..evidence import resolve_evidence as resolve
 

--- a/src/persome/model/activity_source.py
+++ b/src/persome/model/activity_source.py
@@ -107,6 +107,127 @@ class ActivitySource:
         finally:
             self._conn.row_factory = previous_factory
 
+    def event(self, identity: str) -> ActivityEvent | None:
+        """Return one activity by stable identity without expanding the feed.
+
+        Evidence drill-down is an exact lookup.  Rebuilding the bounded recent
+        feed for it is both incorrect for retained activities older than
+        ``limit`` and needlessly expensive because feed construction expands
+        every candidate session into timeline blocks.
+        """
+        normalized = normalize_activity_identity(identity)
+        parts = normalized.split(":", 2)
+        if len(parts) != 3 or parts[0] != "event" or parts[1] not in SOURCE_KINDS:
+            return None
+        kind, source_id = parts[1], parts[2].strip()
+        if not source_id:
+            return None
+
+        previous_factory = self._conn.row_factory
+        self._conn.row_factory = sqlite3.Row
+        try:
+            if kind == "entry":
+                try:
+                    row = self._conn.execute(
+                        "SELECT id, path, timestamp, content FROM entries "
+                        "WHERE id = ? AND prefix = 'event' LIMIT 1",
+                        (source_id,),
+                    ).fetchone()
+                except sqlite3.Error:
+                    return None
+                return self._entry_event(row) if row is not None else None
+
+            if kind == "session":
+                try:
+                    row = self._conn.execute(
+                        "SELECT id, start_time, end_time FROM sessions "
+                        "WHERE id = ? AND status != 'active' AND end_time IS NOT NULL LIMIT 1",
+                        (source_id,),
+                    ).fetchone()
+                except sqlite3.Error:
+                    return None
+                return self._session_event(row) if row is not None else None
+
+            if not self._include_legacy:
+                return None
+            placeholders = ",".join("?" * len(_DONE_INTENT_STATUSES))
+            try:
+                row = self._conn.execute(
+                    f"SELECT id, ts, kind, rationale, payload FROM intents "
+                    f"WHERE id = ? AND (status IN ({placeholders}) "
+                    "OR (status = 'resolved' AND resolution_outcome = 'done')) LIMIT 1",
+                    (source_id, *_DONE_INTENT_STATUSES),
+                ).fetchone()
+            except sqlite3.Error:
+                return None
+            return self._legacy_intent_event(row) if row is not None else None
+        finally:
+            self._conn.row_factory = previous_factory
+
+    def _entry_event(self, row: sqlite3.Row) -> ActivityEvent | None:
+        entry_id, path, timestamp, content = map(lambda value: value or "", row[:4])
+        entry_id = str(entry_id).strip()
+        summary = str(content).strip()
+        if not entry_id or not summary:
+            return None
+        return ActivityEvent(
+            stable_id=f"event:entry:{entry_id}",
+            occurred_at=str(timestamp) or None,
+            summary=summary,
+            participant_ids=self._resolve([], summary),
+            source_kind="entry",
+            source_id=entry_id,
+            source_receipt=f"⟨{entry_id}:{path}⟩",
+        )
+
+    def _session_event(self, row: sqlite3.Row) -> ActivityEvent | None:
+        session_id = str(row[0] or "").strip()
+        start = _parse_time(row[1])
+        end = _parse_time(row[2])
+        if not session_id or start is None or end is None:
+            return None
+        try:
+            blocks = timeline_store.query_range(self._conn, start, end, limit=200)
+        except sqlite3.Error:
+            blocks = []
+        summary = "\n".join(
+            entry.strip() for block in blocks for entry in block.entries if entry and entry.strip()
+        )[:2000]
+        if not summary:
+            summary = f"Session ended at {end.isoformat()}"
+        return ActivityEvent(
+            stable_id=f"event:session:{session_id}",
+            occurred_at=end.isoformat(),
+            summary=summary,
+            participant_ids=self._resolve([], summary),
+            source_kind="session",
+            source_id=session_id,
+            source_receipt=f"⟨{session_id}:sessions⟩",
+        )
+
+    def _legacy_intent_event(self, row: sqlite3.Row) -> ActivityEvent | None:
+        source_id = str(row[0] or "").strip()
+        if not source_id:
+            return None
+        try:
+            payload = json.loads(row[4] or "{}")
+        except (TypeError, ValueError):
+            payload = {}
+        if not isinstance(payload, dict):
+            payload = {}
+        raw_people = payload.get("with") or payload.get("participants") or []
+        names = [str(name) for name in raw_people] if isinstance(raw_people, list) else []
+        summary = str(row[3] or "").strip() or f"Completed {row[2] or 'activity'}"
+        return ActivityEvent(
+            stable_id=f"event:intent:{source_id}",
+            occurred_at=str(row[1]) if row[1] else None,
+            summary=summary,
+            participant_ids=self._resolve(names, summary),
+            source_kind="intent",
+            source_id=source_id,
+            source_receipt=f"⟨{source_id}:intents⟩",
+        )
+
     def _entry_events(self) -> list[ActivityEvent]:
         try:
             rows = self._conn.execute(
@@ -117,25 +238,7 @@ class ActivitySource:
             ).fetchall()
         except sqlite3.Error:
             return []
-        out: list[ActivityEvent] = []
-        for row in rows:
-            entry_id, path, timestamp, content = map(lambda value: value or "", row[:4])
-            entry_id = str(entry_id).strip()
-            summary = str(content).strip()
-            if not entry_id or not summary:
-                continue
-            out.append(
-                ActivityEvent(
-                    stable_id=f"event:entry:{entry_id}",
-                    occurred_at=str(timestamp) or None,
-                    summary=summary,
-                    participant_ids=self._resolve([], summary),
-                    source_kind="entry",
-                    source_id=entry_id,
-                    source_receipt=f"⟨{entry_id}:{path}⟩",
-                )
-            )
-        return out
+        return [event for row in rows if (event := self._entry_event(row)) is not None]
 
     def _session_events(self) -> list[ActivityEvent]:
         try:
@@ -147,37 +250,7 @@ class ActivitySource:
             ).fetchall()
         except sqlite3.Error:
             return []
-        out: list[ActivityEvent] = []
-        for row in rows:
-            session_id = str(row[0] or "").strip()
-            start = _parse_time(row[1])
-            end = _parse_time(row[2])
-            if not session_id or start is None or end is None:
-                continue
-            try:
-                blocks = timeline_store.query_range(self._conn, start, end, limit=200)
-            except sqlite3.Error:
-                blocks = []
-            summary = "\n".join(
-                entry.strip()
-                for block in blocks
-                for entry in block.entries
-                if entry and entry.strip()
-            )[:2000]
-            if not summary:
-                summary = f"Session ended at {end.isoformat()}"
-            out.append(
-                ActivityEvent(
-                    stable_id=f"event:session:{session_id}",
-                    occurred_at=end.isoformat(),
-                    summary=summary,
-                    participant_ids=self._resolve([], summary),
-                    source_kind="session",
-                    source_id=session_id,
-                    source_receipt=f"⟨{session_id}:sessions⟩",
-                )
-            )
-        return out
+        return [event for row in rows if (event := self._session_event(row)) is not None]
 
     def _legacy_intent_events(self) -> list[ActivityEvent]:
         placeholders = ",".join("?" * len(_DONE_INTENT_STATUSES))
@@ -191,27 +264,4 @@ class ActivitySource:
             ).fetchall()
         except sqlite3.Error:
             return []
-        out: list[ActivityEvent] = []
-        for row in rows:
-            source_id = str(row[0] or "").strip()
-            if not source_id:
-                continue
-            try:
-                payload = json.loads(row[4] or "{}")
-            except (TypeError, ValueError):
-                payload = {}
-            raw_people = payload.get("with") or payload.get("participants") or []
-            names = [str(name) for name in raw_people] if isinstance(raw_people, list) else []
-            summary = str(row[3] or "").strip() or f"Completed {row[2] or 'activity'}"
-            out.append(
-                ActivityEvent(
-                    stable_id=f"event:intent:{source_id}",
-                    occurred_at=str(row[1]) if row[1] else None,
-                    summary=summary,
-                    participant_ids=self._resolve(names, summary),
-                    source_kind="intent",
-                    source_id=source_id,
-                    source_receipt=f"⟨{source_id}:intents⟩",
-                )
-            )
-        return out
+        return [event for row in rows if (event := self._legacy_intent_event(row)) is not None]

--- a/tests/js/model_evidence.test.mjs
+++ b/tests/js/model_evidence.test.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  evidenceBreadcrumb,
+  evidenceOverview,
+  nodeEvidenceCards,
+  nodeHistoryCards,
+  relationLabel,
+} from "../../resources/model_assets/evidence.mjs";
+
+const oldPoint = {
+  id: "point-old",
+  content: "The user checked the original evidence.",
+  file_name: "project-persome.md",
+  receipt: "⟨point-old:project-persome.md⟩",
+  status: "superseded",
+};
+const currentPoint = {
+  id: "point-current",
+  content: "The user prefers auditable answers.",
+  file_name: "user-preferences.md",
+  receipt: "⟨point-current:user-preferences.md⟩",
+  supersedes: ["point-old"],
+  status: "active",
+};
+const model = { points: [oldPoint, currentPoint] };
+
+test("turns aggregate receipts into human-readable evidence cards", () => {
+  const face = {
+    id: "face-internal-7",
+    source_receipts: [currentPoint.receipt, oldPoint.receipt],
+  };
+  const cards = nodeEvidenceCards(face, model);
+
+  assert.deepEqual(cards.map((card) => card.label), [
+    "The user prefers auditable answers.",
+    "The user checked the original evidence.",
+  ]);
+  assert.ok(cards.every((card) => !card.label.includes("point-")));
+  assert.equal(evidenceOverview("face", face, model).title, "2 source observations");
+});
+
+test("keeps raw receipts as technical references instead of display labels", () => {
+  const [card] = nodeEvidenceCards(
+    { source_receipts: ["⟨private-id:project-secret-work.md⟩"] },
+    { points: [] },
+  );
+
+  assert.equal(card.label, "Project Secret Work");
+  assert.equal(card.reference, "⟨private-id:project-secret-work.md⟩");
+});
+
+test("labels version history and drill-down breadcrumbs with content", () => {
+  const [history] = nodeHistoryCards(currentPoint, model);
+
+  assert.equal(relationLabel(history.relation), "Previous version");
+  assert.equal(history.label, "The user checked the original evidence.");
+  assert.equal(evidenceBreadcrumb({ label: history.label }), history.label);
+});

--- a/tests/test_activity_source.py
+++ b/tests/test_activity_source.py
@@ -132,6 +132,46 @@ def test_activity_source_can_exclude_legacy_intents(ac_root) -> None:
     assert all(not event.stable_id.startswith("event:intent:") for event in events)
 
 
+def test_exact_activity_lookup_is_not_limited_to_recent_feed(ac_root) -> None:
+    with fts.cursor() as conn:
+        entry_id = _seed_sources(conn)
+        conn.execute(
+            "UPDATE entries SET timestamp = '2020-01-01T00:00:00+00:00' WHERE id = ?",
+            (entry_id,),
+        )
+        newer_entry_id = entries_store.append_entry(
+            conn,
+            name="event-2026-07-10.md",
+            content="A newer retained activity.",
+            tags=["work"],
+        )
+        recent_ids = {event.stable_id for event in ActivitySource(conn, limit=1).events()}
+
+        event = ActivitySource(conn, limit=1).event(f"event:entry:{entry_id}")
+
+    assert f"event:entry:{entry_id}" not in recent_ids
+    assert f"event:entry:{newer_entry_id}" in recent_ids
+    assert event is not None
+    assert event.stable_id == f"event:entry:{entry_id}"
+    assert event.summary == "Reviewed the Persome runtime architecture with Test Contact."
+
+
+def test_exact_activity_lookup_accepts_canonical_and_legacy_stable_ids(ac_root) -> None:
+    with fts.cursor() as conn:
+        entry_id = _seed_sources(conn)
+        source = ActivitySource(conn)
+
+        entry = source.event(f"event:entry:{entry_id}")
+        session = source.event("event:session:synthetic-session")
+        canonical_intent = source.event("event:intent:1")
+        legacy_intent = source.event("event:1")
+
+    assert entry is not None and entry.source_kind == "entry"
+    assert session is not None and session.source_kind == "session"
+    assert canonical_intent is not None and canonical_intent.stable_id == "event:intent:1"
+    assert legacy_intent == canonical_intent
+
+
 def test_activity_source_limit_uses_actual_instant_across_offsets(ac_root) -> None:
     with fts.cursor() as conn:
         _ensure_legacy_intents(conn)

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -1,0 +1,158 @@
+"""Unified evidence resolution across memory, evomem, and captures."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+from persome.evidence import parse_reference, resolve_evidence
+from persome.evomem.models import MemoryLayer, MemoryNode
+from persome.evomem.store import NodeStore
+from persome.store import entries as entries_mod
+from persome.store import fts
+
+
+def test_parse_receipt_keeps_colons_inside_identifier() -> None:
+    receipt = "⟨event:session:synthetic-1:fixtures/session-1.json⟩"
+    assert parse_reference(receipt) == (
+        "event:session:synthetic-1",
+        "fixtures/session-1.json",
+        receipt,
+    )
+
+
+def test_memory_receipt_separates_nearby_context_from_direct_sources(ac_root) -> None:
+    with fts.cursor() as conn:
+        entries_mod.create_file(
+            conn,
+            name="project-persome.md",
+            description="Persome project",
+            tags=["project"],
+        )
+        entry_id = entries_mod.append_entry(
+            conn,
+            name="project-persome.md",
+            content="The evidence viewer preserves provenance.",
+            tags=["decision"],
+            confidence="high",
+        )
+        timestamp = conn.execute(
+            "SELECT timestamp FROM entries WHERE id=?", (entry_id,)
+        ).fetchone()[0]
+        fts.insert_capture(
+            conn,
+            id="capture-nearby",
+            timestamp=timestamp,
+            app_name="Cursor",
+            bundle_id="com.test.cursor",
+            window_title="evidence.py",
+            focused_role="AXTextArea",
+            focused_value="",
+            visible_text="Implementing an evidence resolver",
+            url="",
+        )
+
+        result = resolve_evidence(conn, f"⟨{entry_id}:project-persome.md⟩")
+
+    assert result["kind"] == "memory"
+    assert result["status"] == "active"
+    assert result["metadata"]["confidence"] == "high"
+    assert result["sources"] == []
+    assert result["context"][0]["relation"] == "nearby_context"
+    assert result["context"][0]["id"] == "capture-nearby"
+
+
+def test_point_receipt_exposes_explicit_lineage(ac_root) -> None:
+    store = NodeStore()
+    store.save(
+        MemoryNode(
+            node_id="point-source",
+            content="The user reviewed source evidence.",
+            layer=MemoryLayer.L2_FACT,
+            file_name="project-persome.md",
+            memory_at=datetime(2026, 7, 1, 9, 0, tzinfo=UTC),
+        )
+    )
+    store.save(
+        MemoryNode(
+            node_id="point-derived",
+            content="The user values auditable answers.",
+            layer=MemoryLayer.L3_SUMMARY,
+            file_name="user-preferences.md",
+            abstracted_from=["point-source"],
+            memory_at=datetime(2026, 7, 2, 9, 0, tzinfo=UTC),
+        )
+    )
+
+    with fts.cursor() as conn:
+        result = resolve_evidence(conn, "⟨point-derived:user-preferences.md⟩")
+
+    assert result["kind"] == "point"
+    assert result["summary"] == "The user values auditable answers."
+    assert result["sources"] == [
+        {
+            "relation": "direct_lineage",
+            "kind": "point",
+            "id": "point-source",
+            "reference": "⟨point-source:project-persome.md⟩",
+            "label": "Earlier evidence used to derive this point",
+            "timestamp": None,
+            "status": None,
+            "resolvable": True,
+        }
+    ]
+
+
+def test_capture_resolution_labels_expired_raw_payload_as_metadata_only(ac_root) -> None:
+    with fts.cursor() as conn:
+        fts.insert_capture(
+            conn,
+            id="capture-old",
+            timestamp="2026-07-01T09:00:00+00:00",
+            app_name="Safari",
+            bundle_id="com.apple.Safari",
+            window_title="Persome docs",
+            focused_role="AXWebArea",
+            focused_value="",
+            visible_text="Receipts are stable evidence handles.",
+            url="https://example.test/docs",
+        )
+        result = resolve_evidence(conn, "capture-old")
+
+    assert result["kind"] == "capture"
+    assert result["status"] == "metadata_only"
+    assert result["metadata"]["provenance"] == "observed"
+    assert result["metadata"]["raw_capture_available"] is False
+
+
+def test_missing_receipt_is_preserved_without_fabricating_evidence(ac_root) -> None:
+    receipt = "⟨missing-id:project-missing.md⟩"
+    with fts.cursor() as conn:
+        result = resolve_evidence(conn, receipt)
+
+    assert result["kind"] == "unknown"
+    assert result["status"] == "missing"
+    assert result["canonical_reference"] == receipt
+    assert result["sources"] == []
+    assert result["context"] == []
+
+
+def test_mcp_registers_the_unified_evidence_resolver(ac_root) -> None:
+    from persome.mcp import server as mcp_server
+
+    store = NodeStore()
+    store.save(
+        MemoryNode(
+            node_id="point-mcp",
+            content="Agents can inspect this point's evidence.",
+            layer=MemoryLayer.L2_FACT,
+            file_name="project-persome.md",
+        )
+    )
+    server = mcp_server.build_server(auth_enabled=False)
+    resolve = server._tool_manager._tools["resolve_evidence"].fn
+
+    result = json.loads(resolve("⟨point-mcp:project-persome.md⟩"))
+
+    assert result["kind"] == "point"
+    assert result["id"] == "point-mcp"

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime
+from pathlib import Path
 
 import pytest
 
@@ -65,6 +66,44 @@ def test_memory_receipt_separates_nearby_context_from_direct_sources(ac_root) ->
     assert result["sources"] == []
     assert result["context"][0]["relation"] == "nearby_context"
     assert result["context"][0]["id"] == "capture-nearby"
+
+
+def test_memory_context_uses_occurred_time_and_canonical_stored_path(ac_root) -> None:
+    occurred_at = "2026-06-01T09:00:00+00:00"
+    with fts.cursor() as conn:
+        entries_mod.create_file(
+            conn,
+            name="event-2026-06-01.md",
+            description="Historical event",
+            tags=["event"],
+        )
+        entry_id = entries_mod.append_entry(
+            conn,
+            name="event-2026-06-01.md",
+            content="Reviewed the evidence at the recorded event time.",
+            tags=["work"],
+            occurred_at=occurred_at,
+        )
+        fts.insert_capture(
+            conn,
+            id="capture-at-event",
+            timestamp=occurred_at,
+            app_name="Editor",
+            bundle_id="com.test.editor",
+            window_title="Evidence review",
+            focused_role="AXTextArea",
+            focused_value="",
+            visible_text="Reviewing the evidence",
+            url="",
+        )
+        supplied = f"⟨{entry_id}:wrong-path.md⟩"
+
+        result = resolve_evidence(conn, supplied)
+
+    assert result["reference"] == supplied
+    assert result["canonical_reference"] == f"⟨{entry_id}:event-2026-06-01.md⟩"
+    assert result["path"] == "event-2026-06-01.md"
+    assert [item["id"] for item in result["context"]] == ["capture-at-event"]
 
 
 def test_point_receipt_exposes_explicit_lineage(ac_root) -> None:
@@ -184,6 +223,77 @@ def test_aggregate_geometry_reuses_snapshot_point_labels(ac_root, monkeypatch) -
     assert result["sources"][0]["label"] == "The user checks claims against primary evidence."
 
 
+def test_geometry_resolution_does_not_expand_the_activity_feed(ac_root, monkeypatch) -> None:
+    from persome.model.activity_source import ActivitySource
+
+    with fts.cursor() as conn:
+        ensure_face_schema(conn)
+        conn.execute(
+            "INSERT INTO schema_faces (face_id, level, signature, members, footprints,"
+            " provenance, observations, confidence, status, valid_from, created_at)"
+            " VALUES (?, 1, ?, '[]', '[]', 'both', 3, 0.91, 'active', ?, ?)",
+            (
+                "face-bounded",
+                "Evidence lookup stays bounded.",
+                "2026-07-01T00:00:00+00:00",
+                "2026-07-01T00:00:00+00:00",
+            ),
+        )
+        monkeypatch.setattr(
+            ActivitySource,
+            "events",
+            lambda *_args, **_kwargs: pytest.fail("geometry lookup must not expand activities"),
+        )
+
+        result = resolve_evidence(conn, "face-bounded")
+
+    assert result["kind"] == "face"
+
+
+def test_unknown_reference_does_not_build_the_full_model(ac_root, monkeypatch) -> None:
+    from persome.model import snapshot as snapshot_mod
+
+    monkeypatch.setattr(
+        snapshot_mod,
+        "build_snapshot",
+        lambda *_args, **_kwargs: pytest.fail("unknown refs must not build the model snapshot"),
+    )
+
+    with fts.cursor() as conn:
+        result = resolve_evidence(conn, "not-a-model-id")
+
+    assert result["status"] == "missing"
+
+
+def test_activity_resolution_uses_exact_lookup(ac_root, monkeypatch) -> None:
+    from persome.model.activity_source import ActivitySource
+
+    with fts.cursor() as conn:
+        entries_mod.create_file(
+            conn,
+            name="event-2026-07-01.md",
+            description="Historical activity",
+            tags=["event"],
+        )
+        entry_id = entries_mod.append_entry(
+            conn,
+            name="event-2026-07-01.md",
+            content="Reviewed retained evidence.",
+            tags=["work"],
+        )
+        monkeypatch.setattr(
+            ActivitySource,
+            "events",
+            lambda *_args, **_kwargs: pytest.fail("exact lookup must not build the feed"),
+        )
+
+        result = resolve_evidence(conn, f"event:entry:{entry_id}")
+
+    assert result["kind"] == "activity"
+    assert result["id"] == f"event:entry:{entry_id}"
+    assert result["sources"][0]["id"] == entry_id
+
+
 def test_capture_resolution_labels_expired_raw_payload_as_metadata_only(ac_root) -> None:
     with fts.cursor() as conn:
         fts.insert_capture(
@@ -203,6 +313,57 @@ def test_capture_resolution_labels_expired_raw_payload_as_metadata_only(ac_root)
     assert result["kind"] == "capture"
     assert result["status"] == "metadata_only"
     assert result["metadata"]["provenance"] == "observed"
+    assert result["metadata"]["raw_capture_available"] is False
+
+
+def test_capture_resolution_never_checks_outside_capture_buffer(ac_root, monkeypatch) -> None:
+    hostile_id = "/tmp/persome-evidence-probe"
+    with fts.cursor() as conn:
+        fts.insert_capture(
+            conn,
+            id=hostile_id,
+            timestamp="2026-07-01T09:00:00+00:00",
+            app_name="Imported",
+            bundle_id="com.test.imported",
+            window_title="Unexpected capture id",
+            focused_role="AXTextArea",
+            focused_value="",
+            visible_text="Imported capture metadata",
+            url="",
+        )
+        monkeypatch.setattr(
+            Path,
+            "lstat",
+            lambda *_args, **_kwargs: pytest.fail("hostile IDs must not reach the filesystem"),
+        )
+
+        result = resolve_evidence(conn, hostile_id)
+
+    assert result["kind"] == "capture"
+    assert result["status"] == "metadata_only"
+
+
+def test_capture_resolution_does_not_follow_buffer_symlinks(ac_root) -> None:
+    outside = ac_root.parent / "outside-capture.json"
+    outside.write_text("{}", encoding="utf-8")
+    (ac_root / "capture-buffer" / "linked-capture.json").symlink_to(outside)
+    with fts.cursor() as conn:
+        fts.insert_capture(
+            conn,
+            id="linked-capture",
+            timestamp="2026-07-01T09:00:00+00:00",
+            app_name="Imported",
+            bundle_id="com.test.imported",
+            window_title="Symlinked capture",
+            focused_role="AXTextArea",
+            focused_value="",
+            visible_text="Imported capture metadata",
+            url="",
+        )
+
+        result = resolve_evidence(conn, "linked-capture")
+
+    assert result["status"] == "metadata_only"
     assert result["metadata"]["raw_capture_available"] is False
 
 

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime
 
+import pytest
+
+from persome import evidence as evidence_mod
 from persome.evidence import parse_reference, resolve_evidence
 from persome.evomem.models import MemoryLayer, MemoryNode
 from persome.evomem.store import NodeStore
@@ -145,7 +148,7 @@ def test_point_receipt_exposes_human_readable_version_history(ac_root) -> None:
     assert old["history"][0]["label"] == "The user now prefers concise answers with evidence."
 
 
-def test_aggregate_geometry_labels_inherited_receipts_with_point_content(ac_root) -> None:
+def test_aggregate_geometry_reuses_snapshot_point_labels(ac_root, monkeypatch) -> None:
     store = NodeStore()
     store.save(
         MemoryNode(
@@ -168,6 +171,11 @@ def test_aggregate_geometry_labels_inherited_receipts_with_point_content(ac_root
                 "2026-07-01T00:00:00+00:00",
                 "2026-07-01T00:00:00+00:00",
             ),
+        )
+        monkeypatch.setattr(
+            evidence_mod,
+            "_reference_label",
+            lambda *_args: pytest.fail("snapshot Point labels should not trigger receipt queries"),
         )
         result = resolve_evidence(conn, "face-evidence")
 

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -265,6 +265,68 @@ def test_unknown_reference_does_not_build_the_full_model(ac_root, monkeypatch) -
     assert result["status"] == "missing"
 
 
+@pytest.mark.parametrize(
+    "reference",
+    [
+        "evolution:garbage",
+        "evolution:point-old:point-not-retained",
+        "evolution:wrong-parent:point-current",
+    ],
+)
+def test_unknown_evolution_reference_does_not_build_the_full_model(
+    ac_root, monkeypatch, reference: str
+) -> None:
+    from persome.model import snapshot as snapshot_mod
+
+    store = NodeStore()
+    store.save(
+        MemoryNode(
+            node_id="point-current",
+            content="Current point without the claimed parent.",
+            layer=MemoryLayer.L2_FACT,
+            file_name="project-persome.md",
+        )
+    )
+    monkeypatch.setattr(
+        snapshot_mod,
+        "build_snapshot",
+        lambda *_args, **_kwargs: pytest.fail("unknown evolution must not build the snapshot"),
+    )
+
+    with fts.cursor() as conn:
+        result = resolve_evidence(conn, reference)
+
+    assert result["status"] == "missing"
+
+
+def test_valid_evolution_reference_resolves_the_snapshot_line(ac_root) -> None:
+    store = NodeStore()
+    store.save(
+        MemoryNode(
+            node_id="point-old:with-context",
+            content="The earlier recorded point.",
+            layer=MemoryLayer.L2_FACT,
+            file_name="project-persome.md",
+        )
+    )
+    store.save_and_supersede(
+        MemoryNode(
+            node_id="point-current",
+            content="The current recorded point.",
+            layer=MemoryLayer.L2_FACT,
+            file_name="project-persome.md",
+        ),
+        old_id="point-old:with-context",
+    )
+
+    with fts.cursor() as conn:
+        result = resolve_evidence(conn, "evolution:point-old:with-context:point-current")
+
+    assert result["kind"] == "line"
+    assert result["id"] == "evolution:point-old:with-context:point-current"
+    assert result["sources"][0]["reference"] == "⟨point-current:project-persome.md⟩"
+
+
 def test_activity_resolution_uses_exact_lookup(ac_root, monkeypatch) -> None:
     from persome.model.activity_source import ActivitySource
 

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -10,6 +10,7 @@ from persome.evomem.models import MemoryLayer, MemoryNode
 from persome.evomem.store import NodeStore
 from persome.store import entries as entries_mod
 from persome.store import fts
+from persome.store.schema_faces import ensure_schema as ensure_face_schema
 
 
 def test_parse_receipt_keeps_colons_inside_identifier() -> None:
@@ -56,6 +57,7 @@ def test_memory_receipt_separates_nearby_context_from_direct_sources(ac_root) ->
 
     assert result["kind"] == "memory"
     assert result["status"] == "active"
+    assert result["label"] == "The evidence viewer preserves provenance."
     assert result["metadata"]["confidence"] == "high"
     assert result["sources"] == []
     assert result["context"][0]["relation"] == "nearby_context"
@@ -95,12 +97,83 @@ def test_point_receipt_exposes_explicit_lineage(ac_root) -> None:
             "kind": "point",
             "id": "point-source",
             "reference": "⟨point-source:project-persome.md⟩",
-            "label": "Earlier evidence used to derive this point",
+            "label": "The user reviewed source evidence.",
             "timestamp": None,
             "status": None,
             "resolvable": True,
         }
     ]
+
+
+def test_point_receipt_exposes_human_readable_version_history(ac_root) -> None:
+    store = NodeStore()
+    store.save(
+        MemoryNode(
+            node_id="point-old",
+            content="The user preferred short answers.",
+            layer=MemoryLayer.L2_FACT,
+            file_name="user-preferences.md",
+        )
+    )
+    store.save_and_supersede(
+        MemoryNode(
+            node_id="point-current",
+            content="The user now prefers concise answers with evidence.",
+            layer=MemoryLayer.L2_FACT,
+            file_name="user-preferences.md",
+        ),
+        old_id="point-old",
+    )
+
+    with fts.cursor() as conn:
+        current = resolve_evidence(conn, "point-current")
+        old = resolve_evidence(conn, "point-old")
+
+    assert current["label"] == "The user now prefers concise answers with evidence."
+    assert current["sources"] == []
+    assert current["history"][0] == {
+        "relation": "previous_version",
+        "kind": "point",
+        "id": "point-old",
+        "reference": "⟨point-old:user-preferences.md⟩",
+        "label": "The user preferred short answers.",
+        "timestamp": None,
+        "status": None,
+        "resolvable": True,
+    }
+    assert old["history"][0]["relation"] == "next_version"
+    assert old["history"][0]["label"] == "The user now prefers concise answers with evidence."
+
+
+def test_aggregate_geometry_labels_inherited_receipts_with_point_content(ac_root) -> None:
+    store = NodeStore()
+    store.save(
+        MemoryNode(
+            node_id="point-readable",
+            content="The user checks claims against primary evidence.",
+            layer=MemoryLayer.L2_FACT,
+            file_name="user-research.md",
+        )
+    )
+    with fts.cursor() as conn:
+        ensure_face_schema(conn)
+        conn.execute(
+            "INSERT INTO schema_faces (face_id, level, signature, members, footprints,"
+            " provenance, observations, confidence, status, valid_from, created_at)"
+            " VALUES (?, 1, ?, ?, '[]', 'both', 3, 0.91, 'active', ?, ?)",
+            (
+                "face-evidence",
+                "Research decisions remain auditable.",
+                json.dumps(["point-readable"]),
+                "2026-07-01T00:00:00+00:00",
+                "2026-07-01T00:00:00+00:00",
+            ),
+        )
+        result = resolve_evidence(conn, "face-evidence")
+
+    assert result["kind"] == "face"
+    assert result["label"] == "Research decisions remain auditable."
+    assert result["sources"][0]["label"] == "The user checks claims against primary evidence."
 
 
 def test_capture_resolution_labels_expired_raw_payload_as_metadata_only(ac_root) -> None:

--- a/tests/test_local_api_auth.py
+++ b/tests/test_local_api_auth.py
@@ -179,7 +179,11 @@ def test_browser_bootstrap_is_single_use_and_cookie_is_model_only(
     viewer_page = client.get(viewer_url)
     assert f'<base href="{viewer_url}">' in viewer_page.text
     assert client.get(viewer_url + "graph").status_code == 200
+    evidence = client.get(viewer_url + "evidence?ref=missing-evidence")
+    assert evidence.status_code == 200
+    assert evidence.json()["status"] == "missing"
     assert client.get(viewer_url + "assets/viewer.js").status_code == 200
+    assert client.get("/model/evidence?ref=missing-evidence").status_code == 401
     assert client.get("/status").status_code == 401
 
     # Cookie jars ignore ports. The random path prevents a predictable request

--- a/tests/test_model_layout_asset.py
+++ b/tests/test_model_layout_asset.py
@@ -16,6 +16,7 @@ def test_model_viewer_node_suite() -> None:
         [
             node,
             "--test",
+            "tests/js/model_evidence.test.mjs",
             "tests/js/model_layout.test.mjs",
             "tests/js/model_share.test.mjs",
         ],

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -195,6 +195,9 @@ class TestViewPage:
         assert b"model.root" in viewer.body
         assert b'fetch("./graph"' in viewer.body
         assert b"fetch(`./node" in viewer.body
+        assert b"fetch(`./evidence?ref=" in viewer.body
+        assert b"Evidence receipts" in viewer.body
+        assert b"Nearby context" in viewer.body
         assert b'fetch("/model' not in viewer.body
         assert b"ACESFilmicToneMapping" in viewer.body
         assert b"model.root?.signature" in viewer.body
@@ -227,6 +230,8 @@ class TestViewPage:
         assert b".zoom-controls" in css.body
         assert b".share-button" in css.body
         assert b".share-notice" in css.body
+        assert b".evidence-link" in css.body
+        assert b".evidence-back" in css.body
         assert b"(min-width: 1181px) and (max-width: 1360px)" in css.body
         assert b"top: 116px" in css.body
         assert b"prefers-reduced-motion" in css.body
@@ -249,6 +254,32 @@ class TestViewPage:
         assert "pickables.push(line)" not in viewer
         assert "pointer-events: auto" in css
         assert '.model-label[aria-expanded="true"]' in css
+
+
+class TestEvidenceResolverRoute:
+    def test_point_receipt_resolves_through_unified_endpoint(self, ac_root):
+        _save_point(
+            node_id="point-runtime",
+            content="The runtime stores auditable local context.",
+            file_name="synthetic/runtime.md",
+        )
+
+        detail = routes.model_evidence(ref="⟨point-runtime:synthetic/runtime.md⟩")
+
+        assert detail["kind"] == "point"
+        assert detail["id"] == "point-runtime"
+        assert detail["path"] == "synthetic/runtime.md"
+        assert detail["summary"] == "The runtime stores auditable local context."
+        assert detail["status"] == "active"
+
+    def test_unknown_receipt_remains_an_inspectable_missing_result(self, ac_root):
+        receipt = "⟨expired:project-old.md⟩"
+
+        detail = routes.model_evidence(ref=receipt)
+
+        assert detail["canonical_reference"] == receipt
+        assert detail["status"] == "missing"
+        assert detail["metadata"]["receipt_preserved"] is True
 
 
 class TestNodeReceipts:

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -173,10 +173,16 @@ class TestViewPage:
         assert 'id="zoom-reset"' in body
         assert 'id="zoom-in"' in body
         assert "Scroll or pinch to zoom" in body
+        assert 'role="tablist"' in body
+        assert 'data-detail-tab="overview"' in body
+        assert 'data-detail-tab="evidence"' in body
+        assert 'data-detail-tab="history"' in body
+        assert 'id="evidence-breadcrumbs"' in body
 
     def test_bundled_viewer_assets_are_served(self, ac_root):
         three = routes.model_asset("three.module.js")
         layout = routes.model_asset("layout.mjs")
+        evidence = routes.model_asset("evidence.mjs")
         share = routes.model_asset("share.mjs")
         viewer = routes.model_asset("viewer.js")
         css = routes.model_asset("viewer.css")
@@ -184,6 +190,7 @@ class TestViewPage:
         assert len(three.body) > 1_000_000
         assert b"class WebGLRenderer" in three.body
         assert b"computeClusterLayout" in layout.body
+        assert b"nodeEvidenceCards" in evidence.body
         assert b"buildXIntentUrl" in share.body
         assert b"drawShareCard" in share.body
         assert b'from "./layout.mjs"' in viewer.body
@@ -196,8 +203,10 @@ class TestViewPage:
         assert b'fetch("./graph"' in viewer.body
         assert b"fetch(`./node" in viewer.body
         assert b"fetch(`./evidence?ref=" in viewer.body
-        assert b"Evidence receipts" in viewer.body
+        assert b"Direct evidence" in viewer.body
         assert b"Nearby context" in viewer.body
+        assert b"Technical details" in viewer.body
+        assert b"evidenceTrail" in viewer.body
         assert b'fetch("/model' not in viewer.body
         assert b"ACESFilmicToneMapping" in viewer.body
         assert b"model.root?.signature" in viewer.body
@@ -231,7 +240,7 @@ class TestViewPage:
         assert b".share-button" in css.body
         assert b".share-notice" in css.body
         assert b".evidence-link" in css.body
-        assert b".evidence-back" in css.body
+        assert b".evidence-breadcrumbs" in css.body
         assert b"(min-width: 1181px) and (max-width: 1360px)" in css.body
         assert b"top: 116px" in css.body
         assert b"prefers-reduced-motion" in css.body


### PR DESCRIPTION
## What changed

- add a unified, read-only evidence resolver for model IDs, receipts, memory entries, activities, evomem Points, and captures
- expose the resolver through `GET /model/evidence?ref=...` and a new MCP `resolve_evidence` tool
- make model-viewer receipts clickable with progressive drill-down and back navigation
- keep explicit stored lineage in `sources` and time-adjacent capture clues in a separately labeled `context` collection
- preserve expired or unavailable receipt handles with honest `missing` / `metadata_only` states
- regenerate the committed OpenAPI contract and update MCP, API, and model-format documentation
- add resolver, REST, MCP-registration, viewer-asset, and missing-retention tests

## Why

Persome already persisted receipts and provenance, but the local viewer displayed most receipts as inert text and different evidence types required different read paths. Memory-to-capture investigation also relies on temporal proximity where an explicit source edge is unavailable, which could be mistaken for direct proof.

This change creates one progressive-disclosure contract and makes the distinction between direct lineage and nearby context explicit in both API semantics and UI copy.

## User and developer impact

Owners can click receipts in the local model viewer and follow evidence one layer at a time. MCP clients can use one tool for model, memory, activity, and capture references. Existing `read_receipt` and `/model/node` behavior remains backward compatible.

No database migration or new writer entrance is introduced.

## Validation

- 110 relevant Python tests passed across evidence/model/API/auth/MCP suites
- 7 JavaScript layout/share tests passed
- `node --check resources/model_assets/viewer.js`
- OpenAPI drift test passed after regeneration
- secret scan, PII scan, English-language gate, and documentation-link checks passed
- `git diff --check`
- synthetic demo server startup verified on an isolated temporary root

## Known boundary

This PR does not fabricate exact capture provenance where the current write pipeline stores no direct capture edge. Such results remain explicitly labeled `nearby_context`; adding exact derived-object-to-capture edges is a separate write-path/schema change. Screenshot-level browser QA was unavailable in the current runner, so the viewer change is covered by static interaction assertions and JavaScript checks.
