### PR TITLE
fix: preserve model geometry after verified recovery

### DIFF
--- a/src/persome/api/routes.py
+++ b/src/persome/api/routes.py
@@ -541,7 +541,7 @@ def model_graph() -> dict[str, Any]:
         if cached is not None:
             return cached
 
-        with fts_store.cursor() as conn:
+        with fts_store.canonical_read_cursor() as conn:
             # This bearer/capability-protected loopback route is the owner's raw
             # inspection surface. MCP and CLI exports retain redaction by default.
             snapshot = build_live_snapshot(conn, redact=False)
@@ -576,7 +576,7 @@ def model_evidence(
     from ..evidence import resolve_evidence
     from ..store import fts as fts_store
 
-    with fts_store.cursor() as conn:
+    with fts_store.canonical_read_cursor() as conn:
         return resolve_evidence(conn, ref)
 
 
@@ -599,7 +599,7 @@ def model_node(
     raw: list[dict[str, Any]] = []
     source = ""
     try:
-        with fts_store.cursor() as conn:
+        with fts_store.canonical_read_cursor() as conn:
             conn.row_factory = sqlite3.Row
             if id != "self":
                 try:

--- a/src/persome/integrity.py
+++ b/src/persome/integrity.py
@@ -30,6 +30,7 @@ import tomllib
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 from . import config as config_mod
 from . import paths
@@ -134,6 +135,71 @@ class QuarantinedFile:
 
 class _WriteAuthorityUnresolved(RuntimeError):
     """Recovery found multiple intact sources but no unique canonical one."""
+
+
+def _semantic_sequence(value: object) -> tuple[object, ...]:
+    """Normalize persisted JSON lists and live list values for comparison."""
+    if value is None:
+        return ()
+    if isinstance(value, (list, tuple)):
+        return tuple(value)
+    try:
+        parsed = json.loads(str(value))
+    except (TypeError, ValueError):
+        return ()
+    return tuple(parsed) if isinstance(parsed, list) else ()
+
+
+def _node_geometry_semantics(node: Any) -> tuple[object, ...]:
+    """Fields whose change makes retained Face/Volume/Root output stale.
+
+    ``memory_at`` and ``gmt_created`` are intentionally excluded: Markdown
+    headings normalize timestamp precision during a round trip. Explicit
+    occurrence/validity fields remain semantic and are compared below.
+    """
+    return (
+        str(node.content or ""),
+        str(node.layer),
+        _semantic_sequence(node.supersedes),
+        _semantic_sequence(node.superseded_by),
+        bool(node.is_latest),
+        str(node.status),
+        str(node.file_name or ""),
+        str(node.tags or ""),
+        node.refined_from,
+        _semantic_sequence(node.abstracted_from),
+        node.confidence,
+        bool(node.conflicted),
+        node.occurred_at,
+        node.schema_summary,
+        _semantic_sequence(node.schema_inferences),
+        node.schema_confidence,
+        node.valid_from,
+        node.valid_until,
+    )
+
+
+def _stored_node_geometry_semantics(row: sqlite3.Row) -> tuple[object, ...]:
+    return (
+        str(row["content"] or ""),
+        str(row["layer"]),
+        _semantic_sequence(row["supersedes"]),
+        _semantic_sequence(row["superseded_by"]),
+        bool(row["is_latest"]),
+        str(row["status"]),
+        str(row["file_name"] or ""),
+        str(row["tags"] or ""),
+        row["refined_from"],
+        _semantic_sequence(row["abstracted_from"]),
+        row["confidence"],
+        bool(row["conflicted"]),
+        row["occurred_at"],
+        row["schema_summary"],
+        _semantic_sequence(row["schema_inferences"]),
+        row["schema_confidence"],
+        row["valid_from"],
+        row["valid_until"],
+    )
 
 
 def _timestamp_suffix() -> str:
@@ -1138,6 +1204,7 @@ def _repopulate_after_quarantine(
             "cannot resolve write authority while unsupported Markdown memory files are present"
         )
     current_node_keys = {(node.node_id, node.user_id, node.agent_id) for node in nodes}
+    nodes_by_key = {(node.node_id, node.user_id, node.agent_id): node for node in nodes}
     if len(current_node_keys) != len(nodes):
         seen: set[tuple[str, str, str]] = set()
         duplicates: set[tuple[str, str, str]] = set()
@@ -1149,6 +1216,7 @@ def _repopulate_after_quarantine(
         sample = ", ".join(key[0] for key in sorted(duplicates)[:5])
         raise ValueError(f"duplicate Markdown memory node id(s): {sample}")
     stale_node_keys: list[tuple[str, str, str]] = []
+    changed_node_keys: list[tuple[str, str, str]] = []
     direct_nodes_removed = 0
     derived_geometry_rows_invalidated = 0
     NodeStore()  # create/migrate the canonical node table before one recovery transaction
@@ -1183,6 +1251,21 @@ def _repopulate_after_quarantine(
                 "DELETE FROM evo_nodes WHERE user_id='default' AND agent_id='default' "
                 "AND (file_name LIKE 'event-%' OR instr(file_name, '/') > 0)"
             ).rowcount
+            if snapshot_restored and restore_nodes_from_markdown:
+                stored_nodes = {
+                    (str(row["node_id"]), str(row["user_id"]), str(row["agent_id"])): row
+                    for row in conn.execute(
+                        "SELECT * FROM evo_nodes WHERE user_id='default' AND agent_id='default'"
+                    ).fetchall()
+                }
+                changed_node_keys = sorted(
+                    key
+                    for key, node in nodes_by_key.items()
+                    if key in stored_nodes
+                    and key[1:] == ("default", "default")
+                    and _node_geometry_semantics(node)
+                    != _stored_node_geometry_semantics(stored_nodes[key])
+                )
             # A verified snapshot can be older than the Markdown projection.
             # Under Markdown authority, remove only snapshot nodes that were
             # previously exposed through the non-event retrieval projection
@@ -1217,15 +1300,16 @@ def _repopulate_after_quarantine(
             # source for that evidence while its durable Point set remains compatible
             # with the current Markdown authority.  Discard geometry only when no
             # verified snapshot exists or Markdown proves that canonical Points were
-            # removed.  Newer/additional Points are safe: the next build incrementally
-            # refreshes the retained geometry.  Direct event/nested-memory cleanup is
-            # likewise irrelevant because Faces are mined from durable fact prefixes.
+            # removed or changed semantically. Newer/additional Points are safe: the
+            # next build incrementally refreshes the retained geometry. Direct
+            # event/nested-memory cleanup is likewise irrelevant because Faces are
+            # mined from durable fact prefixes.
             #
             # The old unconditional delete caused a recovered model to keep thousands
             # of Points and Lines but permanently fall back to zero Faces, Volumes,
             # and Root: one rebuild cannot replay the historical resampling gate.
             tables_to_invalidate: list[str] = []
-            if not snapshot_restored or stale_node_keys:
+            if not snapshot_restored or stale_node_keys or changed_node_keys:
                 tables_to_invalidate.extend(["schema_faces", "cross_domain_probe_state"])
             # Relation edges are retained for a known evomem snapshot, but must
             # be cleared when current Markdown/direct sources removed or changed
@@ -1301,6 +1385,7 @@ def _repopulate_after_quarantine(
         "projection_files": projection_files,
         "projection_entries": projection_entries,
         "stale_projected_nodes_removed": len(stale_node_keys),
+        "semantically_changed_projected_nodes": len(changed_node_keys),
         "legacy_direct_nodes_removed": direct_nodes_removed,
         "derived_geometry_rows_invalidated": derived_geometry_rows_invalidated,
         "index_md_rebuilt": index_rebuilt,

--- a/src/persome/integrity.py
+++ b/src/persome/integrity.py
@@ -1211,13 +1211,25 @@ def _repopulate_after_quarantine(
                     "DELETE FROM evo_nodes WHERE node_id=? AND user_id=? AND agent_id=?",
                     stale_node_keys,
                 )
-            # Faces, Volumes, Root, and their probe queue are rebuildable output,
-            # not recovery authority. Always discard snapshot copies so malformed
-            # or stale geometry cannot break the viewer before the required build.
+            # Faces, Volumes, Root, and their probe queue are derived output, but
+            # they also carry multi-run stability evidence that cannot be recreated
+            # from one model build.  A verified snapshot is therefore the recovery
+            # source for that evidence while its durable Point set remains compatible
+            # with the current Markdown authority.  Discard geometry only when no
+            # verified snapshot exists or Markdown proves that canonical Points were
+            # removed.  Newer/additional Points are safe: the next build incrementally
+            # refreshes the retained geometry.  Direct event/nested-memory cleanup is
+            # likewise irrelevant because Faces are mined from durable fact prefixes.
+            #
+            # The old unconditional delete caused a recovered model to keep thousands
+            # of Points and Lines but permanently fall back to zero Faces, Volumes,
+            # and Root: one rebuild cannot replay the historical resampling gate.
+            tables_to_invalidate: list[str] = []
+            if not snapshot_restored or stale_node_keys:
+                tables_to_invalidate.extend(["schema_faces", "cross_domain_probe_state"])
             # Relation edges are retained for a known evomem snapshot, but must
             # be cleared when current Markdown/direct sources removed or changed
             # Points that those relations may expose.
-            tables_to_invalidate = ["schema_faces", "cross_domain_probe_state"]
             if (
                 (snapshot_restored and restore_nodes_from_markdown)
                 or stale_node_keys

--- a/src/persome/model/snapshot.py
+++ b/src/persome/model/snapshot.py
@@ -209,9 +209,18 @@ def _schema_member_aliases(
     if not by_signature or not _table_exists(conn, "entries"):
         return {}
     aliases: dict[str, dict[str, Any]] = {}
-    for row in conn.execute(
-        "SELECT path, content FROM entries WHERE prefix = 'schema' AND superseded = 0"
-    ).fetchall():
+    try:
+        rows = conn.execute(
+            "SELECT path, content FROM entries WHERE prefix = 'schema' AND superseded = 0"
+        ).fetchall()
+    except sqlite3.Error:
+        # ``entries`` is a rebuildable FTS projection. Canonical Points and
+        # geometry live in ordinary tables and must remain inspectable while a
+        # damaged inverted index is awaiting repair. The aliases only propagate
+        # Face receipts through legacy ``schema-*.md`` member keys, so omitting
+        # them is the honest degraded result.
+        return {}
+    for row in rows:
         central = ""
         for line in str(row["content"] or "").splitlines():
             if line.strip().casefold().startswith("central:"):

--- a/src/persome/store/fts.py
+++ b/src/persome/store/fts.py
@@ -961,6 +961,44 @@ def cursor(db_path: Path | None = None) -> Iterator[sqlite3.Connection]:
             conn.close()
 
 
+@contextmanager
+def canonical_read_cursor(db_path: Path | None = None) -> Iterator[sqlite3.Connection]:
+    """Read canonical tables without initializing derived FTS projections.
+
+    Model/evidence inspection must remain available when a rebuildable FTS5
+    index is damaged.  ``cursor()`` intentionally enforces secure FTS setup on
+    every ordinary connection, so it is the wrong boundary for routes that do
+    not query either virtual table.  This read-only connection still uses the
+    shared database-activity lock, path/symlink validation, WAL visibility, and
+    SQLite page-one probe; it simply cannot write or instantiate FTS tables.
+    """
+    database_path = db_path or paths.index_db()
+    _prepare_database_path(database_path)
+    if not database_path.exists():
+        # Preserve first-run behavior: an absent database still needs normal
+        # schema initialization. It cannot contain a corrupt derived index yet.
+        with cursor(database_path) as conn:
+            yield conn
+        return
+
+    with database_activity(database_path):
+        conn = sqlite3.connect(
+            f"{database_path.absolute().as_uri()}?mode=ro",
+            uri=True,
+            isolation_level=None,
+            timeout=10.0,
+            check_same_thread=False,
+        )
+        try:
+            _disable_checkpoint_on_close(conn)
+            conn.row_factory = sqlite3.Row
+            conn.create_function("persome_epoch", 1, capture_timestamp_epoch)
+            conn.execute("SELECT 1 FROM sqlite_master LIMIT 1")
+            yield conn
+        finally:
+            conn.close()
+
+
 def open_runtime_owner() -> sqlite3.Connection:
     """Open and fully initialize the daemon's transaction-free owner handle."""
     if _CLIENT_PROCESS:

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -18,6 +18,7 @@ from persome.evomem.store import NodeStore
 from persome.model import create_build_manifest, load_live_manifest, sync_live_human_markdown
 from persome.store import entries, fts, relation_edges, schema_faces
 from persome.store import files as files_mod
+from persome.store import projector as projector_mod
 
 
 def _make_healthy_db() -> Path:
@@ -25,6 +26,13 @@ def _make_healthy_db() -> Path:
     with fts.cursor() as conn:
         conn.execute("SELECT 1")
     return paths.index_db()
+
+
+def _save_markdown_projection_as_canonical(name: str) -> MemoryNode:
+    parsed = files_mod.read_file(files_mod.memory_path(name)).entries
+    (node,) = projector_mod.rebuild_nodes_from_projection([(name, parsed)])
+    NodeStore(user_id=node.user_id, agent_id=node.agent_id).save(node)
+    return node
 
 
 def _pending_payload(db: Path, quarantine: Path, *, reason: str) -> dict[str, object]:
@@ -911,14 +919,7 @@ def test_markdown_recovery_retains_verified_geometry_when_points_are_compatible(
             content="DURABLE POINT REMAINS PRESENT",
             tags=[],
         )
-    NodeStore().save(
-        MemoryNode(
-            node_id=entry_id,
-            content="DURABLE POINT REMAINS PRESENT",
-            layer=MemoryLayer.L2_FACT,
-            file_name="project-retained.md",
-        )
-    )
+    assert _save_markdown_projection_as_canonical("project-retained.md").node_id == entry_id
     with fts.cursor() as conn:
         schema_faces.upsert_root(
             conn,
@@ -951,7 +952,65 @@ def test_markdown_recovery_retains_verified_geometry_when_points_are_compatible(
     assert probe is not None and tuple(probe) == (2, 1)
     database = json.loads(paths.integrity_recovery_marker().read_text())["database_recovery"]
     assert database["stale_projected_nodes_removed"] == 0
+    assert database["semantically_changed_projected_nodes"] == 0
     assert database["derived_geometry_rows_invalidated"] == 0
+
+
+def test_markdown_recovery_invalidates_geometry_when_same_id_point_changes(
+    ac_root: Path,
+) -> None:
+    config_mod.write_default_if_missing()
+    original = "ORIGINAL POINT USED BY VERIFIED GEOMETRY"
+    corrected = "CORRECTED POINT MUST INVALIDATE VERIFIED GEOMETRY"
+    with fts.cursor() as conn:
+        entries.create_file(
+            conn,
+            name="project-corrected.md",
+            description="Same-ID correction proof",
+            tags=[],
+        )
+        entry_id = entries.append_entry(
+            conn,
+            name="project-corrected.md",
+            content=original,
+            tags=[],
+        )
+    assert _save_markdown_projection_as_canonical("project-corrected.md").node_id == entry_id
+    with fts.cursor() as conn:
+        schema_faces.upsert_root(
+            conn,
+            signature="Root derived from the original Point",
+            members=[entry_id],
+        )
+        conn.execute(
+            "INSERT INTO cross_domain_probe_state"
+            " (pair_key, last_probed_at, probe_count, detected) VALUES (?, ?, 2, 1)",
+            ('["corrected-a","corrected-b"]', "2026-07-12T00:00:00+00:00"),
+        )
+    snapshot = backup.create_snapshot(
+        now=datetime(2026, 7, 12, 9, 0, tzinfo=UTC),
+        structural_only=True,
+    )
+    assert snapshot is not None
+    memory_path = files_mod.memory_path("project-corrected.md")
+    markdown = memory_path.read_text(encoding="utf-8")
+    assert markdown.count(original) == 1
+    files_mod.atomic_write_text(memory_path, markdown.replace(original, corrected, 1))
+    paths.index_db().write_bytes(b"markdown-database-corruption" * 100)
+
+    integrity.check_and_recover()
+
+    with fts.cursor() as conn:
+        point = conn.execute(
+            "SELECT content FROM evo_nodes WHERE node_id=?", (entry_id,)
+        ).fetchone()
+        assert conn.execute("SELECT count(*) FROM schema_faces").fetchone()[0] == 0
+        assert conn.execute("SELECT count(*) FROM cross_domain_probe_state").fetchone()[0] == 0
+    assert point is not None and point[0] == corrected
+    database = json.loads(paths.integrity_recovery_marker().read_text())["database_recovery"]
+    assert database["stale_projected_nodes_removed"] == 0
+    assert database["semantically_changed_projected_nodes"] == 1
+    assert database["derived_geometry_rows_invalidated"] >= 2
 
 
 def test_incomplete_strict_markdown_discovery_never_deletes_snapshot_node(

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -888,6 +888,72 @@ def test_markdown_authority_does_not_resurrect_forgotten_snapshot_node(ac_root: 
     assert database["derived_geometry_rows_invalidated"] >= 3
 
 
+def test_markdown_recovery_retains_verified_geometry_when_points_are_compatible(
+    ac_root: Path,
+) -> None:
+    """A verified snapshot preserves multi-run Face/Volume/Root evidence.
+
+    One post-recovery build cannot replay the historical resampling gate, so
+    deleting compatible derived rows would strand an otherwise healthy model at
+    Points/Lines forever.
+    """
+    config_mod.write_default_if_missing()
+    with fts.cursor() as conn:
+        entries.create_file(
+            conn,
+            name="project-retained.md",
+            description="Geometry retention proof",
+            tags=[],
+        )
+        entry_id = entries.append_entry(
+            conn,
+            name="project-retained.md",
+            content="DURABLE POINT REMAINS PRESENT",
+            tags=[],
+        )
+    NodeStore().save(
+        MemoryNode(
+            node_id=entry_id,
+            content="DURABLE POINT REMAINS PRESENT",
+            layer=MemoryLayer.L2_FACT,
+            file_name="project-retained.md",
+        )
+    )
+    with fts.cursor() as conn:
+        schema_faces.upsert_root(
+            conn,
+            signature="Verified Root must survive compatible recovery",
+            members=[entry_id],
+        )
+        conn.execute(
+            "INSERT INTO cross_domain_probe_state"
+            " (pair_key, last_probed_at, probe_count, detected) VALUES (?, ?, 2, 1)",
+            ('["retained-a","retained-b"]', "2026-07-12T00:00:00+00:00"),
+        )
+    snapshot = backup.create_snapshot(
+        now=datetime(2026, 7, 12, 9, 0, tzinfo=UTC),
+        structural_only=True,
+    )
+    assert snapshot is not None
+    paths.index_db().write_bytes(b"markdown-database-corruption" * 100)
+
+    integrity.check_and_recover()
+
+    with fts.cursor() as conn:
+        root = conn.execute(
+            "SELECT signature FROM schema_faces "
+            "WHERE level=3 AND status='active' AND valid_to IS NULL"
+        ).fetchone()
+        probe = conn.execute(
+            "SELECT probe_count, detected FROM cross_domain_probe_state"
+        ).fetchone()
+    assert root is not None and root[0] == "Verified Root must survive compatible recovery"
+    assert probe is not None and tuple(probe) == (2, 1)
+    database = json.loads(paths.integrity_recovery_marker().read_text())["database_recovery"]
+    assert database["stale_projected_nodes_removed"] == 0
+    assert database["derived_geometry_rows_invalidated"] == 0
+
+
 def test_incomplete_strict_markdown_discovery_never_deletes_snapshot_node(
     ac_root: Path, tmp_path: Path
 ) -> None:

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
@@ -15,7 +16,7 @@ from persome.api.model_view import render_memory_view
 from persome.evomem.models import MemoryLayer, MemoryNode
 from persome.evomem.store import NodeStore
 from persome.model import ActivitySource, ModelBuildCoordinator, create_build_manifest
-from persome.store import fts
+from persome.store import entries, fts, schema_faces
 from persome.store import relation_edges as edges_store
 
 BUILD_KEYS = {
@@ -72,6 +73,66 @@ class TestGraphJson:
 
         assert graph["model"]["stats"]["points"] == 1
         assert graph["model"]["points"][0]["id"] == "point-runtime"
+
+    def test_graph_survives_genuinely_corrupt_entries_fts(self, ac_root):
+        _save_point(node_id="point-corrupt-fts", content="Canonical model remains readable.")
+        signature = "Stable recovery behavior"
+        with fts.cursor() as conn:
+            entries.create_file(
+                conn,
+                name="schema-corrupt-fts.md",
+                description="Legacy schema alias",
+                tags=[],
+            )
+            entries.append_entry(
+                conn,
+                name="schema-corrupt-fts.md",
+                content=f"Central: {signature}",
+                tags=[],
+            )
+            face_id = schema_faces.record_face(
+                conn,
+                source=schema_faces.PROVENANCE_MINED,
+                signature=signature,
+                members=["point-corrupt-fts"],
+            )
+            schema_faces.record_face(
+                conn,
+                source=schema_faces.PROVENANCE_EMERGENT,
+                signature=signature,
+                members=["point-corrupt-fts"],
+            )
+            assert schema_faces.maybe_promote(conn, face_id)
+            assert conn.execute("DELETE FROM entries_data WHERE id > 1").rowcount > 0
+
+        broken = sqlite3.connect(paths.index_db())
+        try:
+            try:
+                findings = [str(row[0]) for row in broken.execute("PRAGMA integrity_check")]
+            except sqlite3.DatabaseError as exc:
+                # SQLite builds disagree on whether corrupt FTS construction is
+                # returned as an integrity finding or raised immediately.
+                findings = [str(exc)]
+            assert any(
+                "entries" in finding
+                and any(
+                    marker in finding
+                    for marker in ("corrupt", "malformed", "vtable constructor failed")
+                )
+                for finding in findings
+            )
+            with pytest.raises(sqlite3.DatabaseError):
+                broken.execute(
+                    "SELECT path, content FROM entries WHERE prefix = 'schema' AND superseded = 0"
+                ).fetchall()
+        finally:
+            broken.close()
+
+        graph = routes.model_graph()
+
+        assert any(point["id"] == "point-corrupt-fts" for point in graph["model"]["points"])
+        assert graph["model"]["stats"]["faces"] == 1
+        assert graph["model"]["faces"][0]["id"] == face_id
 
     def test_graph_uses_transactionally_stable_live_reader(self, ac_root, monkeypatch):
         sentinel = {"schema_version": 1, "source": "live-reader"}

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -60,6 +60,19 @@ def _save_point(
 
 
 class TestGraphJson:
+    def test_graph_does_not_initialize_unrelated_fts_indexes(self, ac_root, monkeypatch):
+        _save_point(node_id="point-runtime", content="Canonical model remains readable.")
+
+        def fail_fts_connect(*args, **kwargs):  # type: ignore[no-untyped-def]
+            raise RuntimeError("derived FTS is malformed")
+
+        monkeypatch.setattr(fts, "connect", fail_fts_connect)
+
+        graph = routes.model_graph()
+
+        assert graph["model"]["stats"]["points"] == 1
+        assert graph["model"]["points"][0]["id"] == "point-runtime"
+
     def test_graph_uses_transactionally_stable_live_reader(self, ac_root, monkeypatch):
         sentinel = {"schema_version": 1, "source": "live-reader"}
         calls = []


### PR DESCRIPTION
## What changed

- retain verified `schema_faces` and cross-domain probe history during recovery when the authoritative Markdown Point set remains compatible
- continue invalidating derived geometry when no verified snapshot exists or Markdown proves canonical Points were removed
- keep the model graph, node, and evidence endpoints available when unrelated rebuildable FTS5 indexes are damaged
- preserve first-run database initialization while using a coordinated read-only connection for existing canonical model data
- add regression coverage for compatible verified-snapshot recovery and FTS-independent model reads

## Why

Faces, Volumes, Root, and cross-domain probe state carry evidence accumulated across multiple model builds. The recovery path previously deleted those rows unconditionally after restoring a verified database snapshot. A single subsequent build cannot replay the historical resampling gate, so an otherwise healthy model could remain stuck with thousands of Points and Lines but zero Faces, Volumes, or Root.

Separately, the model viewer only reads canonical model tables, but its routes used the ordinary FTS connection path. A malformed derived FTS5 index could therefore return HTTP 500 for an otherwise readable personal model.

## Impact

Users recovering from a verified snapshot keep their established upper model layers when durable facts are unchanged. Recovery still fails closed and clears stale geometry when canonical Points were actually removed. If a rebuildable FTS index is damaged, the personal model remains inspectable while repair proceeds.

## Validation

- `uv run pytest tests/test_integrity.py tests/test_model_snapshot.py tests/test_model_routes.py tests/test_api_routes.py tests/test_runtime_model_e2e.py tests/test_capture_scheduler_fts.py tests/test_captures_fts.py -q`
- 141 tests passed
- `git diff --check`
