### PR TITLE
feat: import Apple Health data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,16 @@ jobs:
       - name: Shell syntax
         run: bash -n install.sh uninstall.sh resources/*.sh
 
+      - name: Apple Health Swift package
+        if: runner.os == 'macOS'
+        run: |
+          swift test --package-path connectors/apple-health
+          cd connectors/apple-health
+          xcodebuild -scheme PersomeAppleHealth \
+            -destination 'generic/platform=iOS' \
+            -derivedDataPath "$RUNNER_TEMP/persome-health-derived" \
+            CODE_SIGNING_ALLOWED=NO build
+
       - name: Tests (offline, mocked LLM)
         # The default offline gate: no network, no API key. Markers deselected:
         #   macos       — needs real AX permission / Swift capture helpers

--- a/connectors/apple-health/.gitignore
+++ b/connectors/apple-health/.gitignore
@@ -1,0 +1,2 @@
+.build/
+.swiftpm/

--- a/connectors/apple-health/Package.swift
+++ b/connectors/apple-health/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "PersomeAppleHealth",
+    platforms: [.iOS(.v17), .macOS(.v14)],
+    products: [
+        .library(name: "PersomeAppleHealth", targets: ["PersomeAppleHealth"]),
+    ],
+    targets: [
+        .target(name: "PersomeAppleHealth"),
+        .testTarget(name: "PersomeAppleHealthTests", dependencies: ["PersomeAppleHealth"]),
+    ]
+)

--- a/connectors/apple-health/README.md
+++ b/connectors/apple-health/README.md
@@ -1,0 +1,35 @@
+# Persome Apple Health Connector
+
+This Swift package is the iPhone-side bridge from Apple HealthKit (including
+Apple Watch observations synchronized to the phone) to the owner-local Persome
+Runtime. It requests read-only access, performs anchored incremental queries,
+normalizes samples, and uploads batches to `POST /health-events/import`.
+
+## Embed in an iPhone app
+
+1. Add this directory as a local Swift package in Xcode.
+2. Enable the HealthKit capability for the app target.
+3. Add `NSHealthShareUsageDescription` to the app's `Info.plist`, explaining
+   that selected observations are sent only to the owner's local Persome Runtime.
+4. Create the connector after the user supplies the Runtime URL and local bearer
+   token, then authorize and sync:
+
+```swift
+let client = PersomeHealthClient(
+    runtimeURL: URL(string: "http://192.168.1.10:8742")!,
+    bearerToken: ownerToken
+)
+let connector = AppleHealthConnector(client: client)
+try await connector.requestAuthorization()
+let result = try await connector.sync()
+```
+
+The current Runtime defaults to loopback-only access. An iPhone cannot reach
+`127.0.0.1` on the Mac; production pairing therefore needs a separately reviewed
+LAN/TLS transport or a phone-to-Mac relay. Do not expose the owner token or an
+unencrypted health endpoint to a public network.
+
+The first slice reads steps, heart rate, resting heart rate, active energy,
+sleep analysis, and workouts. Anchors are advanced only after all batches for a
+HealthKit type have uploaded successfully, so interrupted syncs safely replay
+and rely on server-side idempotency.

--- a/connectors/apple-health/README.md
+++ b/connectors/apple-health/README.md
@@ -3,7 +3,9 @@
 This Swift package is the iPhone-side bridge from Apple HealthKit (including
 Apple Watch observations synchronized to the phone) to the owner-local Persome
 Runtime. It requests read-only access, performs anchored incremental queries,
-normalizes samples, and uploads batches to `POST /health-events/import`.
+normalizes samples, and uploads bounded change pages through a
+`HealthEventUploader`. Each page contains additions/corrections and HealthKit
+deletion receipts; its anchor is persisted only after the entire page succeeds.
 
 ## Embed in an iPhone app
 
@@ -11,25 +13,20 @@ normalizes samples, and uploads batches to `POST /health-events/import`.
 2. Enable the HealthKit capability for the app target.
 3. Add `NSHealthShareUsageDescription` to the app's `Info.plist`, explaining
    that selected observations are sent only to the owner's local Persome Runtime.
-4. Create the connector after the user supplies the Runtime URL and local bearer
-   token, then authorize and sync:
+4. Create the connector with an uploader implemented by the host app, then
+   authorize and sync:
 
 ```swift
-let client = PersomeHealthClient(
-    runtimeURL: URL(string: "http://192.168.1.10:8742")!,
-    bearerToken: ownerToken
-)
-let connector = AppleHealthConnector(client: client)
+let connector = AppleHealthConnector(client: secureRelayClient)
 try await connector.requestAuthorization()
 let result = try await connector.sync()
 ```
 
-The current Runtime defaults to loopback-only access. An iPhone cannot reach
-`127.0.0.1` on the Mac; production pairing therefore needs a separately reviewed
-LAN/TLS transport or a phone-to-Mac relay. Do not expose the owner token or an
-unencrypted health endpoint to a public network.
+The Runtime is loopback-only. `PersomeHealthClient` therefore accepts only
+`localhost`, `127.0.0.1`, or `::1` and is intended for the Mac relay and tests.
+Never place the owner bearer on the phone or expose the Runtime over LAN.
 
 The first slice reads steps, heart rate, resting heart rate, active energy,
-sleep analysis, and workouts. Anchors are advanced only after all batches for a
-HealthKit type have uploaded successfully, so interrupted syncs safely replay
-and rely on server-side idempotency.
+sleep analysis, and workouts. Anchored queries use 500-operation pages rather
+than materializing an unlimited history. Interrupted syncs safely replay the
+last unacknowledged page and rely on server-side idempotency.

--- a/connectors/apple-health/Sources/PersomeAppleHealth/AppleHealthConnector.swift
+++ b/connectors/apple-health/Sources/PersomeAppleHealth/AppleHealthConnector.swift
@@ -97,7 +97,9 @@ public final class AppleHealthConnector {
         let quantityIDs: [HKQuantityTypeIdentifier] = [
             .stepCount, .heartRate, .restingHeartRate, .activeEnergyBurned,
         ]
-        var types = quantityIDs.compactMap(HKObjectType.quantityType(forIdentifier:))
+        var types: [HKSampleType] = quantityIDs.compactMap(
+            HKObjectType.quantityType(forIdentifier:)
+        )
         if let sleep = HKObjectType.categoryType(forIdentifier: .sleepAnalysis) { types.append(sleep) }
         types.append(HKObjectType.workoutType())
         return types

--- a/connectors/apple-health/Sources/PersomeAppleHealth/AppleHealthConnector.swift
+++ b/connectors/apple-health/Sources/PersomeAppleHealth/AppleHealthConnector.swift
@@ -1,0 +1,151 @@
+#if canImport(HealthKit) && os(iOS)
+import Foundation
+import HealthKit
+
+@MainActor
+public final class AppleHealthConnector {
+    private let store: HKHealthStore
+    private let client: PersomeHealthClient
+    private let anchors: UserDefaults
+
+    public init(
+        client: PersomeHealthClient,
+        store: HKHealthStore = HKHealthStore(),
+        anchors: UserDefaults = .standard
+    ) {
+        self.client = client
+        self.store = store
+        self.anchors = anchors
+    }
+
+    public func requestAuthorization() async throws {
+        guard HKHealthStore.isHealthDataAvailable() else { throw ConnectorError.unavailable }
+        try await store.requestAuthorization(toShare: [], read: Set(Self.readTypes))
+    }
+
+    public func sync() async throws -> HealthImportResult {
+        var totals = HealthImportResult(schemaVersion: 1, received: 0, inserted: 0, duplicates: 0)
+        for type in Self.readTypes {
+            let (samples, newAnchor) = try await anchoredSamples(for: type)
+            let events = samples.compactMap(Self.normalize)
+            for batch in events.chunked(maxCount: 500) {
+                let result = try await client.upload(batch)
+                totals = totals.adding(result)
+            }
+            save(newAnchor, for: type)
+        }
+        return totals
+    }
+
+    private func anchoredSamples(for type: HKSampleType) async throws -> ([HKSample], HKQueryAnchor?) {
+        try await withCheckedThrowingContinuation { continuation in
+            let query = HKAnchoredObjectQuery(
+                type: type,
+                predicate: nil,
+                anchor: anchor(for: type),
+                limit: HKObjectQueryNoLimit
+            ) { _, samples, _, newAnchor, error in
+                if let error { continuation.resume(throwing: error) }
+                else { continuation.resume(returning: (samples ?? [], newAnchor)) }
+            }
+            store.execute(query)
+        }
+    }
+
+    private func anchor(for type: HKSampleType) -> HKQueryAnchor? {
+        guard let data = anchors.data(forKey: "persome.health.anchor.\(type.identifier)") else {
+            return nil
+        }
+        return try? NSKeyedUnarchiver.unarchivedObject(ofClass: HKQueryAnchor.self, from: data)
+    }
+
+    private func save(_ anchor: HKQueryAnchor?, for type: HKSampleType) {
+        guard let anchor, let data = try? NSKeyedArchiver.archivedData(
+            withRootObject: anchor, requiringSecureCoding: true
+        ) else { return }
+        anchors.set(data, forKey: "persome.health.anchor.\(type.identifier)")
+    }
+
+    private static let readTypes: [HKSampleType] = {
+        let quantityIDs: [HKQuantityTypeIdentifier] = [
+            .stepCount, .heartRate, .restingHeartRate, .activeEnergyBurned,
+        ]
+        var types = quantityIDs.compactMap(HKObjectType.quantityType(forIdentifier:))
+        if let sleep = HKObjectType.categoryType(forIdentifier: .sleepAnalysis) { types.append(sleep) }
+        types.append(HKObjectType.workoutType())
+        return types
+    }()
+
+    private static func normalize(_ sample: HKSample) -> HealthEvent? {
+        let device = sample.device
+        let source = HealthEventSource(
+            device: device?.name ?? device?.model,
+            deviceID: device?.localIdentifier
+        )
+        let base = (
+            id: sample.uuid.uuidString,
+            source: source,
+            start: sample.startDate,
+            end: sample.endDate,
+            timezone: TimeZone.current.identifier,
+            metadata: ["healthkit_type": sample.sampleType.identifier]
+        )
+
+        if let quantity = sample as? HKQuantitySample,
+           let mapping = quantityMapping[quantity.quantityType.identifier] {
+            return HealthEvent(
+                eventID: base.id, source: base.source, metric: mapping.metric,
+                value: .number(quantity.quantity.doubleValue(for: mapping.unit)),
+                unit: mapping.label, startedAt: base.start, endedAt: base.end,
+                timezone: base.timezone, metadata: base.metadata
+            )
+        }
+        if let sleep = sample as? HKCategorySample {
+            return HealthEvent(
+                eventID: base.id, source: base.source, metric: "sleep_stage",
+                value: .text(String(sleep.value)), unit: "category",
+                startedAt: base.start, endedAt: base.end,
+                timezone: base.timezone, metadata: base.metadata
+            )
+        }
+        if let workout = sample as? HKWorkout {
+            return HealthEvent(
+                eventID: base.id, source: base.source, metric: "workout",
+                value: .text(String(workout.workoutActivityType.rawValue)), unit: "activity_type",
+                startedAt: base.start, endedAt: base.end,
+                timezone: base.timezone,
+                metadata: base.metadata.merging(["duration_seconds": String(workout.duration)]) { a, _ in a }
+            )
+        }
+        return nil
+    }
+
+    private static let quantityMapping: [String: (metric: String, unit: HKUnit, label: String)] = [
+        HKQuantityTypeIdentifier.stepCount.rawValue: ("step_count", .count(), "count"),
+        HKQuantityTypeIdentifier.heartRate.rawValue: ("heart_rate", .count().unitDivided(by: .minute()), "bpm"),
+        HKQuantityTypeIdentifier.restingHeartRate.rawValue: ("resting_heart_rate", .count().unitDivided(by: .minute()), "bpm"),
+        HKQuantityTypeIdentifier.activeEnergyBurned.rawValue: ("active_energy", .kilocalorie(), "kcal"),
+    ]
+}
+
+public enum ConnectorError: Error { case unavailable }
+
+private extension Array {
+    func chunked(maxCount: Int) -> [[Element]] {
+        stride(from: 0, to: count, by: maxCount).map {
+            Array(self[$0 ..< Swift.min($0 + maxCount, count)])
+        }
+    }
+}
+
+private extension HealthImportResult {
+    func adding(_ other: Self) -> Self {
+        Self(
+            schemaVersion: schemaVersion,
+            received: received + other.received,
+            inserted: inserted + other.inserted,
+            duplicates: duplicates + other.duplicates
+        )
+    }
+}
+#endif

--- a/connectors/apple-health/Sources/PersomeAppleHealth/AppleHealthConnector.swift
+++ b/connectors/apple-health/Sources/PersomeAppleHealth/AppleHealthConnector.swift
@@ -4,12 +4,13 @@ import HealthKit
 
 @MainActor
 public final class AppleHealthConnector {
+    private static let pageSize = 500
     private let store: HKHealthStore
-    private let client: PersomeHealthClient
+    private let client: any HealthEventUploader
     private let anchors: UserDefaults
 
     public init(
-        client: PersomeHealthClient,
+        client: any HealthEventUploader,
         store: HKHealthStore = HKHealthStore(),
         anchors: UserDefaults = .standard
     ) {
@@ -24,29 +25,55 @@ public final class AppleHealthConnector {
     }
 
     public func sync() async throws -> HealthImportResult {
-        var totals = HealthImportResult(schemaVersion: 1, received: 0, inserted: 0, duplicates: 0)
+        var totals = HealthImportResult.zero
         for type in Self.readTypes {
-            let (samples, newAnchor) = try await anchoredSamples(for: type)
-            let events = samples.compactMap(Self.normalize)
-            for batch in events.chunked(maxCount: 500) {
-                let result = try await client.upload(batch)
-                totals = totals.adding(result)
-            }
-            save(newAnchor, for: type)
+            let result = try await synchronizeAnchoredHealthPages(
+                initialAnchor: anchor(for: type),
+                fetch: { [store] anchor in
+                    let page = try await Self.anchoredPage(
+                        store: store,
+                        type: type,
+                        anchor: anchor
+                    )
+                    return AnchoredHealthPage(
+                        events: page.samples.compactMap(Self.normalize),
+                        deletedEvents: page.deleted.map {
+                            HealthEventDeletion(eventID: $0.uuid.uuidString)
+                        },
+                        nextAnchor: page.nextAnchor,
+                        hasMore: page.samples.count + page.deleted.count >= Self.pageSize
+                    )
+                },
+                upload: { [client] events, deletedEvents in
+                    try await client.upload(events: events, deletedEvents: deletedEvents)
+                },
+                persist: { [weak self] anchor in self?.save(anchor, for: type) }
+            )
+            totals = totals.adding(result)
         }
         return totals
     }
 
-    private func anchoredSamples(for type: HKSampleType) async throws -> ([HKSample], HKQueryAnchor?) {
+    private static func anchoredPage(
+        store: HKHealthStore,
+        type: HKSampleType,
+        anchor: HKQueryAnchor?
+    ) async throws -> (
+        samples: [HKSample],
+        deleted: [HKDeletedObject],
+        nextAnchor: HKQueryAnchor?
+    ) {
         try await withCheckedThrowingContinuation { continuation in
             let query = HKAnchoredObjectQuery(
                 type: type,
                 predicate: nil,
-                anchor: anchor(for: type),
-                limit: HKObjectQueryNoLimit
-            ) { _, samples, _, newAnchor, error in
+                anchor: anchor,
+                limit: pageSize
+            ) { _, samples, deleted, newAnchor, error in
                 if let error { continuation.resume(throwing: error) }
-                else { continuation.resume(returning: (samples ?? [], newAnchor)) }
+                else {
+                    continuation.resume(returning: (samples ?? [], deleted ?? [], newAnchor))
+                }
             }
             store.execute(query)
         }
@@ -129,23 +156,4 @@ public final class AppleHealthConnector {
 }
 
 public enum ConnectorError: Error { case unavailable }
-
-private extension Array {
-    func chunked(maxCount: Int) -> [[Element]] {
-        stride(from: 0, to: count, by: maxCount).map {
-            Array(self[$0 ..< Swift.min($0 + maxCount, count)])
-        }
-    }
-}
-
-private extension HealthImportResult {
-    func adding(_ other: Self) -> Self {
-        Self(
-            schemaVersion: schemaVersion,
-            received: received + other.received,
-            inserted: inserted + other.inserted,
-            duplicates: duplicates + other.duplicates
-        )
-    }
-}
 #endif

--- a/connectors/apple-health/Sources/PersomeAppleHealth/HealthEvent.swift
+++ b/connectors/apple-health/Sources/PersomeAppleHealth/HealthEvent.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+public struct HealthEventSource: Codable, Sendable, Equatable {
+    public let provider: String
+    public let device: String?
+    public let deviceID: String?
+
+    enum CodingKeys: String, CodingKey {
+        case provider, device
+        case deviceID = "device_id"
+    }
+
+    public init(provider: String = "apple_health", device: String?, deviceID: String?) {
+        self.provider = provider
+        self.device = device
+        self.deviceID = deviceID
+    }
+}
+
+public struct HealthEvent: Codable, Sendable, Equatable {
+    public let eventID: String
+    public let source: HealthEventSource
+    public let metric: String
+    public let value: HealthValue
+    public let unit: String
+    public let startedAt: Date
+    public let endedAt: Date?
+    public let timezone: String
+    public let metadata: [String: String]
+
+    enum CodingKeys: String, CodingKey {
+        case source, metric, value, unit, timezone, metadata
+        case eventID = "event_id"
+        case startedAt = "started_at"
+        case endedAt = "ended_at"
+    }
+}
+
+public enum HealthValue: Codable, Sendable, Equatable {
+    case number(Double)
+    case text(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let number = try? container.decode(Double.self) {
+            self = .number(number)
+        } else {
+            self = .text(try container.decode(String.self))
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case let .number(number): try container.encode(number)
+        case let .text(text): try container.encode(text)
+        }
+    }
+}
+
+public struct HealthEventsImport: Codable, Sendable {
+    public let schemaVersion = 1
+    public let events: [HealthEvent]
+
+    enum CodingKeys: String, CodingKey {
+        case events
+        case schemaVersion = "schema_version"
+    }
+
+    public init(events: [HealthEvent]) {
+        self.events = events
+    }
+}
+
+public struct HealthImportResult: Codable, Sendable, Equatable {
+    public let schemaVersion: Int
+    public let received: Int
+    public let inserted: Int
+    public let duplicates: Int
+
+    enum CodingKeys: String, CodingKey {
+        case received, inserted, duplicates
+        case schemaVersion = "schema_version"
+    }
+}
+
+struct APIEnvelope<Value: Codable & Sendable>: Codable, Sendable {
+    let success: Bool
+    let data: Value
+}
+
+extension JSONEncoder {
+    static var persome: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+}

--- a/connectors/apple-health/Sources/PersomeAppleHealth/HealthEvent.swift
+++ b/connectors/apple-health/Sources/PersomeAppleHealth/HealthEvent.swift
@@ -36,6 +36,21 @@ public struct HealthEvent: Codable, Sendable, Equatable {
     }
 }
 
+public struct HealthEventDeletion: Codable, Sendable, Equatable {
+    public let eventID: String
+    public let provider: String
+
+    enum CodingKeys: String, CodingKey {
+        case provider
+        case eventID = "event_id"
+    }
+
+    public init(eventID: String, provider: String = "apple_health") {
+        self.eventID = eventID
+        self.provider = provider
+    }
+}
+
 public enum HealthValue: Codable, Sendable, Equatable {
     case number(Double)
     case text(String)
@@ -61,14 +76,17 @@ public enum HealthValue: Codable, Sendable, Equatable {
 public struct HealthEventsImport: Codable, Sendable {
     public let schemaVersion = 1
     public let events: [HealthEvent]
+    public let deletedEvents: [HealthEventDeletion]
 
     enum CodingKeys: String, CodingKey {
         case events
+        case deletedEvents = "deleted_events"
         case schemaVersion = "schema_version"
     }
 
-    public init(events: [HealthEvent]) {
+    public init(events: [HealthEvent], deletedEvents: [HealthEventDeletion] = []) {
         self.events = events
+        self.deletedEvents = deletedEvents
     }
 }
 
@@ -76,11 +94,29 @@ public struct HealthImportResult: Codable, Sendable, Equatable {
     public let schemaVersion: Int
     public let received: Int
     public let inserted: Int
+    public let corrected: Int
     public let duplicates: Int
+    public let deleted: Int
 
     enum CodingKeys: String, CodingKey {
-        case received, inserted, duplicates
+        case received, inserted, corrected, duplicates, deleted
         case schemaVersion = "schema_version"
+    }
+
+    public init(
+        schemaVersion: Int,
+        received: Int,
+        inserted: Int,
+        corrected: Int,
+        duplicates: Int,
+        deleted: Int
+    ) {
+        self.schemaVersion = schemaVersion
+        self.received = received
+        self.inserted = inserted
+        self.corrected = corrected
+        self.duplicates = duplicates
+        self.deleted = deleted
     }
 }
 

--- a/connectors/apple-health/Sources/PersomeAppleHealth/HealthSync.swift
+++ b/connectors/apple-health/Sources/PersomeAppleHealth/HealthSync.swift
@@ -7,6 +7,10 @@ struct AnchoredHealthPage<Anchor> {
     let hasMore: Bool
 }
 
+enum HealthSyncError: Error {
+    case missingPaginationAnchor
+}
+
 @MainActor
 func synchronizeAnchoredHealthPages<Anchor>(
     initialAnchor: Anchor?,
@@ -19,6 +23,9 @@ func synchronizeAnchoredHealthPages<Anchor>(
 
     while true {
         let page = try await fetch(anchor)
+        if page.hasMore, page.nextAnchor == nil {
+            throw HealthSyncError.missingPaginationAnchor
+        }
         if !page.events.isEmpty || !page.deletedEvents.isEmpty {
             let result = try await upload(page.events, page.deletedEvents)
             totals = totals.adding(result)

--- a/connectors/apple-health/Sources/PersomeAppleHealth/HealthSync.swift
+++ b/connectors/apple-health/Sources/PersomeAppleHealth/HealthSync.swift
@@ -7,11 +7,12 @@ struct AnchoredHealthPage<Anchor> {
     let hasMore: Bool
 }
 
+@MainActor
 func synchronizeAnchoredHealthPages<Anchor>(
     initialAnchor: Anchor?,
-    fetch: (Anchor?) async throws -> AnchoredHealthPage<Anchor>,
-    upload: ([HealthEvent], [HealthEventDeletion]) async throws -> HealthImportResult,
-    persist: (Anchor?) throws -> Void
+    fetch: @MainActor (Anchor?) async throws -> AnchoredHealthPage<Anchor>,
+    upload: @MainActor ([HealthEvent], [HealthEventDeletion]) async throws -> HealthImportResult,
+    persist: @MainActor (Anchor?) throws -> Void
 ) async throws -> HealthImportResult {
     var anchor = initialAnchor
     var totals = HealthImportResult.zero

--- a/connectors/apple-health/Sources/PersomeAppleHealth/HealthSync.swift
+++ b/connectors/apple-health/Sources/PersomeAppleHealth/HealthSync.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+struct AnchoredHealthPage<Anchor> {
+    let events: [HealthEvent]
+    let deletedEvents: [HealthEventDeletion]
+    let nextAnchor: Anchor?
+    let hasMore: Bool
+}
+
+func synchronizeAnchoredHealthPages<Anchor>(
+    initialAnchor: Anchor?,
+    fetch: (Anchor?) async throws -> AnchoredHealthPage<Anchor>,
+    upload: ([HealthEvent], [HealthEventDeletion]) async throws -> HealthImportResult,
+    persist: (Anchor?) throws -> Void
+) async throws -> HealthImportResult {
+    var anchor = initialAnchor
+    var totals = HealthImportResult.zero
+
+    while true {
+        let page = try await fetch(anchor)
+        if !page.events.isEmpty || !page.deletedEvents.isEmpty {
+            let result = try await upload(page.events, page.deletedEvents)
+            totals = totals.adding(result)
+        }
+        try persist(page.nextAnchor)
+        anchor = page.nextAnchor
+        if !page.hasMore { return totals }
+    }
+}
+
+extension HealthImportResult {
+    static let zero = Self(
+        schemaVersion: 1,
+        received: 0,
+        inserted: 0,
+        corrected: 0,
+        duplicates: 0,
+        deleted: 0
+    )
+
+    func adding(_ other: Self) -> Self {
+        Self(
+            schemaVersion: schemaVersion,
+            received: received + other.received,
+            inserted: inserted + other.inserted,
+            corrected: corrected + other.corrected,
+            duplicates: duplicates + other.duplicates,
+            deleted: deleted + other.deleted
+        )
+    }
+}

--- a/connectors/apple-health/Sources/PersomeAppleHealth/PersomeHealthClient.swift
+++ b/connectors/apple-health/Sources/PersomeAppleHealth/PersomeHealthClient.swift
@@ -62,6 +62,6 @@ public actor PersomeHealthClient: HealthEventUploader {
 
     private static func isLoopback(_ host: String?) -> Bool {
         guard let host else { return false }
-        return ["127.0.0.1", "localhost", "::1"].contains(host.lowercased())
+        return ["127.0.0.1", "localhost", "::1", "[::1]"].contains(host.lowercased())
     }
 }

--- a/connectors/apple-health/Sources/PersomeAppleHealth/PersomeHealthClient.swift
+++ b/connectors/apple-health/Sources/PersomeAppleHealth/PersomeHealthClient.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+public enum PersomeHealthClientError: Error, Equatable {
+    case nonHTTPResponse
+    case rejected(status: Int, body: String)
+}
+
+public actor PersomeHealthClient {
+    private let endpoint: URL
+    private let bearerToken: String
+    private let session: URLSession
+
+    public init(runtimeURL: URL, bearerToken: String, session: URLSession = .shared) {
+        endpoint = runtimeURL.appending(path: "health-events/import")
+        self.bearerToken = bearerToken
+        self.session = session
+    }
+
+    public func upload(_ events: [HealthEvent]) async throws -> HealthImportResult {
+        precondition(!events.isEmpty && events.count <= 1_000)
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
+        request.httpBody = try JSONEncoder.persome.encode(HealthEventsImport(events: events))
+
+        let (data, response) = try await session.data(for: request)
+        guard let response = response as? HTTPURLResponse else {
+            throw PersomeHealthClientError.nonHTTPResponse
+        }
+        guard (200 ..< 300).contains(response.statusCode) else {
+            throw PersomeHealthClientError.rejected(
+                status: response.statusCode,
+                body: String(decoding: data.prefix(2_048), as: UTF8.self)
+            )
+        }
+        return try JSONDecoder().decode(APIEnvelope<HealthImportResult>.self, from: data).data
+    }
+}

--- a/connectors/apple-health/Sources/PersomeAppleHealth/PersomeHealthClient.swift
+++ b/connectors/apple-health/Sources/PersomeAppleHealth/PersomeHealthClient.swift
@@ -1,28 +1,51 @@
 import Foundation
 
 public enum PersomeHealthClientError: Error, Equatable {
+    case nonLoopbackRuntime
     case nonHTTPResponse
     case rejected(status: Int, body: String)
 }
 
-public actor PersomeHealthClient {
+public protocol HealthEventUploader: Sendable {
+    func upload(
+        events: [HealthEvent],
+        deletedEvents: [HealthEventDeletion]
+    ) async throws -> HealthImportResult
+}
+
+public extension HealthEventUploader {
+    func upload(_ events: [HealthEvent]) async throws -> HealthImportResult {
+        try await upload(events: events, deletedEvents: [])
+    }
+}
+
+public actor PersomeHealthClient: HealthEventUploader {
     private let endpoint: URL
     private let bearerToken: String
     private let session: URLSession
 
-    public init(runtimeURL: URL, bearerToken: String, session: URLSession = .shared) {
+    public init(runtimeURL: URL, bearerToken: String, session: URLSession = .shared) throws {
+        guard Self.isLoopback(runtimeURL.host) else {
+            throw PersomeHealthClientError.nonLoopbackRuntime
+        }
         endpoint = runtimeURL.appending(path: "health-events/import")
         self.bearerToken = bearerToken
         self.session = session
     }
 
-    public func upload(_ events: [HealthEvent]) async throws -> HealthImportResult {
-        precondition(!events.isEmpty && events.count <= 1_000)
+    public func upload(
+        events: [HealthEvent],
+        deletedEvents: [HealthEventDeletion]
+    ) async throws -> HealthImportResult {
+        precondition(!events.isEmpty || !deletedEvents.isEmpty)
+        precondition(events.count + deletedEvents.count <= 1_000)
         var request = URLRequest(url: endpoint)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
-        request.httpBody = try JSONEncoder.persome.encode(HealthEventsImport(events: events))
+        request.httpBody = try JSONEncoder.persome.encode(
+            HealthEventsImport(events: events, deletedEvents: deletedEvents)
+        )
 
         let (data, response) = try await session.data(for: request)
         guard let response = response as? HTTPURLResponse else {
@@ -35,5 +58,10 @@ public actor PersomeHealthClient {
             )
         }
         return try JSONDecoder().decode(APIEnvelope<HealthImportResult>.self, from: data).data
+    }
+
+    private static func isLoopback(_ host: String?) -> Bool {
+        guard let host else { return false }
+        return ["127.0.0.1", "localhost", "::1"].contains(host.lowercased())
     }
 }

--- a/connectors/apple-health/Tests/PersomeAppleHealthTests/HealthEventTests.swift
+++ b/connectors/apple-health/Tests/PersomeAppleHealthTests/HealthEventTests.swift
@@ -99,3 +99,28 @@ import Testing
     }
     #expect(!persisted)
 }
+
+@Test func refusesToLoopWhenAFullPageHasNoNextAnchor() async {
+    await #expect(throws: HealthSyncError.missingPaginationAnchor) {
+        _ = try await synchronizeAnchoredHealthPages(
+            initialAnchor: nil as String?,
+            fetch: { _ in
+                AnchoredHealthPage(
+                    events: [],
+                    deletedEvents: [HealthEventDeletion(eventID: "deleted-1")],
+                    nextAnchor: nil,
+                    hasMore: true
+                )
+            },
+            upload: { _, _ in .zero },
+            persist: { _ in }
+        )
+    }
+}
+
+@Test func directRuntimeClientAcceptsIPv6Loopback() throws {
+    _ = try PersomeHealthClient(
+        runtimeURL: try #require(URL(string: "http://[::1]:8742")),
+        bearerToken: "test-token"
+    )
+}

--- a/connectors/apple-health/Tests/PersomeAppleHealthTests/HealthEventTests.swift
+++ b/connectors/apple-health/Tests/PersomeAppleHealthTests/HealthEventTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Testing
+@testable import PersomeAppleHealth
+
+@Test func encodesPersomeContract() throws {
+    let event = HealthEvent(
+        eventID: "sample-1",
+        source: HealthEventSource(device: "Apple Watch", deviceID: "local-watch"),
+        metric: "heart_rate",
+        value: .number(72),
+        unit: "bpm",
+        startedAt: try #require(ISO8601DateFormatter().date(from: "2026-07-15T01:30:00Z")),
+        endedAt: nil,
+        timezone: "Asia/Shanghai",
+        metadata: [:]
+    )
+    let data = try JSONEncoder.persome.encode(HealthEventsImport(events: [event]))
+    let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    let events = try #require(object["events"] as? [[String: Any]])
+
+    #expect(object["schema_version"] as? Int == 1)
+    #expect(events[0]["event_id"] as? String == "sample-1")
+    #expect(events[0]["metric"] as? String == "heart_rate")
+    #expect(events[0]["value"] as? Double == 72)
+}

--- a/connectors/apple-health/Tests/PersomeAppleHealthTests/HealthEventTests.swift
+++ b/connectors/apple-health/Tests/PersomeAppleHealthTests/HealthEventTests.swift
@@ -14,7 +14,12 @@ import Testing
         timezone: "Asia/Shanghai",
         metadata: [:]
     )
-    let data = try JSONEncoder.persome.encode(HealthEventsImport(events: [event]))
+    let data = try JSONEncoder.persome.encode(
+        HealthEventsImport(
+            events: [event],
+            deletedEvents: [HealthEventDeletion(eventID: "deleted-1")]
+        )
+    )
     let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
     let events = try #require(object["events"] as? [[String: Any]])
 
@@ -22,4 +27,75 @@ import Testing
     #expect(events[0]["event_id"] as? String == "sample-1")
     #expect(events[0]["metric"] as? String == "heart_rate")
     #expect(events[0]["value"] as? Double == 72)
+    let deletedEvents = try #require(object["deleted_events"] as? [[String: Any]])
+    #expect(deletedEvents[0]["event_id"] as? String == "deleted-1")
+    #expect(deletedEvents[0]["provider"] as? String == "apple_health")
+}
+
+@Test func aggregatesCorrectionsAndDeletionsAcrossBoundedPages() async throws {
+    let result = HealthImportResult(
+        schemaVersion: 1,
+        received: 1,
+        inserted: 0,
+        corrected: 1,
+        duplicates: 0,
+        deleted: 1
+    )
+    var fetchedAnchors: [String?] = []
+    var persistedAnchors: [String?] = []
+    var uploadCount = 0
+
+    let totals = try await synchronizeAnchoredHealthPages(
+        initialAnchor: nil as String?,
+        fetch: { anchor in
+            fetchedAnchors.append(anchor)
+            if anchor == nil {
+                return AnchoredHealthPage(
+                    events: [],
+                    deletedEvents: [HealthEventDeletion(eventID: "deleted-1")],
+                    nextAnchor: "page-1",
+                    hasMore: true
+                )
+            }
+            return AnchoredHealthPage(
+                events: [],
+                deletedEvents: [HealthEventDeletion(eventID: "deleted-2")],
+                nextAnchor: "page-2",
+                hasMore: false
+            )
+        },
+        upload: { _, _ in
+            uploadCount += 1
+            return result
+        },
+        persist: { persistedAnchors.append($0) }
+    )
+
+    #expect(fetchedAnchors.count == 2)
+    #expect(persistedAnchors == ["page-1", "page-2"])
+    #expect(uploadCount == 2)
+    #expect(totals.corrected == 2)
+    #expect(totals.deleted == 2)
+}
+
+@Test func doesNotAdvanceAnchorWhenUploadFails() async {
+    enum ExpectedFailure: Error { case upload }
+    var persisted = false
+
+    await #expect(throws: ExpectedFailure.self) {
+        _ = try await synchronizeAnchoredHealthPages(
+            initialAnchor: nil as String?,
+            fetch: { _ in
+                AnchoredHealthPage(
+                    events: [],
+                    deletedEvents: [HealthEventDeletion(eventID: "deleted-1")],
+                    nextAnchor: "page-1",
+                    hasMore: false
+                )
+            },
+            upload: { _, _ in throw ExpectedFailure.upload },
+            persist: { _ in persisted = true }
+        )
+    }
+    #expect(!persisted)
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -34,6 +34,9 @@ runtime schema.
 `POST /health-events/import` is the local connector boundary for Apple HealthKit,
 Health Connect, vendor APIs, and file/BLE adapters. Every event needs a stable
 provider `event_id`; repeated imports are accepted and counted as duplicates.
+If the same provider ID arrives with changed normalized content, it corrects the
+existing observation and is counted as `corrected`; an identical replay remains
+a `duplicate`.
 Times must be ISO 8601 values with an explicit offset. The Runtime stores raw
 normalized observations and provenance locally; it does not treat consumer
 device measurements as medical diagnoses.

--- a/docs/api.md
+++ b/docs/api.md
@@ -23,10 +23,20 @@ runtime schema.
 | GET | `/permissions` | macOS Accessibility and Screen Recording state. |
 | GET | `/status` | Daemon, capture, OCR, session, memory, and provider status. |
 | POST | `/captures/ingest` | Ingest one bearer-authenticated capture from a trusted local producer. |
+| POST | `/health-events/import` | Import up to 1,000 normalized wearable/health events from a trusted local connector. |
 | GET | `/model` | Open the offline Point/Line/Face/Volume/Root explorer. |
 | GET | `/model/graph` | Read the canonical versioned model snapshot. |
 | GET | `/model/evidence?ref=...` | Resolve a model ID or receipt into direct sources and separately labeled nearby context. |
 | GET | `/model/node?id=...` | Resolve a snapshot Point ID or relation endpoint to receipts and its relation tree. |
+
+### Wearable and health event import
+
+`POST /health-events/import` is the local connector boundary for Apple HealthKit,
+Health Connect, vendor APIs, and file/BLE adapters. Every event needs a stable
+provider `event_id`; repeated imports are accepted and counted as duplicates.
+Times must be ISO 8601 values with an explicit offset. The Runtime stores raw
+normalized observations and provenance locally; it does not treat consumer
+device measurements as medical diagnoses.
 
 The model page renders snapshot Points and Lines directly, then derives the
 Face, Volume, and Root hierarchy from their declared `members`. It loads its

--- a/docs/api.md
+++ b/docs/api.md
@@ -23,7 +23,7 @@ runtime schema.
 | GET | `/permissions` | macOS Accessibility and Screen Recording state. |
 | GET | `/status` | Daemon, capture, OCR, session, memory, and provider status. |
 | POST | `/captures/ingest` | Ingest one bearer-authenticated capture from a trusted local producer. |
-| POST | `/health-events/import` | Import up to 1,000 normalized wearable/health events from a trusted local connector. |
+| POST | `/health-events/import` | Atomically import up to 1,000 normalized wearable/health changes from a trusted local connector. |
 | GET | `/model` | Open the offline Point/Line/Face/Volume/Root explorer. |
 | GET | `/model/graph` | Read the canonical versioned model snapshot. |
 | GET | `/model/evidence?ref=...` | Resolve a model ID or receipt into direct sources and separately labeled nearby context. |
@@ -36,10 +36,17 @@ Health Connect, vendor APIs, and file/BLE adapters. Every event needs a stable
 provider `event_id`; repeated imports are accepted and counted as duplicates.
 If the same provider ID arrives with changed normalized content, it corrects the
 existing observation and is counted as `corrected`; an identical replay remains
-a `duplicate`.
+a `duplicate`. `deleted_events` contains provider-scoped IDs removed by an
+anchored source query. Deletions and new/corrected events commit in one SQLite
+transaction, so a connector can persist its next source anchor only after this
+request succeeds without leaving stale observations behind.
 Times must be ISO 8601 values with an explicit offset. The Runtime stores raw
 normalized observations and provenance locally; it does not treat consumer
 device measurements as medical diagnoses.
+
+The route has a 2 MiB HTTP and semantic payload ceiling, a combined 1,000-change
+limit, 4 KiB UTF-8 string-value limit, and 64 KiB metadata limit per event.
+NaN and infinities are rejected before FastAPI validation can echo invalid JSON.
 
 The model page renders snapshot Points and Lines directly, then derives the
 Face, Volume, and Root hierarchy from their declared `members`. It loads its

--- a/docs/db-schema.sql
+++ b/docs/db-schema.sql
@@ -228,6 +228,31 @@ CREATE TABLE memory_contradictions (
     resolved_at TEXT
 );
 
+-- ---- store/health_events.py ----
+
+CREATE TABLE health_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    provider TEXT NOT NULL,
+    external_id TEXT NOT NULL,
+    metric TEXT NOT NULL,
+    value_json TEXT NOT NULL,
+    unit TEXT NOT NULL,
+    started_at TEXT NOT NULL,
+    ended_at TEXT,
+    timezone TEXT,
+    device TEXT,
+    device_id TEXT,
+    metadata_json TEXT NOT NULL,
+    imported_at TEXT NOT NULL,
+    UNIQUE(provider, external_id)
+);
+
+CREATE INDEX idx_health_events_metric_time
+    ON health_events(metric, started_at DESC);
+
+CREATE INDEX idx_health_events_provider_time
+    ON health_events(provider, started_at DESC);
+
 -- ---- store/memory_deltas.py ----
 
 CREATE TABLE memory_deltas (

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -81,6 +81,15 @@ is degraded or stale, its JSON payload carries an `index_health` object
 capture index raises an actionable tool error rather than returning silently
 partial results.
 
+## Wearable tools
+
+| Tool | Purpose |
+|---|---|
+| `query_health_metrics` | Query owner-authorized wearable observations by metric, provider, time range, and limit. |
+
+Wearable results are raw consumer-device observations with source and import
+timestamps. Clients must not present them as medical diagnoses.
+
 `resolve_evidence` returns explicit stored lineage in `sources` and
 time-adjacent capture clues in `context`. Consumers must not present `context`
 as direct proof. Display `label` as the human-readable card title and keep

--- a/openapi.json
+++ b/openapi.json
@@ -182,6 +182,48 @@
         }
       }
     },
+    "/health-events/import": {
+      "post": {
+        "tags": [
+          "health"
+        ],
+        "summary": "Import Health Events",
+        "description": "Import a normalized, idempotent batch from a trusted local connector.",
+        "operationId": "import_health_events_health_events_import_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HealthEventsImportBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/model": {
       "get": {
         "tags": [
@@ -498,6 +540,153 @@
         },
         "type": "object",
         "title": "HTTPValidationError"
+      },
+      "HealthEvent": {
+        "properties": {
+          "event_id": {
+            "type": "string",
+            "maxLength": 512,
+            "minLength": 1,
+            "title": "Event Id"
+          },
+          "source": {
+            "$ref": "#/components/schemas/HealthEventSource"
+          },
+          "metric": {
+            "type": "string",
+            "maxLength": 96,
+            "minLength": 1,
+            "pattern": "^[a-z][a-z0-9_.-]*$",
+            "title": "Metric"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Value"
+          },
+          "unit": {
+            "type": "string",
+            "maxLength": 32,
+            "title": "Unit",
+            "default": ""
+          },
+          "started_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Started At"
+          },
+          "ended_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ended At"
+          },
+          "timezone": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 64
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Timezone"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Metadata"
+          }
+        },
+        "type": "object",
+        "required": [
+          "event_id",
+          "source",
+          "metric",
+          "value",
+          "started_at"
+        ],
+        "title": "HealthEvent",
+        "description": "One normalized observation produced by HealthKit or another connector."
+      },
+      "HealthEventSource": {
+        "properties": {
+          "provider": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "pattern": "^[a-z0-9][a-z0-9_-]*$",
+            "title": "Provider"
+          },
+          "device": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 160
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Device"
+          },
+          "device_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 256
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Device Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "provider"
+        ],
+        "title": "HealthEventSource",
+        "description": "Device/provider identity attached to a health event."
+      },
+      "HealthEventsImportBody": {
+        "properties": {
+          "schema_version": {
+            "type": "integer",
+            "const": 1,
+            "title": "Schema Version",
+            "default": 1
+          },
+          "events": {
+            "items": {
+              "$ref": "#/components/schemas/HealthEvent"
+            },
+            "type": "array",
+            "maxItems": 1000,
+            "minItems": 1,
+            "title": "Events"
+          }
+        },
+        "type": "object",
+        "required": [
+          "events"
+        ],
+        "title": "HealthEventsImportBody",
+        "description": "Bounded batch of normalized health events."
       },
       "ValidationError": {
         "properties": {

--- a/openapi.json
+++ b/openapi.json
@@ -622,6 +622,30 @@
         "title": "HealthEvent",
         "description": "One normalized observation produced by HealthKit or another connector."
       },
+      "HealthEventDeletion": {
+        "properties": {
+          "event_id": {
+            "type": "string",
+            "maxLength": 512,
+            "minLength": 1,
+            "title": "Event Id"
+          },
+          "provider": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "pattern": "^[a-z0-9][a-z0-9_-]*$",
+            "title": "Provider"
+          }
+        },
+        "type": "object",
+        "required": [
+          "event_id",
+          "provider"
+        ],
+        "title": "HealthEventDeletion",
+        "description": "Provider-scoped deletion receipt emitted by an anchored source query."
+      },
       "HealthEventSource": {
         "properties": {
           "provider": {
@@ -677,16 +701,20 @@
             },
             "type": "array",
             "maxItems": 1000,
-            "minItems": 1,
             "title": "Events"
+          },
+          "deleted_events": {
+            "items": {
+              "$ref": "#/components/schemas/HealthEventDeletion"
+            },
+            "type": "array",
+            "maxItems": 1000,
+            "title": "Deleted Events"
           }
         },
         "type": "object",
-        "required": [
-          "events"
-        ],
         "title": "HealthEventsImportBody",
-        "description": "Bounded batch of normalized health events."
+        "description": "Bounded atomic batch of normalized health changes."
       },
       "ValidationError": {
         "properties": {

--- a/src/persome/api/__init__.py
+++ b/src/persome/api/__init__.py
@@ -22,6 +22,7 @@ from ..config import Config
 from ..logger import get as _get_logger
 from ..security.auth import LocalAPIAuthMiddleware
 from ..security.body_limit import (
+    HEALTH_IMPORT_MAX_REQUEST_BODY_BYTES,
     RequestBodyLimitMiddleware,
     RequestConcurrencyLimitMiddleware,
 )
@@ -226,7 +227,11 @@ def build_api_app(cfg: Config | None = None, *, auth_enabled: bool = True) -> Fa
     )
     app.add_middleware(_AccessLogMiddleware)
     app.add_middleware(_TraceIdMiddleware)
-    app.add_middleware(RequestBodyLimitMiddleware)
+    app.add_middleware(
+        RequestBodyLimitMiddleware,
+        path_limits={"/health-events/import": HEALTH_IMPORT_MAX_REQUEST_BODY_BYTES},
+        strict_json_paths=("/health-events/import",),
+    )
     app.add_middleware(RequestConcurrencyLimitMiddleware)
     if auth_enabled:
         app.add_middleware(LocalAPIAuthMiddleware)

--- a/src/persome/api/models.py
+++ b/src/persome/api/models.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
+from datetime import datetime
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -13,6 +14,8 @@ MAX_CAPTURE_JSON_BYTES = 12 * 1024 * 1024
 MAX_CAPTURE_IMAGE_B64_CHARS = 8 * 1024 * 1024
 MAX_CAPTURE_METADATA_BYTES = 128 * 1024
 MAX_CAPTURE_AX_TREE_BYTES = 8 * 1024 * 1024
+MAX_HEALTH_EVENTS_PER_REQUEST = 1000
+MAX_HEALTH_METADATA_BYTES = 64 * 1024
 
 
 def _json_size(value: Any) -> int:
@@ -108,3 +111,47 @@ class CaptureIngestBody(BaseModel):
         if _json_size(self.model_dump()) > MAX_CAPTURE_JSON_BYTES:
             raise ValueError(f"capture payload exceeds {MAX_CAPTURE_JSON_BYTES} bytes")
         return self
+
+
+class HealthEventSource(BaseModel):
+    """Device/provider identity attached to a health event."""
+
+    provider: str = Field(min_length=1, max_length=64, pattern=r"^[a-z0-9][a-z0-9_-]*$")
+    device: str | None = Field(default=None, max_length=160)
+    device_id: str | None = Field(default=None, max_length=256)
+
+
+class HealthEvent(BaseModel):
+    """One normalized observation produced by HealthKit or another connector."""
+
+    event_id: str = Field(min_length=1, max_length=512)
+    source: HealthEventSource
+    metric: str = Field(min_length=1, max_length=96, pattern=r"^[a-z][a-z0-9_.-]*$")
+    value: float | str
+    unit: str = Field(default="", max_length=32)
+    started_at: datetime
+    ended_at: datetime | None = None
+    timezone: str | None = Field(default=None, max_length=64)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _valid_event(self) -> HealthEvent:
+        if self.started_at.tzinfo is None:
+            raise ValueError("started_at must include a timezone offset")
+        if self.ended_at is not None:
+            if self.ended_at.tzinfo is None:
+                raise ValueError("ended_at must include a timezone offset")
+            if self.ended_at < self.started_at:
+                raise ValueError("ended_at must not precede started_at")
+        if isinstance(self.value, str) and not self.value.strip():
+            raise ValueError("string value must not be empty")
+        if _json_size(self.metadata) > MAX_HEALTH_METADATA_BYTES:
+            raise ValueError(f"metadata exceeds {MAX_HEALTH_METADATA_BYTES} bytes")
+        return self
+
+
+class HealthEventsImportBody(BaseModel):
+    """Bounded batch of normalized health events."""
+
+    schema_version: Literal[1] = 1
+    events: list[HealthEvent] = Field(min_length=1, max_length=MAX_HEALTH_EVENTS_PER_REQUEST)

--- a/src/persome/api/models.py
+++ b/src/persome/api/models.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import math
 from datetime import datetime
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
+
+from ..security.body_limit import HEALTH_IMPORT_MAX_REQUEST_BODY_BYTES
 
 # Capture payloads contain a rendered AX tree and, optionally, one JPEG.  The
 # native producer normally stays well below these limits.  Explicit ceilings
@@ -16,6 +19,7 @@ MAX_CAPTURE_METADATA_BYTES = 128 * 1024
 MAX_CAPTURE_AX_TREE_BYTES = 8 * 1024 * 1024
 MAX_HEALTH_EVENTS_PER_REQUEST = 1000
 MAX_HEALTH_METADATA_BYTES = 64 * 1024
+MAX_HEALTH_STRING_VALUE_BYTES = 4 * 1024
 
 
 def _json_size(value: Any) -> int:
@@ -145,13 +149,46 @@ class HealthEvent(BaseModel):
                 raise ValueError("ended_at must not precede started_at")
         if isinstance(self.value, str) and not self.value.strip():
             raise ValueError("string value must not be empty")
+        if (
+            isinstance(self.value, str)
+            and len(self.value.encode("utf-8")) > MAX_HEALTH_STRING_VALUE_BYTES
+        ):
+            raise ValueError(f"string value exceeds {MAX_HEALTH_STRING_VALUE_BYTES} bytes")
+        if isinstance(self.value, float) and not math.isfinite(self.value):
+            raise ValueError("numeric value must be finite")
         if _json_size(self.metadata) > MAX_HEALTH_METADATA_BYTES:
             raise ValueError(f"metadata exceeds {MAX_HEALTH_METADATA_BYTES} bytes")
         return self
 
 
+class HealthEventDeletion(BaseModel):
+    """Provider-scoped deletion receipt emitted by an anchored source query."""
+
+    event_id: str = Field(min_length=1, max_length=512)
+    provider: str = Field(min_length=1, max_length=64, pattern=r"^[a-z0-9][a-z0-9_-]*$")
+
+
 class HealthEventsImportBody(BaseModel):
-    """Bounded batch of normalized health events."""
+    """Bounded atomic batch of normalized health changes."""
 
     schema_version: Literal[1] = 1
-    events: list[HealthEvent] = Field(min_length=1, max_length=MAX_HEALTH_EVENTS_PER_REQUEST)
+    events: list[HealthEvent] = Field(
+        default_factory=list, max_length=MAX_HEALTH_EVENTS_PER_REQUEST
+    )
+    deleted_events: list[HealthEventDeletion] = Field(
+        default_factory=list,
+        max_length=MAX_HEALTH_EVENTS_PER_REQUEST,
+    )
+
+    @model_validator(mode="after")
+    def _bounded_batch(self) -> HealthEventsImportBody:
+        operation_count = len(self.events) + len(self.deleted_events)
+        if operation_count < 1:
+            raise ValueError("at least one event or deletion is required")
+        if operation_count > MAX_HEALTH_EVENTS_PER_REQUEST:
+            raise ValueError(f"batch exceeds {MAX_HEALTH_EVENTS_PER_REQUEST} operations")
+        if _json_size(self.model_dump(mode="json")) > HEALTH_IMPORT_MAX_REQUEST_BODY_BYTES:
+            raise ValueError(
+                f"health import payload exceeds {HEALTH_IMPORT_MAX_REQUEST_BODY_BYTES} bytes"
+            )
+        return self

--- a/src/persome/api/routes.py
+++ b/src/persome/api/routes.py
@@ -37,8 +37,8 @@ from ..security.auth import (
     consume_browser_bootstrap_nonce,
     issue_browser_bootstrap_nonce,
 )
-from ..store import fts
-from .models import ApiResponse, CaptureIngestBody, ModelPing
+from ..store import fts, health_events
+from .models import ApiResponse, CaptureIngestBody, HealthEventsImportBody, ModelPing
 
 logger = get("persome.api")
 
@@ -487,6 +487,14 @@ def ingest_capture(body: CaptureIngestBody) -> ApiResponse:
     """
     result = scheduler.ingest_capture(_get_cfg(), body.model_dump())
     return ApiResponse(data=result)
+
+
+@router.post("/health-events/import", response_model=ApiResponse, tags=["health"])
+def import_health_events(body: HealthEventsImportBody) -> ApiResponse:
+    """Import a normalized, idempotent batch from a trusted local connector."""
+    with fts.cursor() as conn:
+        result = health_events.import_events(conn, [event.model_dump() for event in body.events])
+    return ApiResponse(data={"schema_version": body.schema_version, **result})
 
 
 # ─── Personal model ───────────────────────────────────────────────────────

--- a/src/persome/api/routes.py
+++ b/src/persome/api/routes.py
@@ -493,7 +493,11 @@ def ingest_capture(body: CaptureIngestBody) -> ApiResponse:
 def import_health_events(body: HealthEventsImportBody) -> ApiResponse:
     """Import a normalized, idempotent batch from a trusted local connector."""
     with fts.cursor() as conn:
-        result = health_events.import_events(conn, [event.model_dump() for event in body.events])
+        result = health_events.import_events(
+            conn,
+            [event.model_dump() for event in body.events],
+            [deletion.model_dump() for deletion in body.deleted_events],
+        )
     return ApiResponse(data={"schema_version": body.schema_version, **result})
 
 

--- a/src/persome/mcp/server.py
+++ b/src/persome/mcp/server.py
@@ -10,6 +10,8 @@ depending on `[mcp] transport`. Exposes:
     related_events, recent_activity
   Raw captures (S1 buffer):
     current_context, search_captures, read_recent_capture
+  Wearable observations:
+    query_health_metrics
   Reference:
     get_schema
 """
@@ -31,7 +33,7 @@ from ..config import load as load_config
 from ..logger import get
 from ..prompts import load as load_prompt
 from ..store import files as files_mod
-from ..store import fts
+from ..store import fts, health_events
 from ..timeline import attention_trajectory as attention_traj
 from ..timeline import store as timeline_store
 from . import captures as captures_mod
@@ -1565,6 +1567,37 @@ def build_server(
             timeline_limit=timeline_limit,
         )
         return json.dumps(result, ensure_ascii=False)
+
+    @server.tool()
+    def query_health_metrics(
+        metric: str | None = None,
+        provider: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        limit: int = 100,
+    ) -> str:
+        """Query owner-authorized wearable and health observations.
+
+        Use for questions about imported steps, heart rate, resting heart rate,
+        active energy, sleep stages, or workouts. Results are raw device
+        observations, not medical conclusions. Filters are exact for `metric`
+        and `provider`; time bounds are ISO 8601 and form [since, until).
+        """
+        metric = bounded_optional_text("metric", metric, maximum=96)
+        provider = bounded_optional_text("provider", provider, maximum=64)
+        since = bounded_optional_text("since", since, maximum=64)
+        until = bounded_optional_text("until", until, maximum=64)
+        limit = bounded_int(limit, minimum=1, maximum=1_000)
+        with fts.cursor() as conn:
+            events = health_events.query_events(
+                conn,
+                metric=metric,
+                provider=provider,
+                since=since,
+                until=until,
+                limit=limit,
+            )
+        return json.dumps({"count": len(events), "events": events}, ensure_ascii=False)
 
     @server.tool()
     def get_schema() -> str:

--- a/src/persome/security/body_limit.py
+++ b/src/persome/security/body_limit.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
+import json
 import threading
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 
 from starlette.datastructures import Headers
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 DEFAULT_MAX_REQUEST_BODY_BYTES = 12 * 1024 * 1024
+HEALTH_IMPORT_MAX_REQUEST_BODY_BYTES = 2 * 1024 * 1024
 DEFAULT_MAX_CONCURRENT_REQUESTS = 16
 
 
@@ -22,11 +24,22 @@ class RequestBodyLimitMiddleware:
     before doing useful work.
     """
 
-    def __init__(self, app: ASGIApp, *, max_bytes: int = DEFAULT_MAX_REQUEST_BODY_BYTES) -> None:
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        max_bytes: int = DEFAULT_MAX_REQUEST_BODY_BYTES,
+        path_limits: Mapping[str, int] | None = None,
+        strict_json_paths: Sequence[str] = (),
+    ) -> None:
         if max_bytes <= 0:
             raise ValueError("max_bytes must be positive")
+        if any(limit <= 0 for limit in (path_limits or {}).values()):
+            raise ValueError("path limits must be positive")
         self.app = app
         self.max_bytes = int(max_bytes)
+        self.path_limits = {path: int(limit) for path, limit in (path_limits or {}).items()}
+        self.strict_json_paths = frozenset(strict_json_paths)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
@@ -34,6 +47,7 @@ class RequestBodyLimitMiddleware:
             return
 
         headers = Headers(scope=scope)
+        max_bytes = self.path_limits.get(scope["path"], self.max_bytes)
         content_lengths = headers.getlist("content-length")
         if len(content_lengths) > 1:
             await self._reject(scope, receive, send, 400, "ambiguous Content-Length")
@@ -48,7 +62,7 @@ class RequestBodyLimitMiddleware:
             if declared < 0:
                 await self._reject(scope, receive, send, 400, "invalid Content-Length")
                 return
-            if declared > self.max_bytes:
+            if declared > max_bytes:
                 await self._reject(scope, receive, send, 413, "request body too large")
                 return
 
@@ -62,11 +76,26 @@ class RequestBodyLimitMiddleware:
             if message["type"] != "http.request":
                 continue
             total += len(message.get("body", b""))
-            if total > self.max_bytes:
+            if total > max_bytes:
                 await self._reject(scope, receive, send, 413, "request body too large")
                 return
             if not message.get("more_body", False):
                 break
+
+        if scope["path"] in self.strict_json_paths:
+            try:
+                json.loads(
+                    b"".join(message.get("body", b"") for message in buffered),
+                    parse_constant=_reject_nonfinite_constant,
+                )
+            except _NonFiniteJSONNumber:
+                await self._reject(scope, receive, send, 400, "non-finite JSON number")
+                return
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                # FastAPI owns ordinary JSON syntax diagnostics.  This early
+                # pass exists only because its validation error echo cannot
+                # safely serialize NaN/Infinity back into standards JSON.
+                pass
 
         replay = _ReplayReceive(buffered, receive)
         await self.app(scope, replay, send)
@@ -100,6 +129,14 @@ class _ReplayReceive:
             # immediate synthetic empty request here would create a hot loop
             # and starve the response producer.
             return await self._fallback()
+
+
+class _NonFiniteJSONNumber(ValueError):
+    pass
+
+
+def _reject_nonfinite_constant(value: str) -> None:
+    raise _NonFiniteJSONNumber(value)
 
 
 class RequestConcurrencyLimitMiddleware:

--- a/src/persome/store/health_events.py
+++ b/src/persome/store/health_events.py
@@ -36,47 +36,82 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
 
 
 def import_events(conn: sqlite3.Connection, events: list[dict[str, Any]]) -> dict[str, int]:
-    """Atomically insert a batch, ignoring events already synced by the provider."""
+    """Atomically import a batch using provider IDs as revision identities.
+
+    A byte-for-byte replay of the normalized event is a duplicate.  When a
+    provider reuses an ID with changed content, the new payload is a correction
+    of that observation rather than a second observation.
+    """
     ensure_schema(conn)
     imported_at = datetime.now(UTC).isoformat(timespec="seconds")
     inserted = 0
+    corrected = 0
     conn.execute("BEGIN IMMEDIATE")
     try:
         for event in events:
             source = event["source"]
-            before = conn.total_changes
-            conn.execute(
+            values = (
+                event["metric"],
+                json.dumps(event["value"], ensure_ascii=False, separators=(",", ":")),
+                event.get("unit") or "",
+                _iso(event["started_at"]),
+                _iso(event.get("ended_at")),
+                event.get("timezone"),
+                source.get("device"),
+                source.get("device_id"),
+                json.dumps(event.get("metadata") or {}, ensure_ascii=False, separators=(",", ":")),
+            )
+            existing = conn.execute(
                 """
-                INSERT OR IGNORE INTO health_events (
+                SELECT metric, value_json, unit, started_at, ended_at, timezone,
+                       device, device_id, metadata_json
+                FROM health_events
+                WHERE provider = ? AND external_id = ?
+                """,
+                (source["provider"], event["event_id"]),
+            ).fetchone()
+            if existing is not None and tuple(existing) == values:
+                continue
+            if existing is None:
+                conn.execute(
+                    """
+                INSERT INTO health_events (
                     provider, external_id, metric, value_json, unit,
                     started_at, ended_at, timezone, device, device_id,
                     metadata_json, imported_at
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
-                (
-                    source["provider"],
-                    event["event_id"],
-                    event["metric"],
-                    json.dumps(event["value"], ensure_ascii=False, separators=(",", ":")),
-                    event.get("unit") or "",
-                    _iso(event["started_at"]),
-                    _iso(event.get("ended_at")),
-                    event.get("timezone"),
-                    source.get("device"),
-                    source.get("device_id"),
-                    json.dumps(
-                        event.get("metadata") or {}, ensure_ascii=False, separators=(",", ":")
+                    (
+                        source["provider"],
+                        event["event_id"],
+                        *values,
+                        imported_at,
                     ),
-                    imported_at,
-                ),
-            )
-            inserted += int(conn.total_changes > before)
+                )
+                inserted += 1
+            else:
+                conn.execute(
+                    """
+                    UPDATE health_events
+                    SET metric = ?, value_json = ?, unit = ?, started_at = ?,
+                        ended_at = ?, timezone = ?, device = ?, device_id = ?,
+                        metadata_json = ?, imported_at = ?
+                    WHERE provider = ? AND external_id = ?
+                    """,
+                    (*values, imported_at, source["provider"], event["event_id"]),
+                )
+                corrected += 1
     except Exception:
         conn.rollback()
         raise
     else:
         conn.commit()
-    return {"received": len(events), "inserted": inserted, "duplicates": len(events) - inserted}
+    return {
+        "received": len(events),
+        "inserted": inserted,
+        "corrected": corrected,
+        "duplicates": len(events) - inserted - corrected,
+    }
 
 
 def _iso(value: Any) -> str | None:

--- a/src/persome/store/health_events.py
+++ b/src/persome/store/health_events.py
@@ -1,0 +1,141 @@
+"""Local persistence for normalized wearable and health observations."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import UTC, datetime
+from typing import Any
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS health_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    provider TEXT NOT NULL,
+    external_id TEXT NOT NULL,
+    metric TEXT NOT NULL,
+    value_json TEXT NOT NULL,
+    unit TEXT NOT NULL,
+    started_at TEXT NOT NULL,
+    ended_at TEXT,
+    timezone TEXT,
+    device TEXT,
+    device_id TEXT,
+    metadata_json TEXT NOT NULL,
+    imported_at TEXT NOT NULL,
+    UNIQUE(provider, external_id)
+);
+CREATE INDEX IF NOT EXISTS idx_health_events_metric_time
+    ON health_events(metric, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_health_events_provider_time
+    ON health_events(provider, started_at DESC);
+"""
+
+
+def ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(SCHEMA)
+
+
+def import_events(conn: sqlite3.Connection, events: list[dict[str, Any]]) -> dict[str, int]:
+    """Atomically insert a batch, ignoring events already synced by the provider."""
+    ensure_schema(conn)
+    imported_at = datetime.now(UTC).isoformat(timespec="seconds")
+    inserted = 0
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        for event in events:
+            source = event["source"]
+            before = conn.total_changes
+            conn.execute(
+                """
+                INSERT OR IGNORE INTO health_events (
+                    provider, external_id, metric, value_json, unit,
+                    started_at, ended_at, timezone, device, device_id,
+                    metadata_json, imported_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    source["provider"],
+                    event["event_id"],
+                    event["metric"],
+                    json.dumps(event["value"], ensure_ascii=False, separators=(",", ":")),
+                    event.get("unit") or "",
+                    _iso(event["started_at"]),
+                    _iso(event.get("ended_at")),
+                    event.get("timezone"),
+                    source.get("device"),
+                    source.get("device_id"),
+                    json.dumps(
+                        event.get("metadata") or {}, ensure_ascii=False, separators=(",", ":")
+                    ),
+                    imported_at,
+                ),
+            )
+            inserted += int(conn.total_changes > before)
+    except Exception:
+        conn.rollback()
+        raise
+    else:
+        conn.commit()
+    return {"received": len(events), "inserted": inserted, "duplicates": len(events) - inserted}
+
+
+def _iso(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def query_events(
+    conn: sqlite3.Connection,
+    *,
+    metric: str | None = None,
+    provider: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Read normalized observations newest-first with optional exact filters."""
+    ensure_schema(conn)
+    clauses: list[str] = []
+    values: list[Any] = []
+    for column, value in (("metric", metric), ("provider", provider)):
+        if value:
+            clauses.append(f"{column} = ?")
+            values.append(value)
+    if since:
+        clauses.append("persome_epoch(started_at) >= persome_epoch(?)")
+        values.append(since)
+    if until:
+        clauses.append("persome_epoch(started_at) < persome_epoch(?)")
+        values.append(until)
+    where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+    values.append(limit)
+    rows = conn.execute(
+        f"""
+        SELECT provider, external_id, metric, value_json, unit, started_at,
+               ended_at, timezone, device, metadata_json, imported_at
+        FROM health_events
+        {where}
+        ORDER BY persome_epoch(started_at) DESC, id DESC
+        LIMIT ?
+        """,  # noqa: S608 - only fixed column fragments are interpolated
+        values,
+    ).fetchall()
+    return [
+        {
+            "provider": row["provider"],
+            "event_id": row["external_id"],
+            "metric": row["metric"],
+            "value": json.loads(row["value_json"]),
+            "unit": row["unit"],
+            "started_at": row["started_at"],
+            "ended_at": row["ended_at"],
+            "timezone": row["timezone"],
+            "device": row["device"],
+            "metadata": json.loads(row["metadata_json"]),
+            "imported_at": row["imported_at"],
+        }
+        for row in rows
+    ]

--- a/src/persome/store/health_events.py
+++ b/src/persome/store/health_events.py
@@ -35,7 +35,11 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
     conn.executescript(SCHEMA)
 
 
-def import_events(conn: sqlite3.Connection, events: list[dict[str, Any]]) -> dict[str, int]:
+def import_events(
+    conn: sqlite3.Connection,
+    events: list[dict[str, Any]],
+    deleted_events: list[dict[str, Any]] | None = None,
+) -> dict[str, int]:
     """Atomically import a batch using provider IDs as revision identities.
 
     A byte-for-byte replay of the normalized event is a duplicate.  When a
@@ -46,8 +50,15 @@ def import_events(conn: sqlite3.Connection, events: list[dict[str, Any]]) -> dic
     imported_at = datetime.now(UTC).isoformat(timespec="seconds")
     inserted = 0
     corrected = 0
+    deleted = 0
     conn.execute("BEGIN IMMEDIATE")
     try:
+        for deletion in deleted_events or []:
+            cursor = conn.execute(
+                "DELETE FROM health_events WHERE provider = ? AND external_id = ?",
+                (deletion["provider"], deletion["event_id"]),
+            )
+            deleted += max(cursor.rowcount, 0)
         for event in events:
             source = event["source"]
             values = (
@@ -111,6 +122,7 @@ def import_events(conn: sqlite3.Connection, events: list[dict[str, Any]]) -> dic
         "inserted": inserted,
         "corrected": corrected,
         "duplicates": len(events) - inserted - corrected,
+        "deleted": deleted,
     }
 
 

--- a/src/persome/store/health_events.py
+++ b/src/persome/store/health_events.py
@@ -144,7 +144,6 @@ def query_events(
     limit: int = 100,
 ) -> list[dict[str, Any]]:
     """Read normalized observations newest-first with optional exact filters."""
-    ensure_schema(conn)
     clauses: list[str] = []
     values: list[Any] = []
     for column, value in (("metric", metric), ("provider", provider)):

--- a/src/persome/store/schema_dump.py
+++ b/src/persome/store/schema_dump.py
@@ -92,6 +92,7 @@ def _index_db_steps() -> list[tuple[str, Callable[[sqlite3.Connection], None]]]:
     from ..evomem import store as evo_store
     from . import (
         contradictions,
+        health_events,
         memory_deltas,
         owner_aliases,
         parser_ticks,
@@ -102,6 +103,7 @@ def _index_db_steps() -> list[tuple[str, Callable[[sqlite3.Connection], None]]]:
     return [
         ("store/relation_edges.py", relation_edges.ensure_schema),
         ("store/contradictions.py", contradictions.ensure_schema),
+        ("store/health_events.py", health_events.ensure_schema),
         ("store/memory_deltas.py", memory_deltas.ensure_schema),
         ("store/owner_aliases.py", owner_aliases.ensure_schema),
         ("store/parser_ticks.py", parser_ticks.ensure_schema),

--- a/tests/test_health_events_import_api.py
+++ b/tests/test_health_events_import_api.py
@@ -42,6 +42,7 @@ def test_import_persists_normalized_event(ac_root) -> None:
         "schema_version": 1,
         "received": 1,
         "inserted": 1,
+        "corrected": 0,
         "duplicates": 0,
     }
 
@@ -59,7 +60,32 @@ def test_import_is_idempotent(ac_root) -> None:
     assert client.post("/health-events/import", json=_payload()).status_code == 200
     response = client.post("/health-events/import", json=_payload())
     assert response.json()["data"]["inserted"] == 0
+    assert response.json()["data"]["corrected"] == 0
     assert response.json()["data"]["duplicates"] == 1
+
+
+def test_same_id_with_changed_content_corrects_existing_event(ac_root) -> None:
+    client = _client()
+    assert client.post("/health-events/import", json=_payload()).status_code == 200
+
+    corrected = _payload()
+    corrected["events"][0]["value"] = 76
+    corrected["events"][0]["metadata"] = {"source_revision": "watchOS", "sync": 2}
+    response = client.post("/health-events/import", json=corrected)
+
+    assert response.status_code == 200, response.text
+    assert response.json()["data"] == {
+        "schema_version": 1,
+        "received": 1,
+        "inserted": 0,
+        "corrected": 1,
+        "duplicates": 0,
+    }
+    with fts.cursor() as conn:
+        rows = conn.execute("SELECT value_json, metadata_json FROM health_events").fetchall()
+    assert [(row["value_json"], row["metadata_json"]) for row in rows] == [
+        ("76.0", '{"source_revision":"watchOS","sync":2}')
+    ]
 
 
 def test_import_rejects_naive_or_reversed_timestamps(ac_root) -> None:

--- a/tests/test_health_events_import_api.py
+++ b/tests/test_health_events_import_api.py
@@ -1,0 +1,88 @@
+"""Normalized wearable/health event import contract."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from persome.api import build_api_app
+from persome.store import fts
+
+
+def _client() -> TestClient:
+    return TestClient(build_api_app(auth_enabled=False))
+
+
+def _payload() -> dict:
+    return {
+        "schema_version": 1,
+        "events": [
+            {
+                "event_id": "HKQuantitySample:heart-rate:abc123",
+                "source": {
+                    "provider": "apple_health",
+                    "device": "Apple Watch",
+                    "device_id": "watch-local-id",
+                },
+                "metric": "heart_rate",
+                "value": 72,
+                "unit": "bpm",
+                "started_at": "2026-07-15T09:30:00+08:00",
+                "ended_at": "2026-07-15T09:30:05+08:00",
+                "timezone": "Asia/Shanghai",
+                "metadata": {"source_revision": "watchOS"},
+            }
+        ],
+    }
+
+
+def test_import_persists_normalized_event(ac_root) -> None:
+    response = _client().post("/health-events/import", json=_payload())
+    assert response.status_code == 200, response.text
+    assert response.json()["data"] == {
+        "schema_version": 1,
+        "received": 1,
+        "inserted": 1,
+        "duplicates": 0,
+    }
+
+    with fts.cursor() as conn:
+        row = conn.execute("SELECT * FROM health_events").fetchone()
+    assert row["provider"] == "apple_health"
+    assert row["external_id"] == "HKQuantitySample:heart-rate:abc123"
+    assert row["metric"] == "heart_rate"
+    assert row["value_json"] == "72.0"
+    assert row["started_at"] == "2026-07-15T09:30:00+08:00"
+
+
+def test_import_is_idempotent(ac_root) -> None:
+    client = _client()
+    assert client.post("/health-events/import", json=_payload()).status_code == 200
+    response = client.post("/health-events/import", json=_payload())
+    assert response.json()["data"]["inserted"] == 0
+    assert response.json()["data"]["duplicates"] == 1
+
+
+def test_import_rejects_naive_or_reversed_timestamps(ac_root) -> None:
+    payload = _payload()
+    payload["events"][0]["started_at"] = "2026-07-15T09:30:00"
+    assert _client().post("/health-events/import", json=payload).status_code == 422
+
+    payload = _payload()
+    payload["events"][0]["ended_at"] = "2026-07-15T09:29:00+08:00"
+    assert _client().post("/health-events/import", json=payload).status_code == 422
+
+
+def test_import_rejects_empty_and_oversized_batches(ac_root) -> None:
+    assert (
+        _client()
+        .post("/health-events/import", json={"schema_version": 1, "events": []})
+        .status_code
+        == 422
+    )
+
+    event = _payload()["events"][0]
+    response = _client().post(
+        "/health-events/import",
+        json={"schema_version": 1, "events": [event] * 1001},
+    )
+    assert response.status_code == 422

--- a/tests/test_health_events_import_api.py
+++ b/tests/test_health_events_import_api.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import copy
+import json
+
+import pytest
 from fastapi.testclient import TestClient
 
 from persome.api import build_api_app
-from persome.store import fts
+from persome.store import fts, health_events
 
 
 def _client() -> TestClient:
@@ -44,6 +48,7 @@ def test_import_persists_normalized_event(ac_root) -> None:
         "inserted": 1,
         "corrected": 0,
         "duplicates": 0,
+        "deleted": 0,
     }
 
     with fts.cursor() as conn:
@@ -80,6 +85,7 @@ def test_same_id_with_changed_content_corrects_existing_event(ac_root) -> None:
         "inserted": 0,
         "corrected": 1,
         "duplicates": 0,
+        "deleted": 0,
     }
     with fts.cursor() as conn:
         rows = conn.execute("SELECT value_json, metadata_json FROM health_events").fetchall()
@@ -111,4 +117,105 @@ def test_import_rejects_empty_and_oversized_batches(ac_root) -> None:
         "/health-events/import",
         json={"schema_version": 1, "events": [event] * 1001},
     )
+    assert response.status_code in {400, 422}
+
+
+def test_deletions_apply_in_same_transaction_before_anchor_can_advance(ac_root) -> None:
+    client = _client()
+    assert client.post("/health-events/import", json=_payload()).status_code == 200
+
+    response = client.post(
+        "/health-events/import",
+        json={
+            "schema_version": 1,
+            "events": [],
+            "deleted_events": [
+                {
+                    "provider": "apple_health",
+                    "event_id": "HKQuantitySample:heart-rate:abc123",
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["data"] == {
+        "schema_version": 1,
+        "received": 0,
+        "inserted": 0,
+        "corrected": 0,
+        "duplicates": 0,
+        "deleted": 1,
+    }
+    with fts.cursor() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM health_events").fetchone()[0] == 0
+
+
+def test_deletion_rolls_back_when_later_event_fails(ac_root) -> None:
+    payload = _payload()["events"][0]
+    with fts.cursor() as conn:
+        health_events.import_events(conn, [payload])
+        with pytest.raises(KeyError):
+            health_events.import_events(
+                conn,
+                [{"event_id": "invalid-after-delete"}],
+                [{"provider": "apple_health", "event_id": payload["event_id"]}],
+            )
+        assert conn.execute("SELECT COUNT(*) FROM health_events").fetchone()[0] == 1
+
+
+@pytest.mark.parametrize("value", ["x" * 4097, float("nan"), float("inf"), -float("inf")])
+def test_import_rejects_unbounded_or_nonfinite_values(ac_root, value) -> None:
+    payload = _payload()
+    payload["events"][0]["value"] = value
+    body = json.dumps(payload)
+    response = _client().post(
+        "/health-events/import",
+        content=body,
+        headers={"content-type": "application/json"},
+    )
+    assert response.status_code in {400, 422}
+
+
+def test_import_rejects_oversized_metadata_and_combined_operations(ac_root) -> None:
+    payload = _payload()
+    payload["events"][0]["metadata"] = {"note": "x" * (64 * 1024)}
+    assert _client().post("/health-events/import", json=payload).status_code == 422
+
+    event = _payload()["events"][0]
+    deletions = [
+        {"provider": "apple_health", "event_id": f"deleted-{index}"} for index in range(1_000)
+    ]
+    response = _client().post(
+        "/health-events/import",
+        json={"schema_version": 1, "events": [event], "deleted_events": deletions},
+    )
     assert response.status_code == 422
+
+
+def test_mixed_deletion_and_insert_is_atomic(ac_root) -> None:
+    client = _client()
+    assert client.post("/health-events/import", json=_payload()).status_code == 200
+    replacement = copy.deepcopy(_payload()["events"][0])
+    replacement["event_id"] = "replacement"
+
+    response = client.post(
+        "/health-events/import",
+        json={
+            "schema_version": 1,
+            "events": [replacement],
+            "deleted_events": [
+                {
+                    "provider": "apple_health",
+                    "event_id": "HKQuantitySample:heart-rate:abc123",
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["deleted"] == 1
+    assert response.json()["data"]["inserted"] == 1
+    with fts.cursor() as conn:
+        ids = [row[0] for row in conn.execute("SELECT external_id FROM health_events")]
+    assert ids == ["replacement"]

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -10,7 +10,7 @@ from persome.mcp import captures as captures_mod
 from persome.mcp import server as mcp_server
 from persome.model import ModelBuildCoordinator, create_build_manifest
 from persome.store import entries as entries_mod
-from persome.store import fts
+from persome.store import fts, health_events
 from persome.timeline import store as timeline_store
 
 BUILD_KEYS = {
@@ -85,6 +85,40 @@ def test_pending_model_work_is_empty_on_fresh_root(ac_root: Path) -> None:
     with fts.cursor() as conn:
         out = mcp_server._pending_model_work(conn)
     assert out == {"pending_reduction": 0, "pending_modeling": 0, "total": 0}
+
+
+def test_query_health_events_filters_and_orders(ac_root: Path) -> None:
+    with fts.cursor() as conn:
+        health_events.import_events(
+            conn,
+            [
+                {
+                    "event_id": "older",
+                    "source": {"provider": "apple_health", "device": "Watch"},
+                    "metric": "heart_rate",
+                    "value": 68.0,
+                    "unit": "bpm",
+                    "started_at": "2026-07-15T09:00:00+08:00",
+                    "metadata": {},
+                },
+                {
+                    "event_id": "newer",
+                    "source": {"provider": "apple_health", "device": "Watch"},
+                    "metric": "heart_rate",
+                    "value": 72.0,
+                    "unit": "bpm",
+                    "started_at": "2026-07-15T09:30:00+08:00",
+                    "metadata": {},
+                },
+            ],
+        )
+        out = health_events.query_events(
+            conn,
+            metric="heart_rate",
+            since="2026-07-15T09:10:00+08:00",
+        )
+    assert [event["event_id"] for event in out] == ["newer"]
+    assert out[0]["value"] == 72.0
 
 
 def test_get_model_snapshot_uses_versioned_contract(ac_root: Path) -> None:

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -88,6 +88,7 @@ def test_pending_model_work_is_empty_on_fresh_root(ac_root: Path) -> None:
 
 
 def test_query_health_events_filters_and_orders(ac_root: Path) -> None:
+    fts.initialize_runtime_schema()
     with fts.cursor() as conn:
         health_events.import_events(
             conn,
@@ -112,6 +113,10 @@ def test_query_health_events_filters_and_orders(ac_root: Path) -> None:
                 },
             ],
         )
+    # Stdio MCP is a shared-database client and must never attempt lazy DDL.
+    # Runtime startup owns schema initialization before clients connect.
+    fts.declare_client_process()
+    with fts.cursor() as conn:
         out = health_events.query_events(
             conn,
             metric="heart_rate",

--- a/tests/test_request_body_limit.py
+++ b/tests/test_request_body_limit.py
@@ -12,6 +12,7 @@ from persome.api import build_api_app
 from persome.config import Config
 from persome.security.body_limit import (
     DEFAULT_MAX_REQUEST_BODY_BYTES,
+    HEALTH_IMPORT_MAX_REQUEST_BODY_BYTES,
     RequestBodyLimitMiddleware,
     RequestConcurrencyLimitMiddleware,
 )
@@ -115,6 +116,18 @@ def test_api_app_enforces_body_limit_before_json_parsing(ac_root) -> None:
         "/captures/ingest",
         content=b"{}",
         headers={"content-length": str(DEFAULT_MAX_REQUEST_BODY_BYTES + 1)},
+    )
+
+    assert response.status_code == 413
+
+
+def test_api_app_enforces_stricter_health_import_body_limit(ac_root) -> None:
+    client = TestClient(build_api_app(Config(), auth_enabled=False))
+
+    response = client.post(
+        "/health-events/import",
+        content=b"{}",
+        headers={"content-length": str(HEALTH_IMPORT_MAX_REQUEST_BODY_BYTES + 1)},
     )
 
     assert response.status_code == 413


### PR DESCRIPTION
## What changed

- Add a normalized, idempotent `/health-events/import` API backed by local SQLite storage.
- Expose wearable observations through the `query_health_metrics` MCP tool.
- Add a Swift Package that incrementally reads Apple HealthKit samples and uploads normalized batches.
- Document the REST, MCP, schema, and connector contracts.

## Why

Persome currently models screen activity but has no structured ingestion path for wearable observations. Reusing screen capture ingestion would discard metric semantics, device provenance, and HealthKit sync identity.

## Impact

This creates the first local-first Apple Watch data path for steps, heart rate, resting heart rate, active energy, sleep, and workouts. Runtime HTTP remains loopback-only; the Swift connector requires a separately reviewed secure phone-to-Mac transport before production deployment.

Consumer-device observations are returned as raw measurements and are not medical diagnoses.

## Validation

- Ruff check and formatting checks passed.
- Targeted Python suite: 91 passed.
- Swift package test: 1 passed.
- `git diff --check` passed.

## Known limitation

The current development machine lacks full Xcode, so HealthKit-specific iOS compilation and on-device authorization/sync still require follow-up validation.
