### PR TITLE
feat: materialize the personal model as HUMAN.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -104,7 +104,9 @@ Each stage records completion, skip, or failure. Enrichment runs every enabled
 substage before surfacing a partial failure, so the manifest cannot call a
 partially failed stage complete. Missing geometry marks the build degraded and
 never overwrites an existing good Root with an empty result. The manifest is
-written atomically with owner-only permissions.
+written atomically with owner-only permissions. The Runtime then
+deterministically renders the raw snapshot as owner-only `HUMAN.md`; this
+projection makes no additional LLM call and never fabricates a Root.
 
 ## Storage
 
@@ -117,6 +119,7 @@ written atomically with owner-only permissions.
 | `memory/*.md` | readable durable memory and schema projections |
 | `index.db` | WAL-mode FTS5, model, provenance, sessions, and vectors |
 | `model-build.json` | last reproducibility manifest |
+| `HUMAN.md` | raw deterministic model reading view, mode `0600` |
 | `exports/*.json` | redacted model snapshots, mode `0600` |
 | `.runtime-state.json` | owner-only Runtime generation and readiness receipt |
 | `native/<source-digest>/` | immutable AX helper/watcher binaries |
@@ -134,6 +137,8 @@ legacy completed activity can be read through a neutral adapter.
   See [MCP.md](MCP.md).
 - Snapshot: versioned Point/Line/Face/Volume/Root JSON. See
   [MODEL_FORMAT.md](MODEL_FORMAT.md).
+- Human view: raw owner-local `HUMAN.md`, backfilled from an existing valid
+  Root on startup/onboarding. JSON remains the machine contract.
 
 ## Invariants
 
@@ -142,6 +147,8 @@ legacy completed activity can be read through a neutral adapter.
   `event:intent:*` records are read-only compatibility data.
 - At most one live Root exists.
 - A model export is redacted by default and written with mode `0600`.
+- A Persome-managed `HUMAN.md` is refreshed automatically; an unknown file at
+  that path is preserved instead of overwritten.
 - SQLite access uses `with fts.cursor() as conn:` so readers and the writer
   coexist under WAL mode.
 - LLM calls flow through `writer/llm.py` over Anthropic Messages or

--- a/MODEL_FORMAT.md
+++ b/MODEL_FORMAT.md
@@ -6,6 +6,14 @@ inside `/model/graph` expose the same schema; consumers must not import internal
 DAOs or query SQLite tables directly. Redaction policy differs: export and MCP
 redact by default, while the owner-only loopback viewer uses raw local content.
 
+`<PERSOME_ROOT>/HUMAN.md` (`~/.persome/HUMAN.md` by default) is a separate,
+deterministic reading view of that snapshot, not another model or import
+format. It contains raw local Root, Volume, and Face text, is written
+owner-only with mode `0600`, and may change when Persome's renderer changes.
+The versioned JSON snapshot and its build manifest remain authoritative for
+machines, reproducibility, receipts, and redacted export. A missing Root renders
+an explicit still-forming placeholder rather than a fabricated identity.
+
 ## Top-level schema
 
 ```json

--- a/README.md
+++ b/README.md
@@ -254,6 +254,15 @@ persome onboard
 persome model open --after 30
 ```
 
+Persome also maintains `~/.persome/HUMAN.md`, a raw, owner-only (`0600`),
+human-readable projection of the current personal model. Existing users get it
+from an already valid Root after `persome update`, or after
+`uv tool upgrade personal-model` followed by `persome onboard`; that backfill
+does not recapture activity or call an LLM. If no verified Root exists yet, the
+file honestly says that the model is still forming and refreshes after a later
+build. Persome replaces only a `HUMAN.md` carrying its own management marker;
+an unknown file you created at that path is preserved.
+
 For an installation created by `install.sh`, run the transactional updater from
 any directory:
 
@@ -273,6 +282,9 @@ OCR repair, backup, and uninstall details.
 
 - Durable Markdown, SQLite/FTS5, model snapshots, and logs live under
   `~/.persome` unless `PERSOME_ROOT` is set.
+- `~/.persome/HUMAN.md` is a raw local reading view; the versioned JSON
+  snapshot remains the machine-readable authority and the default export stays
+  redacted.
 - AX is the default signal. Optional PP-OCRv6 runs locally in an isolated
   subprocess with bundled weights.
 - The HTTP/MCP server is restricted to loopback (`127.0.0.1` by default), requires an owner-local
@@ -403,6 +415,7 @@ persome model status
 persome faces-report
 persome contradictions
 persome model open
+# Read the raw owner-only personal-model projection at ~/.persome/HUMAN.md
 
 # Correct or revoke one memory while retaining its audit trail
 persome correct --help
@@ -448,6 +461,9 @@ advice, export sensitivity, reset behavior, and manual removal steps.
 - Screenshots are omitted from MCP by default and encrypted at rest when
   retention is enabled.
 - `persome model export` is redacted by default; `--raw` is an explicit opt-out.
+- `~/.persome/HUMAN.md` is raw personal data, not a sharing artifact. Persome
+  refreshes its managed copy; make corrections through `persome correct`
+  instead of editing the projection.
 - There is no built-in remote account, sync service, telemetry, meeting audio
   capture, computer-use actuation, or filesystem profiler.
 

--- a/SECURITY_PRIVACY.md
+++ b/SECURITY_PRIVACY.md
@@ -15,6 +15,7 @@ The default data root is `~/.persome` and can be redirected with
 | indexes/model | `index.db` | SQLite WAL, FTS5, vectors, provenance, geometry |
 | provider/local API secrets | `env` | dotenv file, mode `0600` |
 | build metadata | `model-build.json` | hashes/IDs, no API keys |
+| human-readable model | `HUMAN.md` | raw deterministic projection, mode `0600`; not redacted for sharing |
 | exported model | `exports/*.json` | redacted by default, mode `0600` |
 | Runtime receipts | `.runtime-state.json`, `.update-state.json` | owner-only generation, policy, and transaction metadata |
 | native AX binaries | `native/<source-digest>/` | immutable machine-local permission principals |
@@ -125,6 +126,9 @@ model stages report degradation rather than silently claiming success.
   send returned personal data to its own model provider.
 - `/model/graph` is a raw owner-local inspection surface. Default CLI/MCP model
   export is redacted; the browser viewer is not a safe publication artifact.
+- `HUMAN.md` is also a raw owner-local inspection surface, despite its readable
+  format and `0600` mode. Do not publish or attach it as though it were a
+  redacted export.
 - Wildcard and LAN binds are rejected even when a bearer is configured because
   the Runtime does not terminate TLS. Exposing it through a tunnel changes the
   privacy boundary and is not a supported deployment.
@@ -152,11 +156,13 @@ from the selected write authority; they do not erase provenance history.
 For irreversible deletion, stop the daemon and run `persome clean memory` or
 `persome clean all`. The memory command also removes canonical evomem state,
 relations, geometry, every file under `memory/` (including interrupted atomic
-writes), exports, projections, backups, and recovery markers. The all command also
-removes captures, timeline/session state, legacy Chat-era history and skills
-from older releases, logs, and SQLite files while preserving config, env, and
-the installed virtualenv. See
+writes), the generated `HUMAN.md`, exports, projections, backups, and recovery
+markers. The all command also removes `HUMAN.md`, captures, timeline/session
+state, legacy Chat-era history and skills from older releases, logs, and SQLite
+files while preserving config, env, and the installed virtualenv. See
 [operations and data control](docs/operations.md).
+These explicit erasure commands remove the root-level `HUMAN.md` path even if
+automatic refresh had preserved it as an unrecognized user-authored file.
 
 `persome clean captures` and `persome clean timeline` scrub the same tables
 from retained SQLite snapshots, unfinished `.tmp` snapshots, and integrity

--- a/docs/model-contract.md
+++ b/docs/model-contract.md
@@ -13,6 +13,24 @@ persome model status
 persome model export --out model-snapshot.json
 ```
 
+## Human-readable projection
+
+After a build, Persome deterministically projects the raw current snapshot to
+`<PERSOME_ROOT>/HUMAN.md` (`~/.persome/HUMAN.md` by default). The file is an
+owner-local `0600` reading surface, not a second model contract: the versioned
+JSON snapshot, build manifest, and evidence APIs remain the machine authority.
+No additional capture or LLM call is needed to render it.
+
+Daemon startup and `persome onboard` reconcile the file from an existing valid
+Root, so upgrades backfill it without rebuilding the user's history. With no
+verified Root, Persome writes a truthful forming placeholder and replaces that
+placeholder after later model builds. Automatic refresh replaces only files
+with Persome's projection marker. If an unrecognized, self-authored
+`HUMAN.md` already occupies the path, Persome preserves it and reports the
+conflict instead of overwriting it. Direct edits to a managed projection are
+not a correction interface and may be replaced; use `persome correct` for model
+changes.
+
 `model build` uses an exclusive `<PERSOME_ROOT>/model-build.lock`. It waits up to 30 seconds by
 default; `--wait-seconds` changes the bound and `--no-wait` returns `busy` immediately. The kernel
 releases the lock on process exit. A run first atomically records `status: building`, invalidating
@@ -122,6 +140,8 @@ mode `0600`. Callers must opt out explicitly with `redact=False`. A fixed `gener
 
 The `model` object in loopback `/model/graph` uses the same schema but raw local
 content so the owner can inspect the real model. It is not a publication export.
+`HUMAN.md` uses the same raw owner-local boundary and likewise must not be
+treated as a safe sharing artifact.
 
 The synthetic contract fixture lives at
 [`tests/fixtures/runtime_model/model_seed.json`](../tests/fixtures/runtime_model/model_seed.json). It

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -73,6 +73,7 @@ and old helper path.
 | `backup/` | SQLite safety snapshots containing personal model state |
 | `logs/` | daemon and launchd logs; may contain operational context |
 | `model-build.json` | latest build manifest and degraded-stage report |
+| `HUMAN.md` | raw deterministic reading view of the current model; owner-only mode `0600` |
 | `.integrity-recovery.pending.json` | crash-resumable full-database quarantine/replay journal |
 | `.integrity-config-recovery.pending.json` | config-quarantine intent retained until database authority is reconciled |
 | `.pid`, `.runtime-state.json` | compatibility PID plus owner-only generation, phase, permission, OCR-worker, and capture/privacy receipt |
@@ -87,6 +88,12 @@ Treat the whole root as sensitive. Backups and exports are copies of personal
 data, not harmless metadata. Persome enforces `0700` on the root/data
 directories and `0600` on sensitive files, repairs legacy modes once after an
 upgrade, and gives its LaunchAgent umask `0077`.
+
+`HUMAN.md` is regenerated from the model without capture or an LLM call. A
+valid pre-existing Root is backfilled during daemon startup or onboarding; no
+Root produces an honest forming placeholder. Refreshes overwrite only the
+Persome-managed projection marker. An unknown file at that path is left in
+place and reported rather than adopted or overwritten.
 
 ## Startup recovery
 
@@ -194,6 +201,11 @@ Invoking `bash install.sh` from a checkout when Persome is already installed
 delegates to `persome update --source <checkout>` so manual reinstalls receive
 the same stop, rollback, and post-install proof guarantees.
 
+The updated Runtime reconciles `HUMAN.md` from the current valid Root during
+startup/onboarding, so `persome update` backfills existing users without new
+capture or model calls. Package-manager users receive the same reconciliation
+after `uv tool upgrade personal-model` followed by `persome onboard`.
+
 `persome update --source /path/to/checkout` is the explicit developer/offline
 path. The supplied tree must have the complete Persome source layout; the
 updater never pulls or rewrites it.
@@ -242,7 +254,9 @@ persome model open
 ```
 
 The viewer and `GET /model/graph` are raw owner-local inspection surfaces.
-Model export and MCP snapshot export redact by default.
+`HUMAN.md` is another raw owner-local inspection surface. Model export and MCP
+snapshot export redact by default, and their versioned JSON remains the machine
+authority.
 
 ## Correct and revoke
 
@@ -275,7 +289,7 @@ Stop the daemon first so no writer can race the deletion.
 persome stop
 
 # Delete every file under memory/, FTS entries, canonical evomem, relations,
-# Faces, Volumes, Root, exports, projections, backups, and recovery markers.
+# Faces, Volumes, Root, HUMAN.md, exports, projections, backups, and recovery markers.
 # Captures/timeline remain.
 persome clean memory
 
@@ -284,6 +298,10 @@ persome clean memory
 # Keep config, env, and the installed venv.
 persome clean all
 ```
+
+Both `clean memory` and `clean all` remove the root-level `HUMAN.md` path as
+part of an explicit erasure, even when refresh previously preserved it as an
+unrecognized user-authored file.
 
 Clean commands refuse to run while the daemon PID is live, even with `--yes`,
 so a writer cannot retain an open SQLite handle or recreate data mid-erasure.

--- a/docs/runtime-internals.md
+++ b/docs/runtime-internals.md
@@ -51,6 +51,13 @@ is recoverable from the candidate marker. The updater pins both `PERSOME_ROOT`
 and the installer's `PERSOME_INSTALL_HOME` to the active data root so an isolated
 profile cannot be redirected to `~/.persome`.
 
+Model builds materialize `<PERSOME_ROOT>/HUMAN.md` after producing the current
+raw snapshot. Daemon startup and `persome onboard` also reconcile it, which
+backfills a valid existing Root after `persome update` or after
+`uv tool upgrade personal-model` plus onboarding without recapture or an LLM
+call. Reconciliation emits a forming placeholder when no Root exists and
+refuses to replace an unmarked file at that path.
+
 `start` holds `<PERSOME_ROOT>/.daemon.lock` from preflight through the entire
 foreground or double-forked daemon lifetime. This prevents two concurrent
 starters from both passing the PID check. The daemon writes a numeric `.pid` for
@@ -107,6 +114,7 @@ labels, ports, and data roots do not belong in core.
 | `model-build.lock` | cross-process build lock |
 | `session-model.lock` | cross-process terminal-session finalization lock |
 | `model-build.json` | last build manifest |
+| `HUMAN.md` | Persome-managed raw model reading view; owner-only mode `0600` |
 | `.integrity-recovery.pending.json` | resumable full-database recovery phase journal |
 | `.integrity-config-recovery.pending.json` | pre-quarantine config intent and authority guard |
 | `.integrity-recovery.json` | last completed quarantine/recovery report |

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -872,6 +872,13 @@ def onboard(
     _init()
     env_file_mod.load_env_file(paths.env_file())
     try:
+        from .model.human import sync_live_human_markdown
+
+        human_path = sync_live_human_markdown()
+        console.print(f"[green]✓ HUMAN.md ready[/green]  [dim]{human_path}[/dim]")
+    except Exception as exc:  # noqa: BLE001 - onboarding still proves the core Runtime
+        console.print(f"[yellow]⚠ HUMAN.md was preserved or could not be refreshed: {exc}[/yellow]")
+    try:
         proof = onboarding_mod.onboard(
             tier=tier,
             gui=gui,
@@ -2766,6 +2773,8 @@ def model_build(
                 "[yellow]Deferred pairs stay queued for later scheduled or explicit builds.[/yellow]"
             )
     console.print(f"manifest: {result.manifest_path}")
+    if (human_path := getattr(result, "human_path", None)) is not None:
+        console.print(f"HUMAN.md: {human_path}")
 
 
 @model_app.command("export")
@@ -3452,6 +3461,7 @@ def _clean_memory() -> tuple[int, int, int, int]:
             paths.exports_dir(),
             paths.backup_dir(),
             paths.root() / "projection-md",
+            paths.human_file(),
             paths.model_build_manifest(),
             paths.model_build_lock(),
             paths.session_model_lock(),
@@ -3463,6 +3473,7 @@ def _clean_memory() -> tuple[int, int, int, int]:
     artifacts += sum(
         _remove_path(path)
         for path in _private_atomic_crash_artifacts(
+            paths.human_file(),
             paths.model_build_manifest(),
             paths.integrity_recovery_marker(),
             paths.integrity_recovery_pending(),
@@ -3579,6 +3590,7 @@ def clean_all(
         paths.exports_dir(),
         paths.backup_dir(),
         paths.root() / "projection-md",
+        paths.human_file(),
         # Legacy Chat-era data written by versions that still shipped the Chat
         # feature; keep purging it so a full wipe stays a full wipe.
         paths.root() / "chat-history",
@@ -3599,6 +3611,7 @@ def clean_all(
     )
     quarantined_personal_data = tuple(paths.root().glob("*.corrupt.*"))
     atomic_crash_data = _private_atomic_crash_artifacts(
+        paths.human_file(),
         paths.model_build_manifest(),
         paths.integrity_recovery_marker(),
         paths.integrity_recovery_pending(),

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -868,14 +868,15 @@ def onboard(
 ) -> None:
     """Verify capture permissions/policy, Runtime ownership, and live readiness."""
     from . import onboarding as onboarding_mod
+    from .model.human import HumanMarkdownDeferred, sync_live_human_markdown
 
     _init()
     env_file_mod.load_env_file(paths.env_file())
     try:
-        from .model.human import sync_live_human_markdown
-
         human_path = sync_live_human_markdown()
         console.print(f"[green]✓ HUMAN.md ready[/green]  [dim]{human_path}[/dim]")
+    except HumanMarkdownDeferred:
+        console.print("[dim]• HUMAN.md will be created after the Runtime update commits[/dim]")
     except Exception as exc:  # noqa: BLE001 - onboarding still proves the core Runtime
         console.print(f"[yellow]⚠ HUMAN.md was preserved or could not be refreshed: {exc}[/yellow]")
     try:

--- a/src/persome/daemon.py
+++ b/src/persome/daemon.py
@@ -331,6 +331,16 @@ async def _run(cfg: Config, *, capture_only: bool = False, hard_exit: bool = Fal
 
     fts_hybrid.wire_read_path(cfg)
 
+    # Upgrade backfill: released models already have a valid Root/snapshot but
+    # predate the owner-local HUMAN.md projection. Materialize it at startup
+    # without recapture or another LLM call; later model builds refresh it.
+    try:
+        from .model.human import sync_live_human_markdown
+
+        await asyncio.to_thread(sync_live_human_markdown)
+    except Exception:  # noqa: BLE001 - a derived Markdown view never blocks Runtime startup
+        logger.exception("HUMAN.md startup projection failed")
+
     # A process crash cannot run SessionManager.force_end. Close any rows owned
     # by the previous daemon before capture can create a new active session; the
     # reducer-retry task below immediately catches them up through modeling.

--- a/src/persome/daemon.py
+++ b/src/persome/daemon.py
@@ -36,6 +36,7 @@ logger = get("persome.daemon")
 # keep the daemon process alive and inert indefinitely (capture stopped, health
 # "stale", pid still listed as running).
 _SHUTDOWN_TIMEOUT_SECONDS = 10.0
+_HUMAN_UPDATE_POLL_SECONDS = 0.1
 
 
 @dataclass(frozen=True)
@@ -77,6 +78,24 @@ async def _shutdown_tasks(tasks: list[asyncio.Task], *, timeout: float) -> None:
             timeout,
             sorted(t.get_name() for t in pending),
         )
+
+
+async def _sync_human_after_update_commit() -> None:
+    """Publish HUMAN.md only if this candidate Runtime survives update commit."""
+    from .model.human import HumanMarkdownDeferred, sync_live_human_markdown
+
+    while True:
+        while os.path.lexists(paths.update_state_file()):
+            await asyncio.sleep(_HUMAN_UPDATE_POLL_SECONDS)
+        try:
+            await asyncio.to_thread(sync_live_human_markdown)
+        except HumanMarkdownDeferred:
+            # A new receipt appeared between the path check and publication.
+            await asyncio.sleep(_HUMAN_UPDATE_POLL_SECONDS)
+            continue
+        except Exception:  # noqa: BLE001 - a derived Markdown view never blocks Runtime
+            logger.exception("HUMAN.md post-update projection failed")
+        return
 
 
 async def _mcp_loop(cfg: Config) -> None:
@@ -332,14 +351,27 @@ async def _run(cfg: Config, *, capture_only: bool = False, hard_exit: bool = Fal
     fts_hybrid.wire_read_path(cfg)
 
     # Upgrade backfill: released models already have a valid Root/snapshot but
-    # predate the owner-local HUMAN.md projection. Materialize it at startup
-    # without recapture or another LLM call; later model builds refresh it.
-    try:
-        from .model.human import sync_live_human_markdown
+    # predate the owner-local HUMAN.md projection. A candidate Runtime must not
+    # publish raw data until the old updater commits; rollback kills that
+    # candidate before it clears the durable update receipt.
+    from .model.human import HumanMarkdownDeferred, sync_live_human_markdown
 
-        await asyncio.to_thread(sync_live_human_markdown)
-    except Exception:  # noqa: BLE001 - a derived Markdown view never blocks Runtime startup
-        logger.exception("HUMAN.md startup projection failed")
+    deferred_human_task: asyncio.Task[None] | None = None
+    if os.path.lexists(paths.update_state_file()):
+        deferred_human_task = asyncio.create_task(
+            _sync_human_after_update_commit(),
+            name="human-post-update",
+        )
+    else:
+        try:
+            await asyncio.to_thread(sync_live_human_markdown)
+        except HumanMarkdownDeferred:
+            deferred_human_task = asyncio.create_task(
+                _sync_human_after_update_commit(),
+                name="human-post-update",
+            )
+        except Exception:  # noqa: BLE001 - a derived Markdown view never blocks Runtime startup
+            logger.exception("HUMAN.md startup projection failed")
 
     # A process crash cannot run SessionManager.force_end. Close any rows owned
     # by the previous daemon before capture can create a new active session; the
@@ -452,7 +484,10 @@ async def _run(cfg: Config, *, capture_only: bool = False, hard_exit: bool = Fal
 
     # Soft path (tests / embedded callers drive `_run` directly and expect it to
     # return): full graceful drain, no hard-exit.
-    await _shutdown_tasks(tasks, timeout=_SHUTDOWN_TIMEOUT_SECONDS)
+    shutdown_tasks = [*tasks]
+    if deferred_human_task is not None:
+        shutdown_tasks.append(deferred_human_task)
+    await _shutdown_tasks(shutdown_tasks, timeout=_SHUTDOWN_TIMEOUT_SECONDS)
 
     # Flush the currently open session so its S2 reducer has a chance
     # to run. The daemon-thread reducer spawned by the callback will be

--- a/src/persome/integrity.py
+++ b/src/persome/integrity.py
@@ -1301,17 +1301,29 @@ def _reconcile_resolved_write_authority(authority: str) -> dict[str, object]:
 
 
 def _invalidate_model_manifest() -> bool:
-    """Remove build metadata that belongs to the quarantined database."""
+    """Remove derived model views that belong to the quarantined database."""
     manifest = paths.model_build_manifest()
+    manifest_invalidated = True
     try:
         manifest.unlink(missing_ok=True)
-        return True
     except OSError as exc:
+        manifest_invalidated = False
         _log.warning(
             "integrity: failed to invalidate stale model build manifest",
             extra={"path": str(manifest), "error": str(exc)},
         )
-        return False
+    try:
+        from .model.human import HumanMarkdownConflict, remove_managed_human_markdown
+
+        remove_managed_human_markdown()
+    except HumanMarkdownConflict as exc:
+        _log.warning("integrity: preserving user-owned HUMAN.md", extra={"error": str(exc)})
+    except (OSError, RuntimeError) as exc:
+        _log.warning(
+            "integrity: failed to remove stale HUMAN.md projection",
+            extra={"path": str(paths.human_file()), "error": str(exc)},
+        )
+    return manifest_invalidated
 
 
 def _capture_buffer_replay_available() -> bool:

--- a/src/persome/model/__init__.py
+++ b/src/persome/model/__init__.py
@@ -21,6 +21,11 @@ from .build import (
     run_model_build,
 )
 from .entity_source import EntityEvent, EntitySource, MemoryPersonNameSource
+from .human import (
+    materialize_human_markdown,
+    render_human_markdown,
+    sync_live_human_markdown,
+)
 from .manifest import (
     create_build_manifest,
     detect_core_commit,
@@ -64,9 +69,12 @@ __all__ = [
     "load_live_manifest",
     "is_activity_identity",
     "is_valid_build_manifest",
+    "materialize_human_markdown",
     "model_status",
     "normalize_activity_identity",
     "prompt_hashes",
+    "render_human_markdown",
     "run_model_build",
+    "sync_live_human_markdown",
     "validate_snapshot",
 ]

--- a/src/persome/model/build.py
+++ b/src/persome/model/build.py
@@ -14,11 +14,13 @@ from typing import Any
 
 from .. import paths
 from ..evomem.store import NodeStore
+from ..logger import get
 from ..store import fts
 from .manifest import create_build_manifest, is_valid_build_manifest
 from .snapshot import build_snapshot
 
 DEFAULT_WAIT_SECONDS = 30.0
+logger = get("persome.model.build")
 _MODEL_STAGES = (
     "reducer",
     "classifier",
@@ -70,6 +72,7 @@ class ModelBuildResult:
     stats: dict[str, Any]
     stages: dict[str, dict[str, Any]]
     manifest_path: Path
+    human_path: Path | None = None
 
 
 class ModelBuildCoordinator:
@@ -502,14 +505,23 @@ def run_model_build(
         with fts.cursor() as conn:
             snapshot = build_snapshot(
                 conn,
+                redact=False,
                 generated_at=completed_dt.isoformat(),
                 build_metadata=manifest,
             )
         _write_json_owner_only(paths.model_build_manifest(), manifest)
+        human_path: Path | None = None
+        try:
+            from .human import materialize_human_markdown
+
+            human_path = materialize_human_markdown(snapshot)
+        except Exception as exc:  # noqa: BLE001 - a derived view never fails the build
+            logger.warning("HUMAN.md projection failed after model build: %s", exc)
         return ModelBuildResult(
             status=manifest["status"],
             manifest=manifest,
             stats=snapshot["stats"],
             stages=outcome.stages,
             manifest_path=paths.model_build_manifest(),
+            human_path=human_path,
         )

--- a/src/persome/model/build.py
+++ b/src/persome/model/build.py
@@ -382,6 +382,16 @@ def _shared_build_lock_if_available() -> Iterator[bool]:
         handle.close()
 
 
+@contextmanager
+def live_model_generation() -> Iterator[dict[str, Any]]:
+    """Hold one stable model generation while a derived projection is published."""
+    with _shared_build_lock_if_available() as shared_lock_acquired:
+        if shared_lock_acquired:
+            yield _classify_persisted_manifest(load_last_manifest())
+        else:
+            yield _building_manifest(load_last_manifest())
+
+
 def load_live_manifest() -> dict[str, Any]:
     """Return truthful metadata for a live projection or export.
 
@@ -391,11 +401,33 @@ def load_live_manifest() -> dict[str, Any]:
     the pre-marker race where a builder owns the exclusive lock but has not yet
     replaced the previous completed manifest.
     """
-    with _shared_build_lock_if_available() as shared_lock_acquired:
-        manifest = load_last_manifest()
-        if not shared_lock_acquired:
-            return _building_manifest(manifest)
-        return _classify_persisted_manifest(manifest)
+    with live_model_generation() as manifest:
+        return manifest
+
+
+def _build_live_snapshot_from_manifest(
+    conn: Any,
+    build_metadata: dict[str, Any],
+    *,
+    redact: bool = True,
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    """Read one SQLite snapshot using metadata from a held model generation."""
+    savepoint = "persome_live_model_snapshot"
+    conn.execute(f"SAVEPOINT {savepoint}")
+    try:
+        snapshot = build_snapshot(
+            conn,
+            redact=redact,
+            generated_at=generated_at,
+            build_metadata=build_metadata,
+        )
+        conn.execute(f"RELEASE SAVEPOINT {savepoint}")
+        return snapshot
+    except BaseException:
+        conn.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+        conn.execute(f"RELEASE SAVEPOINT {savepoint}")
+        raise
 
 
 def build_live_snapshot(
@@ -411,29 +443,13 @@ def build_live_snapshot(
     lock, the public manifest is ``building`` and the SQLite savepoint still
     gives all geometry queries one WAL snapshot.
     """
-    with _shared_build_lock_if_available() as shared_lock_acquired:
-        if shared_lock_acquired:
-            # Our own shared lock would make a separate exclusive-lock probe
-            # look busy. With the shared lock held, no structural writer can
-            # start, so classify the persisted manifest directly.
-            build_metadata = _classify_persisted_manifest(load_last_manifest())
-        else:
-            build_metadata = _building_manifest(load_last_manifest())
-        savepoint = "persome_live_model_snapshot"
-        conn.execute(f"SAVEPOINT {savepoint}")
-        try:
-            snapshot = build_snapshot(
-                conn,
-                redact=redact,
-                generated_at=generated_at,
-                build_metadata=build_metadata,
-            )
-            conn.execute(f"RELEASE SAVEPOINT {savepoint}")
-            return snapshot
-        except BaseException:
-            conn.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
-            conn.execute(f"RELEASE SAVEPOINT {savepoint}")
-            raise
+    with live_model_generation() as build_metadata:
+        return _build_live_snapshot_from_manifest(
+            conn,
+            build_metadata,
+            redact=redact,
+            generated_at=generated_at,
+        )
 
 
 def run_model_build(

--- a/src/persome/model/human.py
+++ b/src/persome/model/human.py
@@ -1,0 +1,584 @@
+"""Owner-local ``HUMAN.md`` projection of the versioned personal model."""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import re
+import stat
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .. import paths
+from .snapshot import SCHEMA_VERSION, validate_snapshot
+
+HUMAN_SCHEMA_VERSION = 1
+HUMAN_RENDERER_VERSION = 1
+_PROJECTION_NAME = "persome-model"
+_MAX_FACES = 8
+_MAX_VOLUMES = 8
+_HANDLE_RE = re.compile(r"⟨([^⟨⟩]+)⟩")
+_SUPPORTED_BUILD_STATUSES = frozenset({"complete", "degraded"})
+
+
+class HumanMarkdownConflict(RuntimeError):
+    """The target exists but is not a Persome-managed HUMAN.md projection."""
+
+
+@dataclass(frozen=True)
+class _ManagedHuman:
+    values: dict[str, Any]
+    identity: tuple[int, int]
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self.values.get(key, default)
+
+
+def _yaml_scalar(value: Any) -> str:
+    """Return a JSON scalar, which is also a safe YAML scalar."""
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _one_line(value: Any) -> str:
+    return " ".join(str(value or "").split())
+
+
+def _safe_markdown(value: Any, *, multiline: bool = False) -> str:
+    """Neutralize Markdown links, images, HTML, code fences, and block markers."""
+    text = str(value or "")
+    if not multiline:
+        text = _one_line(text)
+    text = (
+        text.replace("\\", "\\\\")
+        .replace("`", "\\`")
+        .replace("[", "\\[")
+        .replace("]", "\\]")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+    )
+    if not multiline:
+        return text
+
+    safe_lines: list[str] = []
+    for line in text.splitlines():
+        line = re.sub(r"[ \t]{2,}", " ", line).rstrip()
+        if re.match(r"^\s*(?:#{1,6}|>|[-+*]\s|\d+[.)]\s|~~~)", line):
+            first = len(line) - len(line.lstrip())
+            line = f"{line[:first]}\\{line[first:]}"
+        safe_lines.append(line)
+    return re.sub(r"\n{3,}", "\n\n", "\n".join(safe_lines)).strip()
+
+
+def _schema_sort_key(item: dict[str, Any]) -> tuple[float, float, str]:
+    return (
+        -float(item.get("observations") or 0),
+        -float(item.get("confidence") or 0.0),
+        str(item.get("id") or ""),
+    )
+
+
+def _known_handle_map(
+    root: dict[str, Any] | None,
+    volumes: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    members = (root or {}).get("members")
+    if isinstance(members, list):
+        root_members = {str(member) for member in members}
+        eligible = [item for item in volumes if str(item.get("id") or "") in root_members]
+    else:
+        eligible = volumes
+    return {
+        _one_line(item.get("signature")).casefold(): item
+        for item in eligible
+        if _one_line(item.get("signature"))
+    }
+
+
+def _portrait_and_handles(
+    signature: str,
+    known_handles: dict[str, dict[str, Any]],
+) -> tuple[str, list[dict[str, Any]]]:
+    selected: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    def replace(match: re.Match[str]) -> str:
+        value = _one_line(match.group(1))
+        item = known_handles.get(value.casefold())
+        if item is None:
+            return "" if value.casefold() == "truncated" else match.group(0)
+        item_id = str(item.get("id") or "")
+        if item_id and item_id not in seen:
+            seen.add(item_id)
+            selected.append(item)
+        return ""
+
+    portrait = _HANDLE_RE.sub(replace, signature)
+    portrait = re.sub(r"[ \t]*\(\s*\)", "", portrait)
+    portrait = re.sub(r"[ \t]+([,.;:!?])", r"\1", portrait)
+    portrait = _safe_markdown(portrait, multiline=True)
+    return portrait, selected
+
+
+def _schema_bullet(item: dict[str, Any]) -> str:
+    signature = _safe_markdown(item.get("signature"))
+    observations = int(item.get("observations") or 0)
+    confidence = float(item.get("confidence") or 0.0)
+    return f"- {signature} _(evidence {observations}; confidence {confidence:.2f})_"
+
+
+def _selected_volumes(
+    root: dict[str, Any] | None,
+    volumes: list[dict[str, Any]],
+    referenced: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    selected = list(referenced)
+    seen = {str(item.get("id") or "") for item in selected}
+    members = (root or {}).get("members")
+    if isinstance(members, list):
+        root_members = {str(member) for member in members}
+        candidates = [item for item in volumes if str(item.get("id") or "") in root_members]
+    else:
+        candidates = volumes
+    for item in sorted(candidates, key=_schema_sort_key):
+        item_id = str(item.get("id") or "")
+        if item_id and item_id not in seen:
+            seen.add(item_id)
+            selected.append(item)
+    return selected[:_MAX_VOLUMES]
+
+
+def _frontmatter(
+    snapshot: dict[str, Any],
+    *,
+    redacted: bool,
+) -> list[str]:
+    root = snapshot.get("root") if isinstance(snapshot.get("root"), dict) else None
+    build = snapshot.get("build") if isinstance(snapshot.get("build"), dict) else {}
+    return [
+        "---",
+        f"human_schema_version: {HUMAN_SCHEMA_VERSION}",
+        f"renderer_version: {HUMAN_RENDERER_VERSION}",
+        f"model_schema_version: {_yaml_scalar(snapshot.get('schema_version'))}",
+        f"generated_at: {_yaml_scalar(snapshot.get('generated_at'))}",
+        f"build_id: {_yaml_scalar(build.get('build_id'))}",
+        f"build_status: {_yaml_scalar(build.get('status'))}",
+        f"root_id: {_yaml_scalar(root.get('id') if root else None)}",
+        'visibility: "owner-only"',
+        f"redacted: {str(redacted).lower()}",
+        f"projection: {_yaml_scalar(_PROJECTION_NAME)}",
+        "---",
+    ]
+
+
+def render_human_markdown(snapshot: dict[str, Any], *, redacted: bool = False) -> str:
+    """Render a deterministic, compact Markdown view without another LLM call."""
+    validate_snapshot(snapshot)
+    root = snapshot.get("root") if isinstance(snapshot.get("root"), dict) else None
+    build = snapshot.get("build") if isinstance(snapshot.get("build"), dict) else {}
+    volumes = [dict(item) for item in snapshot.get("volumes") or []]
+    known_handles = _known_handle_map(root, volumes)
+    portrait, referenced = _portrait_and_handles(
+        str(root.get("signature") or "") if root else "",
+        known_handles,
+    )
+    faces = sorted(
+        (dict(item) for item in snapshot.get("faces") or [] if _one_line(item.get("signature"))),
+        key=_schema_sort_key,
+    )[:_MAX_FACES]
+    selected_volumes = _selected_volumes(root, volumes, referenced)
+    stats = snapshot.get("stats") if isinstance(snapshot.get("stats"), dict) else {}
+
+    lines = [
+        *_frontmatter(snapshot, redacted=redacted),
+        "",
+        "# HUMAN.md",
+        "",
+        "> Generated locally by Persome from evidence on this Mac.",
+        "> This living model is incomplete by design and changes as new evidence arrives.",
+        "> Direct edits are replaced on refresh; use `persome correct` to change the model.",
+        "",
+        "## Persome's portrait of me",
+        "",
+    ]
+    if root is None:
+        lines.extend(
+            [
+                "Persome has not formed a verified Root yet. No identity portrait is being ",
+                "claimed. This file will update automatically after the model has enough ",
+                "evidence and a completed `persome model build`.",
+            ]
+        )
+    else:
+        lines.append(portrait or "The current Root does not contain a readable portrait yet.")
+
+    if faces:
+        lines.extend(["", "## Stable patterns", ""])
+        lines.extend(_schema_bullet(item) for item in faces)
+        if len(snapshot.get("faces") or []) > len(faces):
+            lines.append(f"> Showing {len(faces)} of {len(snapshot['faces'])} Faces.")
+    if selected_volumes:
+        lines.extend(["", "## Cross-domain patterns", ""])
+        lines.extend(_schema_bullet(item) for item in selected_volumes)
+        if len(volumes) > len(selected_volumes):
+            lines.append(f"> Showing {len(selected_volumes)} of {len(volumes)} Volumes.")
+
+    evolution_lines = int(stats.get("evolution_lines") or 0)
+    relation_lines = int(stats.get("relation_lines") or 0)
+    degraded = (
+        build.get("degraded_stages") if isinstance(build.get("degraded_stages"), list) else []
+    )
+    lines.extend(
+        [
+            "",
+            "## Model provenance",
+            "",
+            f"- Build: `{_safe_markdown(build.get('build_id'))}` "
+            f"({_safe_markdown(build.get('status')) or 'unknown'})",
+            f"- Generated: `{_safe_markdown(snapshot.get('generated_at'))}`",
+            f"- Geometry: {int(stats.get('points') or 0)} Points, "
+            f"{evolution_lines + relation_lines} Lines, "
+            f"{int(stats.get('faces') or 0)} Faces, "
+            f"{int(stats.get('volumes') or 0)} Volumes, "
+            f"{int(stats.get('roots') or 0)} Root",
+            f"- Evidence receipts: {int(stats.get('receipts') or 0)}",
+            f"- Degraded stages: {_safe_markdown(', '.join(map(str, degraded))) or 'none'}",
+            "- Full evidence: `persome model export` or MCP `get_model_snapshot`",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _managed_metadata(path: Path) -> _ManagedHuman | None:
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    for _attempt in range(3):
+        try:
+            metadata = path.lstat()
+        except FileNotFoundError:
+            return None
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+            raise HumanMarkdownConflict(f"refusing to replace non-regular HUMAN.md: {path}")
+        try:
+            fd = os.open(path, flags)
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise HumanMarkdownConflict(f"cannot safely inspect HUMAN.md: {path}") from exc
+        try:
+            opened = os.fstat(fd)
+            if (opened.st_dev, opened.st_ino) != (metadata.st_dev, metadata.st_ino):
+                continue
+            if not stat.S_ISREG(opened.st_mode) or opened.st_nlink != 1:
+                raise HumanMarkdownConflict(f"refusing to replace non-regular HUMAN.md: {path}")
+            try:
+                header_bytes = os.read(fd, 65_537)
+                existing = header_bytes.decode("utf-8")
+                if not existing.startswith("---\n"):
+                    raise ValueError("missing Persome frontmatter")
+                header = existing.split("---", 2)[1]
+            except (OSError, UnicodeDecodeError, IndexError, ValueError) as exc:
+                raise HumanMarkdownConflict(
+                    f"refusing to replace unrecognized HUMAN.md: {path}"
+                ) from exc
+            values: dict[str, Any] = {}
+            for line in header.splitlines():
+                key, separator, value = line.partition(":")
+                if not separator:
+                    continue
+                try:
+                    values[key.strip()] = json.loads(value.strip())
+                except json.JSONDecodeError:
+                    values[key.strip()] = value.strip()
+            if values.get("projection") != _PROJECTION_NAME:
+                raise HumanMarkdownConflict(f"refusing to replace user-owned HUMAN.md: {path}")
+            os.fchmod(fd, 0o600)
+            return _ManagedHuman(values=values, identity=(opened.st_dev, opened.st_ino))
+        finally:
+            os.close(fd)
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return None
+    raise HumanMarkdownConflict(f"HUMAN.md changed during ownership inspection: {path}")
+
+
+@contextmanager
+def _human_lock(target: Path) -> Iterator[None]:
+    lock_path = target.parent / f".{target.name}.lock"
+    if target == paths.human_file():
+        handle = paths.open_private_lock_file(lock_path)
+    else:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        flags = (
+            os.O_RDWR
+            | os.O_APPEND
+            | os.O_CREAT
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_NONBLOCK", 0)
+        )
+        try:
+            fd = os.open(lock_path, flags, 0o600)
+        except OSError as exc:
+            raise HumanMarkdownConflict(f"cannot safely lock HUMAN.md: {target}") from exc
+        try:
+            metadata = os.fstat(fd)
+            if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+                raise HumanMarkdownConflict(f"unsafe HUMAN.md lock target: {lock_path}")
+            os.fchmod(fd, 0o600)
+            handle = os.fdopen(fd, "a+b")
+        except BaseException:
+            os.close(fd)
+            raise
+    with handle:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise HumanMarkdownConflict(f"HUMAN.md refresh is already active: {target}") from exc
+        try:
+            _recover_hardlink_crash(target)
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _stage_private_text(target: Path, content: str) -> Path:
+    """Write a complete private inode next to target without publishing it."""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, name = tempfile.mkstemp(prefix=f".{target.name}.", dir=target.parent)
+    staged = Path(name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            os.fchmod(handle.fileno(), 0o600)
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except BaseException:
+        staged.unlink(missing_ok=True)
+        raise
+    return staged
+
+
+def _fsync_parent(target: Path) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        directory_fd = os.open(target.parent, flags)
+    except OSError:
+        return
+    try:
+        os.fsync(directory_fd)
+    except OSError:
+        pass
+    finally:
+        os.close(directory_fd)
+
+
+def _recover_hardlink_crash(target: Path) -> None:
+    """Drop only our same-inode temp names after a link-publication crash."""
+    try:
+        target_metadata = target.lstat()
+    except FileNotFoundError:
+        return
+    if not stat.S_ISREG(target_metadata.st_mode) or target_metadata.st_nlink <= 1:
+        return
+
+    identity = (target_metadata.st_dev, target_metadata.st_ino)
+    lock_name = f".{target.name}.lock"
+    removed = False
+    try:
+        candidates = tuple(target.parent.glob(f".{target.name}.*"))
+    except OSError as exc:
+        raise HumanMarkdownConflict(f"cannot inspect HUMAN.md crash artifacts: {target}") from exc
+    for candidate in candidates:
+        if candidate.name == lock_name:
+            continue
+        try:
+            metadata = candidate.lstat()
+        except FileNotFoundError:
+            continue
+        if stat.S_ISREG(metadata.st_mode) and (metadata.st_dev, metadata.st_ino) == identity:
+            try:
+                candidate.unlink()
+            except OSError as exc:
+                raise HumanMarkdownConflict(
+                    f"cannot recover HUMAN.md crash artifact: {candidate}"
+                ) from exc
+            removed = True
+    if removed:
+        _fsync_parent(target)
+
+
+def _move_existing_target(target: Path) -> Path:
+    """Move the exact current target aside so it can be verified before replacement."""
+    fd, name = tempfile.mkstemp(prefix=f".{target.name}.replaced.", dir=target.parent)
+    os.close(fd)
+    displaced = Path(name)
+    try:
+        os.replace(target, displaced)
+    except BaseException:
+        displaced.unlink(missing_ok=True)
+        raise
+    return displaced
+
+
+def _restore_displaced(target: Path, displaced: Path) -> bool:
+    """Restore a captured unknown inode without overwriting a newer target."""
+    try:
+        metadata = displaced.lstat()
+        if stat.S_ISREG(metadata.st_mode):
+            os.link(displaced, target, follow_symlinks=False)
+        elif stat.S_ISLNK(metadata.st_mode):
+            os.symlink(os.readlink(displaced), target)
+        else:
+            return False
+    except OSError:
+        return False
+    displaced.unlink(missing_ok=True)
+    _fsync_parent(target)
+    return True
+
+
+def _raise_changed_target(target: Path, displaced: Path) -> None:
+    if _restore_displaced(target, displaced):
+        raise HumanMarkdownConflict(f"HUMAN.md changed during refresh and was preserved: {target}")
+    raise HumanMarkdownConflict(
+        f"HUMAN.md changed during refresh; preserved the displaced file at {displaced}"
+    )
+
+
+def _capture_managed_target(target: Path, expected: _ManagedHuman) -> Path:
+    try:
+        displaced = _move_existing_target(target)
+    except FileNotFoundError as exc:
+        raise HumanMarkdownConflict(f"HUMAN.md disappeared during refresh: {target}") from exc
+    try:
+        captured = _managed_metadata(displaced)
+    except HumanMarkdownConflict:
+        _raise_changed_target(target, displaced)
+    if captured is None or captured.identity != expected.identity:
+        _raise_changed_target(target, displaced)
+    return displaced
+
+
+def _publish_staged(target: Path, staged: Path, expected: _ManagedHuman | None) -> None:
+    displaced: Path | None = None
+    if expected is not None:
+        displaced = _capture_managed_target(target, expected)
+    try:
+        # Hard-link publication is create-if-absent. Unlike os.replace(), it
+        # cannot destroy an unknown file an editor placed after our check.
+        os.link(staged, target, follow_symlinks=False)
+    except FileExistsError as exc:
+        if displaced is not None:
+            displaced.unlink(missing_ok=True)
+        raise HumanMarkdownConflict(
+            f"refusing to replace HUMAN.md created during refresh: {target}"
+        ) from exc
+    except BaseException as exc:
+        if displaced is not None and not _restore_displaced(target, displaced):
+            raise RuntimeError(
+                f"HUMAN.md refresh failed; previous projection preserved at {displaced}"
+            ) from exc
+        raise
+    staged.unlink(missing_ok=True)
+    if displaced is not None:
+        displaced.unlink(missing_ok=True)
+    _fsync_parent(target)
+
+
+def remove_managed_human_markdown(path: Path | None = None) -> bool:
+    """Remove only a Persome-owned projection; preserve unknown user files."""
+    target = path or paths.human_file()
+    with _human_lock(target):
+        metadata = _managed_metadata(target)
+        if metadata is None:
+            return False
+        displaced = _capture_managed_target(target, metadata)
+        displaced.unlink(missing_ok=True)
+        _fsync_parent(target)
+        return True
+
+
+def materialize_human_markdown(
+    snapshot: dict[str, Any],
+    *,
+    out_path: Path | None = None,
+    redacted: bool = False,
+) -> Path:
+    """Atomically write a truthful HUMAN.md, including an honest cold-start view."""
+    validate_snapshot(snapshot)
+    target = out_path or paths.human_file()
+    content = render_human_markdown(snapshot, redacted=redacted)
+    with _human_lock(target):
+        metadata = _managed_metadata(target)
+        staged = _stage_private_text(target, content)
+        try:
+            _publish_staged(target, staged, metadata)
+        finally:
+            staged.unlink(missing_ok=True)
+    return target
+
+
+def _placeholder_snapshot(manifest: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": manifest.get("completed_at") or manifest.get("started_at"),
+        "build": manifest,
+        "points": [],
+        "lines": [],
+        "faces": [],
+        "volumes": [],
+        "root": None,
+        "receipts": [],
+        "stats": {
+            "points": 0,
+            "active_points": 0,
+            "evolution_lines": 0,
+            "relation_lines": 0,
+            "faces": 0,
+            "volumes": 0,
+            "roots": 0,
+            "receipts": 0,
+            "redactions": {},
+        },
+    }
+
+
+def sync_live_human_markdown() -> Path:
+    """Backfill or refresh HUMAN.md from an existing Runtime model.
+
+    This is the upgrade path for users whose model predates the file. Matching
+    build and renderer versions are a cheap no-op. Missing Roots receive an
+    explicit forming-state file rather than a fabricated portrait.
+    """
+    from ..store import fts
+    from .build import build_live_snapshot, load_live_manifest
+
+    target = paths.human_file()
+    manifest = load_live_manifest()
+    current = _managed_metadata(target)
+    build_id = manifest.get("build_id")
+    if (
+        current is not None
+        and current.get("human_schema_version") == HUMAN_SCHEMA_VERSION
+        and current.get("renderer_version") == HUMAN_RENDERER_VERSION
+        and current.get("build_id") == build_id
+        and current.get("build_status") == manifest.get("status")
+    ):
+        return target
+
+    if manifest.get("status") == "building" and current is not None:
+        return target
+    if manifest.get("status") not in _SUPPORTED_BUILD_STATUSES:
+        return materialize_human_markdown(_placeholder_snapshot(manifest), out_path=target)
+
+    with fts.cursor() as conn:
+        snapshot = build_live_snapshot(conn, redact=False)
+    snapshot_build = snapshot.get("build") if isinstance(snapshot.get("build"), dict) else {}
+    if snapshot_build.get("status") not in _SUPPORTED_BUILD_STATUSES:
+        return materialize_human_markdown(_placeholder_snapshot(snapshot_build), out_path=target)
+    return materialize_human_markdown(snapshot, out_path=target)

--- a/src/persome/model/human.py
+++ b/src/persome/model/human.py
@@ -6,13 +6,13 @@ import fcntl
 import json
 import os
 import re
+import secrets
 import stat
-import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, BinaryIO
 
 from .. import paths
 from .snapshot import SCHEMA_VERSION, validate_snapshot
@@ -24,10 +24,15 @@ _MAX_FACES = 8
 _MAX_VOLUMES = 8
 _HANDLE_RE = re.compile(r"⟨([^⟨⟩]+)⟩")
 _SUPPORTED_BUILD_STATUSES = frozenset({"complete", "degraded"})
+_TRANSACTION_VERSION = 1
 
 
 class HumanMarkdownConflict(RuntimeError):
     """The target exists but is not a Persome-managed HUMAN.md projection."""
+
+
+class HumanMarkdownDeferred(RuntimeError):
+    """Canonical publication is deferred until an in-flight update commits."""
 
 
 @dataclass(frozen=True)
@@ -37,6 +42,14 @@ class _ManagedHuman:
 
     def get(self, key: str, default: Any = None) -> Any:
         return self.values.get(key, default)
+
+
+@dataclass(frozen=True)
+class _HumanTransaction:
+    operation: str
+    stage_name: str
+    expected: tuple[int, int] | None
+    candidate: tuple[int, int] | None
 
 
 def _yaml_scalar(value: Any) -> str:
@@ -307,10 +320,312 @@ def _managed_metadata(path: Path) -> _ManagedHuman | None:
     raise HumanMarkdownConflict(f"HUMAN.md changed during ownership inspection: {path}")
 
 
+def _fsync_parent(target: Path) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        directory_fd = os.open(target.parent, flags)
+    except OSError:
+        return
+    try:
+        os.fsync(directory_fd)
+    except OSError:
+        pass
+    finally:
+        os.close(directory_fd)
+
+
+def _is_canonical_target(target: Path) -> bool:
+    return os.path.abspath(os.fspath(target)) == os.path.abspath(os.fspath(paths.human_file()))
+
+
+def _raise_if_update_pending(target: Path) -> None:
+    if _is_canonical_target(target) and os.path.lexists(paths.update_state_file()):
+        raise HumanMarkdownDeferred("HUMAN.md publication waits for the Runtime update to commit")
+
+
+def _path_identity(path: Path) -> tuple[int, int] | None:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return None
+    return metadata.st_dev, metadata.st_ino
+
+
+def _parse_identity(value: Any) -> tuple[int, int] | None:
+    if value is None:
+        return None
+    if (
+        not isinstance(value, list)
+        or len(value) != 2
+        or any(type(item) is not int or item < 0 for item in value)
+    ):
+        raise ValueError("invalid HUMAN.md transaction identity")
+    return value[0], value[1]
+
+
+def _write_transaction(handle: BinaryIO, transaction: _HumanTransaction | None) -> None:
+    if transaction is None:
+        payload = (
+            json.dumps({"version": _TRANSACTION_VERSION, "clear": True}, sort_keys=True).encode(
+                "utf-8"
+            )
+            + b"\n"
+        )
+    else:
+        payload = (
+            json.dumps(
+                {
+                    "version": _TRANSACTION_VERSION,
+                    "operation": transaction.operation,
+                    "stage": transaction.stage_name,
+                    "expected": list(transaction.expected) if transaction.expected else None,
+                    "candidate": list(transaction.candidate) if transaction.candidate else None,
+                },
+                sort_keys=True,
+            ).encode("utf-8")
+            + b"\n"
+        )
+    # Never erase the last durable recovery record before its successor is
+    # complete. A crash-shortened tail is discarded at its last newline; the
+    # preceding fsynced record remains authoritative.
+    handle.flush()
+    handle.seek(0)
+    existing = handle.read()
+    complete_length = existing.rfind(b"\n") + 1
+    if complete_length != len(existing):
+        os.ftruncate(handle.fileno(), complete_length)
+        os.fsync(handle.fileno())
+    handle.seek(0, os.SEEK_END)
+    written = handle.write(payload)
+    if written != len(payload):
+        raise OSError("short HUMAN.md transaction journal write")
+    handle.flush()
+    os.fsync(handle.fileno())
+    if transaction is None:
+        # The durable clear record makes both the old log and an empty inode
+        # truthful. Compacting is therefore safe on either side of a crash.
+        os.ftruncate(handle.fileno(), 0)
+        os.fsync(handle.fileno())
+        handle.seek(0)
+
+
+def _read_transaction(target: Path, handle: BinaryIO) -> _HumanTransaction | None:
+    handle.seek(0)
+    if os.fstat(handle.fileno()).st_size > 16_384:
+        raise HumanMarkdownConflict(f"HUMAN.md transaction journal is too large: {target}")
+    payload = handle.read()
+    current: _HumanTransaction | None = None
+    for raw_record in payload.splitlines(keepends=True):
+        if not raw_record.endswith(b"\n"):
+            break
+        try:
+            value = json.loads(raw_record.decode("utf-8"))
+            if not isinstance(value, dict) or value.get("version") != _TRANSACTION_VERSION:
+                raise ValueError("invalid version")
+            if value.get("clear") is True:
+                current = None
+                continue
+            operation = value.get("operation")
+            stage_name = value.get("stage")
+            prefix = f".{target.name}.persome-stage."
+            token = stage_name.removeprefix(prefix) if isinstance(stage_name, str) else ""
+            if operation not in {"publish", "remove"}:
+                raise ValueError("invalid operation")
+            if (
+                not isinstance(stage_name, str)
+                or not stage_name.startswith(prefix)
+                or not re.fullmatch(r"[0-9a-f]{32}", token)
+            ):
+                raise ValueError("invalid stage")
+            expected = _parse_identity(value.get("expected"))
+            candidate = _parse_identity(value.get("candidate"))
+            if operation == "remove" and (expected is None or candidate is not None):
+                raise ValueError("invalid remove transaction")
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+            raise HumanMarkdownConflict(f"invalid HUMAN.md transaction journal: {target}") from exc
+        current = _HumanTransaction(operation, stage_name, expected, candidate)
+    return current
+
+
+def _new_stage_path(target: Path) -> Path:
+    for _attempt in range(8):
+        candidate = target.parent / f".{target.name}.persome-stage.{secrets.token_hex(16)}"
+        if not os.path.lexists(candidate):
+            return candidate
+    raise HumanMarkdownConflict(f"cannot reserve a HUMAN.md transaction stage: {target}")
+
+
+def _unlink_if_identity(path: Path, identity: tuple[int, int]) -> bool:
+    if _path_identity(path) != identity:
+        return False
+    try:
+        path.unlink()
+    except OSError as exc:
+        raise HumanMarkdownConflict(f"cannot remove HUMAN.md transaction stage: {path}") from exc
+    return True
+
+
+def _managed_identity_matches(path: Path, identity: tuple[int, int]) -> bool:
+    try:
+        managed = _managed_metadata(path)
+    except HumanMarkdownConflict:
+        return False
+    return managed is not None and managed.identity == identity
+
+
+def _clear_recovered_transaction(target: Path, handle: BinaryIO) -> None:
+    _fsync_parent(target)
+    _write_transaction(handle, None)
+
+
+def _recover_publish_transaction(
+    target: Path,
+    stage: Path,
+    transaction: _HumanTransaction,
+    handle: BinaryIO,
+) -> None:
+    expected = transaction.expected
+    candidate = transaction.candidate
+    if candidate is None:
+        # Content is written only after the candidate identity is journaled. A
+        # crash in this reservation window can therefore leave at most an empty
+        # owner-only inode, never raw model text.
+        try:
+            metadata = stage.lstat()
+        except FileNotFoundError:
+            metadata = None
+        if metadata is not None:
+            safe_empty_reservation = (
+                stat.S_ISREG(metadata.st_mode)
+                and metadata.st_nlink == 1
+                and metadata.st_size == 0
+                and metadata.st_uid == os.getuid()
+                and not metadata.st_mode & 0o077
+            )
+            if not safe_empty_reservation:
+                _write_transaction(handle, None)
+                raise HumanMarkdownConflict(
+                    f"preserved an unrecognized HUMAN.md transaction stage: {stage}"
+                )
+            stage.unlink()
+        _clear_recovered_transaction(target, handle)
+        return
+
+    target_identity = _path_identity(target)
+    stage_identity = _path_identity(stage)
+
+    if expected is None:
+        if target_identity == candidate:
+            if stage_identity == candidate:
+                _unlink_if_identity(stage, candidate)
+            elif stage_identity is not None:
+                _write_transaction(handle, None)
+                raise HumanMarkdownConflict(
+                    f"preserved a changed HUMAN.md transaction stage: {stage}"
+                )
+            _clear_recovered_transaction(target, handle)
+            return
+        if stage_identity == candidate:
+            _unlink_if_identity(stage, candidate)
+        elif stage_identity is not None:
+            _write_transaction(handle, None)
+            raise HumanMarkdownConflict(
+                f"preserved an unrecognized HUMAN.md transaction stage: {stage}"
+            )
+        _clear_recovered_transaction(target, handle)
+        return
+
+    if target_identity == candidate:
+        if stage_identity is None:
+            _clear_recovered_transaction(target, handle)
+            return
+        if stage_identity == expected and _managed_identity_matches(stage, expected):
+            _unlink_if_identity(stage, expected)
+            _clear_recovered_transaction(target, handle)
+            return
+        try:
+            paths.atomic_exchange(stage, target)
+        except (OSError, ValueError) as exc:
+            raise HumanMarkdownConflict(
+                f"cannot restore a concurrently changed HUMAN.md from {stage}"
+            ) from exc
+        if not _unlink_if_identity(stage, candidate):
+            _clear_recovered_transaction(target, handle)
+            raise HumanMarkdownConflict(
+                f"preserved a concurrently changed HUMAN.md stage after rollback: {stage}"
+            )
+        _clear_recovered_transaction(target, handle)
+        return
+
+    if stage_identity == candidate:
+        _unlink_if_identity(stage, candidate)
+        _clear_recovered_transaction(target, handle)
+        return
+    if stage_identity == expected and _managed_identity_matches(stage, expected):
+        _unlink_if_identity(stage, expected)
+        _clear_recovered_transaction(target, handle)
+        return
+    if stage_identity is None:
+        _clear_recovered_transaction(target, handle)
+        return
+    if target_identity is None:
+        try:
+            paths.atomic_rename_noreplace(stage, target)
+        except (OSError, ValueError) as exc:
+            raise HumanMarkdownConflict(
+                f"cannot restore a displaced user HUMAN.md from {stage}"
+            ) from exc
+        _clear_recovered_transaction(target, handle)
+        return
+    _write_transaction(handle, None)
+    raise HumanMarkdownConflict(f"preserved a displaced user HUMAN.md at {stage}")
+
+
+def _recover_remove_transaction(
+    target: Path,
+    stage: Path,
+    transaction: _HumanTransaction,
+    handle: BinaryIO,
+) -> None:
+    expected = transaction.expected
+    assert expected is not None
+    target_identity = _path_identity(target)
+    stage_identity = _path_identity(stage)
+    if stage_identity is None:
+        _clear_recovered_transaction(target, handle)
+        return
+    if stage_identity == expected and _managed_identity_matches(stage, expected):
+        _unlink_if_identity(stage, expected)
+        _clear_recovered_transaction(target, handle)
+        return
+    if target_identity is None:
+        try:
+            paths.atomic_rename_noreplace(stage, target)
+        except (OSError, ValueError) as exc:
+            raise HumanMarkdownConflict(
+                f"cannot restore a user HUMAN.md displaced during removal: {stage}"
+            ) from exc
+        _clear_recovered_transaction(target, handle)
+        return
+    _write_transaction(handle, None)
+    raise HumanMarkdownConflict(f"preserved a displaced user HUMAN.md at {stage}")
+
+
+def _recover_transaction(target: Path, handle: BinaryIO) -> None:
+    transaction = _read_transaction(target, handle)
+    if transaction is None:
+        return
+    stage = target.parent / transaction.stage_name
+    if transaction.operation == "publish":
+        _recover_publish_transaction(target, stage, transaction, handle)
+    else:
+        _recover_remove_transaction(target, stage, transaction, handle)
+
+
 @contextmanager
-def _human_lock(target: Path) -> Iterator[None]:
+def _human_lock(target: Path) -> Iterator[BinaryIO]:
     lock_path = target.parent / f".{target.name}.lock"
-    if target == paths.human_file():
+    if _is_canonical_target(target):
         handle = paths.open_private_lock_file(lock_path)
     else:
         target.parent.mkdir(parents=True, exist_ok=True)
@@ -340,167 +655,139 @@ def _human_lock(target: Path) -> Iterator[None]:
         except BlockingIOError as exc:
             raise HumanMarkdownConflict(f"HUMAN.md refresh is already active: {target}") from exc
         try:
-            _recover_hardlink_crash(target)
-            yield
+            _recover_transaction(target, handle)
+            yield handle
         finally:
             fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
-def _stage_private_text(target: Path, content: str) -> Path:
-    """Write a complete private inode next to target without publishing it."""
+def _stage_publish_transaction(
+    target: Path,
+    content: str,
+    expected: _ManagedHuman | None,
+    handle: BinaryIO,
+) -> tuple[Path, _HumanTransaction]:
     target.parent.mkdir(parents=True, exist_ok=True)
-    fd, name = tempfile.mkstemp(prefix=f".{target.name}.", dir=target.parent)
-    staged = Path(name)
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as handle:
-            os.fchmod(handle.fileno(), 0o600)
-            handle.write(content)
-            handle.flush()
-            os.fsync(handle.fileno())
-    except BaseException:
-        staged.unlink(missing_ok=True)
-        raise
-    return staged
-
-
-def _fsync_parent(target: Path) -> None:
-    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
-    try:
-        directory_fd = os.open(target.parent, flags)
-    except OSError:
-        return
-    try:
-        os.fsync(directory_fd)
-    except OSError:
-        pass
-    finally:
-        os.close(directory_fd)
-
-
-def _recover_hardlink_crash(target: Path) -> None:
-    """Drop only our same-inode temp names after a link-publication crash."""
-    try:
-        target_metadata = target.lstat()
-    except FileNotFoundError:
-        return
-    if not stat.S_ISREG(target_metadata.st_mode) or target_metadata.st_nlink <= 1:
-        return
-
-    identity = (target_metadata.st_dev, target_metadata.st_ino)
-    lock_name = f".{target.name}.lock"
-    removed = False
-    try:
-        candidates = tuple(target.parent.glob(f".{target.name}.*"))
-    except OSError as exc:
-        raise HumanMarkdownConflict(f"cannot inspect HUMAN.md crash artifacts: {target}") from exc
-    for candidate in candidates:
-        if candidate.name == lock_name:
-            continue
-        try:
-            metadata = candidate.lstat()
-        except FileNotFoundError:
-            continue
-        if stat.S_ISREG(metadata.st_mode) and (metadata.st_dev, metadata.st_ino) == identity:
-            try:
-                candidate.unlink()
-            except OSError as exc:
-                raise HumanMarkdownConflict(
-                    f"cannot recover HUMAN.md crash artifact: {candidate}"
-                ) from exc
-            removed = True
-    if removed:
-        _fsync_parent(target)
-
-
-def _move_existing_target(target: Path) -> Path:
-    """Move the exact current target aside so it can be verified before replacement."""
-    fd, name = tempfile.mkstemp(prefix=f".{target.name}.replaced.", dir=target.parent)
-    os.close(fd)
-    displaced = Path(name)
-    try:
-        os.replace(target, displaced)
-    except BaseException:
-        displaced.unlink(missing_ok=True)
-        raise
-    return displaced
-
-
-def _restore_displaced(target: Path, displaced: Path) -> bool:
-    """Restore a captured unknown inode without overwriting a newer target."""
-    try:
-        metadata = displaced.lstat()
-        if stat.S_ISREG(metadata.st_mode):
-            os.link(displaced, target, follow_symlinks=False)
-        elif stat.S_ISLNK(metadata.st_mode):
-            os.symlink(os.readlink(displaced), target)
-        else:
-            return False
-    except OSError:
-        return False
-    displaced.unlink(missing_ok=True)
-    _fsync_parent(target)
-    return True
-
-
-def _raise_changed_target(target: Path, displaced: Path) -> None:
-    if _restore_displaced(target, displaced):
-        raise HumanMarkdownConflict(f"HUMAN.md changed during refresh and was preserved: {target}")
-    raise HumanMarkdownConflict(
-        f"HUMAN.md changed during refresh; preserved the displaced file at {displaced}"
+    stage = _new_stage_path(target)
+    transaction = _HumanTransaction(
+        operation="publish",
+        stage_name=stage.name,
+        expected=expected.identity if expected else None,
+        candidate=None,
     )
-
-
-def _capture_managed_target(target: Path, expected: _ManagedHuman) -> Path:
+    _write_transaction(handle, transaction)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
     try:
-        displaced = _move_existing_target(target)
-    except FileNotFoundError as exc:
-        raise HumanMarkdownConflict(f"HUMAN.md disappeared during refresh: {target}") from exc
+        fd = os.open(stage, flags, 0o600)
+    except OSError as exc:
+        _write_transaction(handle, None)
+        raise HumanMarkdownConflict(f"cannot create HUMAN.md transaction stage: {stage}") from exc
+    candidate: tuple[int, int] | None = None
     try:
-        captured = _managed_metadata(displaced)
-    except HumanMarkdownConflict:
-        _raise_changed_target(target, displaced)
-    if captured is None or captured.identity != expected.identity:
-        _raise_changed_target(target, displaced)
-    return displaced
-
-
-def _publish_staged(target: Path, staged: Path, expected: _ManagedHuman | None) -> None:
-    displaced: Path | None = None
-    if expected is not None:
-        displaced = _capture_managed_target(target, expected)
-    try:
-        # Hard-link publication is create-if-absent. Unlike os.replace(), it
-        # cannot destroy an unknown file an editor placed after our check.
-        os.link(staged, target, follow_symlinks=False)
-    except FileExistsError as exc:
-        if displaced is not None:
-            displaced.unlink(missing_ok=True)
-        raise HumanMarkdownConflict(
-            f"refusing to replace HUMAN.md created during refresh: {target}"
-        ) from exc
-    except BaseException as exc:
-        if displaced is not None and not _restore_displaced(target, displaced):
-            raise RuntimeError(
-                f"HUMAN.md refresh failed; previous projection preserved at {displaced}"
-            ) from exc
+        metadata = os.fstat(fd)
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+            raise HumanMarkdownConflict(f"unsafe HUMAN.md transaction stage: {stage}")
+        os.fchmod(fd, 0o600)
+        candidate = metadata.st_dev, metadata.st_ino
+        transaction = _HumanTransaction(
+            operation="publish",
+            stage_name=stage.name,
+            expected=expected.identity if expected else None,
+            candidate=candidate,
+        )
+        _write_transaction(handle, transaction)
+        with os.fdopen(fd, "w", encoding="utf-8") as stage_handle:
+            fd = -1
+            stage_handle.write(content)
+            stage_handle.flush()
+            os.fsync(stage_handle.fileno())
+        _fsync_parent(target)
+        return stage, transaction
+    except BaseException:
+        if fd >= 0:
+            os.close(fd)
+        if candidate is not None:
+            _unlink_if_identity(stage, candidate)
+        _clear_recovered_transaction(target, handle)
         raise
-    staged.unlink(missing_ok=True)
-    if displaced is not None:
-        displaced.unlink(missing_ok=True)
-    _fsync_parent(target)
+
+
+def _publish_text_transaction(
+    target: Path,
+    content: str,
+    expected: _ManagedHuman | None,
+    handle: BinaryIO,
+) -> None:
+    stage, transaction = _stage_publish_transaction(target, content, expected, handle)
+    candidate = transaction.candidate
+    assert candidate is not None
+    try:
+        if expected is None:
+            try:
+                os.link(stage, target, follow_symlinks=False)
+            except FileExistsError as exc:
+                raise HumanMarkdownConflict(
+                    f"refusing to replace HUMAN.md created during refresh: {target}"
+                ) from exc
+            _fsync_parent(target)
+            if _path_identity(target) != candidate:
+                raise HumanMarkdownConflict(f"HUMAN.md changed during publication: {target}")
+            if not _unlink_if_identity(stage, candidate):
+                raise HumanMarkdownConflict(
+                    f"HUMAN.md transaction stage changed during publication: {stage}"
+                )
+        else:
+            try:
+                paths.atomic_exchange(stage, target)
+            except (OSError, ValueError) as exc:
+                raise HumanMarkdownConflict(
+                    f"cannot atomically replace managed HUMAN.md: {target}"
+                ) from exc
+            _fsync_parent(target)
+            captured = _managed_metadata(stage)
+            if captured is None or captured.identity != expected.identity:
+                raise HumanMarkdownConflict(f"HUMAN.md changed during refresh: {target}")
+            if _path_identity(target) != candidate:
+                raise HumanMarkdownConflict(f"HUMAN.md changed after publication: {target}")
+            if not _unlink_if_identity(stage, expected.identity):
+                raise HumanMarkdownConflict(
+                    f"HUMAN.md transaction stage changed during publication: {stage}"
+                )
+        _fsync_parent(target)
+        _write_transaction(handle, None)
+    except BaseException:
+        _recover_transaction(target, handle)
+        raise
 
 
 def remove_managed_human_markdown(path: Path | None = None) -> bool:
     """Remove only a Persome-owned projection; preserve unknown user files."""
     target = path or paths.human_file()
-    with _human_lock(target):
+    with _human_lock(target) as handle:
         metadata = _managed_metadata(target)
         if metadata is None:
             return False
-        displaced = _capture_managed_target(target, metadata)
-        displaced.unlink(missing_ok=True)
-        _fsync_parent(target)
-        return True
+        stage = _new_stage_path(target)
+        transaction = _HumanTransaction("remove", stage.name, metadata.identity, None)
+        _write_transaction(handle, transaction)
+        try:
+            try:
+                paths.atomic_rename_noreplace(target, stage)
+            except (OSError, ValueError) as exc:
+                raise HumanMarkdownConflict(f"cannot atomically remove HUMAN.md: {target}") from exc
+            _fsync_parent(target)
+            captured = _managed_metadata(stage)
+            if captured is None or captured.identity != metadata.identity:
+                raise HumanMarkdownConflict(f"HUMAN.md changed during removal: {target}")
+            if not _unlink_if_identity(stage, metadata.identity):
+                raise HumanMarkdownConflict(
+                    f"HUMAN.md transaction stage changed during removal: {stage}"
+                )
+            _clear_recovered_transaction(target, handle)
+            return True
+        except BaseException:
+            _recover_transaction(target, handle)
+            raise
 
 
 def materialize_human_markdown(
@@ -510,16 +797,14 @@ def materialize_human_markdown(
     redacted: bool = False,
 ) -> Path:
     """Atomically write a truthful HUMAN.md, including an honest cold-start view."""
-    validate_snapshot(snapshot)
     target = out_path or paths.human_file()
+    _raise_if_update_pending(target)
+    validate_snapshot(snapshot)
     content = render_human_markdown(snapshot, redacted=redacted)
-    with _human_lock(target):
+    with _human_lock(target) as handle:
+        _raise_if_update_pending(target)
         metadata = _managed_metadata(target)
-        staged = _stage_private_text(target, content)
-        try:
-            _publish_staged(target, staged, metadata)
-        finally:
-            staged.unlink(missing_ok=True)
+        _publish_text_transaction(target, content, metadata, handle)
     return target
 
 
@@ -556,29 +841,30 @@ def sync_live_human_markdown() -> Path:
     explicit forming-state file rather than a fabricated portrait.
     """
     from ..store import fts
-    from .build import build_live_snapshot, load_live_manifest
+    from .build import _build_live_snapshot_from_manifest, live_model_generation
 
     target = paths.human_file()
-    manifest = load_live_manifest()
-    current = _managed_metadata(target)
-    build_id = manifest.get("build_id")
-    if (
-        current is not None
-        and current.get("human_schema_version") == HUMAN_SCHEMA_VERSION
-        and current.get("renderer_version") == HUMAN_RENDERER_VERSION
-        and current.get("build_id") == build_id
-        and current.get("build_status") == manifest.get("status")
-    ):
-        return target
+    _raise_if_update_pending(target)
+    with live_model_generation() as manifest:
+        with _human_lock(target):
+            current = _managed_metadata(target)
+        build_id = manifest.get("build_id")
+        if (
+            current is not None
+            and current.get("human_schema_version") == HUMAN_SCHEMA_VERSION
+            and current.get("renderer_version") == HUMAN_RENDERER_VERSION
+            and current.get("build_id") == build_id
+            and current.get("build_status") == manifest.get("status")
+        ):
+            return target
 
-    if manifest.get("status") == "building" and current is not None:
-        return target
-    if manifest.get("status") not in _SUPPORTED_BUILD_STATUSES:
-        return materialize_human_markdown(_placeholder_snapshot(manifest), out_path=target)
+        if manifest.get("status") == "building":
+            if current is not None:
+                return target
+            raise HumanMarkdownConflict("HUMAN.md backfill waits for the active model build")
+        if manifest.get("status") not in _SUPPORTED_BUILD_STATUSES:
+            return materialize_human_markdown(_placeholder_snapshot(manifest), out_path=target)
 
-    with fts.cursor() as conn:
-        snapshot = build_live_snapshot(conn, redact=False)
-    snapshot_build = snapshot.get("build") if isinstance(snapshot.get("build"), dict) else {}
-    if snapshot_build.get("status") not in _SUPPORTED_BUILD_STATUSES:
-        return materialize_human_markdown(_placeholder_snapshot(snapshot_build), out_path=target)
-    return materialize_human_markdown(snapshot, out_path=target)
+        with fts.cursor() as conn:
+            snapshot = _build_live_snapshot_from_manifest(conn, manifest, redact=False)
+        return materialize_human_markdown(snapshot, out_path=target)

--- a/src/persome/paths.py
+++ b/src/persome/paths.py
@@ -56,6 +56,11 @@ def model_build_manifest() -> Path:
     return root() / "model-build.json"
 
 
+def human_file() -> Path:
+    """Latest owner-only, human-readable projection of the personal model."""
+    return root() / "HUMAN.md"
+
+
 def config_file() -> Path:
     return root() / "config.toml"
 

--- a/src/persome/paths.py
+++ b/src/persome/paths.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import contextlib
+import ctypes
+import errno
 import os
 import stat
+import sys
 import tempfile
 from pathlib import Path
 from typing import BinaryIO, TextIO
@@ -59,6 +62,11 @@ def model_build_manifest() -> Path:
 def human_file() -> Path:
     """Latest owner-only, human-readable projection of the personal model."""
     return root() / "HUMAN.md"
+
+
+def update_state_file() -> Path:
+    """Durable receipt for an uncommitted Runtime update transaction."""
+    return root() / ".update-state.json"
 
 
 def config_file() -> Path:
@@ -256,6 +264,55 @@ def atomic_write_private_text(path: Path, content: str, *, encoding: str = "utf-
     finally:
         temporary.unlink(missing_ok=True)
     return path
+
+
+def _atomic_rename_with_flags(first: Path, second: Path, *, darwin: int, linux: int) -> None:
+    """Run one same-directory flagged rename without a destructive fallback."""
+    if first.parent != second.parent:
+        raise ValueError("atomic rename paths must share one parent")
+    encoded_first = os.fsencode(first)
+    encoded_second = os.fsencode(second)
+    library = ctypes.CDLL(None, use_errno=True)
+    try:
+        if sys.platform == "darwin":
+            rename = library.renameatx_np
+            rename.argtypes = [
+                ctypes.c_int,
+                ctypes.c_char_p,
+                ctypes.c_int,
+                ctypes.c_char_p,
+                ctypes.c_uint,
+            ]
+            rename.restype = ctypes.c_int
+            result = rename(-2, encoded_first, -2, encoded_second, darwin)
+        elif sys.platform.startswith("linux"):
+            rename = library.renameat2
+            rename.argtypes = [
+                ctypes.c_int,
+                ctypes.c_char_p,
+                ctypes.c_int,
+                ctypes.c_char_p,
+                ctypes.c_uint,
+            ]
+            rename.restype = ctypes.c_int
+            result = rename(-100, encoded_first, -100, encoded_second, linux)
+        else:  # pragma: no cover - Persome is macOS-only; Linux supports CI.
+            raise OSError(errno.ENOSYS, f"flagged rename is unavailable on {sys.platform}")
+    except AttributeError as exc:  # pragma: no cover - current macOS/glibc expose these symbols.
+        raise OSError(errno.ENOSYS, "flagged rename is unavailable") from exc
+    if result != 0:
+        error_number = ctypes.get_errno()
+        raise OSError(error_number, os.strerror(error_number), str(first), str(second))
+
+
+def atomic_exchange(first: Path, second: Path) -> None:
+    """Atomically exchange two existing same-directory paths."""
+    _atomic_rename_with_flags(first, second, darwin=0x00000002, linux=0x00000002)
+
+
+def atomic_rename_noreplace(first: Path, second: Path) -> None:
+    """Atomically rename without replacing a concurrently created destination."""
+    _atomic_rename_with_flags(first, second, darwin=0x00000004, linux=0x00000001)
 
 
 def open_private_append_text(

--- a/src/persome/updater.py
+++ b/src/persome/updater.py
@@ -10,7 +10,6 @@ stay identical to a manual update.
 from __future__ import annotations
 
 import contextlib
-import ctypes
 import fcntl
 import importlib.metadata
 import json
@@ -149,7 +148,7 @@ def _update_replacement_dir() -> Path:
 
 
 def _update_state_file() -> Path:
-    return paths.root() / ".update-state.json"
+    return paths.update_state_file()
 
 
 def _venv_dir() -> Path:
@@ -731,42 +730,12 @@ def transaction_prepared() -> bool:
 def _atomic_exchange(first: Path, second: Path) -> None:
     """Exchange two same-filesystem directories in one kernel operation."""
 
-    if first.parent != second.parent:
-        raise UpdateError("update directories must share one parent for atomic exchange")
-    encoded_first = os.fsencode(first)
-    encoded_second = os.fsencode(second)
-    library = ctypes.CDLL(None, use_errno=True)
-    result: int
-    if sys.platform == "darwin":
-        rename = library.renameatx_np
-        rename.argtypes = [
-            ctypes.c_int,
-            ctypes.c_char_p,
-            ctypes.c_int,
-            ctypes.c_char_p,
-            ctypes.c_uint,
-        ]
-        rename.restype = ctypes.c_int
-        result = rename(-2, encoded_first, -2, encoded_second, 0x00000002)
-    elif sys.platform.startswith("linux"):
-        rename = library.renameat2
-        rename.argtypes = [
-            ctypes.c_int,
-            ctypes.c_char_p,
-            ctypes.c_int,
-            ctypes.c_char_p,
-            ctypes.c_uint,
-        ]
-        rename.restype = ctypes.c_int
-        result = rename(-100, encoded_first, -100, encoded_second, 0x00000002)
-    else:  # pragma: no cover - Persome is macOS-only; Linux supports CI.
-        raise UpdateError(f"atomic virtualenv exchange is unavailable on {sys.platform}")
-    if result != 0:
-        error_number = ctypes.get_errno()
+    try:
+        paths.atomic_exchange(first, second)
+    except (OSError, ValueError) as exc:
         raise UpdateError(
-            "could not atomically exchange the active and candidate Runtime: "
-            f"{os.strerror(error_number)}"
-        )
+            f"could not atomically exchange the active and candidate Runtime: {exc}"
+        ) from exc
     _fsync_root()
 
 

--- a/tests/test_clean_cli.py
+++ b/tests/test_clean_cli.py
@@ -79,6 +79,7 @@ def test_clean_memory_removes_canonical_model_exports_and_backups(ac_root) -> No
     (paths.exports_dir() / "model.json").write_text("{}")
     paths.backup_dir().mkdir()
     (paths.backup_dir() / "evo.db").write_text("synthetic")
+    paths.human_file().write_text("# HUMAN.md\n")
     paths.model_build_manifest().write_text("{}")
 
     files, entries, model_rows, artifacts = cli._clean_memory()
@@ -86,9 +87,10 @@ def test_clean_memory_removes_canonical_model_exports_and_backups(ac_root) -> No
     assert files == 1
     assert entries == 1
     assert model_rows >= 2
-    assert artifacts == 3
+    assert artifacts == 4
     assert not paths.exports_dir().exists()
     assert not paths.backup_dir().exists()
+    assert not paths.human_file().exists()
     assert not paths.model_build_manifest().exists()
     with fts.cursor() as conn:
         assert conn.execute("SELECT COUNT(*) FROM entries").fetchone()[0] == 0
@@ -102,6 +104,7 @@ def test_clean_all_keeps_only_install_configuration(ac_root) -> None:
     _seed_model()
     paths.config_file().write_text("[capture]\n")
     paths.env_file().write_text("PERSOME_LLM_API_KEY=synthetic\n")
+    paths.human_file().write_text("# HUMAN.md\n")
     (paths.root() / "venv").mkdir()
     # Legacy Chat-era data from an older install: a full wipe must still purge it.
     (paths.root() / "chat-history").mkdir()
@@ -120,6 +123,7 @@ def test_clean_all_keeps_only_install_configuration(ac_root) -> None:
         paths.capture_buffer_dir(),
         paths.memory_dir(),
         paths.logs_dir(),
+        paths.human_file(),
         paths.root() / "chat-history",
         paths.root() / "skills",
         paths.index_db(),

--- a/tests/test_cli_model.py
+++ b/tests/test_cli_model.py
@@ -64,6 +64,7 @@ def test_model_build_loads_runtime_env_before_llm_work(
                 "roots": 1,
             },
             manifest_path=paths.model_build_manifest(),
+            human_path=None,
         )
 
     monkeypatch.setattr(model_mod, "run_model_build", fake_build)
@@ -74,6 +75,7 @@ def test_model_build_loads_runtime_env_before_llm_work(
     assert seen == [expected]
     assert "cross-domain: probed=8 deferred=3 limit=8" in result.output
     assert "Deferred pairs stay queued" in result.output
+    assert "HUMAN.md:" not in result.output
 
 
 def test_model_build_cli_reports_integrity_recovery_block(

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -349,6 +349,7 @@ class TestRunLifecycle:
         self, ac_root: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from persome import paths
+        from persome.model import human as human_mod
 
         # All tasks return immediately; FIRST_COMPLETED then unblocks _run and
         # it proceeds through the normal (non-cancelled) shutdown path.
@@ -361,12 +362,38 @@ class TestRunLifecycle:
         monkeypatch.setattr(
             "persome.daemon._build_task_registry", lambda _receipt=None: stub_registry
         )
+        sync_human = MagicMock(return_value=paths.human_file())
+        monkeypatch.setattr(human_mod, "sync_live_human_markdown", sync_human)
 
         await _run(self._no_task_cfg(), capture_only=True)
 
+        sync_human.assert_called_once_with()
         # Health invariant: a cleanly stopped daemon leaves no pid file behind.
         assert not paths.pid_file().exists()
         assert not paths.runtime_state_file().exists()
+
+    async def test_human_projection_failure_does_not_crash_startup(
+        self, ac_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from persome.model import human as human_mod
+
+        async def returns() -> None:
+            return
+
+        stub_registry = [
+            replace(td, create=lambda c, sm: returns()) for td in _build_task_registry()
+        ]
+        monkeypatch.setattr(
+            "persome.daemon._build_task_registry", lambda _receipt=None: stub_registry
+        )
+        sync_human = MagicMock(side_effect=RuntimeError("synthetic HUMAN.md failure"))
+        monkeypatch.setattr(human_mod, "sync_live_human_markdown", sync_human)
+
+        with patch("persome.daemon.logger") as logger:
+            await _run(self._no_task_cfg(), capture_only=True)
+
+        sync_human.assert_called_once_with()
+        logger.exception.assert_any_call("HUMAN.md startup projection failed")
 
     async def test_force_end_failure_does_not_crash_shutdown(
         self, ac_root: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -30,6 +30,7 @@ from persome.daemon import (
     _on_task_done,
     _run,
     _shutdown_tasks,
+    _sync_human_after_update_commit,
 )
 
 
@@ -394,6 +395,71 @@ class TestRunLifecycle:
 
         sync_human.assert_called_once_with()
         logger.exception.assert_any_call("HUMAN.md startup projection failed")
+
+    async def test_candidate_runtime_creates_no_human_artifacts_before_update_commit(
+        self, ac_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from persome import paths
+        from persome.model import human as human_mod
+
+        async def returns() -> None:
+            return
+
+        stub_registry = [
+            replace(td, create=lambda c, sm: returns()) for td in _build_task_registry()
+        ]
+        monkeypatch.setattr(
+            "persome.daemon._build_task_registry", lambda _receipt=None: stub_registry
+        )
+        paths.update_state_file().write_text("pending\n", encoding="utf-8")
+        sync_human = MagicMock(return_value=paths.human_file())
+        monkeypatch.setattr(human_mod, "sync_live_human_markdown", sync_human)
+
+        await _run(self._no_task_cfg(), capture_only=True)
+
+        sync_human.assert_not_called()
+        assert not paths.human_file().exists()
+        assert list(ac_root.glob(".HUMAN.md.*")) == []
+
+    async def test_human_projection_waits_for_update_commit(
+        self, ac_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from persome import paths
+        from persome.model import human as human_mod
+
+        paths.update_state_file().write_text("pending\n", encoding="utf-8")
+        sync_human = MagicMock(return_value=paths.human_file())
+        monkeypatch.setattr(human_mod, "sync_live_human_markdown", sync_human)
+        monkeypatch.setattr("persome.daemon._HUMAN_UPDATE_POLL_SECONDS", 0.001)
+
+        task = asyncio.create_task(_sync_human_after_update_commit())
+        await asyncio.sleep(0.01)
+        sync_human.assert_not_called()
+
+        paths.update_state_file().unlink()
+        await asyncio.wait_for(task, timeout=1)
+        sync_human.assert_called_once_with()
+
+    async def test_rollback_cancels_deferred_human_projection(
+        self, ac_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from persome import paths
+        from persome.model import human as human_mod
+
+        paths.update_state_file().write_text("pending\n", encoding="utf-8")
+        sync_human = MagicMock(return_value=paths.human_file())
+        monkeypatch.setattr(human_mod, "sync_live_human_markdown", sync_human)
+        monkeypatch.setattr("persome.daemon._HUMAN_UPDATE_POLL_SECONDS", 0.001)
+
+        task = asyncio.create_task(_sync_human_after_update_commit())
+        await asyncio.sleep(0.01)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        paths.update_state_file().unlink()
+        await asyncio.sleep(0.01)
+        sync_human.assert_not_called()
 
     async def test_force_end_failure_does_not_crash_shutdown(
         self, ac_root: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_human_md.py
+++ b/tests/test_human_md.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+import fcntl
+import os
+import stat
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from persome.model import human
+
+
+def _manifest(*, build_id: str | None = "build-1", status: str = "complete") -> dict[str, Any]:
+    return {
+        "build_id": build_id,
+        "status": status,
+        "started_at": "2026-07-13T12:00:00Z" if build_id else None,
+        "completed_at": "2026-07-13T12:00:01Z" if build_id else None,
+        "degraded_stages": [],
+    }
+
+
+def _schema_item(
+    item_id: str,
+    signature: str,
+    *,
+    observations: int,
+    confidence: float = 0.8,
+) -> dict[str, Any]:
+    return {
+        "id": item_id,
+        "signature": signature,
+        "observations": observations,
+        "confidence": confidence,
+    }
+
+
+def _snapshot(
+    *,
+    build_id: str = "build-1",
+    generated_at: str = "2026-07-13T12:00:01Z",
+    root: dict[str, Any] | None = None,
+    faces: list[dict[str, Any]] | None = None,
+    volumes: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    face_items = faces or []
+    volume_items = volumes or []
+    root_item = root
+    return {
+        "schema_version": 1,
+        "generated_at": generated_at,
+        "build": _manifest(build_id=build_id),
+        "points": [
+            {
+                "id": "point-private-id",
+                "content": "POINT_PRIVATE_CONTENT_DO_NOT_RENDER",
+                "path": "/Users/alice/private/point.md",
+            }
+        ],
+        "lines": [],
+        "faces": face_items,
+        "volumes": volume_items,
+        "root": root_item,
+        "receipts": [
+            {
+                "id": "receipt-private-id",
+                "quote": "RECEIPT_PRIVATE_QUOTE_DO_NOT_RENDER",
+                "path": "/Users/alice/private/evidence.jsonl",
+            }
+        ],
+        "stats": {
+            "points": 1,
+            "active_points": 1,
+            "evolution_lines": 2,
+            "relation_lines": 3,
+            "faces": len(face_items),
+            "volumes": len(volume_items),
+            "roots": int(root_item is not None),
+            "receipts": 1,
+            "redactions": {},
+        },
+    }
+
+
+def test_render_is_deterministic_safe_and_keeps_only_unknown_handles() -> None:
+    known_volume = _schema_item(
+        "volume-known",
+        "Known Domain",
+        observations=12,
+        confidence=0.91,
+    )
+    snapshot = _snapshot(
+        root={
+            "id": "root-1",
+            "signature": (
+                "Builds ![tracking](https://invalid.example/pixel) and "
+                "[click me](https://invalid.example) <script>alert(1)</script> "
+                "across ⟨Known Domain⟩ while retaining ⟨Unrecognized Lens⟩."
+            ),
+            "members": ["volume-known"],
+        },
+        faces=[_schema_item("face-1", "Careful execution", observations=7)],
+        volumes=[known_volume],
+    )
+
+    first = human.render_human_markdown(snapshot)
+    second = human.render_human_markdown(snapshot)
+
+    assert first == second
+    assert first.startswith(
+        "---\n"
+        f"human_schema_version: {human.HUMAN_SCHEMA_VERSION}\n"
+        f"renderer_version: {human.HUMAN_RENDERER_VERSION}\n"
+        "model_schema_version: 1\n"
+    )
+    assert 'build_id: "build-1"' in first
+    assert 'build_status: "complete"' in first
+    assert 'root_id: "root-1"' in first
+    assert 'visibility: "owner-only"' in first
+    assert "redacted: false" in first
+    assert 'projection: "persome-model"' in first
+
+    portrait = first.split("## Persome's portrait of me", 1)[1].split("## Stable patterns", 1)[0]
+    assert "⟨Known Domain⟩" not in portrait
+    assert "⟨Unrecognized Lens⟩" in portrait
+    assert "![tracking](" not in portrait
+    assert "[click me](" not in portrait
+    assert "<script>" not in portrait
+    assert r"!\[tracking\](https://invalid.example/pixel)" in portrait
+    assert r"\[click me\](https://invalid.example)" in portrait
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in portrait
+    assert "- Known Domain _(evidence 12; confidence 0.91)_" in first
+
+    assert "POINT_PRIVATE_CONTENT_DO_NOT_RENDER" not in first
+    assert "RECEIPT_PRIVATE_QUOTE_DO_NOT_RENDER" not in first
+    assert "point-private-id" not in first
+    assert "receipt-private-id" not in first
+    assert "/Users/alice/private" not in first
+
+
+def test_render_sorts_and_caps_faces_and_root_member_volumes() -> None:
+    faces = [
+        _schema_item(f"face-{index:02d}", f"Face rank {index:02d}", observations=index)
+        for index in range(10)
+    ]
+    volumes = [
+        _schema_item(
+            f"volume-{index:02d}",
+            f"Volume rank {index:02d}",
+            observations=index,
+        )
+        for index in range(10)
+    ]
+    snapshot = _snapshot(
+        root={
+            "id": "root-1",
+            "signature": "A compact portrait without embedded handles.",
+            "members": [item["id"] for item in volumes],
+        },
+        faces=list(reversed(faces)),
+        volumes=list(reversed(volumes)),
+    )
+
+    rendered = human.render_human_markdown(snapshot)
+    face_section = rendered.split("## Stable patterns", 1)[1].split("## Cross-domain patterns", 1)[
+        0
+    ]
+    volume_section = rendered.split("## Cross-domain patterns", 1)[1].split(
+        "## Model provenance", 1
+    )[0]
+
+    assert face_section.index("Face rank 09") < face_section.index("Face rank 08")
+    assert volume_section.index("Volume rank 09") < volume_section.index("Volume rank 08")
+    assert "Face rank 02" in face_section
+    assert "Face rank 01" not in face_section
+    assert "Volume rank 02" in volume_section
+    assert "Volume rank 01" not in volume_section
+    assert "> Showing 8 of 10 Faces." in face_section
+    assert "> Showing 8 of 10 Volumes." in volume_section
+
+
+def test_materialize_is_owner_only_and_atomically_replaces_managed_file(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "HUMAN.md"
+    initial = _snapshot(generated_at="2026-07-13T12:00:01Z")
+    updated = _snapshot(generated_at="2026-07-13T12:00:02Z")
+    human.materialize_human_markdown(initial, out_path=target)
+
+    with target.open("r", encoding="utf-8") as previous_handle:
+        previous_inode = os.fstat(previous_handle.fileno()).st_ino
+        human.materialize_human_markdown(updated, out_path=target)
+
+        assert target.stat().st_ino != previous_inode
+        assert "2026-07-13T12:00:01Z" in previous_handle.read()
+
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    assert "2026-07-13T12:00:02Z" in target.read_text(encoding="utf-8")
+    assert list(tmp_path.glob(".HUMAN.md.*")) == [tmp_path / ".HUMAN.md.lock"]
+    assert stat.S_IMODE((tmp_path / ".HUMAN.md.lock").stat().st_mode) == 0o600
+
+
+def test_materialize_preserves_unrecognized_existing_file(tmp_path: Path) -> None:
+    target = tmp_path / "HUMAN.md"
+    unknown = '# My hand-written HUMAN.md\n\n---\nprojection: "persome-model"\n---\n'
+    target.write_text(unknown, encoding="utf-8")
+    target.chmod(0o640)
+    before = target.stat()
+
+    with pytest.raises(human.HumanMarkdownConflict, match="refusing to replace"):
+        human.materialize_human_markdown(_snapshot(), out_path=target)
+
+    after = target.stat()
+    assert target.read_text(encoding="utf-8") == unknown
+    assert after.st_ino == before.st_ino
+    assert stat.S_IMODE(after.st_mode) == stat.S_IMODE(before.st_mode)
+
+
+def test_materialize_preserves_symlink_and_its_target(tmp_path: Path) -> None:
+    victim = tmp_path / "user-notes.md"
+    victim.write_text("do not replace me\n", encoding="utf-8")
+    target = tmp_path / "HUMAN.md"
+    target.symlink_to(victim)
+
+    with pytest.raises(human.HumanMarkdownConflict, match="non-regular"):
+        human.materialize_human_markdown(_snapshot(), out_path=target)
+
+    assert target.is_symlink()
+    assert target.readlink() == victim
+    assert victim.read_text(encoding="utf-8") == "do not replace me\n"
+
+
+def test_materialize_preserves_hard_link_and_its_target(tmp_path: Path) -> None:
+    victim = tmp_path / "user-notes.md"
+    victim.write_text("do not replace me\n", encoding="utf-8")
+    target = tmp_path / "HUMAN.md"
+    os.link(victim, target)
+    before = victim.stat()
+
+    with pytest.raises(human.HumanMarkdownConflict, match="non-regular"):
+        human.materialize_human_markdown(_snapshot(), out_path=target)
+
+    assert target.stat().st_ino == before.st_ino
+    assert victim.stat().st_nlink == 2
+    assert victim.read_text(encoding="utf-8") == "do not replace me\n"
+
+
+@pytest.mark.parametrize("operation", ["refresh", "remove"])
+def test_managed_operation_preserves_unknown_file_swapped_in_after_check(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+) -> None:
+    target = tmp_path / "HUMAN.md"
+    human.materialize_human_markdown(_snapshot(), out_path=target)
+    original_move = human._move_existing_target
+    replacement = "# Edited concurrently\n\nThis file belongs to the user.\n"
+
+    def swap_then_move(path: Path) -> Path:
+        editor_temp = path.with_name("editor-HUMAN.md")
+        editor_temp.write_text(replacement, encoding="utf-8")
+        editor_temp.chmod(0o640)
+        os.replace(editor_temp, path)
+        return original_move(path)
+
+    monkeypatch.setattr(human, "_move_existing_target", swap_then_move)
+
+    with pytest.raises(human.HumanMarkdownConflict, match="changed during refresh"):
+        if operation == "refresh":
+            human.materialize_human_markdown(
+                _snapshot(generated_at="2026-07-13T12:00:02Z"),
+                out_path=target,
+            )
+        else:
+            human.remove_managed_human_markdown(target)
+
+    assert target.read_text(encoding="utf-8") == replacement
+    assert stat.S_IMODE(target.stat().st_mode) == 0o640
+
+
+def test_materialize_fails_open_when_another_projection_holds_the_lock(tmp_path: Path) -> None:
+    target = tmp_path / "HUMAN.md"
+    lock_path = tmp_path / ".HUMAN.md.lock"
+    lock_path.touch(mode=0o600)
+
+    with lock_path.open("a+b") as lock_handle:
+        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        with pytest.raises(human.HumanMarkdownConflict, match="already active"):
+            human.materialize_human_markdown(_snapshot(), out_path=target)
+
+    assert not target.exists()
+
+
+def test_materialize_recovers_same_inode_staged_link_after_crash(tmp_path: Path) -> None:
+    target = tmp_path / "HUMAN.md"
+    human.materialize_human_markdown(_snapshot(), out_path=target)
+    stranded = tmp_path / ".HUMAN.md.stranded"
+    os.link(target, stranded)
+    assert target.stat().st_nlink == 2
+
+    human.materialize_human_markdown(
+        _snapshot(generated_at="2026-07-13T12:00:02Z"),
+        out_path=target,
+    )
+
+    assert not stranded.exists()
+    assert target.stat().st_nlink == 1
+    assert "2026-07-13T12:00:02Z" in target.read_text(encoding="utf-8")
+
+
+def test_materialize_recovers_unknown_restore_link_but_still_preserves_it(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "HUMAN.md"
+    unknown = "# Concurrent user file\n"
+    target.write_text(unknown, encoding="utf-8")
+    target.chmod(0o640)
+    stranded = tmp_path / ".HUMAN.md.replaced.stranded"
+    os.link(target, stranded)
+
+    with pytest.raises(human.HumanMarkdownConflict, match="refusing to replace"):
+        human.materialize_human_markdown(_snapshot(), out_path=target)
+
+    assert not stranded.exists()
+    assert target.read_text(encoding="utf-8") == unknown
+    assert target.stat().st_nlink == 1
+    assert stat.S_IMODE(target.stat().st_mode) == 0o640
+
+
+def test_sync_writes_truthful_cold_start_placeholder(
+    ac_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = _manifest(build_id=None, status="not_built")
+    monkeypatch.setattr("persome.model.build.load_live_manifest", lambda: manifest)
+
+    target = human.sync_live_human_markdown()
+    rendered = target.read_text(encoding="utf-8")
+
+    assert target == ac_root / "HUMAN.md"
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    assert "build_id: null" in rendered
+    assert 'build_status: "not_built"' in rendered
+    assert "root_id: null" in rendered
+    assert "has not formed a verified Root yet" in rendered
+    assert "No identity portrait is being" in rendered
+    assert "## Stable patterns" not in rendered
+    assert "## Cross-domain patterns" not in rendered
+
+
+def test_sync_is_noop_when_build_schema_and_renderer_match(
+    ac_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    snapshot = _snapshot(root={"id": "root-1", "signature": "Stable portrait", "members": []})
+    target = human.materialize_human_markdown(snapshot)
+    before = target.stat()
+    before_content = target.read_bytes()
+    monkeypatch.setattr(
+        "persome.model.build.load_live_manifest",
+        lambda: snapshot["build"],
+    )
+
+    def fail_if_rebuilt(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("matching HUMAN.md must not rebuild the live snapshot")
+
+    monkeypatch.setattr("persome.model.build.build_live_snapshot", fail_if_rebuilt)
+
+    assert human.sync_live_human_markdown() == ac_root / "HUMAN.md"
+    after = target.stat()
+    assert after.st_ino == before.st_ino
+    assert after.st_mtime_ns == before.st_mtime_ns
+    assert target.read_bytes() == before_content

--- a/tests/test_human_md.py
+++ b/tests/test_human_md.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+import errno
 import fcntl
 import os
 import stat
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
 import pytest
 
+from persome import paths
+from persome.model import build as model_build
 from persome.model import human
 
 
@@ -182,6 +186,7 @@ def test_render_sorts_and_caps_faces_and_root_member_volumes() -> None:
 
 def test_materialize_is_owner_only_and_atomically_replaces_managed_file(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     target = tmp_path / "HUMAN.md"
     initial = _snapshot(generated_at="2026-07-13T12:00:01Z")
@@ -190,11 +195,21 @@ def test_materialize_is_owner_only_and_atomically_replaces_managed_file(
 
     with target.open("r", encoding="utf-8") as previous_handle:
         previous_inode = os.fstat(previous_handle.fileno()).st_ino
+        original_exchange = human.paths.atomic_exchange
+        observations: list[tuple[bool, bool]] = []
+
+        def observed_exchange(first: Path, second: Path) -> None:
+            before = second.exists()
+            original_exchange(first, second)
+            observations.append((before, second.exists()))
+
+        monkeypatch.setattr(human.paths, "atomic_exchange", observed_exchange)
         human.materialize_human_markdown(updated, out_path=target)
 
         assert target.stat().st_ino != previous_inode
         assert "2026-07-13T12:00:01Z" in previous_handle.read()
 
+    assert observations == [(True, True)]
     assert stat.S_IMODE(target.stat().st_mode) == 0o600
     assert "2026-07-13T12:00:02Z" in target.read_text(encoding="utf-8")
     assert list(tmp_path.glob(".HUMAN.md.*")) == [tmp_path / ".HUMAN.md.lock"]
@@ -254,19 +269,37 @@ def test_managed_operation_preserves_unknown_file_swapped_in_after_check(
 ) -> None:
     target = tmp_path / "HUMAN.md"
     human.materialize_human_markdown(_snapshot(), out_path=target)
-    original_move = human._move_existing_target
     replacement = "# Edited concurrently\n\nThis file belongs to the user.\n"
+    swapped = False
 
-    def swap_then_move(path: Path) -> Path:
-        editor_temp = path.with_name("editor-HUMAN.md")
+    def swap_target() -> None:
+        nonlocal swapped
+        editor_temp = target.with_name("editor-HUMAN.md")
         editor_temp.write_text(replacement, encoding="utf-8")
         editor_temp.chmod(0o640)
-        os.replace(editor_temp, path)
-        return original_move(path)
+        os.replace(editor_temp, target)
+        swapped = True
 
-    monkeypatch.setattr(human, "_move_existing_target", swap_then_move)
+    if operation == "refresh":
+        original_exchange = human.paths.atomic_exchange
 
-    with pytest.raises(human.HumanMarkdownConflict, match="changed during refresh"):
+        def swap_then_exchange(first: Path, second: Path) -> None:
+            if not swapped and second == target:
+                swap_target()
+            original_exchange(first, second)
+
+        monkeypatch.setattr(human.paths, "atomic_exchange", swap_then_exchange)
+    else:
+        original_rename = human.paths.atomic_rename_noreplace
+
+        def swap_then_rename(first: Path, second: Path) -> None:
+            if not swapped and first == target:
+                swap_target()
+            original_rename(first, second)
+
+        monkeypatch.setattr(human.paths, "atomic_rename_noreplace", swap_then_rename)
+
+    with pytest.raises(human.HumanMarkdownConflict, match="refusing to replace|changed"):
         if operation == "refresh":
             human.materialize_human_markdown(
                 _snapshot(generated_at="2026-07-13T12:00:02Z"),
@@ -292,40 +325,143 @@ def test_materialize_fails_open_when_another_projection_holds_the_lock(tmp_path:
     assert not target.exists()
 
 
-def test_materialize_recovers_same_inode_staged_link_after_crash(tmp_path: Path) -> None:
+def test_materialize_preserves_managed_human_hardlink_backup(tmp_path: Path) -> None:
     target = tmp_path / "HUMAN.md"
     human.materialize_human_markdown(_snapshot(), out_path=target)
-    stranded = tmp_path / ".HUMAN.md.stranded"
-    os.link(target, stranded)
+    before = target.read_bytes()
+    backup = tmp_path / ".HUMAN.md.my-backup"
+    os.link(target, backup)
     assert target.stat().st_nlink == 2
 
-    human.materialize_human_markdown(
-        _snapshot(generated_at="2026-07-13T12:00:02Z"),
-        out_path=target,
-    )
+    with pytest.raises(human.HumanMarkdownConflict, match="non-regular"):
+        human.materialize_human_markdown(
+            _snapshot(generated_at="2026-07-13T12:00:02Z"),
+            out_path=target,
+        )
 
-    assert not stranded.exists()
-    assert target.stat().st_nlink == 1
-    assert "2026-07-13T12:00:02Z" in target.read_text(encoding="utf-8")
+    assert backup.exists()
+    assert target.stat().st_ino == backup.stat().st_ino
+    assert target.stat().st_nlink == 2
+    assert target.read_bytes() == before
 
 
-def test_materialize_recovers_unknown_restore_link_but_still_preserves_it(
+def test_materialize_preserves_unknown_human_hardlink_backup(
     tmp_path: Path,
 ) -> None:
     target = tmp_path / "HUMAN.md"
     unknown = "# Concurrent user file\n"
     target.write_text(unknown, encoding="utf-8")
     target.chmod(0o640)
-    stranded = tmp_path / ".HUMAN.md.replaced.stranded"
-    os.link(target, stranded)
+    backup = tmp_path / ".HUMAN.md.my-backup"
+    os.link(target, backup)
 
     with pytest.raises(human.HumanMarkdownConflict, match="refusing to replace"):
         human.materialize_human_markdown(_snapshot(), out_path=target)
 
-    assert not stranded.exists()
+    assert backup.exists()
     assert target.read_text(encoding="utf-8") == unknown
-    assert target.stat().st_nlink == 1
+    assert target.stat().st_ino == backup.stat().st_ino
+    assert target.stat().st_nlink == 2
     assert stat.S_IMODE(target.stat().st_mode) == 0o640
+
+
+def test_materialize_recovers_journaled_initial_link_crash(tmp_path: Path) -> None:
+    target = tmp_path / "HUMAN.md"
+    initial = _snapshot(generated_at="2026-07-13T12:00:01Z")
+    with human._human_lock(target) as handle:
+        stage, _transaction = human._stage_publish_transaction(
+            target,
+            human.render_human_markdown(initial),
+            None,
+            handle,
+        )
+        os.link(stage, target, follow_symlinks=False)
+
+    assert target.stat().st_nlink == 2
+    assert stage.exists()
+
+    human.materialize_human_markdown(
+        _snapshot(generated_at="2026-07-13T12:00:02Z"),
+        out_path=target,
+    )
+
+    assert not stage.exists()
+    assert target.stat().st_nlink == 1
+    assert "2026-07-13T12:00:02Z" in target.read_text(encoding="utf-8")
+    assert (tmp_path / ".HUMAN.md.lock").read_bytes() == b""
+
+
+def test_materialize_recovers_journaled_post_exchange_crash(tmp_path: Path) -> None:
+    target = tmp_path / "HUMAN.md"
+    human.materialize_human_markdown(_snapshot(), out_path=target)
+    crashed = _snapshot(generated_at="2026-07-13T12:00:02Z")
+    with human._human_lock(target) as handle:
+        expected = human._managed_metadata(target)
+        assert expected is not None
+        stage, _transaction = human._stage_publish_transaction(
+            target,
+            human.render_human_markdown(crashed),
+            expected,
+            handle,
+        )
+        paths.atomic_exchange(stage, target)
+
+    assert stage.exists()
+    assert "2026-07-13T12:00:02Z" in target.read_text(encoding="utf-8")
+
+    human.materialize_human_markdown(
+        _snapshot(generated_at="2026-07-13T12:00:03Z"),
+        out_path=target,
+    )
+
+    assert not stage.exists()
+    assert "2026-07-13T12:00:03Z" in target.read_text(encoding="utf-8")
+    assert list(tmp_path.glob(".HUMAN.md.persome-stage.*")) == []
+
+
+def test_materialize_ignores_truncated_transaction_tail(tmp_path: Path) -> None:
+    target = tmp_path / "HUMAN.md"
+    stage = human._new_stage_path(target)
+    transaction = human._HumanTransaction("publish", stage.name, None, None)
+
+    with human._human_lock(target) as handle:
+        human._write_transaction(handle, transaction)
+        handle.seek(0, os.SEEK_END)
+        handle.write(b'{"candidate": [1,')
+        handle.flush()
+        os.fsync(handle.fileno())
+
+    human.materialize_human_markdown(_snapshot(), out_path=target)
+
+    assert target.exists()
+    assert not stage.exists()
+    assert (tmp_path / ".HUMAN.md.lock").read_bytes() == b""
+
+
+def test_materialize_fails_closed_when_atomic_exchange_is_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = tmp_path / "HUMAN.md"
+    human.materialize_human_markdown(_snapshot(), out_path=target)
+    before = target.stat()
+    before_content = target.read_bytes()
+
+    def unsupported(_first: Path, _second: Path) -> None:
+        raise OSError(errno.ENOTSUP, "unsupported")
+
+    monkeypatch.setattr(human.paths, "atomic_exchange", unsupported)
+    with pytest.raises(human.HumanMarkdownConflict, match="cannot atomically replace"):
+        human.materialize_human_markdown(
+            _snapshot(generated_at="2026-07-13T12:00:02Z"),
+            out_path=target,
+        )
+
+    after = target.stat()
+    assert after.st_ino == before.st_ino
+    assert target.read_bytes() == before_content
+    assert list(tmp_path.glob(".HUMAN.md.persome-stage.*")) == []
+    assert (tmp_path / ".HUMAN.md.lock").read_bytes() == b""
 
 
 def test_sync_writes_truthful_cold_start_placeholder(
@@ -333,7 +469,12 @@ def test_sync_writes_truthful_cold_start_placeholder(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     manifest = _manifest(build_id=None, status="not_built")
-    monkeypatch.setattr("persome.model.build.load_live_manifest", lambda: manifest)
+
+    @contextmanager
+    def generation():
+        yield manifest
+
+    monkeypatch.setattr("persome.model.build.live_model_generation", generation)
 
     target = human.sync_live_human_markdown()
     rendered = target.read_text(encoding="utf-8")
@@ -357,18 +498,78 @@ def test_sync_is_noop_when_build_schema_and_renderer_match(
     target = human.materialize_human_markdown(snapshot)
     before = target.stat()
     before_content = target.read_bytes()
-    monkeypatch.setattr(
-        "persome.model.build.load_live_manifest",
-        lambda: snapshot["build"],
-    )
+
+    @contextmanager
+    def generation():
+        yield snapshot["build"]
+
+    monkeypatch.setattr("persome.model.build.live_model_generation", generation)
 
     def fail_if_rebuilt(*args: Any, **kwargs: Any) -> dict[str, Any]:
         raise AssertionError("matching HUMAN.md must not rebuild the live snapshot")
 
-    monkeypatch.setattr("persome.model.build.build_live_snapshot", fail_if_rebuilt)
+    monkeypatch.setattr("persome.model.build._build_live_snapshot_from_manifest", fail_if_rebuilt)
 
     assert human.sync_live_human_markdown() == ac_root / "HUMAN.md"
     after = target.stat()
     assert after.st_ino == before.st_ino
     assert after.st_mtime_ns == before.st_mtime_ns
     assert target.read_bytes() == before_content
+
+
+def test_sync_holds_shared_generation_lock_through_publication(
+    ac_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    snapshot = _snapshot(root={"id": "root-1", "signature": "Stable portrait", "members": []})
+    original_materialize = human.materialize_human_markdown
+
+    @contextmanager
+    def locked_generation():
+        with model_build._shared_build_lock_if_available() as acquired:
+            assert acquired is True
+            yield snapshot["build"]
+
+    monkeypatch.setattr(model_build, "live_model_generation", locked_generation)
+    monkeypatch.setattr(
+        model_build,
+        "_build_live_snapshot_from_manifest",
+        lambda _conn, _manifest, *, redact: snapshot,
+    )
+
+    def checked_materialize(*args: Any, **kwargs: Any) -> Path:
+        with (
+            pytest.raises(model_build.ModelBuildBusy),
+            model_build.ModelBuildCoordinator().acquire(wait_seconds=0),
+        ):
+            pass
+        return original_materialize(*args, **kwargs)
+
+    monkeypatch.setattr(human, "materialize_human_markdown", checked_materialize)
+
+    assert human.sync_live_human_markdown() == ac_root / "HUMAN.md"
+    assert 'build_id: "build-1"' in paths.human_file().read_text(encoding="utf-8")
+
+
+def test_sync_does_not_publish_placeholder_during_active_build(ac_root: Path) -> None:
+    with (
+        model_build.ModelBuildCoordinator().acquire(wait_seconds=0),
+        pytest.raises(human.HumanMarkdownConflict, match="active model build"),
+    ):
+        human.sync_live_human_markdown()
+
+    assert not paths.human_file().exists()
+
+
+def test_update_receipt_defers_all_canonical_publication_without_artifacts(
+    ac_root: Path,
+) -> None:
+    paths.update_state_file().write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(human.HumanMarkdownDeferred, match="update to commit"):
+        human.materialize_human_markdown(_snapshot())
+    with pytest.raises(human.HumanMarkdownDeferred, match="update to commit"):
+        human.sync_live_human_markdown()
+
+    assert not paths.human_file().exists()
+    assert list(ac_root.glob(".HUMAN.md.*")) == []

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -15,7 +15,7 @@ from persome import integrity, paths
 from persome.evomem import backup
 from persome.evomem.models import MemoryLayer, MemoryNode
 from persome.evomem.store import NodeStore
-from persome.model import create_build_manifest, load_live_manifest
+from persome.model import create_build_manifest, load_live_manifest, sync_live_human_markdown
 from persome.store import entries, fts, relation_edges, schema_faces
 from persome.store import files as files_mod
 
@@ -115,12 +115,15 @@ def test_corrupt_db_replays_memory_and_invalidates_stale_model_build(ac_root: Pa
         paths.model_build_manifest(),
         json.dumps({"status": "complete", "build_id": "stale-build"}),
     )
+    sync_live_human_markdown()
+    assert paths.human_file().exists()
     paths.index_db().write_bytes(b"not-a-sqlite-database" * 100)
 
     recovered = integrity.check_and_recover()
 
     assert [item.kind for item in recovered] == ["database"]
     assert not paths.model_build_manifest().exists()
+    assert not paths.human_file().exists()
     with fts.cursor() as conn:
         row = conn.execute(
             "SELECT content FROM entries WHERE id=?",
@@ -640,11 +643,14 @@ def test_unknown_authority_invalidates_completed_model_manifest(ac_root: Path) -
         completed_at="2026-07-12T09:01:00+08:00",
     )
     paths.atomic_write_private_text(paths.model_build_manifest(), json.dumps(manifest))
+    unknown_human = "# My hand-authored HUMAN.md\n\nDo not replace this file.\n"
+    paths.atomic_write_private_text(paths.human_file(), unknown_human)
     paths.config_file().write_text("[[[ corrupt config", encoding="utf-8")
 
     integrity.check_and_recover()
 
     assert not paths.model_build_manifest().exists()
+    assert paths.human_file().read_text(encoding="utf-8") == unknown_human
     assert load_live_manifest()["status"] == "not_built"
     database = json.loads(paths.integrity_recovery_marker().read_text())["database_recovery"]
     assert database["status"] == "partial"

--- a/tests/test_model_snapshot.py
+++ b/tests/test_model_snapshot.py
@@ -26,6 +26,7 @@ from persome.model import (
     load_live_manifest,
     model_status,
     run_model_build,
+    sync_live_human_markdown,
 )
 from persome.store import fts, schema_faces
 from persome.store import relation_edges as edges
@@ -296,8 +297,36 @@ def test_fresh_root_rebuild_is_structurally_identical(ac_root, monkeypatch, tmp_
     assert first == second
 
 
+def test_upgrade_backfills_human_from_existing_root_without_rebuild(
+    ac_root, monkeypatch, tmp_path
+) -> None:
+    seeded = _seed_model(monkeypatch)
+    timestamp = seeded["seed"]["generated_at"]
+    manifest = create_build_manifest(
+        core_commit="0123456789abcdef",
+        prompt_dir=tmp_path / "missing-prompts",
+        started_at=timestamp,
+        completed_at=timestamp,
+        trigger="pre-human-upgrade",
+        mode="mock",
+    )
+    paths.atomic_write_private_text(
+        paths.model_build_manifest(),
+        json.dumps(manifest, ensure_ascii=False, sort_keys=True),
+    )
+
+    assert not paths.human_file().exists()
+    human_path = sync_live_human_markdown()
+    rendered = human_path.read_text(encoding="utf-8")
+
+    assert f'build_id: "{manifest["build_id"]}"' in rendered
+    assert f'root_id: "{seeded["root_id"]}"' in rendered
+    assert "Persome has not formed a verified Root yet" not in rendered
+    assert human_path.stat().st_mode & 0o777 == 0o600
+
+
 def test_model_build_persists_complete_owner_only_manifest(ac_root, monkeypatch) -> None:
-    _seed_model(monkeypatch)
+    seeded = _seed_model(monkeypatch)
     cfg = config_mod.load(ac_root / "config.toml")
     moments = iter(
         [
@@ -319,6 +348,14 @@ def test_model_build_persists_complete_owner_only_manifest(ac_root, monkeypatch)
     assert result.stages == pipeline.stages
     assert load_last_manifest() == result.manifest
     assert result.manifest_path.stat().st_mode & 0o777 == 0o600
+    human_path = paths.human_file()
+    assert result.human_path == human_path
+    human = human_path.read_text(encoding="utf-8")
+    assert human_path.stat().st_mode & 0o777 == 0o600
+    assert f'build_id: "{result.manifest["build_id"]}"' in human
+    assert f'root_id: "{seeded["root_id"]}"' in human
+    assert "# HUMAN.md" in human
+    assert "Persome has not formed a verified Root yet" not in human
 
 
 def test_empty_model_build_is_degraded_not_success(ac_root) -> None:
@@ -334,6 +371,31 @@ def test_empty_model_build_is_degraded_not_success(ac_root) -> None:
     assert result.manifest["degraded_stages"] == ["model_contract"]
     assert result.stats["points"] == 0
     assert result.stats["roots"] == 0
+    human_path = paths.human_file()
+    human = human_path.read_text(encoding="utf-8")
+    assert human_path.stat().st_mode & 0o777 == 0o600
+    assert 'build_status: "degraded"' in human
+    assert "root_id: null" in human
+    assert "Persome has not formed a verified Root yet" in human
+    assert "## Stable patterns" not in human
+    assert "## Cross-domain patterns" not in human
+
+
+def test_model_build_preserves_unknown_human_and_reports_no_projection(ac_root) -> None:
+    unknown = "# My HUMAN.md\n\nPersome must not replace this file.\n"
+    paths.human_file().write_text(unknown, encoding="utf-8")
+    cfg = config_mod.load(ac_root / "config.toml")
+    result = run_model_build(
+        cfg,
+        pipeline_runner=lambda _cfg: PipelineOutcome(),
+        now=lambda: datetime(2026, 7, 10, 8, 0, tzinfo=UTC),
+        trigger="test-human-conflict",
+    )
+
+    assert result.status == "degraded"
+    assert result.human_path is None
+    assert load_last_manifest() == result.manifest
+    assert paths.human_file().read_text(encoding="utf-8") == unknown
 
 
 def test_interrupted_model_build_invalidates_previous_completed_manifest(ac_root) -> None:

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import httpx
 import pytest
@@ -622,10 +623,14 @@ def test_success_is_printed_and_uses_a_nonblocking_notification(
     assert calls == [(onboarding._NOTIFICATION_SCRIPT, {"timeout": 5})]
 
 
-def test_cli_onboard_reports_each_completed_gate(
+def test_cli_onboard_reports_each_completed_gate_and_syncs_human(
     ac_root: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    from persome.model import human as human_mod
+
     capture_path = ac_root / "capture-buffer" / "fresh.json"
+    sync_human = MagicMock(return_value=paths.human_file())
+    monkeypatch.setattr(human_mod, "sync_live_human_markdown", sync_human)
     monkeypatch.setattr(
         onboarding,
         "onboard",
@@ -642,6 +647,7 @@ def test_cli_onboard_reports_each_completed_gate(
     result = CliRunner().invoke(app, ["onboard"])
 
     assert result.exit_code == 0, result.output
+    sync_human.assert_called_once_with()
     assert "Accessibility granted" in result.output
     assert "Screen Recording granted" in result.output
     assert "Isolated local OCR worker ready" in result.output


### PR DESCRIPTION
# What

Materialize the current personal model as a deterministic, owner-only `~/.persome/HUMAN.md` reading view. The projection maps Root, Faces, root-member Volumes, build metadata, and aggregate provenance into Markdown while keeping the versioned JSON snapshot authoritative.

It refreshes after model builds and backfills existing users during Runtime startup or `persome onboard`. Users without a verified Root receive an honest still-forming placeholder; no recapture or additional LLM call is required.

# Why

Persome presents itself as a living, evidence-backed HUMAN.md, but did not previously provide that artifact. This gives owners a first-class, inspectable local file without renaming or weakening the canonical Point/Line/Face/Volume/Root model contract.

The implementation also preserves an unknown user-authored `HUMAN.md`, fails open if projection work cannot complete, and recovers safely from concurrent editor writes and interrupted atomic publication.

# How verified

- `PERSOME_LLM_MOCK=1 uv run pytest -m "not macos and not integration" -q` — 1927 passed, 15 deselected
- Focused HUMAN/build/daemon/onboarding/integrity/clean/CLI suite — 198 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python scripts/secret_scan.py`
- `uv run python scripts/pii_scan.py`
- `uv run python scripts/language_scan.py`
- `uv run python scripts/check_doc_links.py`

---

- [x] Commits are signed off (`git commit -s`) — DCO required, see CONTRIBUTING.md
- [x] No real names / emails / tokens in code or test fixtures (synthetic data only)
- [x] Secret scan passes (`scripts/secret_scan.py`)
- [x] Human-authored repository text is English (`scripts/language_scan.py` passes)
