### PR TITLE
feat: fund model processing through MCP sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,12 +128,17 @@ After successful interactive onboarding, the source installer schedules the one-
 - On Apple Silicon, onboarding verifies the isolated local OCR worker when OCR is enabled.
 - It proves the final lifecycle owner and Runtime generation, then reports a fresh-capture receipt in standard daemon mode or an explicit readiness/privacy receipt for supported alternate modes such as trusted ingest.
 
-An LLM is optional for collection and BM25 recall, but required for semantic modeling. If provider setup was skipped, run:
+An LLM is optional for collection and BM25 recall, but required for semantic modeling. You can configure a hosted/local provider for unattended processing:
 
 ```text
 persome llm setup
 persome llm status --check
 ```
+
+Alternatively, a trusted MCP client that supports Sampling with tools can
+explicitly call `process_pending_model_work`. That path uses the model allowance
+already available to the connected agent without exposing its login token to
+Persome; it does not power unattended background processing.
 
 ### 3. Connect a trusted MCP client
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -85,8 +85,10 @@ Common model stages are `timeline`, `reducer`, `classifier`, `memory_delta`,
 `cross_domain_sweeper`, `root_synthesis`, `contradiction_check`, and
 `memory_decay`. Tool-loop stages require function/tool calling; JSON stages
 require reliable structured output. Without a hosted credential or keyless
-local endpoint, Persome still captures and serves BM25, but semantic model
-stages remain degraded.
+local endpoint, Persome still captures and serves BM25. A connected client that
+advertises MCP Sampling with tools can explicitly call
+`process_pending_model_work` to process a bounded backlog with the client's own
+model allowance; otherwise semantic model stages remain degraded.
 
 Hosted presets currently include Anthropic, OpenAI, DeepSeek, OpenRouter,
 Gemini, Groq, Mistral, xAI, Qwen, Moonshot/Kimi, Zhipu GLM, SiliconFlow,

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -62,6 +62,8 @@ Example stdio client configuration:
 | `verify_fact` | Check a claim against current and superseded memory. |
 | `remember` | Append an explicit, auditable memory. |
 | `correct_memory` | Supersede or revoke memory through the correction workflow. |
+| `process_pending_model_work` | Process a bounded number of pending sessions with the connected client's model allowance through MCP Sampling. |
+| `get_pending_model_work` | Inspect the semantic session backlog without invoking a model. |
 
 ## Capture and state tools
 
@@ -110,12 +112,30 @@ port = 8742
   canonical `GET /health` is public.
 - MCP returns local personal data, including raw screen text from capture tools;
   only connect trusted clients.
-- The MCP server does not forward results to a model provider by itself. A
-  connected agent may do so.
+- Read tools do not invoke a model provider. The explicit
+  `process_pending_model_work` tool sends modeling prompts and tool results back
+  to the originating trusted client through MCP Sampling; the client remains in
+  control of its model, authentication, approval policy, and allowance.
 - Screenshots are excluded unless a tool call explicitly requests one.
 - `get_model_snapshot` redacts detectable secrets and local paths by default.
 - Write tools are explicit and auditable; the removed computer-use tools are
   not part of this server.
+
+## Agent-funded modeling
+
+`process_pending_model_work(max_sessions=1)` is the provider-neutral path for
+using a model entitlement already available in Codex, Claude, or another MCP
+client. Persome negotiates the client's `sampling` and `sampling.tools`
+capabilities. When supported, stage prompts run through
+`sampling/createMessage`; no subscription credential or OAuth token is read,
+copied, or persisted by Persome.
+
+The operation must originate in a client tool call and is bounded to 1–10
+sessions. Persome does not initiate MCP Sampling from its background daemon.
+Clients that only implement MCP tools return
+`client_missing_sampling_with_tools`; use another compatible client, a local
+provider, or a configured API provider in that case. Existing scheduled writers
+continue to use the configured provider route.
 
 The same loopback ASGI app serves `/model` and the authenticated REST
 routes. Use `persome model open` for a one-time browser bootstrap.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -132,6 +132,9 @@ copied, or persisted by Persome.
 
 The operation must originate in a client tool call and is bounded to 1–10
 sessions. Persome does not initiate MCP Sampling from its background daemon.
+Cancelling the originating tool call cancels any in-flight Sampling request;
+the per-call Sampling deadline does the same, and either path rejects further
+Sampling calls so no additional client allowance is spent.
 Clients that only implement MCP tools return
 `client_missing_sampling_with_tools`; use another compatible client, a local
 provider, or a configured API provider in that case. Existing scheduled writers

--- a/docs/writer.md
+++ b/docs/writer.md
@@ -215,6 +215,10 @@ selected projections and preserve receipts/history.
   `persome llm setup`. Anthropic Messages and OpenAI-compatible Chat
   Completions share one response/tool-loop contract; keys come from
   `<PERSOME_ROOT>/env`.
+- During an explicit MCP `process_pending_model_work` request, the same stage
+  contract is temporarily backed by MCP Sampling. The connected client spends
+  its own model allowance; Persome receives completions, never its login token.
+  This override is request-scoped and does not enable unattended daemon calls.
 - Terminal finalization sets `sessions.modeled_at` only after every enabled
   stage completes or reports a deliberate benign skip.
 - Semantic-stage errors degrade the model and remain retryable; they do not

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "python-frontmatter>=1.1",
     "mss>=9.0",
     "Pillow>=10.0",
-    "mcp>=1.0",
+    "mcp>=1.23.0",
     "fastapi>=0.115",
     # Imported directly by the local API/streaming surface. Declare these instead
     # of relying on FastAPI or MCP to keep pulling them transitively.

--- a/src/persome/mcp/server.py
+++ b/src/persome/mcp/server.py
@@ -675,6 +675,19 @@ def _get_schema() -> dict[str, Any]:
     return {"schema": load_prompt("schema.md")}
 
 
+def _pending_model_work(conn) -> dict[str, int]:  # type: ignore[no-untyped-def]
+    """Cheap backlog summary used before an allowance-consuming Sampling call."""
+    from ..session import store as session_store
+
+    reduction = len(session_store.list_pending_reduction(conn))
+    modeling = len(session_store.list_pending_modeling(conn))
+    return {
+        "pending_reduction": reduction,
+        "pending_modeling": modeling,
+        "total": reduction + modeling,
+    }
+
+
 _SERVER_INSTRUCTIONS = """\
 # Persome — the user's local personal memory
 
@@ -781,6 +794,15 @@ top-down — who they are (resident), what happened (recall), what was on screen
 
 - `get_schema()` — memory file naming and structural spec. Rarely needed during normal query flow.
 
+### User-funded model processing
+
+- `get_pending_model_work()` — inspect the backlog without spending model tokens.
+- `process_pending_model_work(max_sessions?)` — explicitly process up to 1–10
+  pending sessions by asking this MCP client to perform Sampling. Call only when
+  the user asks to build/update their Personal Model or approves using the
+  current agent's allowance. It requires MCP Sampling with tools and never gives
+  Persome access to the client's login token.
+
 ## Reading a search result
 
 Each hit carries more than text — use all of it:
@@ -861,7 +883,11 @@ def build_server(
     transports. A stdio client has no HTTP surface, so importing and building
     that application would only add several seconds of cold-start work.
     """
-    from mcp.server.fastmcp import FastMCP  # lazy import
+    from mcp.server.fastmcp import Context, FastMCP  # lazy import
+
+    # FastMCP evaluates postponed annotations in the function's module globals
+    # when registering nested tools.
+    globals()["Context"] = Context
 
     if auth_enabled:
         from ..security.auth import reset_browser_auth_state
@@ -1550,6 +1576,68 @@ def build_server(
         directly.
         """
         return json.dumps(_get_schema(), ensure_ascii=False)
+
+    @server.tool()
+    def get_pending_model_work() -> str:
+        """Return pending semantic session counts without invoking any model."""
+        with fts.cursor() as conn:
+            return json.dumps(_pending_model_work(conn), ensure_ascii=False)
+
+    @server.tool()
+    async def process_pending_model_work(
+        ctx: Context,
+        max_sessions: int = 1,
+    ) -> str:
+        """Process pending Personal Model sessions using this MCP client's model.
+
+        This is the user-funded modeling path: Persome requests MCP Sampling from
+        the originating client, so Codex, Claude, or another compatible agent uses
+        its own authenticated model entitlement. Persome never receives the
+        client's login token. The call is explicit and bounded because it may
+        consume the user's agent allowance.
+
+        Requires the client to advertise MCP Sampling with tools. Clients that
+        only support ordinary MCP tool calls cannot use this path; configure an
+        API/local provider or use a compatible agent instead.
+        """
+        import asyncio
+        from dataclasses import asdict
+
+        from mcp import types
+
+        from ..writer import agent as writer_agent
+        from ..writer.agent_funded import SamplingBridge, use_bridge
+
+        max_sessions = bounded_int(max_sessions, minimum=1, maximum=10)
+        capability = types.ClientCapabilities(
+            sampling=types.SamplingCapability(tools=types.SamplingToolsCapability())
+        )
+        if not ctx.session.check_client_capability(capability):
+            return json.dumps(
+                {
+                    "status": "unsupported",
+                    "reason": "client_missing_sampling_with_tools",
+                    "processed": 0,
+                },
+                ensure_ascii=False,
+            )
+
+        loop = asyncio.get_running_loop()
+        bridge = SamplingBridge(loop=loop, session=ctx.session)
+
+        def _run() -> Any:
+            with use_bridge(bridge):
+                return writer_agent.run(cfg, limit=max_sessions)
+
+        result = await asyncio.to_thread(_run)
+        return json.dumps(
+            {
+                "status": "completed",
+                "max_sessions": max_sessions,
+                **asdict(result),
+            },
+            ensure_ascii=False,
+        )
 
     # ─── Agent-Native Persome: memory write-back (the loop, Phase 3) ──────────────────────
     from . import memory_write as _memory_write

--- a/src/persome/mcp/server.py
+++ b/src/persome/mcp/server.py
@@ -1606,7 +1606,7 @@ def build_server(
         from mcp import types
 
         from ..writer import agent as writer_agent
-        from ..writer.agent_funded import SamplingBridge, use_bridge
+        from ..writer.agent_funded import SamplingBridge, run_request_scoped, use_bridge
 
         max_sessions = bounded_int(max_sessions, minimum=1, maximum=10)
         capability = types.ClientCapabilities(
@@ -1629,10 +1629,12 @@ def build_server(
             with use_bridge(bridge):
                 return writer_agent.run(cfg, limit=max_sessions)
 
-        result = await asyncio.to_thread(_run)
+        result = await run_request_scoped(bridge, _run)
+        status = "aborted" if bridge.cancelled else "completed"
         return json.dumps(
             {
-                "status": "completed",
+                "status": status,
+                **({"reason": bridge.cancel_reason} if bridge.cancelled else {}),
                 "max_sessions": max_sessions,
                 **asdict(result),
             },

--- a/src/persome/writer/agent.py
+++ b/src/persome/writer/agent.py
@@ -249,18 +249,29 @@ def finalize_session(
             fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
 
 
-def run(cfg: Config) -> WriterRunResult:
+def run(cfg: Config, *, limit: int | None = None) -> WriterRunResult:
     """Reduce pending sessions, then finish every unmodeled reduced session."""
     result = WriterRunResult()
     if not cfg.reducer.enabled:
         logger.info("writer run: reducer disabled, nothing to do")
         return result
 
-    reduce_results = session_reducer.reduce_all_pending(cfg)
+    reduction_limit = limit
+    if limit is not None:
+        # Existing reduced sessions already consume this request's allowance.
+        # Only reduce enough additional sessions to keep the unique session
+        # count within the user-approved bound.
+        with fts.cursor() as conn:
+            already_pending = session_store.list_pending_modeling(conn)
+        reduction_limit = max(0, limit - len(already_pending[:limit]))
+
+    reduce_results = session_reducer.reduce_all_pending(cfg, limit=reduction_limit)
     result.reduced = sum(1 for rr in reduce_results if rr.succeeded)
 
     with fts.cursor() as conn:
         pending = session_store.list_pending_modeling(conn)
+    if limit is not None:
+        pending = pending[: max(0, limit)]
     reduced_by_id = {rr.session_id: rr for rr in reduce_results}
     for row in pending:
         rr = reduced_by_id.get(row.id)

--- a/src/persome/writer/agent_funded.py
+++ b/src/persome/writer/agent_funded.py
@@ -10,12 +10,16 @@ loop.
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import json
-from collections.abc import Iterator
+import threading
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
-from dataclasses import dataclass
-from typing import Any
+from dataclasses import dataclass, field
+from typing import Any, TypeVar
+
+_T = TypeVar("_T")
 
 _ACTIVE_BRIDGE: ContextVar[SamplingBridge | None] = ContextVar(
     "persome_agent_funded_bridge", default=None
@@ -43,13 +47,52 @@ def _text(value: Any) -> str:
     return json.dumps(value, ensure_ascii=False)
 
 
-@dataclass(frozen=True)
+class SamplingRequestCancelled(RuntimeError):
+    """The request-scoped Sampling bridge can no longer spend allowance."""
+
+
+class SamplingRequestTimeout(SamplingRequestCancelled):
+    """One client Sampling request exceeded the bridge deadline."""
+
+
+@dataclass
 class SamplingBridge:
     """Thread-safe facade over one connected MCP client session."""
 
     loop: asyncio.AbstractEventLoop
     session: Any
     timeout_seconds: float = 120.0
+    _cancelled: threading.Event = field(default_factory=threading.Event, init=False, repr=False)
+    _pending_lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
+    _pending: set[concurrent.futures.Future[Any]] = field(
+        default_factory=set, init=False, repr=False
+    )
+    _cancel_reason: str | None = field(default=None, init=False, repr=False)
+
+    @property
+    def cancelled(self) -> bool:
+        return self._cancelled.is_set()
+
+    @property
+    def cancel_reason(self) -> str | None:
+        with self._pending_lock:
+            return self._cancel_reason
+
+    def cancel(self, reason: str = "request_cancelled") -> None:
+        """Reject future Sampling calls and cancel any currently pending one."""
+        with self._pending_lock:
+            if not self._cancelled.is_set():
+                self._cancel_reason = reason
+                self._cancelled.set()
+            pending = tuple(self._pending)
+        for future in pending:
+            future.cancel()
+
+    def _raise_if_cancelled(self) -> None:
+        if self.cancelled:
+            raise SamplingRequestCancelled(
+                f"MCP Sampling bridge cancelled: {self.cancel_reason or 'request_cancelled'}"
+            )
 
     def complete(
         self,
@@ -58,11 +101,36 @@ class SamplingBridge:
         tools: list[dict[str, Any]] | None,
         max_tokens: int,
     ) -> Any:
+        self._raise_if_cancelled()
         future = asyncio.run_coroutine_threadsafe(
             self._complete(messages=messages, tools=tools, max_tokens=max_tokens),
             self.loop,
         )
-        return future.result(timeout=self.timeout_seconds)
+        with self._pending_lock:
+            if self._cancelled.is_set():
+                future.cancel()
+                reason = self._cancel_reason or "request_cancelled"
+            else:
+                self._pending.add(future)
+                reason = None
+        if reason is not None:
+            raise SamplingRequestCancelled(f"MCP Sampling bridge cancelled: {reason}")
+
+        try:
+            return future.result(timeout=self.timeout_seconds)
+        except concurrent.futures.TimeoutError as exc:
+            self.cancel("sampling_timeout")
+            raise SamplingRequestTimeout(
+                f"MCP Sampling request exceeded {self.timeout_seconds:g}s"
+            ) from exc
+        except concurrent.futures.CancelledError as exc:
+            self.cancel(self.cancel_reason or "request_cancelled")
+            raise SamplingRequestCancelled(
+                f"MCP Sampling bridge cancelled: {self.cancel_reason or 'request_cancelled'}"
+            ) from exc
+        finally:
+            with self._pending_lock:
+                self._pending.discard(future)
 
     async def _complete(
         self,
@@ -75,16 +143,40 @@ class SamplingBridge:
 
         from .llm import _build_response
 
+        self._raise_if_cancelled()
         system_parts: list[str] = []
         sampling_messages: list[Any] = []
+        pending_tool_results: list[Any] = []
+
+        def flush_tool_results() -> None:
+            if not pending_tool_results:
+                return
+            sampling_messages.append(
+                types.SamplingMessage(role="user", content=list(pending_tool_results))
+            )
+            pending_tool_results.clear()
+
         for message in messages:
             role = message.get("role")
             if role == "system":
                 system_parts.append(_text(message.get("content")))
                 continue
 
-            content: list[Any] = []
             plain = _text(message.get("content"))
+            if role == "tool":
+                pending_tool_results.append(
+                    types.ToolResultContent(
+                        type="tool_result",
+                        toolUseId=str(message.get("tool_call_id") or ""),
+                        content=[types.TextContent(type="text", text=plain)],
+                    )
+                )
+                continue
+
+            # SEP-1577 requires all results for one assistant tool-use turn to be
+            # in one user message containing only tool_result blocks.
+            flush_tool_results()
+            content: list[Any] = []
             if plain:
                 content.append(types.TextContent(type="text", text=plain))
             if role == "assistant":
@@ -103,14 +195,6 @@ class SamplingBridge:
                             input=arguments if isinstance(arguments, dict) else {},
                         )
                     )
-            elif role == "tool":
-                content.append(
-                    types.ToolResultContent(
-                        type="tool_result",
-                        toolUseId=str(message.get("tool_call_id") or ""),
-                        content=[types.TextContent(type="text", text=plain)],
-                    )
-                )
             if not content:
                 content.append(types.TextContent(type="text", text=""))
             sampling_messages.append(
@@ -119,6 +203,7 @@ class SamplingBridge:
                     content=content,
                 )
             )
+        flush_tool_results()
 
         sampling_tools = None
         if tools:
@@ -168,3 +253,18 @@ class SamplingBridge:
             "toolUse": "tool_calls",
         }.get(stop_reason, "stop")
         return response
+
+
+async def run_request_scoped(
+    bridge: SamplingBridge,
+    func: Callable[[], _T],
+) -> _T:
+    """Run synchronous work while tying its Sampling calls to this request."""
+    try:
+        return await asyncio.to_thread(func)
+    except asyncio.CancelledError:
+        bridge.cancel("request_cancelled")
+        raise
+    except BaseException:
+        bridge.cancel("request_failed")
+        raise

--- a/src/persome/writer/agent_funded.py
+++ b/src/persome/writer/agent_funded.py
@@ -1,0 +1,170 @@
+"""Bridge synchronous modeling stages to an originating MCP client's model.
+
+MCP sampling is deliberately request-scoped: Persome never reads a client's
+login token and never attempts background sampling without an originating MCP
+request.  The synchronous writer runs in a worker thread while this bridge
+marshals ``sampling/createMessage`` calls back onto the MCP session's event
+loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any
+
+_ACTIVE_BRIDGE: ContextVar[SamplingBridge | None] = ContextVar(
+    "persome_agent_funded_bridge", default=None
+)
+
+
+def active_bridge() -> SamplingBridge | None:
+    return _ACTIVE_BRIDGE.get()
+
+
+@contextmanager
+def use_bridge(bridge: SamplingBridge) -> Iterator[None]:
+    token = _ACTIVE_BRIDGE.set(bridge)
+    try:
+        yield
+    finally:
+        _ACTIVE_BRIDGE.reset(token)
+
+
+def _text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=False)
+
+
+@dataclass(frozen=True)
+class SamplingBridge:
+    """Thread-safe facade over one connected MCP client session."""
+
+    loop: asyncio.AbstractEventLoop
+    session: Any
+    timeout_seconds: float = 120.0
+
+    def complete(
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+        max_tokens: int,
+    ) -> Any:
+        future = asyncio.run_coroutine_threadsafe(
+            self._complete(messages=messages, tools=tools, max_tokens=max_tokens),
+            self.loop,
+        )
+        return future.result(timeout=self.timeout_seconds)
+
+    async def _complete(
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+        max_tokens: int,
+    ) -> Any:
+        from mcp import types
+
+        from .llm import _build_response
+
+        system_parts: list[str] = []
+        sampling_messages: list[Any] = []
+        for message in messages:
+            role = message.get("role")
+            if role == "system":
+                system_parts.append(_text(message.get("content")))
+                continue
+
+            content: list[Any] = []
+            plain = _text(message.get("content"))
+            if plain:
+                content.append(types.TextContent(type="text", text=plain))
+            if role == "assistant":
+                for call in message.get("tool_calls") or []:
+                    fn = call.get("function") or {}
+                    raw = fn.get("arguments") or "{}"
+                    try:
+                        arguments = json.loads(raw) if isinstance(raw, str) else raw
+                    except json.JSONDecodeError:
+                        arguments = {}
+                    content.append(
+                        types.ToolUseContent(
+                            type="tool_use",
+                            id=str(call.get("id") or ""),
+                            name=str(fn.get("name") or ""),
+                            input=arguments if isinstance(arguments, dict) else {},
+                        )
+                    )
+            elif role == "tool":
+                content.append(
+                    types.ToolResultContent(
+                        type="tool_result",
+                        toolUseId=str(message.get("tool_call_id") or ""),
+                        content=[types.TextContent(type="text", text=plain)],
+                    )
+                )
+            if not content:
+                content.append(types.TextContent(type="text", text=""))
+            sampling_messages.append(
+                types.SamplingMessage(
+                    role="assistant" if role == "assistant" else "user",
+                    content=content,
+                )
+            )
+
+        sampling_tools = None
+        if tools:
+            sampling_tools = []
+            for tool in tools:
+                fn = tool.get("function") if tool.get("type") == "function" else tool
+                fn = fn if isinstance(fn, dict) else {}
+                sampling_tools.append(
+                    types.Tool(
+                        name=str(fn.get("name") or ""),
+                        description=str(fn.get("description") or ""),
+                        inputSchema=fn.get("parameters")
+                        or fn.get("input_schema")
+                        or {"type": "object", "properties": {}},
+                    )
+                )
+
+        result = await self.session.create_message(
+            sampling_messages,
+            max_tokens=max_tokens,
+            system_prompt="\n\n".join(system_parts) or None,
+            tools=sampling_tools,
+            tool_choice=types.ToolChoice(mode="auto") if sampling_tools else None,
+        )
+        blocks = result.content if isinstance(result.content, list) else [result.content]
+        text_parts: list[str] = []
+        tool_calls: list[dict[str, Any]] = []
+        for block in blocks:
+            if getattr(block, "type", None) == "text":
+                text_parts.append(getattr(block, "text", "") or "")
+            elif getattr(block, "type", None) == "tool_use":
+                tool_calls.append(
+                    {
+                        "id": getattr(block, "id", None),
+                        "function": {
+                            "name": getattr(block, "name", ""),
+                            "arguments": json.dumps(
+                                getattr(block, "input", {}) or {}, ensure_ascii=False
+                            ),
+                        },
+                    }
+                )
+        response = _build_response("\n".join(text_parts), tool_calls)
+        stop_reason = str(getattr(result, "stopReason", "") or "")
+        response.choices[0].finish_reason = {
+            "maxTokens": "length",
+            "toolUse": "tool_calls",
+        }.get(stop_reason, "stop")
+        return response

--- a/src/persome/writer/llm.py
+++ b/src/persome/writer/llm.py
@@ -666,6 +666,12 @@ def _call_llm_with_retry(
             return resp
 
         except Exception as exc:  # noqa: BLE001
+            # Cancellation and timeout are terminal for a request-funded run.
+            # Retrying would either waste time or create another allowance spend.
+            from .agent_funded import SamplingRequestCancelled
+
+            if isinstance(exc, SamplingRequestCancelled):
+                raise
             exc_type = type(exc).__name__.lower()
             exc_str = str(exc).lower()
 

--- a/src/persome/writer/llm.py
+++ b/src/persome/writer/llm.py
@@ -288,6 +288,19 @@ def call_llm(
         return _mock_response(stage, messages, tools, json_mode)
 
     model_cfg = cfg.model_for(stage)
+    # An originating MCP request may lend its client's model through Sampling.
+    # This takes precedence over configured providers for only that request and
+    # never exposes or persists the client's authentication material.
+    from .agent_funded import active_bridge
+
+    bridge = active_bridge()
+    if bridge is not None:
+        return bridge.complete(
+            messages=messages,
+            tools=tools,
+            max_tokens=model_cfg.max_tokens or _DEFAULT_MAX_TOKENS,
+        )
+
     override = os.environ.get("PERSOME_FALLBACK_MODEL")
     if override:
         model_cfg = ModelConfig(**{**model_cfg.__dict__, "model": override})

--- a/src/persome/writer/session_reducer.py
+++ b/src/persome/writer/session_reducer.py
@@ -380,7 +380,7 @@ def retry_due(cfg: Config) -> list[ReduceResult]:
     return results
 
 
-def reduce_all_pending(cfg: Config) -> list[ReduceResult]:
+def reduce_all_pending(cfg: Config, *, limit: int | None = None) -> list[ReduceResult]:
     """Unconditional catch-up: reduce every non-reduced ended/failed session.
 
     Called from the daily 23:55 safety-net. Covers ``ended`` rows
@@ -389,6 +389,8 @@ def reduce_all_pending(cfg: Config) -> list[ReduceResult]:
     """
     with fts.cursor() as conn:
         rows = session_store.list_pending_reduction(conn)
+    if limit is not None:
+        rows = rows[: max(0, limit)]
     out: list[ReduceResult] = []
     for row in rows:
         if row.end_time is None:

--- a/tests/test_agent_funded_sampling.py
+++ b/tests/test_agent_funded_sampling.py
@@ -7,11 +7,19 @@ import json
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
 from mcp import types
+from mcp.server.session import ServerSession
 
 from persome.config import Config
 from persome.writer import llm as llm_mod
-from persome.writer.agent_funded import SamplingBridge, use_bridge
+from persome.writer.agent_funded import (
+    SamplingBridge,
+    SamplingRequestCancelled,
+    SamplingRequestTimeout,
+    run_request_scoped,
+    use_bridge,
+)
 
 
 class _FakeSession:
@@ -22,6 +30,41 @@ class _FakeSession:
     async def create_message(self, messages, **kwargs):  # type: ignore[no-untyped-def]
         self.calls.append({"messages": messages, **kwargs})
         return self.result
+
+
+class _ValidatingServerSession(ServerSession):
+    """Minimal ServerSession seam that retains the SDK's request validation."""
+
+    def __init__(self, result: Any) -> None:
+        self.result = result
+        self.requests: list[Any] = []
+        self._client_params = SimpleNamespace(  # noqa: SLF001
+            capabilities=types.ClientCapabilities(
+                sampling=types.SamplingCapability(tools=types.SamplingToolsCapability())
+            )
+        )
+
+    async def send_request(self, request, result_type, **kwargs):  # type: ignore[no-untyped-def]
+        del result_type, kwargs
+        self.requests.append(request)
+        return self.result
+
+
+class _BlockingSession:
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.cancelled = asyncio.Event()
+        self.calls = 0
+
+    async def create_message(self, messages, **kwargs):  # type: ignore[no-untyped-def]
+        del messages, kwargs
+        self.calls += 1
+        self.started.set()
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            self.cancelled.set()
+            raise
 
 
 def test_sampling_bridge_adapts_text_and_tool_calls() -> None:
@@ -100,7 +143,7 @@ def test_sampling_bridge_round_trips_tool_results() -> None:
         stopReason="endTurn",
         content=types.TextContent(type="text", text=json.dumps({"ok": True})),
     )
-    session = _FakeSession(result)
+    session = _ValidatingServerSession(result)
 
     async def run() -> None:
         bridge = SamplingBridge(loop=asyncio.get_running_loop(), session=session)
@@ -113,17 +156,90 @@ def test_sampling_bridge_round_trips_tool_results() -> None:
                         {
                             "id": "call-1",
                             "function": {"name": "read_memory", "arguments": "{}"},
-                        }
+                        },
+                        {
+                            "id": "call-2",
+                            "function": {"name": "search_memory", "arguments": "{}"},
+                        },
                     ],
                 },
                 {"role": "tool", "tool_call_id": "call-1", "content": '{"value": 1}'},
+                {"role": "tool", "tool_call_id": "call-2", "content": '{"value": 2}'},
             ],
-            tools=None,
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read_memory",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "search_memory",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                },
+            ],
             max_tokens=128,
         )
 
     asyncio.run(run())
-    sent = session.calls[0]["messages"]
-    assert sent[0].content[0].type == "tool_use"
-    assert sent[1].content[1].type == "tool_result"
-    assert sent[1].content[1].toolUseId == "call-1"
+    sent = session.requests[0].root.params.messages
+    assert [block.type for block in sent[0].content] == ["tool_use", "tool_use"]
+    assert [block.type for block in sent[1].content] == ["tool_result", "tool_result"]
+    assert [block.toolUseId for block in sent[1].content] == ["call-1", "call-2"]
+
+
+def test_sampling_timeout_cancels_pending_and_rejects_further_spend() -> None:
+    async def run() -> None:
+        session = _BlockingSession()
+        bridge = SamplingBridge(
+            loop=asyncio.get_running_loop(),
+            session=session,
+            timeout_seconds=0.01,
+        )
+
+        def complete() -> Any:
+            return bridge.complete(
+                messages=[{"role": "user", "content": "model this"}],
+                tools=None,
+                max_tokens=32,
+            )
+
+        with pytest.raises(SamplingRequestTimeout, match="exceeded"):
+            await asyncio.to_thread(complete)
+        await asyncio.wait_for(session.cancelled.wait(), timeout=1)
+        assert bridge.cancel_reason == "sampling_timeout"
+        with pytest.raises(SamplingRequestCancelled, match="sampling_timeout"):
+            await asyncio.to_thread(complete)
+        assert session.calls == 1
+
+    asyncio.run(run())
+
+
+def test_request_cancellation_cancels_pending_and_rejects_further_spend() -> None:
+    async def run() -> None:
+        session = _BlockingSession()
+        bridge = SamplingBridge(loop=asyncio.get_running_loop(), session=session)
+
+        def complete() -> Any:
+            return bridge.complete(
+                messages=[{"role": "user", "content": "model this"}],
+                tools=None,
+                max_tokens=32,
+            )
+
+        task = asyncio.create_task(run_request_scoped(bridge, complete))
+        await asyncio.wait_for(session.started.wait(), timeout=1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        await asyncio.wait_for(session.cancelled.wait(), timeout=1)
+        assert bridge.cancel_reason == "request_cancelled"
+        with pytest.raises(SamplingRequestCancelled, match="request_cancelled"):
+            await asyncio.to_thread(complete)
+        assert session.calls == 1
+
+    asyncio.run(run())

--- a/tests/test_agent_funded_sampling.py
+++ b/tests/test_agent_funded_sampling.py
@@ -1,0 +1,129 @@
+"""MCP Sampling-backed Personal Model inference."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from typing import Any
+
+from mcp import types
+
+from persome.config import Config
+from persome.writer import llm as llm_mod
+from persome.writer.agent_funded import SamplingBridge, use_bridge
+
+
+class _FakeSession:
+    def __init__(self, result: Any) -> None:
+        self.result = result
+        self.calls: list[dict[str, Any]] = []
+
+    async def create_message(self, messages, **kwargs):  # type: ignore[no-untyped-def]
+        self.calls.append({"messages": messages, **kwargs})
+        return self.result
+
+
+def test_sampling_bridge_adapts_text_and_tool_calls() -> None:
+    result = types.CreateMessageResultWithTools(
+        role="assistant",
+        model="client-owned-model",
+        stopReason="toolUse",
+        content=[
+            types.TextContent(type="text", text="working"),
+            types.ToolUseContent(
+                type="tool_use",
+                id="call-1",
+                name="commit",
+                input={"content": "durable fact"},
+            ),
+        ],
+    )
+    session = _FakeSession(result)
+
+    async def run() -> Any:
+        bridge = SamplingBridge(loop=asyncio.get_running_loop(), session=session)
+        return await bridge._complete(  # noqa: SLF001 - direct async seam avoids thread deadlock
+            messages=[
+                {"role": "system", "content": "system"},
+                {"role": "user", "content": "model this"},
+            ],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "commit",
+                        "description": "persist",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+            max_tokens=256,
+        )
+
+    response = asyncio.run(run())
+    assert llm_mod.extract_text(response) == "working"
+    assert llm_mod.extract_tool_calls(response) == [
+        {"id": "call-1", "name": "commit", "arguments": {"content": "durable fact"}}
+    ]
+    assert response.choices[0].finish_reason == "tool_calls"
+    assert session.calls[0]["system_prompt"] == "system"
+    assert session.calls[0]["tools"][0].name == "commit"
+
+
+def test_call_llm_prefers_request_scoped_sampling_bridge(monkeypatch) -> None:
+    monkeypatch.delenv("PERSOME_LLM_MOCK", raising=False)
+    seen: dict[str, Any] = {}
+
+    class _Bridge:
+        def complete(self, **kwargs: Any) -> Any:
+            seen.update(kwargs)
+            return SimpleNamespace(source="sampling")
+
+    with use_bridge(_Bridge()):  # type: ignore[arg-type]
+        result = llm_mod.call_llm(
+            Config(),
+            "timeline",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=None,
+        )
+
+    assert result.source == "sampling"
+    assert seen["messages"][0]["content"] == "hello"
+    assert seen["max_tokens"] > 0
+
+
+def test_sampling_bridge_round_trips_tool_results() -> None:
+    result = types.CreateMessageResultWithTools(
+        role="assistant",
+        model="client-owned-model",
+        stopReason="endTurn",
+        content=types.TextContent(type="text", text=json.dumps({"ok": True})),
+    )
+    session = _FakeSession(result)
+
+    async def run() -> None:
+        bridge = SamplingBridge(loop=asyncio.get_running_loop(), session=session)
+        await bridge._complete(  # noqa: SLF001
+            messages=[
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "function": {"name": "read_memory", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call-1", "content": '{"value": 1}'},
+            ],
+            tools=None,
+            max_tokens=128,
+        )
+
+    asyncio.run(run())
+    sent = session.calls[0]["messages"]
+    assert sent[0].content[0].type == "tool_use"
+    assert sent[1].content[1].type == "tool_result"
+    assert sent[1].content[1].toolUseId == "call-1"

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -81,6 +81,12 @@ def test_get_schema() -> None:
     assert "Memory Organization Spec" in out["schema"]
 
 
+def test_pending_model_work_is_empty_on_fresh_root(ac_root: Path) -> None:
+    with fts.cursor() as conn:
+        out = mcp_server._pending_model_work(conn)
+    assert out == {"pending_reduction": 0, "pending_modeling": 0, "total": 0}
+
+
 def test_get_model_snapshot_uses_versioned_contract(ac_root: Path) -> None:
     with fts.cursor() as conn:
         out = mcp_server._get_model_snapshot(conn)
@@ -158,6 +164,9 @@ def test_get_model_snapshot_preserves_saved_manifest(ac_root: Path) -> None:
 def test_server_reports_runtime_version(ac_root: Path) -> None:
     server = mcp_server.build_server(auth_enabled=False)
     assert server._mcp_server.version == __version__
+    tool = server._tool_manager.get_tool("process_pending_model_work")
+    assert tool is not None
+    assert "ctx" not in tool.parameters["properties"]
 
 
 def test_stdio_server_skips_daemon_http_routes(ac_root: Path) -> None:

--- a/tests/test_writer_agent.py
+++ b/tests/test_writer_agent.py
@@ -109,6 +109,43 @@ def test_writer_run_respects_reducer_disabled(ac_root: Path, monkeypatch) -> Non
     assert result.reduced == 0
 
 
+def test_writer_run_limit_counts_existing_modeled_backlog_first(
+    ac_root: Path, monkeypatch
+) -> None:
+    start = datetime(2026, 4, 21, 9, 0, tzinfo=_TZ)
+    with fts.cursor() as conn:
+        session_store.insert(
+            conn,
+            session_store.SessionRow(
+                id="already-reduced",
+                start_time=start,
+                end_time=start + timedelta(minutes=5),
+                status="reduced",
+            ),
+        )
+
+    seen: dict[str, Any] = {}
+
+    def fake_reduce_all_pending(cfg, *, limit=None):  # type: ignore[no-untyped-def]
+        seen["reduction_limit"] = limit
+        return []
+
+    finalized: list[str] = []
+
+    def fake_finalize(cfg, *, session_id, **kwargs):  # type: ignore[no-untyped-def]
+        finalized.append(session_id)
+        return agent.SessionModelResult(session_id=session_id, skipped_reason="test")
+
+    monkeypatch.setattr(agent.session_reducer, "reduce_all_pending", fake_reduce_all_pending)
+    monkeypatch.setattr(agent, "finalize_session", fake_finalize)
+
+    cfg = config_mod.load(ac_root / "config.toml")
+    agent.run(cfg, limit=1)
+
+    assert seen["reduction_limit"] == 0
+    assert finalized == ["already-reduced"]
+
+
 def test_terminal_finalizer_applies_default_person_model(
     ac_root: Path,
     fake_llm,

--- a/tests/test_writer_agent.py
+++ b/tests/test_writer_agent.py
@@ -109,9 +109,7 @@ def test_writer_run_respects_reducer_disabled(ac_root: Path, monkeypatch) -> Non
     assert result.reduced == 0
 
 
-def test_writer_run_limit_counts_existing_modeled_backlog_first(
-    ac_root: Path, monkeypatch
-) -> None:
+def test_writer_run_limit_counts_existing_modeled_backlog_first(ac_root: Path, monkeypatch) -> None:
     start = datetime(2026, 4, 21, 9, 0, tzinfo=_TZ)
     with fts.cursor() as conn:
         session_store.insert(

--- a/uv.lock
+++ b/uv.lock
@@ -32,14 +32,14 @@ name = "aiohttp"
 version = "3.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohappyeyeballs" },
-    { name = "aiosignal" },
-    { name = "attrs" },
-    { name = "frozenlist" },
-    { name = "multidict" },
-    { name = "propcache" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-    { name = "yarl" },
+    { name = "aiohappyeyeballs", marker = "sys_platform == 'darwin'" },
+    { name = "aiosignal", marker = "sys_platform == 'darwin'" },
+    { name = "attrs", marker = "sys_platform == 'darwin'" },
+    { name = "frozenlist", marker = "sys_platform == 'darwin'" },
+    { name = "multidict", marker = "sys_platform == 'darwin'" },
+    { name = "propcache", marker = "sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' and sys_platform == 'darwin'" },
+    { name = "yarl", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/82/78/8ea7308cac6934de8c74a14f3d5f65d1c89287426688be79538d0e5c013d/aiohttp-3.14.1.tar.gz", hash = "sha256:307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035", size = 7955794, upload-time = "2026-06-07T21:09:35.529Z" }
 wheels = [
@@ -56,8 +56,8 @@ name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "frozenlist" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "frozenlist", marker = "sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' and sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
@@ -69,12 +69,12 @@ name = "aistudio-sdk"
 version = "0.3.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "bce-python-sdk" },
-    { name = "click" },
-    { name = "prettytable" },
-    { name = "psutil" },
-    { name = "requests" },
-    { name = "tqdm" },
+    { name = "bce-python-sdk", marker = "sys_platform == 'darwin'" },
+    { name = "click", marker = "sys_platform == 'darwin'" },
+    { name = "prettytable", marker = "sys_platform == 'darwin'" },
+    { name = "psutil", marker = "sys_platform == 'darwin'" },
+    { name = "requests", marker = "sys_platform == 'darwin'" },
+    { name = "tqdm", marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/77/cd71a481bb7a76b0e9d0b6bf47711c627b1dd079001ea246893f19a9d04c/aistudio_sdk-0.3.8-py3-none-any.whl", hash = "sha256:bfc96af7243ac2ee3303014849aa4028717cce5afa622af8cfe3a1d44d1941d6", size = 62972, upload-time = "2025-09-19T11:42:39.384Z" },
@@ -144,10 +144,10 @@ name = "bce-python-sdk"
 version = "0.9.72"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "crc32c" },
-    { name = "future" },
-    { name = "pycryptodome" },
-    { name = "six" },
+    { name = "crc32c", marker = "sys_platform == 'darwin'" },
+    { name = "future", marker = "sys_platform == 'darwin'" },
+    { name = "pycryptodome", marker = "sys_platform == 'darwin'" },
+    { name = "six", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/32/bb/1ccb8b28bfa0802356f8588e479adb61cfd2268b37fabc6c8a805d645cd5/bce_python_sdk-0.9.72.tar.gz", hash = "sha256:d9db568698792d74db4245252d98776eae8c9c5225fc0ba86548dfc52d478fcc", size = 302207, upload-time = "2026-06-08T12:10:32.326Z" }
 wheels = [
@@ -298,9 +298,6 @@ wheels = [
 name = "colorlog"
 version = "6.10.1"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
 sdist = { url = "https://files.pythonhosted.org/packages/a2/61/f083b5ac52e505dfc1c624eafbf8c7589a0d7f32daa398d2e7590efa5fda/colorlog-6.10.1.tar.gz", hash = "sha256:eb4ae5cb65fe7fec7773c2306061a8e63e02efc2c72eba9d27b0fa23c94f1321", size = 17162, upload-time = "2025-10-16T16:14:11.978Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl", hash = "sha256:2d7e8348291948af66122cff006c9f8da6255d224e7cf8e37d8de2df3bad8c9c", size = 11743, upload-time = "2025-10-16T16:14:10.512Z" },
@@ -592,15 +589,15 @@ name = "huggingface-hub"
 version = "1.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "httpx" },
-    { name = "packaging" },
-    { name = "pyyaml" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
+    { name = "click", marker = "sys_platform == 'darwin'" },
+    { name = "filelock", marker = "sys_platform == 'darwin'" },
+    { name = "fsspec", marker = "sys_platform == 'darwin'" },
+    { name = "hf-xet", marker = "(platform_machine == 'AMD64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'darwin') or (platform_machine == 'amd64' and sys_platform == 'darwin') or (platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin')" },
+    { name = "httpx", marker = "sys_platform == 'darwin'" },
+    { name = "packaging", marker = "sys_platform == 'darwin'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin'" },
+    { name = "tqdm", marker = "sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/77/ea/dc54b4dda5841cb3a7812a178695be776e7c15c597887c2ed892f17d015a/huggingface_hub-1.22.0.tar.gz", hash = "sha256:e2dfe5fe1ec3b87ba2709aa34555b23e3f3f6ad4d7255238e13ddb8348e6bbfa", size = 914232, upload-time = "2026-07-03T09:46:44.685Z" }
 wheels = [
@@ -764,13 +761,13 @@ name = "modelscope"
 version = "1.38.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock" },
-    { name = "modelscope-hub" },
-    { name = "packaging" },
-    { name = "requests" },
-    { name = "setuptools" },
-    { name = "tqdm" },
-    { name = "urllib3" },
+    { name = "filelock", marker = "sys_platform == 'darwin'" },
+    { name = "modelscope-hub", marker = "sys_platform == 'darwin'" },
+    { name = "packaging", marker = "sys_platform == 'darwin'" },
+    { name = "requests", marker = "sys_platform == 'darwin'" },
+    { name = "setuptools", marker = "sys_platform == 'darwin'" },
+    { name = "tqdm", marker = "sys_platform == 'darwin'" },
+    { name = "urllib3", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/72/b37f46f8e1900c64485420b210eecda1f758cbd0fe8ade60c5bbf883b25e/modelscope-1.38.1.tar.gz", hash = "sha256:a81f3685b1545f52b415d88a763456416aa65170e622f9dcc02eadb3f8e1cfa0", size = 4542886, upload-time = "2026-07-06T15:13:56.427Z" }
 wheels = [
@@ -782,10 +779,10 @@ name = "modelscope-hub"
 version = "0.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock" },
-    { name = "requests" },
-    { name = "tqdm" },
-    { name = "urllib3" },
+    { name = "filelock", marker = "sys_platform == 'darwin'" },
+    { name = "requests", marker = "sys_platform == 'darwin'" },
+    { name = "tqdm", marker = "sys_platform == 'darwin'" },
+    { name = "urllib3", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b6/cb/6b9d3fcbcd09db6cdd7f1e0fd60be2998c99db07be28f37982c0dbd14496/modelscope_hub-0.1.7.tar.gz", hash = "sha256:b78730f3923cf13d5fbc56c6224a5ba617bf111a562fe3808c03e34c3c07840f", size = 126616, upload-time = "2026-07-07T07:35:36.465Z" }
 wheels = [
@@ -920,7 +917,7 @@ name = "opencv-contrib-python"
 version = "4.10.0.84"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/33/7b8ec6c4d45e678b26297e4a5e76464a93033a9adcc8c17eac01097065f6/opencv-contrib-python-4.10.0.84.tar.gz", hash = "sha256:4a3eae0ed9cadf1abe9293a6938a25a540e2fd6d7fc308595caa5896c8b36a0c", size = 150433857, upload-time = "2024-06-17T18:30:50.217Z" }
 wheels = [
@@ -932,7 +929,7 @@ name = "opt-einsum"
 version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7d/bf/9257e53a0e7715bc1127e15063e831f076723c6cd60985333a1c18878fb8/opt_einsum-3.3.0.tar.gz", hash = "sha256:59f6475f77bbc37dcf7cd748519c0ec60722e91e63ca114e68821c0c54a46549", size = 73951, upload-time = "2020-07-19T22:40:32.141Z" }
 wheels = [
@@ -962,11 +959,11 @@ name = "paddleocr"
 version = "3.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
-    { name = "paddlex", extra = ["ocr-core"] },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "typing-extensions" },
+    { name = "aiohttp", marker = "sys_platform == 'darwin'" },
+    { name = "paddlex", extra = ["ocr-core"], marker = "sys_platform == 'darwin'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin'" },
+    { name = "requests", marker = "sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/97/b1/9454e886afa925067ce51de2e513d146524645888de299d51ddc1caa3100/paddleocr-3.7.0.tar.gz", hash = "sha256:9b81eb62cf37e590d4873e60262ff56f968ff9de6ce1f565749760ceb1c422e2", size = 3082862, upload-time = "2026-06-11T12:09:52.545Z" }
 wheels = [
@@ -978,15 +975,15 @@ name = "paddlepaddle"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
-    { name = "networkx" },
-    { name = "numpy" },
-    { name = "opt-einsum" },
-    { name = "pillow" },
-    { name = "protobuf" },
-    { name = "safetensors" },
-    { name = "setuptools" },
-    { name = "typing-extensions" },
+    { name = "httpx", marker = "sys_platform == 'darwin'" },
+    { name = "networkx", marker = "sys_platform == 'darwin'" },
+    { name = "numpy", marker = "sys_platform == 'darwin'" },
+    { name = "opt-einsum", marker = "sys_platform == 'darwin'" },
+    { name = "pillow", marker = "sys_platform == 'darwin'" },
+    { name = "protobuf", marker = "sys_platform == 'darwin'" },
+    { name = "safetensors", marker = "sys_platform == 'darwin'" },
+    { name = "setuptools", marker = "sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/97/62d061b4700a7020506f4db80c4721100b5b2fa0709f4e999c38dc7e2293/paddlepaddle-3.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d7827d867503b502a881c718e3743d9b91648a62d01f93bcd5ba3d7846de5ab5", size = 104546703, upload-time = "2026-03-26T11:18:20.499Z" },
@@ -998,24 +995,24 @@ name = "paddlex"
 version = "3.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aistudio-sdk" },
-    { name = "chardet" },
-    { name = "colorlog" },
-    { name = "filelock" },
-    { name = "huggingface-hub" },
-    { name = "modelscope" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "pandas" },
-    { name = "pillow" },
-    { name = "prettytable" },
-    { name = "py-cpuinfo" },
-    { name = "pydantic" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "ruamel-yaml" },
-    { name = "typing-extensions" },
-    { name = "ujson" },
+    { name = "aistudio-sdk", marker = "sys_platform == 'darwin'" },
+    { name = "chardet", marker = "sys_platform == 'darwin'" },
+    { name = "colorlog", marker = "sys_platform == 'darwin'" },
+    { name = "filelock", marker = "sys_platform == 'darwin'" },
+    { name = "huggingface-hub", marker = "sys_platform == 'darwin'" },
+    { name = "modelscope", marker = "sys_platform == 'darwin'" },
+    { name = "numpy", marker = "sys_platform == 'darwin'" },
+    { name = "packaging", marker = "sys_platform == 'darwin'" },
+    { name = "pandas", marker = "sys_platform == 'darwin'" },
+    { name = "pillow", marker = "sys_platform == 'darwin'" },
+    { name = "prettytable", marker = "sys_platform == 'darwin'" },
+    { name = "py-cpuinfo", marker = "sys_platform == 'darwin'" },
+    { name = "pydantic", marker = "sys_platform == 'darwin'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin'" },
+    { name = "requests", marker = "sys_platform == 'darwin'" },
+    { name = "ruamel-yaml", marker = "sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
+    { name = "ujson", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dd/96/1e86d4056ffc1e494c53aebab7e2faf08dcf8b929180f9872ae46632e9bd/paddlex-3.7.2.tar.gz", hash = "sha256:6a60b4595e2d51460f7f51326672adca86b89ff9ecfd02ac348fb69739e0093c", size = 4415130, upload-time = "2026-06-25T05:50:53.34Z" }
 wheels = [
@@ -1024,12 +1021,12 @@ wheels = [
 
 [package.optional-dependencies]
 ocr-core = [
-    { name = "imagesize" },
-    { name = "opencv-contrib-python" },
-    { name = "pyclipper" },
-    { name = "pypdfium2" },
-    { name = "python-bidi" },
-    { name = "shapely" },
+    { name = "imagesize", marker = "sys_platform == 'darwin'" },
+    { name = "opencv-contrib-python", marker = "sys_platform == 'darwin'" },
+    { name = "pyclipper", marker = "sys_platform == 'darwin'" },
+    { name = "pypdfium2", marker = "sys_platform == 'darwin'" },
+    { name = "python-bidi", marker = "sys_platform == 'darwin'" },
+    { name = "shapely", marker = "sys_platform == 'darwin'" },
 ]
 
 [[package]]
@@ -1037,8 +1034,8 @@ name = "pandas"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "python-dateutil" },
+    { name = "numpy", marker = "sys_platform == 'darwin'" },
+    { name = "python-dateutil", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
 wheels = [
@@ -1090,7 +1087,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=42.0" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", extras = ["socks"], specifier = ">=0.27" },
-    { name = "mcp", specifier = ">=1.0" },
+    { name = "mcp", specifier = ">=1.23.0" },
     { name = "mss", specifier = ">=9.0" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "openai", specifier = ">=1.75,<3" },
@@ -1223,7 +1220,7 @@ name = "prettytable"
 version = "3.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wcwidth" },
+    { name = "wcwidth", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/81/74/ba08d81e668ccfe8658d7520a307e63c19862c08eb4ccb26f356c5239a7a/prettytable-3.18.0.tar.gz", hash = "sha256:439217116152244369caf3d9f1caf2f9fe29b03bd79e88d2928c8e718c95d680", size = 76373, upload-time = "2026-06-22T16:07:50.174Z" }
 wheels = [
@@ -1488,7 +1485,7 @@ name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "six" },
+    { name = "six", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
@@ -1701,7 +1698,7 @@ name = "shapely"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4d/bc/0989043118a27cccb4e906a46b7565ce36ca7b57f5a18b78f4f1b0f72d9d/shapely-2.1.2.tar.gz", hash = "sha256:2ed4ecb28320a433db18a5bf029986aa8afcfd740745e78847e330d5d94922a9", size = 315489, upload-time = "2025-09-24T13:51:41.432Z" }
 wheels = [
@@ -1930,9 +1927,9 @@ name = "yarl"
 version = "1.24.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "idna" },
-    { name = "multidict" },
-    { name = "propcache" },
+    { name = "idna", marker = "sys_platform == 'darwin'" },
+    { name = "multidict", marker = "sys_platform == 'darwin'" },
+    { name = "propcache", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/79/12/1e8f37460ea0f7eb59c221fdaf0ed75e7ac43e97f8093b9c6f411df50a78/yarl-1.24.2.tar.gz", hash = "sha256:9ac374123c6fd7abf64d1fec93962b0bd4ee2c19751755a762a72dd96c0378f8", size = 210798, upload-time = "2026-05-19T21:31:05.599Z" }
 wheels = [


### PR DESCRIPTION
## What changed

- add `get_pending_model_work` for a zero-model-call backlog summary
- add bounded `process_pending_model_work(max_sessions=1)` for request-scoped, agent-funded modeling
- bridge the existing synchronous writer/tool loop to MCP `sampling/createMessage`
- negotiate Sampling-with-tools and return an explicit unsupported result for incompatible clients
- preserve existing API-key, local-provider, and unattended daemon routes
- document the privacy, capability, and background-processing boundaries

## Why

Persome semantic modeling previously required a separately configured provider credential. Users who already pay for Codex, Claude, or another compatible MCP agent should be able to explicitly spend that agent allowance without exposing or copying the agent's login token into Persome.

## Impact

A trusted MCP client that advertises Sampling with tools can process 1–10 pending sessions per approved call. Persome does not initiate Sampling from the background daemon, and clients without the required capability degrade safely.

## Validation

- `uv run ruff check` on all touched Python and test files
- 47 focused tests passed
- `PERSOME_LLM_MOCK=1 uv run pytest -m "not macos and not integration" -q`: 2019 passed, 15 deselected
- `git diff --check`
