### PR TITLE
fix(model): make nodes and lines reliably selectable

### DIFF
--- a/docs/model-contract.md
+++ b/docs/model-contract.md
@@ -89,8 +89,10 @@ cards with drill-down breadcrumbs, and History keeps Point predecessor/successor
 from derivation sources. Raw IDs, paths, and receipts stay collapsed under technical details. Labels
 and tabs are keyboard-focusable; Escape closes the selection. Nodes retain a 12-pixel minimum
 screen-space hit target so distant geometry stays selectable. Evolution and relation Lines open
-their own endpoint, predicate, and evidence detail through an 8-pixel screen-space hit target; node
-hits always win where geometry overlaps. Derived hierarchy connectors remain visual-only.
+their own human-readable endpoint, exact predicate, and evidence detail through an 8-pixel
+screen-space hit target; node hits always win where geometry overlaps. Keyboard focus reveals a
+line picker with the same detail action. Raw line and endpoint IDs remain inside collapsed technical
+details. Derived hierarchy connectors remain visual-only.
 `window.__persomeInteractionState` exposes aggregate interaction counts and hit-target bounds for
 local smoke tests.
 

--- a/docs/model-contract.md
+++ b/docs/model-contract.md
@@ -84,9 +84,12 @@ Point labels, receipts, source names, timestamps, and viewer credentials are exc
 artifact; the owner attaches the downloaded image and confirms the post in X.
 
 Visible node labels and their Point, Face, Volume, Root, or context meshes open the same provenance
-detail panel. Labels are keyboard-focusable; Escape closes the selection. Lines remain visual
-evidence of evolution, relation, and hierarchy and are intentionally excluded from pointer picking.
-`window.__persomeInteractionState` exposes aggregate interaction counts for local smoke tests.
+detail panel. Labels are keyboard-focusable; Escape closes the selection. Nodes retain a 12-pixel
+minimum screen-space hit target so distant geometry stays selectable. Evolution and relation Lines
+open their own endpoint, predicate, and evidence detail through an 8-pixel screen-space hit target;
+node hits always win where geometry overlaps. Derived hierarchy connectors remain visual-only.
+`window.__persomeInteractionState` exposes aggregate interaction counts and hit-target bounds for
+local smoke tests.
 
 Zoom is relative to the fitted model: the visible minus, percentage, and plus controls cover 50%
 through 400%, the percentage resets to 100%, and the plus, minus, and zero keys provide the same

--- a/resources/model_assets/evidence.mjs
+++ b/resources/model_assets/evidence.mjs
@@ -116,4 +116,42 @@ export function evidenceBreadcrumb(data) {
   return compactText(data?.label || data?.summary, humanizePath(data?.path) || data?.kind || "Evidence", 72);
 }
 
+function modelNodeLabel(id, model) {
+  if (id === "self") return "You";
+  const candidates = [
+    ["point", model?.points || [], "Observed point"],
+    ["face", model?.faces || [], "Model pattern"],
+    ["volume", model?.volumes || [], "Model structure"],
+    ["root", model?.root ? [model.root] : [], "Personal model"],
+  ];
+  for (const [, nodes, fallback] of candidates) {
+    const node = nodes.find((item) => item.id === id);
+    if (node) {
+      return compactText(
+        node.content || node.signature || node.label || node.title,
+        fallback,
+        88,
+      );
+    }
+  }
+  return "Context node";
+}
+
+export function linePresentation(line, model) {
+  const fallbackPredicate = line?.kind === "evolution" ? "supersedes" : "relation";
+  const predicate = compactText(line?.predicate, fallbackPredicate, 72);
+  const label = String(line?.label || "").replace(/\s+/g, " ").trim().slice(0, 88);
+  const source = modelNodeLabel(line?.source, model);
+  const target = modelNodeLabel(line?.target, model);
+  const title = label || predicate;
+  return {
+    title,
+    predicate,
+    label: label && label !== predicate ? label : "",
+    source,
+    target,
+    option: `${title}: ${source} → ${target}`,
+  };
+}
+
 export const evidenceText = { compactText, humanizePath, parseReceipt };

--- a/resources/model_assets/layout.mjs
+++ b/resources/model_assets/layout.mjs
@@ -438,6 +438,64 @@ export function computeClusterLayout(model) {
 
 export const layoutMath = { distance, magnitude, stableHash };
 
+function pointSegmentDistanceSquared(pointer, start, end) {
+  const dx = end.x - start.x;
+  const dy = end.y - start.y;
+  const lengthSquared = dx * dx + dy * dy;
+  if (lengthSquared <= Number.EPSILON) {
+    return (pointer.x - start.x) ** 2 + (pointer.y - start.y) ** 2;
+  }
+  const projection = Math.max(0, Math.min(1, (
+    (pointer.x - start.x) * dx + (pointer.y - start.y) * dy
+  ) / lengthSquared));
+  const closestX = start.x + projection * dx;
+  const closestY = start.y + projection * dy;
+  return (pointer.x - closestX) ** 2 + (pointer.y - closestY) ** 2;
+}
+
+export function pickScreenTarget(
+  pointer,
+  nodes = [],
+  lines = [],
+  { nodeRadius = 12, lineRadius = 8 } = {},
+) {
+  let bestNode = null;
+  nodes.forEach((candidate) => {
+    const radius = Math.max(nodeRadius, Number(candidate.radius || 0));
+    const distanceSquared = (pointer.x - candidate.x) ** 2 + (pointer.y - candidate.y) ** 2;
+    if (distanceSquared > radius * radius) return;
+    if (
+      !bestNode
+      || distanceSquared < bestNode.distanceSquared
+      || (
+        Math.abs(distanceSquared - bestNode.distanceSquared) <= Number.EPSILON
+        && Number(candidate.depth || 0) < Number(bestNode.candidate.depth || 0)
+      )
+    ) {
+      bestNode = { candidate, distanceSquared };
+    }
+  });
+  if (bestNode) return bestNode.candidate.target;
+
+  let bestLine = null;
+  lines.forEach((candidate) => {
+    const radius = Math.max(lineRadius, Number(candidate.radius || 0));
+    const distanceSquared = pointSegmentDistanceSquared(pointer, candidate.start, candidate.end);
+    if (distanceSquared > radius * radius) return;
+    if (
+      !bestLine
+      || distanceSquared < bestLine.distanceSquared
+      || (
+        Math.abs(distanceSquared - bestLine.distanceSquared) <= Number.EPSILON
+        && Number(candidate.depth || 0) < Number(bestLine.candidate.depth || 0)
+      )
+    ) {
+      bestLine = { candidate, distanceSquared };
+    }
+  });
+  return bestLine?.candidate.target || null;
+}
+
 function clampZoomPercent(value, minPercent = 50, maxPercent = 400) {
   return Math.max(minPercent, Math.min(maxPercent, Math.round(value)));
 }

--- a/resources/model_assets/viewer.css
+++ b/resources/model_assets/viewer.css
@@ -602,6 +602,58 @@ button {
 .swatch.volume { color: var(--volume); border: 1px solid var(--volume); background: transparent; }
 .swatch.root { color: var(--root); background: var(--root); transform: rotate(45deg); border-radius: 2px; }
 
+.line-explorer {
+  position: absolute;
+  z-index: 20;
+  top: 12px;
+  left: 50%;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  border: 0;
+  clip-path: inset(50%);
+  transform: translateX(-50%);
+}
+
+.line-explorer:focus-within {
+  display: grid;
+  width: min(420px, calc(100vw - 32px));
+  height: auto;
+  padding: 12px;
+  overflow: visible;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 13px;
+  background: var(--surface-strong);
+  clip-path: none;
+  gap: 6px;
+}
+
+.line-explorer label {
+  color: var(--dim);
+  font-size: 8px;
+  font-weight: 750;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.line-explorer select {
+  width: 100%;
+  min-height: 36px;
+  padding: 7px 9px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 9px;
+  background: #12101d;
+  color: var(--text);
+  font: 10px/1.4 -apple-system, BlinkMacSystemFont, "SF Pro Display", sans-serif;
+}
+
+.line-explorer select:focus-visible {
+  border-color: var(--line);
+  outline: 2px solid color-mix(in srgb, var(--line) 65%, transparent);
+  outline-offset: 2px;
+}
+
 .detail {
   position: absolute;
   z-index: 14;

--- a/resources/model_assets/viewer.css
+++ b/resources/model_assets/viewer.css
@@ -630,6 +630,7 @@ button {
 
 .detail[data-kind="point"] { --detail-accent: var(--point); }
 .detail[data-kind="context"] { --detail-accent: var(--muted); }
+.detail[data-kind="line"] { --detail-accent: var(--line); }
 .detail[data-kind="face"] { --detail-accent: var(--face); }
 .detail[data-kind="volume"] { --detail-accent: var(--volume); }
 .detail[data-kind="root"] { --detail-accent: var(--root); }

--- a/resources/model_assets/viewer.js
+++ b/resources/model_assets/viewer.js
@@ -5,6 +5,7 @@ import { computeClusterLayout, pickScreenTarget, zoomMath } from "./layout.mjs";
 import {
   evidenceBreadcrumb,
   evidenceOverview,
+  linePresentation,
   nodeEvidenceCards,
   nodeHistoryCards,
   relationLabel,
@@ -50,6 +51,8 @@ const zoomResetButton = document.getElementById("zoom-reset");
 const zoomInButton = document.getElementById("zoom-in");
 const shareButton = document.getElementById("share-x");
 const shareNoticeEl = document.getElementById("share-notice");
+const lineExplorerEl = document.getElementById("line-explorer");
+const lineSelectEl = document.getElementById("line-select");
 
 const scene = new THREE.Scene();
 scene.fog = new THREE.FogExp2(0x070610, 0.026);
@@ -117,6 +120,7 @@ let portraitMode = null;
 let labels = [];
 let pickables = [];
 let screenLinePickables = [];
+let lineNavigatorItems = [];
 let selectionTargets = new Map();
 let positions = new Map();
 let items = new Map();
@@ -333,6 +337,33 @@ function registerScreenLinePickable(lineObject, item, start, end) {
   return lineObject;
 }
 
+function renderLineExplorer(lines) {
+  lineNavigatorItems = lines;
+  lineSelectEl.replaceChildren();
+  const placeholder = document.createElement("option");
+  placeholder.value = "";
+  placeholder.disabled = lines.length > 0;
+  placeholder.selected = true;
+  placeholder.textContent = lines.length ? "Choose a relationship…" : "No model lines available";
+  lineSelectEl.appendChild(placeholder);
+  lines.forEach((line, index) => {
+    const option = document.createElement("option");
+    option.value = String(index + 1);
+    option.textContent = linePresentation(line, model).option;
+    lineSelectEl.appendChild(option);
+  });
+  lineExplorerEl.hidden = lines.length === 0;
+  syncLineExplorer();
+}
+
+function syncLineExplorer() {
+  lineSelectEl.disabled = !layerVisible.lines || lineNavigatorItems.length === 0;
+  const selectedIndex = selected?.kind === "line"
+    ? lineNavigatorItems.findIndex((line) => line.id === selected.id)
+    : -1;
+  lineSelectEl.value = selectedIndex >= 0 ? String(selectedIndex + 1) : "";
+}
+
 function disposeGraph() {
   scene.remove(graph);
   graph.traverse((object) => {
@@ -346,6 +377,7 @@ function disposeGraph() {
   labels = [];
   pickables = [];
   screenLinePickables = [];
+  renderLineExplorer([]);
   selectionTargets = new Map();
   positions = new Map();
   items = new Map();
@@ -628,6 +660,10 @@ function buildScene() {
   });
   currentLayout.contextIds.forEach(addContextNode);
   visibleLines.forEach(addModelLine);
+  const renderedLineItems = visibleLines.filter(
+    (line) => positions.has(line.source) && positions.has(line.target),
+  );
+  renderLineExplorer(renderedLineItems);
   visibleFaces.forEach((face) => addFace(face, labeledFaces.has(face.id)));
   visibleVolumes.forEach((volume) => addVolume(volume, labeledVolumes.has(volume.id)));
   if (visibleRoot) addRoot(visibleRoot);
@@ -636,7 +672,7 @@ function buildScene() {
   renderStatus();
   emptyEl.hidden = visiblePoints.length > 0;
   frameLayout(false);
-  const renderedLines = visibleLines.filter((line) => positions.has(line.source) && positions.has(line.target)).length;
+  const renderedLines = renderedLineItems.length;
   window.__persomeViewerState = {
     schemaVersion: model.schema_version,
     generatedAt: modelGeneratedAt || null,
@@ -823,6 +859,7 @@ function syncSelectionState() {
       }
     });
   });
+  syncLineExplorer();
   window.__persomeInteractionState = {
     linePickables: pickables.filter((object) => object.isLine).length,
     screenLinePickables: screenLinePickables.length,
@@ -1118,7 +1155,19 @@ function renderNodeHistory(item) {
   history.forEach((link) => detailHistoryEl.appendChild(evidenceCard(link)));
 }
 
+function appendLineTechnicalDetails(item) {
+  const details = technicalDetails({ id: item.id });
+  const body = details.querySelector("div");
+  body.textContent = [
+    item.id ? `Line ID: ${item.id}` : "",
+    item.source ? `Source ID: ${item.source}` : "",
+    item.target ? `Target ID: ${item.target}` : "",
+  ].filter(Boolean).join("\n");
+  detailSummaryEl.appendChild(details);
+}
+
 function showDetails(kind, item) {
+  const lineDetail = kind === "line" ? linePresentation(item, model) : null;
   selected = { kind, id: item.id };
   selectedItem = item;
   pauseAutoRotate();
@@ -1126,21 +1175,24 @@ function showDetails(kind, item) {
   detailEl.dataset.kind = kind;
   detailKindEl.textContent = kind;
   detailTitleEl.textContent = (
-    item.content || item.signature || item.label || item.predicate || item.kind || item.id
+    lineDetail?.title
+    || item.content || item.signature || item.label || item.predicate || item.kind || item.id
   );
   evidenceTrail = [{ label: detailTitleEl.textContent, data: null }];
   detailMetaEl.replaceChildren();
   appendMeta("Layer", item.layer || item.level);
   appendMeta("Status", item.status);
   appendMeta("Type", item.kind);
-  appendMeta("Predicate", item.label || item.predicate);
-  appendMeta("From", item.source);
-  appendMeta("To", item.target);
+  appendMeta("Predicate", lineDetail?.predicate);
+  appendMeta("Label", lineDetail?.label);
+  appendMeta("From", lineDetail?.source);
+  appendMeta("To", lineDetail?.target);
   appendMeta("Confidence", item.confidence);
   appendMeta("Observations", item.observations);
   appendMeta("Valid from", item.valid_from);
   appendMeta("Members", item.members?.length);
   renderOverview(kind, item);
+  if (lineDetail) appendLineTechnicalDetails(item);
   renderNodeEvidence(kind, item);
   renderNodeHistory(item);
   setDetailTab("overview");
@@ -1418,6 +1470,12 @@ document.querySelectorAll("[data-layer]").forEach((button) => {
     applyLayerVisibility();
     if (window.__persomeViewerState) window.__persomeViewerState.layers = { ...layerVisible };
   });
+});
+
+lineSelectEl.addEventListener("change", () => {
+  const index = Number(lineSelectEl.value) - 1;
+  const item = lineNavigatorItems[index];
+  if (item) showDetails("line", item);
 });
 
 detailTabEls.forEach((button, index) => {

--- a/resources/model_assets/viewer.js
+++ b/resources/model_assets/viewer.js
@@ -1,7 +1,7 @@
 import * as THREE from "three";
 import { OrbitControls } from "three/addons/controls/OrbitControls.js";
 import { CSS2DObject, CSS2DRenderer } from "three/addons/renderers/CSS2DRenderer.js";
-import { computeClusterLayout, zoomMath } from "./layout.mjs";
+import { computeClusterLayout, pickScreenTarget, zoomMath } from "./layout.mjs";
 import {
   SHARE_CARD_HEIGHT,
   SHARE_CARD_WIDTH,
@@ -103,6 +103,7 @@ let evidenceRequest = 0;
 let portraitMode = null;
 let labels = [];
 let pickables = [];
+let screenLinePickables = [];
 let selectionTargets = new Map();
 let positions = new Map();
 let items = new Map();
@@ -117,10 +118,19 @@ let lastZoomPercent = null;
 let lastFrameTime = performance.now();
 let shareReady = false;
 const layerVisible = { points: true, lines: true, faces: true, volumes: true, root: true };
-const kindLayers = { point: "points", context: "points", face: "faces", volume: "volumes", root: "root" };
+const kindLayers = {
+  point: "points",
+  context: "points",
+  line: "lines",
+  face: "faces",
+  volume: "volumes",
+  root: "root",
+};
 const raycaster = new THREE.Raycaster();
 const pointer = new THREE.Vector2();
 const zoomDirection = new THREE.Vector3();
+const MIN_NODE_HIT_RADIUS_PX = 12;
+const MIN_LINE_HIT_RADIUS_PX = 8;
 const ZOOM_MIN_PERCENT = 50;
 const ZOOM_MAX_PERCENT = 400;
 const ZOOM_STEP_PERCENT = 25;
@@ -299,6 +309,15 @@ function addLine(start, end, color, opacity, dashed, layer = "lines") {
   return line;
 }
 
+function registerScreenLinePickable(lineObject, item, start, end) {
+  registerSelectionTarget("line", item.id, lineObject);
+  lineObject.userData.pickSegment = { start: start.clone(), end: end.clone() };
+  lineObject.userData.baseOpacity = Number(lineObject.material.opacity || 0);
+  screenLinePickables.push(lineObject);
+  items.set(selectionKey("line", item.id), item);
+  return lineObject;
+}
+
 function disposeGraph() {
   scene.remove(graph);
   graph.traverse((object) => {
@@ -311,6 +330,7 @@ function disposeGraph() {
   scene.add(graph);
   labels = [];
   pickables = [];
+  screenLinePickables = [];
   selectionTargets = new Map();
   positions = new Map();
   items = new Map();
@@ -326,9 +346,9 @@ function addPoint(point, position, baseRadius, showLabel, promoted) {
   const material = new THREE.MeshStandardMaterial({
     color: COLORS.points,
     emissive: COLORS.points,
-    emissiveIntensity: active ? (promoted ? 0.62 : 0.24) : 0.06,
+    emissiveIntensity: active ? (promoted ? 0.72 : 0.34) : 0.12,
     transparent: true,
-    opacity: active ? (promoted ? 0.98 : 0.56) : (promoted ? 0.22 : 0.08),
+    opacity: active ? (promoted ? 1 : 0.72) : (promoted ? 0.42 : 0.22),
     roughness: 0.26,
   });
   const mesh = registerPickable(new THREE.Mesh(geometry, material), "points", "point", point);
@@ -384,7 +404,7 @@ function addClusterHalo(memberPositions, center) {
       new THREE.MeshBasicMaterial({
         color: COLORS.faces,
         transparent: true,
-        opacity: 0.035,
+        opacity: 0.065,
         wireframe: true,
         depthWrite: false,
       })
@@ -443,7 +463,7 @@ function addVolume(volume, showLabel) {
         emissive: COLORS.volumes,
         emissiveIntensity: 0.42,
         transparent: true,
-        opacity: 0.52,
+        opacity: 0.72,
         wireframe: true,
       })
     ),
@@ -519,8 +539,15 @@ function addModelLine(line) {
   const sourceCluster = currentLayout?.pointClusterById.get(line.source);
   const targetCluster = currentLayout?.pointClusterById.get(line.target);
   const sameCluster = sourceCluster && sourceCluster === targetCluster;
-  const opacity = evolution ? (sameCluster ? 0.34 : 0.08) : 0.34;
-  addLine(start, end, evolution ? COLORS.lines : 0x6ebf8e, opacity, !evolution);
+  const opacity = evolution ? (sameCluster ? 0.5 : 0.16) : 0.46;
+  const lineObject = addLine(
+    start,
+    end,
+    evolution ? COLORS.lines : 0x6ebf8e,
+    opacity,
+    !evolution,
+  );
+  registerScreenLinePickable(lineObject, line, start, end);
 }
 
 function addOrbitRing(radius, color, opacity, rotation, layer) {
@@ -772,13 +799,20 @@ function syncSelectionState() {
     targets.forEach((target) => {
       if (target.element) {
         target.element.setAttribute("aria-expanded", String(active));
+      } else if (target.isLine && target.material) {
+        const baseOpacity = Number(target.userData.baseOpacity || 0);
+        target.material.opacity = active ? Math.min(1, baseOpacity * 2 + 0.24) : baseOpacity;
+        target.renderOrder = active ? 5 : 0;
       } else if (target.isMesh) {
-        target.scale.setScalar(active ? 1.32 : 1);
+        target.scale.setScalar(active ? 1.45 : 1);
       }
     });
   });
   window.__persomeInteractionState = {
     linePickables: pickables.filter((object) => object.isLine).length,
+    screenLinePickables: screenLinePickables.length,
+    minimumNodeHitRadiusPx: MIN_NODE_HIT_RADIUS_PX,
+    minimumLineHitRadiusPx: MIN_LINE_HIT_RADIUS_PX,
     nodePickables: pickables.length,
     interactiveLabels: labels.filter((label) => Boolean(label.userData.ref)).length,
     selected: selected ? { ...selected } : null,
@@ -978,12 +1012,17 @@ function showDetails(kind, item) {
   syncSelectionState();
   detailEl.dataset.kind = kind;
   detailKindEl.textContent = kind;
-  detailTitleEl.textContent = item.content || item.signature || item.label || item.id;
+  detailTitleEl.textContent = (
+    item.content || item.signature || item.label || item.predicate || item.kind || item.id
+  );
   detailMetaEl.replaceChildren();
   appendMeta("ID", item.id);
   appendMeta("Layer", item.layer || item.level);
   appendMeta("Status", item.status);
+  appendMeta("Type", item.kind);
   appendMeta("Predicate", item.label || item.predicate);
+  appendMeta("From", item.source);
+  appendMeta("To", item.target);
   appendMeta("Confidence", item.confidence);
   appendMeta("Observations", item.observations);
   appendMeta("Valid from", item.valid_from);
@@ -1282,10 +1321,61 @@ document.getElementById("play").addEventListener("click", (event) => {
 function pickAt(event) {
   const bounds = renderer.domElement.getBoundingClientRect();
   if (!bounds.width || !bounds.height) return null;
-  pointer.x = ((event.clientX - bounds.left) / bounds.width) * 2 - 1;
-  pointer.y = -((event.clientY - bounds.top) / bounds.height) * 2 + 1;
+  const localPointer = {
+    x: event.clientX - bounds.left,
+    y: event.clientY - bounds.top,
+  };
+  const projectWorldPoint = (worldPosition) => {
+    const projected = worldPosition.clone().project(camera);
+    if (projected.z < -1 || projected.z > 1) return null;
+    return {
+      x: (projected.x + 1) * 0.5 * bounds.width,
+      y: (1 - projected.y) * 0.5 * bounds.height,
+      depth: projected.z,
+    };
+  };
+  const worldPosition = new THREE.Vector3();
+  const nodeCandidates = pickables.filter((object) => object.visible).map((object) => {
+    object.getWorldPosition(worldPosition);
+    const projected = projectWorldPoint(worldPosition);
+    return projected ? { ...projected, target: object } : null;
+  }).filter(Boolean);
+  const screenNode = pickScreenTarget(
+    localPointer,
+    nodeCandidates,
+    [],
+    { nodeRadius: MIN_NODE_HIT_RADIUS_PX },
+  );
+  if (screenNode) return { object: screenNode };
+
+  pointer.x = (localPointer.x / bounds.width) * 2 - 1;
+  pointer.y = -(localPointer.y / bounds.height) * 2 + 1;
   raycaster.setFromCamera(pointer, camera);
-  return raycaster.intersectObjects(pickables.filter((object) => object.visible), false)[0] || null;
+  const meshHit = raycaster.intersectObjects(
+    pickables.filter((object) => object.visible),
+    false,
+  )[0];
+  if (meshHit) return meshHit;
+
+  const lineCandidates = screenLinePickables.filter((object) => object.visible).map((object) => {
+    const segment = object.userData.pickSegment;
+    const start = segment ? projectWorldPoint(segment.start) : null;
+    const end = segment ? projectWorldPoint(segment.end) : null;
+    if (!start || !end) return null;
+    return {
+      start,
+      end,
+      depth: Math.min(start.depth, end.depth),
+      target: object,
+    };
+  }).filter(Boolean);
+  const screenLine = pickScreenTarget(
+    localPointer,
+    [],
+    lineCandidates,
+    { lineRadius: MIN_LINE_HIT_RADIUS_PX },
+  );
+  return screenLine ? { object: screenLine } : null;
 }
 
 renderer.domElement.addEventListener("pointerdown", (event) => {

--- a/src/persome/api/model_view.py
+++ b/src/persome/api/model_view.py
@@ -24,6 +24,13 @@ _MEMORY_VIEW_TEMPLATE = """<!doctype html>
 </head>
 <body>
   <main id="viewer" aria-label="Persome personal model explorer">
+    <div id="line-explorer" class="line-explorer" hidden>
+      <label for="line-select">Open a model line</label>
+      <select id="line-select">
+        <option value="">Choose a relationship…</option>
+      </select>
+    </div>
+
     <div id="canvas"></div>
 
     <header class="topbar">
@@ -75,13 +82,6 @@ _MEMORY_VIEW_TEMPLATE = """<!doctype html>
       <div><span class="swatch volume"></span><b>Volume</b><span>cross-pattern structure</span></div>
       <div><span class="swatch root"></span><b>Root</b><span>current personal model</span></div>
     </aside>
-
-    <div id="line-explorer" class="line-explorer" hidden>
-      <label for="line-select">Open a model line</label>
-      <select id="line-select">
-        <option value="">Choose a relationship…</option>
-      </select>
-    </div>
 
     <aside id="detail" class="detail" aria-labelledby="detail-title" aria-live="polite" hidden>
       <button id="close-detail" class="icon-button close" type="button" aria-label="Close details" title="Close details">×</button>

--- a/src/persome/api/model_view.py
+++ b/src/persome/api/model_view.py
@@ -76,6 +76,13 @@ _MEMORY_VIEW_TEMPLATE = """<!doctype html>
       <div><span class="swatch root"></span><b>Root</b><span>current personal model</span></div>
     </aside>
 
+    <div id="line-explorer" class="line-explorer" hidden>
+      <label for="line-select">Open a model line</label>
+      <select id="line-select">
+        <option value="">Choose a relationship…</option>
+      </select>
+    </div>
+
     <aside id="detail" class="detail" aria-labelledby="detail-title" aria-live="polite" hidden>
       <button id="close-detail" class="icon-button close" type="button" aria-label="Close details" title="Close details">×</button>
       <p class="detail-eyebrow"><span id="detail-kind" class="detail-kind"></span><span>Evidence-backed</span></p>

--- a/tests/js/model_evidence.test.mjs
+++ b/tests/js/model_evidence.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   evidenceBreadcrumb,
   evidenceOverview,
+  linePresentation,
   nodeEvidenceCards,
   nodeHistoryCards,
   relationLabel,
@@ -57,4 +58,23 @@ test("labels version history and drill-down breadcrumbs with content", () => {
   assert.equal(relationLabel(history.relation), "Previous version");
   assert.equal(history.label, "The user checked the original evidence.");
   assert.equal(evidenceBreadcrumb({ label: history.label }), history.label);
+});
+
+test("presents line endpoints without exposing raw node IDs or replacing the predicate", () => {
+  const relation = linePresentation({
+    id: "relation-private-7",
+    kind: "relation",
+    label: "maintains",
+    predicate: "participates_in",
+    source: "point-current",
+    target: "private-context-id",
+  }, model);
+
+  assert.equal(relation.title, "maintains");
+  assert.equal(relation.label, "maintains");
+  assert.equal(relation.predicate, "participates_in");
+  assert.equal(relation.source, "The user prefers auditable answers.");
+  assert.equal(relation.target, "Context node");
+  assert.ok(!JSON.stringify(relation).includes("point-current"));
+  assert.ok(!JSON.stringify(relation).includes("private-context-id"));
 });

--- a/tests/js/model_layout.test.mjs
+++ b/tests/js/model_layout.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   computeClusterLayout,
   layoutMath,
+  pickScreenTarget,
   zoomMath,
 } from "../../resources/model_assets/layout.mjs";
 
@@ -137,4 +138,62 @@ test("steps fitted zoom predictably through rapid actions and clamps its range",
   assert.equal(zoomMath.nextPercent(113, -1), 100);
   assert.equal(zoomMath.nextPercent(50, -1), 50);
   assert.equal(zoomMath.nextPercent(400, 1), 400);
+});
+
+test("gives small nodes a stable screen-space hit target ahead of crossing lines", () => {
+  const pointTarget = { id: "point" };
+  const lineTarget = { id: "line" };
+  const hit = pickScreenTarget(
+    { x: 111, y: 100 },
+    [{ x: 100, y: 100, depth: 0.4, target: pointTarget }],
+    [{
+      start: { x: 80, y: 100 },
+      end: { x: 140, y: 100 },
+      depth: 0.2,
+      target: lineTarget,
+    }],
+  );
+
+  assert.equal(hit, pointTarget);
+});
+
+test("selects relationship lines near their rendered segment without widening raycasts", () => {
+  const lineTarget = { id: "relation" };
+  const hit = pickScreenTarget(
+    { x: 70, y: 56 },
+    [],
+    [{
+      start: { x: 20, y: 50 },
+      end: { x: 120, y: 50 },
+      depth: 0.3,
+      target: lineTarget,
+    }],
+  );
+  const miss = pickScreenTarget(
+    { x: 70, y: 62 },
+    [],
+    [{
+      start: { x: 20, y: 50 },
+      end: { x: 120, y: 50 },
+      depth: 0.3,
+      target: lineTarget,
+    }],
+  );
+
+  assert.equal(hit, lineTarget);
+  assert.equal(miss, null);
+});
+
+test("chooses the nearest projected node when hit targets overlap", () => {
+  const near = { id: "near" };
+  const far = { id: "far" };
+  const hit = pickScreenTarget(
+    { x: 100, y: 100 },
+    [
+      { x: 100, y: 100, depth: 0.7, target: far },
+      { x: 100, y: 100, depth: 0.1, target: near },
+    ],
+  );
+
+  assert.equal(hit, near);
 });

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -349,7 +349,15 @@ class TestViewPage:
         assert "MIN_NODE_HIT_RADIUS_PX = 12" in viewer
         assert "MIN_LINE_HIT_RADIUS_PX = 8" in viewer
         assert 'registerSelectionTarget("line", item.id, lineObject)' in viewer
+        assert 'id="line-select"' in page
+        assert 'lineSelectEl.addEventListener("change"' in viewer
+        assert "placeholder.disabled = lines.length > 0" in viewer
+        assert "linePresentation(item, model)" in viewer
+        assert 'appendMeta("Predicate", lineDetail?.predicate)' in viewer
+        assert 'appendMeta("From", lineDetail?.source)' in viewer
+        assert "item.source ? `Source ID: ${item.source}`" in viewer
         assert "pointer-events: auto" in css
+        assert ".line-explorer:focus-within" in css
         assert '.model-label[aria-expanded="true"]' in css
         assert '.detail[data-kind="line"]' in css
 

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -240,7 +240,7 @@ class TestViewPage:
         assert share.media_type == "text/javascript"
         assert css.media_type == "text/css"
 
-    def test_viewer_interaction_contract_prefers_labels_over_lines(self, ac_root):
+    def test_viewer_interaction_contract_keeps_nodes_ahead_of_clickable_lines(self, ac_root):
         page = render_memory_view()
         viewer = routes.model_asset("viewer.js").body.decode()
         css = routes.model_asset("viewer.css").body.decode()
@@ -252,8 +252,13 @@ class TestViewPage:
         assert 'event.key === "Escape"' in viewer
         assert "raycaster.params.Line" not in viewer
         assert "pickables.push(line)" not in viewer
+        assert "screenLinePickables.push(lineObject)" in viewer
+        assert "MIN_NODE_HIT_RADIUS_PX = 12" in viewer
+        assert "MIN_LINE_HIT_RADIUS_PX = 8" in viewer
+        assert 'registerSelectionTarget("line", item.id, lineObject)' in viewer
         assert "pointer-events: auto" in css
         assert '.model-label[aria-expanded="true"]' in css
+        assert '.detail[data-kind="line"]' in css
 
 
 class TestEvidenceResolverRoute:


### PR DESCRIPTION
## What changed

- give Point, Face, Volume, Root, and context nodes a 12-pixel minimum screen-space hit target
- make evolution and relation Lines selectable through a separate 8-pixel screen-space hit target
- keep node selection ahead of crossing Lines and leave derived hierarchy connectors visual-only
- show Line type, predicate, source, target, and available evidence in the existing detail panel
- strengthen historical Point, Face halo, Volume, and cross-cluster Line visibility
- expose aggregate hit-target bounds for local smoke tests and document the interaction contract

## Why

The viewer previously raycast only the rendered node mesh. Small or distant Points therefore became difficult to select, especially in dense models. Model Lines were intentionally excluded from all picking, so users could see a relationship but could not inspect it. Historical Points and cross-cluster evolution Lines could also render at very low opacity.

The new screen-space picker provides stable pointer targets independent of camera distance without widening Three.js Line raycasts, which could otherwise let Lines steal clicks from nodes.

## User impact

- distant nodes remain selectable at normal zoom levels
- nodes win when a relationship crosses the same pointer position
- model relationship Lines open meaningful details and evidence
- the five model layers remain visually distinct in dense graphs

## Stack

This Draft PR is based on `agent/add-evidence-drilldown` / #56 because it extends that PR's evidence detail panel. After #56 merges, this branch can be rebased or retargeted to `main`.

## Validation

- 21 relevant Python route, asset, and OpenAPI tests passed
- 10 JavaScript layout, picking, and share tests passed
- `node --check resources/model_assets/viewer.js`
- full Ruff and format checks passed
- secret, PII, language, and documentation-link scans passed
- isolated showcase served 424 Points, 146 Lines, 12 Faces, 4 Volumes, and 1 Root with the new assets
- `git diff --check`

The in-app browser runtime had no controllable browser available, so screenshot-level pointer QA could not be automated in this runner. The interaction is covered by deterministic screen-space picking tests and served-asset smoke checks.
