### PR TITLE
feat: randomize X share copy

### DIFF
--- a/docs/model-contract.md
+++ b/docs/model-contract.md
@@ -79,7 +79,8 @@ recognizably personal without changing the snapshot. The `Local only` treatment 
 a publishing control. The viewer never uploads the model or exposes its owner-only URL. An explicit
 `Share` action renders a fixed-size PNG locally from the unlabeled WebGL constellation, adds the Root
 identity statement, up to three highest-level Volume or Face signatures, aggregate layer counts, and
-Persome branding, downloads it, and opens an X composer with standard copy and tags. Individual
+Persome branding, downloads it, and opens an X composer with one of three standard copy variants,
+each carrying the Personal Model tag and official account mention. Individual
 Point labels, receipts, source names, timestamps, and viewer credentials are excluded from the share
 artifact; the owner attaches the downloaded image and confirms the post in X.
 

--- a/resources/model_assets/share.mjs
+++ b/resources/model_assets/share.mjs
@@ -2,24 +2,37 @@ export const SHARE_CARD_WIDTH = 1200;
 export const SHARE_CARD_HEIGHT = 675;
 export const SHARE_FILE_NAME = "my-persome-constellation.png";
 export const SHARE_URL = "https://github.com/Intuition-Lab/personal-model";
-export const SHARE_HASHTAGS = ["Persome", "PersonalAI"];
-export const SHARE_TEXT = [
-  "My Mac has been quietly learning the shape of how I work.",
-  "",
-  "This is my personal constellation — built locally from real context with Persome.",
-  "",
-  "Build yours →",
-].join("\n");
+export const SHARE_TEXTS = Object.freeze([
+  [
+    "I let @PersonalModel_ observe how I use my Mac, and apparently this is what I look like 😳",
+    "",
+    "#PersonalModel @PersonalModel_",
+  ].join("\n"),
+  [
+    "I let my @PersonalModel_ learn from how I use my Mac. I didn’t expect this is how it sees me 😳",
+    "",
+    "#PersonalModel @PersonalModel_",
+  ].join("\n"),
+  [
+    "I let @PersonalModel_ observe how I use my Mac, and this is the model it built 🤔",
+    "",
+    "#PersonalModel @PersonalModel_",
+  ].join("\n"),
+]);
+
+export function pickShareText(random = Math.random) {
+  const index = Math.floor(random() * SHARE_TEXTS.length);
+  return SHARE_TEXTS[Math.max(0, Math.min(index, SHARE_TEXTS.length - 1))];
+}
 
 export function buildXIntentUrl({
-  text = SHARE_TEXT,
+  text,
   url = SHARE_URL,
-  hashtags = SHARE_HASHTAGS,
+  random = Math.random,
 } = {}) {
   const params = new URLSearchParams();
-  params.set("text", text);
+  params.set("text", text ?? pickShareText(random));
   params.set("url", url);
-  params.set("hashtags", hashtags.join(","));
   return `https://x.com/intent/tweet?${params.toString()}`;
 }
 

--- a/tests/js/model_share.test.mjs
+++ b/tests/js/model_share.test.mjs
@@ -5,22 +5,53 @@ import {
   SHARE_CARD_HEIGHT,
   SHARE_CARD_WIDTH,
   SHARE_FILE_NAME,
-  SHARE_HASHTAGS,
-  SHARE_TEXT,
+  SHARE_TEXTS,
   SHARE_URL,
   buildXIntentUrl,
+  pickShareText,
   shareNarrative,
   shareStats,
 } from "../../resources/model_assets/share.mjs";
 
-test("builds an X composer URL with the standard copy, destination, and tags", () => {
-  const intent = new URL(buildXIntentUrl());
+const EXPECTED_SHARE_TEXTS = [
+  [
+    "I let @PersonalModel_ observe how I use my Mac, and apparently this is what I look like 😳",
+    "",
+    "#PersonalModel @PersonalModel_",
+  ].join("\n"),
+  [
+    "I let my @PersonalModel_ learn from how I use my Mac. I didn’t expect this is how it sees me 😳",
+    "",
+    "#PersonalModel @PersonalModel_",
+  ].join("\n"),
+  [
+    "I let @PersonalModel_ observe how I use my Mac, and this is the model it built 🤔",
+    "",
+    "#PersonalModel @PersonalModel_",
+  ].join("\n"),
+];
+
+test("keeps the three approved X share variants verbatim", () => {
+  assert.deepEqual(SHARE_TEXTS, EXPECTED_SHARE_TEXTS);
+});
+
+test("selects each X share variant from an equal third of the random range", () => {
+  assert.equal(pickShareText(() => 0), EXPECTED_SHARE_TEXTS[0]);
+  assert.equal(pickShareText(() => (1 / 3) - Number.EPSILON), EXPECTED_SHARE_TEXTS[0]);
+  assert.equal(pickShareText(() => 1 / 3), EXPECTED_SHARE_TEXTS[1]);
+  assert.equal(pickShareText(() => (2 / 3) - Number.EPSILON), EXPECTED_SHARE_TEXTS[1]);
+  assert.equal(pickShareText(() => 2 / 3), EXPECTED_SHARE_TEXTS[2]);
+  assert.equal(pickShareText(() => 0.999999), EXPECTED_SHARE_TEXTS[2]);
+});
+
+test("builds an X composer URL with a selected variant and destination", () => {
+  const intent = new URL(buildXIntentUrl({ random: () => 0.5 }));
 
   assert.equal(intent.origin, "https://x.com");
   assert.equal(intent.pathname, "/intent/tweet");
-  assert.equal(intent.searchParams.get("text"), SHARE_TEXT);
+  assert.equal(intent.searchParams.get("text"), EXPECTED_SHARE_TEXTS[1]);
   assert.equal(intent.searchParams.get("url"), SHARE_URL);
-  assert.equal(intent.searchParams.get("hashtags"), SHARE_HASHTAGS.join(","));
+  assert.equal(intent.searchParams.get("hashtags"), null);
   assert.ok(!intent.href.includes("localhost"));
   assert.ok(!intent.href.includes("/model/"));
 });


### PR DESCRIPTION
## Summary

- replace the single X share message with the three approved Personal Model variants
- choose one variant uniformly on every Share click
- keep `#PersonalModel` and `@PersonalModel_` in the copy while continuing to append the repository URL
- update the model contract and add deterministic boundary tests for all three equal probability ranges

## User impact

Shared model posts now rotate between three concise, official-account-tagged messages without changing the local image export or X handoff flow.

## Validation

- `node --test tests/js/model_share.test.mjs`
- `node --check resources/model_assets/share.mjs`
- `uv run pytest tests/test_model_routes.py -q`
- `git diff --check`
