### PR TITLE
mcp: survive uvicorn SystemExit, name corruption recovery, fit instructions in client truncation budget

### DIFF
--- a/src/persome/daemon.py
+++ b/src/persome/daemon.py
@@ -133,6 +133,32 @@ async def _mcp_loop(cfg: Config) -> None:
                     exc,
                 )
                 return
+        except SystemExit as exc:
+            # uvicorn converts transport startup failures (a port it cannot
+            # bind, EPERM from macOS local-network privacy) into
+            # SystemExit(STARTUP_FAILURE), which sails past the OSError and
+            # Exception arms, kills the whole daemon — capture included — and
+            # leaves the supervisor restarting us into the same wall. Unwrap
+            # the original bind error and apply the same policy as above.
+            cause = exc.__context__
+            if isinstance(cause, OSError) and cause.errno == _errno.EADDRINUSE:
+                logger.warning(
+                    "mcp server failed to bind %s:%d — address in use, retrying in %.0fs",
+                    cfg.mcp.host,
+                    cfg.mcp.port,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+                delay = min(delay * 2, 60.0)
+            else:
+                logger.error(
+                    "mcp server startup failed (exit code %s) on %s:%d — %s",
+                    exc.code,
+                    cfg.mcp.host,
+                    cfg.mcp.port,
+                    cause,
+                )
+                return
         except Exception as exc:  # noqa: BLE001
             logger.warning("mcp server crashed: %s (restarting in %.0fs)", exc, delay)
             await asyncio.sleep(delay)

--- a/src/persome/daemon.py
+++ b/src/persome/daemon.py
@@ -102,6 +102,8 @@ async def _mcp_loop(cfg: Config) -> None:
     """Host the MCP server inside the daemon. On crash, back off and restart."""
     import errno as _errno
 
+    from uvicorn.server import STARTUP_FAILURE as _UVICORN_STARTUP_FAILURE
+
     from .mcp import server as mcp_server
 
     delay = 2.0
@@ -141,7 +143,13 @@ async def _mcp_loop(cfg: Config) -> None:
             # leaves the supervisor restarting us into the same wall. Unwrap
             # the original bind error and apply the same policy as above.
             cause = exc.__context__
-            if isinstance(cause, OSError) and cause.errno == _errno.EADDRINUSE:
+            # SystemExit is a control-flow signal, not a normal server crash.
+            # Handle only uvicorn's documented bind-failure shape; an
+            # intentional exit (including SystemExit(3) without an OSError
+            # context) must keep its normal process-level semantics.
+            if exc.code != _UVICORN_STARTUP_FAILURE or not isinstance(cause, OSError):
+                raise
+            if cause.errno == _errno.EADDRINUSE:
                 logger.warning(
                     "mcp server failed to bind %s:%d — address in use, retrying in %.0fs",
                     cfg.mcp.host,

--- a/src/persome/mcp/server.py
+++ b/src/persome/mcp/server.py
@@ -561,78 +561,51 @@ def _get_schema() -> dict[str, Any]:
 _SERVER_INSTRUCTIONS = """\
 # Persome — the user's local personal memory
 
-## What this is
+Persome is the user's private, local-first memory: durable facts (identity, preferences, habits, projects, people, schedule) plus raw recent on-screen activity. Query it instead of asking the user to repeat context or guessing.
 
-Persome is the user's private, local-first memory layer. The user installed it so agents can recover context from their real computer use instead of asking the user to repeat themselves or guessing blindly.
+## When to use (decision rule)
 
-It stores durable facts about the user and their machine, including:
+Call Persome BEFORE asking a clarifying question or saying "I don't know", whenever the request may depend on context outside this chat:
 
-- identity, role, preferences, habits, and working style
-- schedule, ongoing projects, people, and organizations
-- recent screen-activity summaries, including apps, files, errors, and documents viewed
+- ambiguous references: "this", "that", "it", "the bug", "the file", "the doc"
+- present tense: "what am I working on", "what's open on my screen"
+- recency: "yesterday", "last week", "earlier", "continue what I was doing"
+- prior project / person / tool context: "introduce my project"
+- personalization: "write it the way I usually do"
+- cross-session continuity, recent decisions, ongoing work
 
-It exposes two read-only layers:
+A missed lookup is worse than an unnecessary one — the tools are local and cheap; `[]` / `null` is still information. Skip only when the request is fully specified in-chat or only live external state matters.
 
-- **Compressed memory** — curated Markdown files containing distilled facts, decisions, preferences, summaries, and durable context
-- **Raw captures (S1 buffer)** — literal recent on-screen content, including visible text, focused elements, URLs, and optional screenshots
+## Tool routing
 
-The compressed layer tells you that something happened and why it matters.
-The raw layer tells you exactly what was on screen.
+- who the user is / how they work / match their style → `behavior_patterns()`
+- who X is / how X relates to people & projects → `entity_graph(name)`
+- what happened / was decided / durable facts → `search(query)` — semantic, paraphrase ok
+- is this still true (versions, status, schedules) → `verify_fact(claim)`
+- what the user is doing right now / ambiguous pronoun → `current_context()`
+- exact string seen or typed on screen (errors, URLs, code) → `search_captures(query)`, then `read_recent_capture(...)`
+- what the user has been up to lately → `recent_activity()`; focus/time spent → `attention_trajectory()`
+- browse files → `list_memories()` / `read_memory(path)`
+- the user corrects a wrong memory → `correct_memory(correction)`; a durable new finding → `remember(content)`
+- unsure between compressed vs raw → `search` and `search_captures` in parallel
 
-Use compressed memory for durable knowledge.
-Use raw captures for grounding, disambiguation, and exact recent context.
-Often, you should move from one into the other.
+Details follow; the rules above suffice if this document was truncated.
 
-## When to use
+## The two layers
 
-Use Persome whenever the request depends on context that is likely outside the current chat.
+- **Compressed memory** — curated Markdown files of distilled facts, decisions, preferences, summaries. It tells you that something happened and why it matters.
+- **Raw captures (S1 buffer)** — literal recent on-screen content: visible text, focused elements, URLs, optional screenshots. It tells you exactly what was on screen.
 
-This includes:
-
-- recent on-screen activity
-- ambiguous references such as "this", "that", "it", "the bug", "the file", "the tab", or "the doc"
-- prior project / person / tool context
-- learned preferences, habits, or workflow patterns
-- writing or generation that should reflect the user's ongoing projects, established framing, terminology, tone, or style
-- action selection that should reflect the user's established workflows or destinations
-- cross-session continuity
-- recent work history, decisions, or ongoing tasks
-
-Canonical triggers:
-
-- "what's the bug of that?"
-- "introduce my project"
-- "continue what I was doing"
-- "write this the way I usually do"
-- "draft this in the style of my project"
-- "schedule this the way I usually do"
-- "put this in the right calendar"
-- "what did I decide about X?"
-
-Examples:
-
-- User refers to "that" after viewing code → query Persome before asking them to paste anything.
-- User opens a fresh chat and asks about an existing project → retrieve project memory before asking for background.
-- User asks for an action that depends on personal workflow → retrieve preference memory before choosing a tool, destination, or account.
-- User asks for writing, messaging, or framing that should match prior context, terminology, tone, or preferences → retrieve relevant memory before drafting.
-
-If the user appears to assume shared context from recent computer use, query Persome before asking a clarification question.
-
-When in doubt, look it up.
-A missed lookup is often worse than an unnecessary one.
-These tools are local and cheap; `[]` or `null` is still useful information.
+Use compressed memory for durable knowledge, raw captures for grounding, disambiguation, and exact recent context. Often, move from one into the other.
 
 ## When NOT to use
-
-Do not use Persome when:
 
 - the request is fully specified in-chat
 - the task is self-contained and does not benefit from user-specific context
 - a fresher or authoritative source of truth should be used directly
 - the user explicitly wants no prior context used
 
-Persome complements live sources of truth; it does not replace them.
-Use it to recover context, not to invent certainty.
+Persome complements live sources of truth; it does not replace them. Use it to recover context, not to invent certainty.
 
 ## Tools
 
@@ -699,17 +672,7 @@ Each hit carries more than text — use all of it:
 - `chains` (top-level) — how the hits connect back to the user, with receipt
   pointers `⟨entry_id:path⟩`. Anchors listed as orphans have no proven link yet.
 
-## Choosing and combining tools
-
-- **Question-type routing**
-  - Who is the user / how do they work / match their style → `behavior_patterns()`.
-  - Who is X / how does X relate to people & projects / past org states → `entity_graph(...)` (search only finds text; the graph knows structure).
-  - What happened / what was decided / durable facts → `search(...)`.
-  - Is this still true → `verify_fact(...)`.
-  - What is this hit based on → `read_receipt(...)`, then follow its capture breadcrumbs.
-  - What am I doing right now → `current_context()`.
-  - Exact string the user just saw/typed → `search_captures(...)` → `read_recent_capture(...)`.
-  - If unsure between compressed and raw, query `search` and `search_captures` in parallel.
+## Combining tools
 
 - **The evidence ladder (progressive disclosure)** — every memory is auditable four
   layers down; go only as deep as the user's question demands:
@@ -724,18 +687,6 @@ Each hit carries more than text — use all of it:
 - **Freshness discipline** — memory is ranked by relevance AND recency, but an old
   strong match can still surface. Before asserting any time-sensitive fact as
   current: check `age_days`, and when it matters, `verify_fact`.
-
-## Decision rule
-
-Default to using Persome when memory could:
-
-- resolve ambiguity
-- restore missing context
-- avoid making the user restate known information
-- personalize writing
-- personalize action selection
-
-Do not default to it when the task is already fully specified or when only live state matters.
 
 ## If retrieval is weak
 

--- a/src/persome/mcp/server.py
+++ b/src/persome/mcp/server.py
@@ -561,11 +561,11 @@ def _get_schema() -> dict[str, Any]:
 _SERVER_INSTRUCTIONS = """\
 # Persome — the user's local personal memory
 
-Persome is the user's private, local-first memory: durable facts (identity, preferences, habits, projects, people, schedule) plus raw recent on-screen activity. Query it instead of asking the user to repeat context or guessing.
+Persome is the user's private local memory: durable facts plus recent screen activity. Query it before asking the user to repeat context or guessing.
 
 ## When to use (decision rule)
 
-Call Persome BEFORE asking a clarifying question or saying "I don't know", whenever the request may depend on context outside this chat:
+Call Persome before clarifying or saying "I don't know" when the request may depend on context outside this chat:
 
 - ambiguous references: "this", "that", "it", "the bug", "the file", "the doc"
 - present tense: "what am I working on", "what's open on my screen"
@@ -586,6 +586,7 @@ A missed lookup is worse than an unnecessary one — the tools are local and che
 - exact string seen or typed on screen (errors, URLs, code) → `search_captures(query)`, then `read_recent_capture(...)`
 - what the user has been up to lately → `recent_activity()`; focus/time spent → `attention_trajectory()`
 - browse files → `list_memories()` / `read_memory(path)`
+- audit a memory/model claim → `resolve_evidence(reference)` / `read_receipt(entry_id)`
 - the user corrects a wrong memory → `correct_memory(correction)`; a durable new finding → `remember(content)`
 - unsure between compressed vs raw → `search` and `search_captures` in parallel
 

--- a/src/persome/store/fts.py
+++ b/src/persome/store/fts.py
@@ -385,12 +385,18 @@ def connect(db_path: Path | None = None) -> sqlite3.Connection:
     except sqlite3.DatabaseError as exc:
         conn.close()
         if any(sig in str(exc) for sig in _CORRUPTION_SIGNATURES):
-            raise CorruptDatabaseError(
-                f"{db_path.name} is damaged ({exc}). Restart the Persome daemon "
-                "(`persome start`) to quarantine it and restore from the latest "
-                "verified snapshot plus Markdown replay; memory Markdown files "
-                "are unaffected."
-            ) from exc
+            if db_path.resolve() == paths.index_db().resolve():
+                recovery = (
+                    "Run `persome stop` if the daemon is running, then `persome start` "
+                    "to quarantine it and restore from the latest verified snapshot plus "
+                    "Markdown replay; memory Markdown files are unaffected."
+                )
+            else:
+                recovery = (
+                    "Replace or rebuild this database from a verified source; automatic "
+                    "daemon-start recovery applies only to the live index.db."
+                )
+            raise CorruptDatabaseError(f"{db_path.name} is damaged ({exc}). {recovery}") from exc
         raise
     # SQLite's built-in date parser does not understand every ISO form Python's
     # historical ingest accepted (notably basic ISO), and interprets naive

--- a/src/persome/store/fts.py
+++ b/src/persome/store/fts.py
@@ -18,6 +18,18 @@ from ..logger import get
 
 logger = get("persome.store")
 
+
+class CorruptDatabaseError(sqlite3.DatabaseError):
+    """The index database file itself is damaged (bad header / malformed image).
+
+    Subclasses ``sqlite3.DatabaseError`` so every existing handler still
+    matches; the message adds the recovery path so an MCP client or a log
+    reader sees what to do instead of a bare ``file is not a database``.
+    """
+
+
+_CORRUPTION_SIGNATURES = ("file is not a database", "database disk image is malformed")
+
 _MIN_SECURE_FTS_SQLITE = (3, 42, 0)
 _FTS_TABLES = ("entries", "captures_fts")
 _SECURE_FTS_MIGRATION_VERSION = 20260711
@@ -364,6 +376,22 @@ def connect(db_path: Path | None = None) -> sqlite3.Connection:
             paths.ensure_private_file(artifact)
     conn = sqlite3.connect(db_path, isolation_level=None, timeout=10.0, check_same_thread=False)
     conn.row_factory = sqlite3.Row
+    # sqlite3.connect is lazy: a damaged header only surfaces on first use,
+    # as a bare "file is not a database" with no recovery path — which MCP
+    # agents and tick logs then repeat verbatim for hours. Probe page 1 now
+    # and turn corruption into one actionable, still-DatabaseError signal.
+    try:
+        conn.execute("SELECT 1 FROM sqlite_master LIMIT 1")
+    except sqlite3.DatabaseError as exc:
+        conn.close()
+        if any(sig in str(exc) for sig in _CORRUPTION_SIGNATURES):
+            raise CorruptDatabaseError(
+                f"{db_path.name} is damaged ({exc}). Restart the Persome daemon "
+                "(`persome start`) to quarantine it and restore from the latest "
+                "verified snapshot plus Markdown replay; memory Markdown files "
+                "are unaffected."
+            ) from exc
+        raise
     # SQLite's built-in date parser does not understand every ISO form Python's
     # historical ingest accepted (notably basic ISO), and interprets naive
     # values as UTC instead of local wall time. Keep one shared parser for all

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -315,7 +315,7 @@ class TestMcpLoop:
         sleep.assert_awaited_once()
         assert calls["n"] == 2
 
-    async def test_uvicorn_systemexit_other_cause_returns_immediately(self) -> None:
+    async def test_uvicorn_systemexit_other_bind_error_returns_immediately(self) -> None:
         async def run_async(cfg: Config) -> None:
             try:
                 raise PermissionError(1, "operation not permitted")
@@ -331,6 +331,18 @@ class TestMcpLoop:
         # Hard failure: log + return with the daemon still alive, no backoff.
         log.error.assert_called_once()
         sleep.assert_not_awaited()
+
+    @pytest.mark.parametrize("code", [0, 3])
+    async def test_non_uvicorn_systemexit_propagates(self, code: int) -> None:
+        async def run_async(cfg: Config) -> None:
+            raise SystemExit(code)
+
+        with (
+            patch("persome.mcp.server.run_async", side_effect=run_async),
+            pytest.raises(SystemExit) as raised,
+        ):
+            await _mcp_loop(Config())
+        assert raised.value.code == code
 
     async def test_cancellation_propagates(self) -> None:
         async def run_async(cfg: Config) -> None:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -289,6 +289,49 @@ class TestMcpLoop:
         sleep.assert_awaited_once()
         assert calls["n"] == 2
 
+    async def test_uvicorn_systemexit_wrapping_eaddrinuse_retries(self) -> None:
+        # uvicorn converts bind failures into SystemExit(3); letting it escape
+        # took down the whole daemon and left launchd crash-looping into the
+        # still-bound port. The loop must unwrap it and back off like a plain
+        # EADDRINUSE.
+        calls = {"n": 0}
+
+        async def run_async(cfg: Config) -> None:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                try:
+                    raise OSError(errno.EADDRINUSE, "address in use")
+                except OSError:
+                    # mirrors uvicorn's sys.exit(STARTUP_FAILURE): __context__
+                    # carries the bind error even with display suppressed
+                    raise SystemExit(3) from None
+            return
+
+        with (
+            patch("persome.mcp.server.run_async", side_effect=run_async),
+            patch("persome.daemon.asyncio.sleep") as sleep,
+        ):
+            await _mcp_loop(Config())
+        sleep.assert_awaited_once()
+        assert calls["n"] == 2
+
+    async def test_uvicorn_systemexit_other_cause_returns_immediately(self) -> None:
+        async def run_async(cfg: Config) -> None:
+            try:
+                raise PermissionError(1, "operation not permitted")
+            except PermissionError:
+                raise SystemExit(3) from None
+
+        with (
+            patch("persome.mcp.server.run_async", side_effect=run_async),
+            patch("persome.daemon.asyncio.sleep") as sleep,
+            patch("persome.daemon.logger") as log,
+        ):
+            await _mcp_loop(Config())
+        # Hard failure: log + return with the daemon still alive, no backoff.
+        log.error.assert_called_once()
+        sleep.assert_not_awaited()
+
     async def test_cancellation_propagates(self) -> None:
         async def run_async(cfg: Config) -> None:
             raise asyncio.CancelledError

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -165,6 +165,34 @@ def test_stdio_server_skips_daemon_http_routes(ac_root: Path) -> None:
     assert server._custom_starlette_routes == []
 
 
+# MCP clients truncate server instructions hard (Claude Code cuts at 2048
+# chars); everything an agent needs to decide WHETHER and WHAT to call must
+# survive that cut, with the fold marker telling truncated clients the rest
+# is elaboration.
+_INSTRUCTIONS_TRUNCATION_BUDGET = 2048
+
+
+def test_server_instructions_fit_client_truncation_budget() -> None:
+    head = mcp_server._SERVER_INSTRUCTIONS[:_INSTRUCTIONS_TRUNCATION_BUDGET]
+    assert "## When to use" in head
+    assert "## Tool routing" in head
+    for tool in (
+        "behavior_patterns",
+        "entity_graph",
+        "search(query)",
+        "verify_fact",
+        "current_context",
+        "search_captures",
+        "recent_activity",
+        "list_memories",
+        "read_memory",
+        "correct_memory",
+        "remember",
+    ):
+        assert tool in head, f"routing for {tool} fell below the truncation fold"
+    assert "suffice if this document was truncated" in head
+
+
 # ─── search_captures + current_context ────────────────────────────────────
 
 

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -173,7 +173,8 @@ _INSTRUCTIONS_TRUNCATION_BUDGET = 2048
 
 
 def test_server_instructions_fit_client_truncation_budget() -> None:
-    head = mcp_server._SERVER_INSTRUCTIONS[:_INSTRUCTIONS_TRUNCATION_BUDGET]
+    instructions = mcp_server._SERVER_INSTRUCTIONS
+    head = instructions[:_INSTRUCTIONS_TRUNCATION_BUDGET]
     assert "## When to use" in head
     assert "## Tool routing" in head
     for tool in (
@@ -186,11 +187,17 @@ def test_server_instructions_fit_client_truncation_budget() -> None:
         "recent_activity",
         "list_memories",
         "read_memory",
+        "resolve_evidence",
+        "read_receipt",
         "correct_memory",
         "remember",
     ):
         assert tool in head, f"routing for {tool} fell below the truncation fold"
-    assert "suffice if this document was truncated" in head
+    fold = "Details follow; the rules above suffice if this document was truncated."
+    assert fold in head
+    # Some clients enforce transport budgets in bytes instead of code points.
+    fold_end = instructions.index(fold) + len(fold)
+    assert len(instructions[:fold_end].encode("utf-8")) <= _INSTRUCTIONS_TRUNCATION_BUDGET
 
 
 # ─── search_captures + current_context ────────────────────────────────────

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -52,6 +52,18 @@ def test_make_id_uniqueness() -> None:
     assert len(ids) == 200
 
 
+def test_connect_names_recovery_path_on_corrupt_header(ac_root: Path) -> None:
+    # A live incident shape: page 1 of index.db overwritten, so every fresh
+    # connection failed with a bare "file is not a database" that MCP clients
+    # retried verbatim for hours. The probe must convert it into one
+    # actionable, still-catchable DatabaseError naming the recovery path.
+    db = ac_root / "index.db"
+    db.write_bytes(b"\x0d\x00\x00\x00" + b"\x00" * 4092)
+
+    with pytest.raises(fts.CorruptDatabaseError, match="persome start"):
+        fts.connect(db)
+
+
 def test_create_append_search(ac_root: Path) -> None:
     with fts.cursor() as conn:
         entries_mod.create_file(

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -60,8 +60,21 @@ def test_connect_names_recovery_path_on_corrupt_header(ac_root: Path) -> None:
     db = ac_root / "index.db"
     db.write_bytes(b"\x0d\x00\x00\x00" + b"\x00" * 4092)
 
-    with pytest.raises(fts.CorruptDatabaseError, match="persome start"):
+    with pytest.raises(fts.CorruptDatabaseError, match="persome start") as raised:
         fts.connect(db)
+    assert "persome stop" in str(raised.value)
+
+
+def test_connect_does_not_claim_startup_recovery_for_external_database(ac_root: Path) -> None:
+    db = ac_root / "exports" / "damaged-snapshot.db"
+    db.parent.mkdir()
+    db.write_bytes(b"\x0d\x00\x00\x00" + b"\x00" * 4092)
+
+    with pytest.raises(fts.CorruptDatabaseError) as raised:
+        fts.connect(db)
+    message = str(raised.value)
+    assert "persome start" not in message
+    assert "automatic daemon-start recovery applies only to the live index.db" in message
 
 
 def test_create_append_search(ac_root: Path) -> None:


### PR DESCRIPTION
## Why

Field report: Claude Code and Codex sessions against the Persome MCP were unstable — agents often never called the tools, and calls that did happen frequently errored. Root-causing on a live install found three independent defects, each fixed here.

### 1. Agents "forget" to call: the instructions never reach the model

Claude Code truncates MCP server instructions at **2048 chars** (`Server instructions truncated from 9886 to 2048 chars` in its MCP logs). Everything that steers an agent toward calling Persome — the When-to-use triggers, decision rule, and per-tool routing — sat below that cut and never reached the model. Codex does not surface server instructions at all, so tool descriptions must carry the weight there.

**Fix:** restructure `_SERVER_INSTRUCTIONS` so the decision-critical content (triggers, decision rule, full tool routing, fold marker) fits in the first 2048 chars; drop below-fold sections the new header made redundant. A regression test pins the budget.

### 2. Daemon crash-loop: uvicorn converts bind failures into SystemExit

A live incident produced 22 `daemon crashed` entries: uvicorn turns MCP transport startup failures (EADDRINUSE from an orphaned listener, EPERM from macOS local-network privacy) into `SystemExit(3)`, which sails past `_mcp_loop`'s `except OSError` / `except Exception` arms, kills the whole daemon — capture included — and leaves launchd restarting it into the same still-bound port.

**Fix:** catch `SystemExit` in `_mcp_loop`, unwrap the bind error from `__context__`, and apply the existing policy — back off on EADDRINUSE, log-and-return otherwise. The daemon (and capture) stays alive either way.

### 3. Corruption surfaces as a bare, unactionable error

When `index.db` lost its header page (live incident: page 1 overwritten at 02:16, every fresh connection failing from then on), MCP clients and daemon ticks saw only `file is not a database` — repeated verbatim for hours (84 failed ticks) with no recovery route, while the sanctioned quarantine + snapshot-restore + Markdown-replay flow sat one daemon restart away.

**Fix:** `fts.connect` probes page 1 on open and raises `CorruptDatabaseError` — still a `sqlite3.DatabaseError` for every existing handler — whose message names the actual recovery path.

## Testing

- `PERSOME_LLM_MOCK=1 uv run pytest tests/test_store.py tests/test_daemon.py tests/test_mcp_tools.py tests/test_captures_fts.py -m "not macos and not integration"` — 91 passed
- `ruff check` / `ruff format --check` clean on touched files; PII and secret scans clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)