### PR TITLE
test: replace personal owner identity fixtures

### DIFF
--- a/tests/test_entity_source.py
+++ b/tests/test_entity_source.py
@@ -104,13 +104,13 @@ def test_memory_person_source_filters_configured_owner_alias(ac_root) -> None:
     NodeStore().save(
         MemoryNode(
             node_id=node_id,
-            content="Singularity-tian opened a pull request.",
+            content="Casey-Example opened a pull request.",
             layer=MemoryLayer.L2_FACT,
-            file_name="person-singularity-tian.md",
+            file_name="person-casey-example.md",
             confidence="high",
         )
     )
-    cfg = SimpleNamespace(memory_delta=SimpleNamespace(owner_aliases=["Singularity-tian"]))
+    cfg = SimpleNamespace(memory_delta=SimpleNamespace(owner_aliases=["Casey-Example"]))
 
     assert MemoryPersonNameSource(cfg=cfg).events() == []
 
@@ -119,9 +119,9 @@ def test_memory_person_source_filters_learned_owner_alias(ac_root) -> None:
     NodeStore().save(
         MemoryNode(
             node_id="point-person-learned-owner",
-            content="Singularity-tian opened a pull request.",
+            content="Casey-Example opened a pull request.",
             layer=MemoryLayer.L2_FACT,
-            file_name="person-singularity-tian.md",
+            file_name="person-casey-example.md",
             confidence="high",
         )
     )
@@ -129,10 +129,10 @@ def test_memory_person_source_filters_learned_owner_alias(ac_root) -> None:
         for session_id in ("owner-1", "owner-2"):
             owner_identity.record_candidate(
                 conn,
-                alias="Singularity-tian",
+                alias="Casey-Example",
                 session_id=session_id,
                 source_kind=owner_alias_store.SOURCE_OWNED_ACCOUNT,
-                quote="own account Singularity-tian",
+                quote="own account Casey-Example",
                 confidence=0.9,
             )
     cfg = SimpleNamespace(memory_delta=SimpleNamespace(owner_aliases=[]))

--- a/tests/test_memory_delta.py
+++ b/tests/test_memory_delta.py
@@ -109,16 +109,16 @@ def test_delta_persisted_shadow_with_counts(ac_root, fake_llm) -> None:
 def test_roster_reserves_self_and_owner_aliases(ac_root) -> None:
     cfg = _cfg()
     cfg.memory_delta.owner_aliases = [
-        "Tianyi Zhang",
-        "\u5f20\u5929\u7fca",
-        "Singularity-tian",
+        "Casey Example",
+        "\u793a\u4f8b\u7532",
+        "Casey-Example",
     ]
 
     roster = delta_mod._load_roster(cfg)
 
     assert roster[0] == (
         "self",
-        ["Tianyi Zhang", "\u5f20\u5929\u7fca", "Singularity-tian"],
+        ["Casey Example", "\u793a\u4f8b\u7532", "Casey-Example"],
     )
     rendered = delta_mod._render_roster(roster)
     assert "self" in rendered and "memory owner" in rendered
@@ -127,17 +127,17 @@ def test_roster_reserves_self_and_owner_aliases(ac_root) -> None:
 def test_owner_alias_canonicalizes_to_self_but_never_mints_person(ac_root) -> None:
     from persome.evomem import identity as identity_mod
 
-    roster = identity_mod.Roster.build([("self", ["Singularity-tian"]), ("Kevin", [])])
-    quote = "Singularity-tian reviewed the launch plan with Kevin"
+    roster = identity_mod.Roster.build([("self", ["Casey-Example"]), ("Kevin", [])])
+    quote = "Casey-Example reviewed the launch plan with Kevin"
     raw = {
         "entities": [
-            {"ref": "Singularity-tian", "kind": "person", "quote": quote, "confidence": 0.9},
+            {"ref": "Casey-Example", "kind": "person", "quote": quote, "confidence": 0.9},
             {"ref": "Kevin", "kind": "person", "quote": quote, "confidence": 0.9},
         ],
         "assertions": [],
         "relations": [
             {
-                "src": {"ref": "Singularity-tian"},
+                "src": {"ref": "Casey-Example"},
                 "dst": {"ref": "Kevin"},
                 "predicate": "knows",
                 "label": "teammates",
@@ -159,14 +159,14 @@ def test_owner_alias_canonicalizes_to_self_but_never_mints_person(ac_root) -> No
 
 
 def test_ai_owner_alias_evidence_promotes_without_user_config(ac_root, fake_llm) -> None:
-    quote = "Opened the user's own GitHub account Singularity-tian with Kevin"
+    quote = "Opened the user's own GitHub account Casey-Example with Kevin"
     start, end = _seed_session_blocks([f"[Chrome] {quote}"])
     fake_llm.set_default(
         delta_mod.STAGE,
         _payload(
             owner_alias_candidates=[
                 {
-                    "alias": "Singularity-tian",
+                    "alias": "Casey-Example",
                     "source_kind": "owned_account",
                     "quote": quote,
                     "confidence": 0.94,
@@ -174,7 +174,7 @@ def test_ai_owner_alias_evidence_promotes_without_user_config(ac_root, fake_llm)
             ],
             entities=[
                 {
-                    "new_entity": "Singularity-tian",
+                    "new_entity": "Casey-Example",
                     "kind": "person",
                     "quote": quote,
                     "confidence": 0.94,
@@ -189,7 +189,7 @@ def test_ai_owner_alias_evidence_promotes_without_user_config(ac_root, fake_llm)
             assertions=[],
             relations=[
                 {
-                    "src": {"new_entity": "Singularity-tian"},
+                    "src": {"new_entity": "Casey-Example"},
                     "dst": {"new_entity": "Kevin"},
                     "predicate": "knows",
                     "label": "collaborators",
@@ -208,12 +208,12 @@ def test_ai_owner_alias_evidence_promotes_without_user_config(ac_root, fake_llm)
     with fts.cursor() as conn:
         assert (
             conn.execute(
-                "SELECT status FROM owner_aliases WHERE alias_key='singularity-tian'"
+                "SELECT status FROM owner_aliases WHERE alias_key='casey-example'"
             ).fetchone()[0]
             == "pending"
         )
         payload = json.loads(deltas_store.latest_for_session(conn, "owner-session-1")["payload"])
-    assert all(entity.get("new_entity") != "Singularity-tian" for entity in payload["entities"])
+    assert all(entity.get("new_entity") != "Casey-Example" for entity in payload["entities"])
     assert payload["relations"] == []
 
     second = delta_mod.run_after_session(
@@ -222,17 +222,17 @@ def test_ai_owner_alias_evidence_promotes_without_user_config(ac_root, fake_llm)
     assert second.counts["owner_alias_candidates"] == 1
     with fts.cursor() as conn:
         row = conn.execute(
-            "SELECT status, evidence_count FROM owner_aliases WHERE alias_key='singularity-tian'"
+            "SELECT status, evidence_count FROM owner_aliases WHERE alias_key='casey-example'"
         ).fetchone()
         payload = json.loads(deltas_store.latest_for_session(conn, "owner-session-2")["payload"])
         owner_points = conn.execute(
-            "SELECT COUNT(*) FROM evo_nodes WHERE file_name='person-singularity-tian.md'"
+            "SELECT COUNT(*) FROM evo_nodes WHERE file_name='person-casey-example.md'"
             " AND is_latest=1 AND status='active'"
         ).fetchone()[0]
     assert tuple(row) == ("active", 2)
     assert payload["relations"][0]["src"] == {"ref": "self"}
     assert owner_points == 0
-    assert delta_mod._load_roster(cfg)[0] == ("self", ["Singularity-tian"])
+    assert delta_mod._load_roster(cfg)[0] == ("self", ["Casey-Example"])
 
 
 def test_render_blocks_excludes_local_model_output_and_mixed_focus(ac_root) -> None:

--- a/tests/test_owner_identity.py
+++ b/tests/test_owner_identity.py
@@ -19,18 +19,18 @@ def test_owned_account_requires_two_independent_sessions(ac_root) -> None:
     with fts.cursor() as conn:
         first = owner_identity.record_candidate(
             conn,
-            alias="Singularity-tian",
+            alias="Casey-Example",
             session_id="session-1",
             source_kind=alias_store.SOURCE_OWNED_ACCOUNT,
-            quote="Opened the user's own GitHub account Singularity-tian",
+            quote="Opened the user's own GitHub account Casey-Example",
             confidence=0.91,
         )
         duplicate = owner_identity.record_candidate(
             conn,
-            alias="Singularity-tian",
+            alias="Casey-Example",
             session_id="session-1",
             source_kind=alias_store.SOURCE_OWNED_ACCOUNT,
-            quote="Opened the user's own GitHub account Singularity-tian",
+            quote="Opened the user's own GitHub account Casey-Example",
             confidence=0.94,
         )
         assert first is not None and first.status == alias_store.STATUS_PENDING
@@ -38,26 +38,26 @@ def test_owned_account_requires_two_independent_sessions(ac_root) -> None:
 
         second = owner_identity.record_candidate(
             conn,
-            alias="Singularity-tian",
+            alias="Casey-Example",
             session_id="session-2",
             source_kind=alias_store.SOURCE_OWNED_ACCOUNT,
-            quote="Returned to own repositories for Singularity-tian",
+            quote="Returned to own repositories for Casey-Example",
             confidence=0.9,
         )
 
     assert second is not None and second.status == alias_store.STATUS_ACTIVE
     assert second.evidence_count == 2 and second.activated_now
-    assert owner_identity.active_aliases(_cfg()) == ["Singularity-tian"]
+    assert owner_identity.active_aliases(_cfg()) == ["Casey-Example"]
 
 
 def test_explicit_authored_identity_promotes_immediately(ac_root) -> None:
     with fts.cursor() as conn:
         state = owner_identity.record_candidate(
             conn,
-            alias="\u5f20\u5929\u7fca",
+            alias="\u793a\u4f8b\u7532",
             session_id="session-explicit",
             source_kind=alias_store.SOURCE_EXPLICIT_SELF,
-            quote="\u6211\u53eb\u5f20\u5929\u7fca",
+            quote="\u6211\u53eb\u793a\u4f8b\u7532",
             confidence=0.96,
         )
 
@@ -118,15 +118,15 @@ def test_stale_pending_alias_no_longer_blocks_person_graph(ac_root) -> None:
 def test_promotion_retires_existing_person_and_derived_schema(ac_root) -> None:
     memory = EvoMemory()
     memory.add_direct(
-        "Singularity-tian",
+        "Casey-Example",
         layer=MemoryLayer.L5_KNOWLEDGE,
-        file_name="person-singularity-tian",
+        file_name="person-casey-example",
         tags="person-entity",
     )
     memory.add_direct(
         "The person iterates on pull requests.",
         layer=MemoryLayer.L6_SCHEMA,
-        file_name="schema-person-singularity-tian",
+        file_name="schema-person-casey-example",
         tags="schema stable",
     )
 
@@ -134,21 +134,21 @@ def test_promotion_retires_existing_person_and_derived_schema(ac_root) -> None:
         for session_id in ("session-1", "session-2"):
             owner_identity.record_candidate(
                 conn,
-                alias="Singularity-tian",
+                alias="Casey-Example",
                 session_id=session_id,
                 source_kind=alias_store.SOURCE_OWNED_ACCOUNT,
-                quote="own GitHub account Singularity-tian",
+                quote="own GitHub account Casey-Example",
                 confidence=0.91,
             )
         active = conn.execute(
             "SELECT file_name FROM evo_nodes WHERE is_latest=1 AND status='active'"
-            " AND file_name IN ('person-singularity-tian.md',"
-            " 'schema-person-singularity-tian.md')"
+            " AND file_name IN ('person-casey-example.md',"
+            " 'schema-person-casey-example.md')"
         ).fetchall()
         retired = conn.execute(
             "SELECT COUNT(*) FROM evo_nodes WHERE status='shadow' AND is_latest=0"
-            " AND file_name IN ('person-singularity-tian.md',"
-            " 'schema-person-singularity-tian.md')"
+            " AND file_name IN ('person-casey-example.md',"
+            " 'schema-person-casey-example.md')"
         ).fetchone()[0]
 
     assert active == [] and retired == 2

--- a/tests/test_person_graph.py
+++ b/tests/test_person_graph.py
@@ -147,15 +147,15 @@ def test_pending_owner_alias_never_mints_person(ac_root):
     with fts.cursor() as conn:
         owner_alias_store.record_evidence(
             conn,
-            alias="Singularity-tian",
+            alias="Casey-Example",
             session_id="owner-session-1",
             source_kind=owner_alias_store.SOURCE_OWNED_ACCOUNT,
-            quote="own GitHub account Singularity-tian",
+            quote="own GitHub account Casey-Example",
             confidence=0.9,
         )
 
     graph = PersonGraph(_mem(), cfg=_on(), name_source=_StaticSource([]))
-    assert graph.record(PersonEvent(name="Singularity-tian", summary="opened a PR")) is None
+    assert graph.record(PersonEvent(name="Casey-Example", summary="opened a PR")) is None
     assert graph.list_persons() == []
 
 

--- a/tests/test_update_memory.py
+++ b/tests/test_update_memory.py
@@ -142,20 +142,20 @@ def test_entity_op_can_merge_identity_into_reserved_self(ac_root):
         res = C.update_memory(
             _cfg(),
             conn,
-            "Singularity-tian is my GitHub handle",
+            "Casey-Example is my GitHub handle",
             llm_call=_llm(
                 {
                     "supersede": [],
-                    "entity_op": {"op": "merge_into_self", "entity": "Singularity-tian"},
+                    "entity_op": {"op": "merge_into_self", "entity": "Casey-Example"},
                     "reason": "owner handle",
                 }
             ),
         )
         row = conn.execute(
-            "SELECT status, decision_source FROM owner_aliases WHERE alias_key='singularity-tian'"
+            "SELECT status, decision_source FROM owner_aliases WHERE alias_key='casey-example'"
         ).fetchone()
 
-    assert res.ok and "merged Singularity-tian → self" in res.applied
+    assert res.ok and "merged Casey-Example → self" in res.applied
     assert tuple(row) == ("active", "user")
 
 
@@ -185,18 +185,18 @@ def test_owner_alias_correction_preserves_agent_provenance(ac_root):
         res = C.update_memory(
             _cfg(),
             conn,
-            "Singularity-tian is the owner's GitHub handle",
+            "Casey-Example is the owner's GitHub handle",
             source="agent",
             llm_call=_llm(
                 {
                     "supersede": [],
-                    "entity_op": {"op": "merge_into_self", "entity": "Singularity-tian"},
+                    "entity_op": {"op": "merge_into_self", "entity": "Casey-Example"},
                     "reason": "owner handle",
                 }
             ),
         )
         source = conn.execute(
-            "SELECT decision_source FROM owner_aliases WHERE alias_key='singularity-tian'"
+            "SELECT decision_source FROM owner_aliases WHERE alias_key='casey-example'"
         ).fetchone()[0]
 
     assert res.ok and source == "agent"


### PR DESCRIPTION
## What changed

- replace the real owner name, Chinese name, and GitHub handle used by owner-identity tests with synthetic fixtures
- keep normalized SQLite keys and person/schema slugs lowercase while preserving mixed-case alias coverage
- retain README and contributor metadata because those are legitimate public attributions

## Why

The test suite should not embed a contributor's personal owner identity. Although tests are isolated from the real Persome data root and are not packaged in the wheel, synthetic fixtures avoid confusion and remove an unnecessary local capture/identity-learning surface for source contributors.

## Impact

Runtime behavior and public contracts are unchanged. The same owner-alias promotion, canonicalization, correction, and person-retirement paths remain covered.

## Validation

- `PERSOME_LLM_MOCK=1 uv run pytest -m "not macos and not integration" -q` — 1911 passed, 15 deselected
- targeted owner-identity tests — 59 passed
- `uv run ruff check` on the five changed files
- `uv run ruff format --check` on the five changed files
- secret, PII, and language scans
- `git diff --check`
