### PR TITLE
Add privacy-safe HUMAN.md share card

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -228,6 +228,30 @@
         }
       }
     },
+    "/model/share-card": {
+      "get": {
+        "tags": [
+          "model"
+        ],
+        "summary": "Model Share Card",
+        "description": "Return the minimal, canonically scrubbed HUMAN.md Card projection.",
+        "operationId": "model_share_card_model_share_card_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Model Share Card Model Share Card Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/model/evidence": {
       "get": {
         "tags": [

--- a/resources/model_assets/share.mjs
+++ b/resources/model_assets/share.mjs
@@ -1,6 +1,40 @@
 export const SHARE_CARD_WIDTH = 1080;
 export const SHARE_CARD_HEIGHT = 1350;
 export const SHARE_FILE_NAME = "my-human-card.png";
+export const SHARE_URL = "https://github.com/Intuition-Lab/personal-model";
+export const SHARE_TEXTS = Object.freeze([
+  [
+    "I let @PersonalModel_ observe how I use my Mac, and apparently this is what I look like 😳",
+    "",
+    "#PersonalModel @PersonalModel_",
+  ].join("\n"),
+  [
+    "I let my @PersonalModel_ learn from how I use my Mac. I didn’t expect this is how it sees me 😳",
+    "",
+    "#PersonalModel @PersonalModel_",
+  ].join("\n"),
+  [
+    "I let @PersonalModel_ observe how I use my Mac, and this is the model it built 🤔",
+    "",
+    "#PersonalModel @PersonalModel_",
+  ].join("\n"),
+]);
+
+export function pickShareText(random = Math.random) {
+  const index = Math.floor(random() * SHARE_TEXTS.length);
+  return SHARE_TEXTS[Math.max(0, Math.min(index, SHARE_TEXTS.length - 1))];
+}
+
+export function buildXIntentUrl({
+  text,
+  url = SHARE_URL,
+  random = Math.random,
+} = {}) {
+  const params = new URLSearchParams();
+  params.set("text", text ?? pickShareText(random));
+  params.set("url", url);
+  return `https://x.com/intent/tweet?${params.toString()}`;
+}
 
 const CARD_FIELDS = Object.freeze([
   ["optimizesFor", "Optimizes for"],
@@ -29,23 +63,16 @@ function rankedPatterns(model = {}) {
 /**
  * Build the public projection used by the share card.
  *
- * Only Root/Face signatures are eligible. Receipts, quotes, paths, IDs, source
- * content, and other model metadata never cross this boundary. A future model
- * may provide explicit `root.human_card` copy; current models fall back to the
- * strongest public summaries.
+ * Only summaries from the server's canonically scrubbed `/model/share-card`
+ * projection are eligible. The raw owner graph must never be passed here.
  */
 export function humanCard(model = {}) {
-  const explicit = model.root?.human_card || {};
   const patterns = rankedPatterns(model);
   return {
-    optimizesFor: clean(explicit.optimizes_for || patterns[0]?.signature)
-      || "depth over speed",
-    currentRoot: clean(explicit.current_root || model.root?.signature)
-      || "still forming from local context",
-    decisionStyle: clean(explicit.decision_style || patterns[1]?.signature)
-      || "evidence first, intuition at the edge",
-    aiShould: clean(explicit.ai_should || patterns[2]?.signature)
-      || "challenge premature expansion",
+    optimizesFor: clean(patterns[0]?.signature) || "depth over speed",
+    currentRoot: clean(model.root?.signature) || "still forming from local context",
+    decisionStyle: clean(patterns[1]?.signature) || "evidence first, intuition at the edge",
+    aiShould: clean(patterns[2]?.signature) || "challenge premature expansion",
     neverExpose: "private source content",
   };
 }

--- a/resources/model_assets/share.mjs
+++ b/resources/model_assets/share.mjs
@@ -1,86 +1,52 @@
-export const SHARE_CARD_WIDTH = 1200;
-export const SHARE_CARD_HEIGHT = 675;
-export const SHARE_FILE_NAME = "my-persome-constellation.png";
-export const SHARE_URL = "https://github.com/Intuition-Lab/personal-model";
-export const SHARE_TEXTS = Object.freeze([
-  [
-    "I let @PersonalModel_ observe how I use my Mac, and apparently this is what I look like 😳",
-    "",
-    "#PersonalModel @PersonalModel_",
-  ].join("\n"),
-  [
-    "I let my @PersonalModel_ learn from how I use my Mac. I didn’t expect this is how it sees me 😳",
-    "",
-    "#PersonalModel @PersonalModel_",
-  ].join("\n"),
-  [
-    "I let @PersonalModel_ observe how I use my Mac, and this is the model it built 🤔",
-    "",
-    "#PersonalModel @PersonalModel_",
-  ].join("\n"),
+export const SHARE_CARD_WIDTH = 1080;
+export const SHARE_CARD_HEIGHT = 1350;
+export const SHARE_FILE_NAME = "my-human-card.png";
+
+const CARD_FIELDS = Object.freeze([
+  ["optimizesFor", "Optimizes for"],
+  ["currentRoot", "Current root"],
+  ["decisionStyle", "Decision style"],
+  ["aiShould", "AI should"],
+  ["neverExpose", "Never expose"],
 ]);
 
-export function pickShareText(random = Math.random) {
-  const index = Math.floor(random() * SHARE_TEXTS.length);
-  return SHARE_TEXTS[Math.max(0, Math.min(index, SHARE_TEXTS.length - 1))];
-}
-
-export function buildXIntentUrl({
-  text,
-  url = SHARE_URL,
-  random = Math.random,
-} = {}) {
-  const params = new URLSearchParams();
-  params.set("text", text ?? pickShareText(random));
-  params.set("url", url);
-  return `https://x.com/intent/tweet?${params.toString()}`;
-}
-
-export function shareStats(model = {}) {
-  const stats = model.stats || {};
-  const lineCount = (stats.evolution_lines || 0) + (stats.relation_lines || 0);
-  return [
-    ["POINTS", stats.points || model.points?.length || 0],
-    ["LINES", lineCount || model.lines?.length || 0],
-    ["FACES", stats.faces || model.faces?.length || 0],
-    ["VOLUMES", stats.volumes || model.volumes?.length || 0],
-    ["ROOT", stats.roots || Number(Boolean(model.root))],
-  ];
-}
-
-function cleanNarrative(value, limit = 220) {
+function clean(value, limit = 132) {
   const text = String(value || "").replace(/\s+/g, " ").trim();
   if (text.length <= limit) return text;
   return `${text.slice(0, Math.max(0, limit - 1)).trimEnd()}…`;
 }
 
-function narrativeStrength(item) {
-  const evidence = item.observations
-    || item.source_receipts?.length
-    || item.member_receipts?.length
-    || 0;
-  return (Number(item.confidence) || 0) * 1000 + evidence;
+function rankedPatterns(model = {}) {
+  return [...(model.faces || [])]
+    .filter((item) => item?.signature)
+    .sort((left, right) => {
+      const leftStrength = Number(left.observations || 0) * 2 + Number(left.confidence || 0);
+      const rightStrength = Number(right.observations || 0) * 2 + Number(right.confidence || 0);
+      return rightStrength - leftStrength || String(left.id || "").localeCompare(String(right.id || ""));
+    });
 }
 
-export function shareNarrative(model = {}) {
-  const candidates = [
-    ...(model.volumes || []).map((item) => ({ ...item, kind: "VOLUME" })),
-    ...(model.faces || []).map((item) => ({ ...item, kind: "FACE" })),
-  ].filter((item) => item.signature);
-  candidates.sort((a, b) => {
-    const kindDelta = Number(b.kind === "VOLUME") - Number(a.kind === "VOLUME");
-    if (kindDelta) return kindDelta;
-    return narrativeStrength(b) - narrativeStrength(a) || String(a.id).localeCompare(String(b.id));
-  });
+/**
+ * Build the public projection used by the share card.
+ *
+ * Only Root/Face signatures are eligible. Receipts, quotes, paths, IDs, source
+ * content, and other model metadata never cross this boundary. A future model
+ * may provide explicit `root.human_card` copy; current models fall back to the
+ * strongest public summaries.
+ */
+export function humanCard(model = {}) {
+  const explicit = model.root?.human_card || {};
+  const patterns = rankedPatterns(model);
   return {
-    root: cleanNarrative(
-      model.root?.signature,
-      240,
-    ) || "A living personal model, shaped by real context over time.",
-    highlights: candidates.slice(0, 3).map((item) => ({
-      kind: item.kind,
-      text: cleanNarrative(item.signature, 110),
-    })),
+    optimizesFor: clean(explicit.optimizes_for || patterns[0]?.signature)
+      || "depth over speed",
+    currentRoot: clean(explicit.current_root || model.root?.signature)
+      || "still forming from local context",
+    decisionStyle: clean(explicit.decision_style || patterns[1]?.signature)
+      || "evidence first, intuition at the edge",
+    aiShould: clean(explicit.ai_should || patterns[2]?.signature)
+      || "challenge premature expansion",
+    neverExpose: "private source content",
   };
 }
 
@@ -92,10 +58,10 @@ function wrappedLines(context, text, maxWidth, maxLines) {
     const next = current ? `${current} ${word}` : word;
     if (context.measureText(next).width <= maxWidth || !current) {
       current = next;
-      return;
+    } else {
+      lines.push(current);
+      current = word;
     }
-    lines.push(current);
-    current = word;
   });
   if (current) lines.push(current);
   if (lines.length <= maxLines) return lines;
@@ -114,158 +80,51 @@ function drawWrappedText(context, text, x, y, maxWidth, lineHeight, maxLines) {
   return lines.length;
 }
 
-function drawCover(context, source, width, height) {
-  const sourceWidth = source.width || source.videoWidth || width;
-  const sourceHeight = source.height || source.videoHeight || height;
-  const scale = Math.max(width / sourceWidth, height / sourceHeight);
-  const drawWidth = sourceWidth * scale;
-  const drawHeight = sourceHeight * scale;
-  context.drawImage(
-    source,
-    (width - drawWidth) / 2,
-    (height - drawHeight) / 2,
-    drawWidth,
-    drawHeight,
-  );
-}
-
-function drawBrandMark(context, x, y) {
-  context.save();
-  context.strokeStyle = "rgba(255, 255, 255, 0.22)";
-  context.lineWidth = 1;
-  context.beginPath();
-  context.arc(x, y, 18, 0, Math.PI * 2);
-  context.stroke();
-
-  const nodes = [
-    [0, -6, "#ff6b8a"],
-    [-6, 5, "#ff64d6"],
-    [7, 5, "#7798ff"],
-  ];
-  context.strokeStyle = "rgba(255, 255, 255, 0.19)";
-  context.beginPath();
-  context.moveTo(x, y - 6);
-  context.lineTo(x - 6, y + 5);
-  context.lineTo(x + 7, y + 5);
-  context.closePath();
-  context.stroke();
-  nodes.forEach(([dx, dy, color]) => {
-    context.fillStyle = color;
-    context.shadowColor = color;
-    context.shadowBlur = 10;
-    context.beginPath();
-    context.arc(x + dx, y + dy, 3, 0, Math.PI * 2);
-    context.fill();
-  });
-  context.restore();
-}
-
-export function drawShareCard(context, source, model = {}) {
+export function drawShareCard(context, model = {}) {
   const width = SHARE_CARD_WIDTH;
   const height = SHARE_CARD_HEIGHT;
-  const narrative = shareNarrative(model);
+  const card = humanCard(model);
 
   context.save();
-  context.fillStyle = "#070610";
+  context.fillStyle = "#f3f0e9";
   context.fillRect(0, 0, width, height);
 
-  const aura = context.createRadialGradient(760, 300, 20, 760, 300, 610);
-  aura.addColorStop(0, "rgba(105, 92, 210, 0.24)");
-  aura.addColorStop(0.46, "rgba(49, 35, 91, 0.13)");
-  aura.addColorStop(1, "rgba(7, 6, 16, 0)");
-  context.fillStyle = aura;
+  const glow = context.createRadialGradient(900, 120, 10, 900, 120, 660);
+  glow.addColorStop(0, "rgba(255, 116, 82, 0.16)");
+  glow.addColorStop(0.54, "rgba(255, 116, 82, 0.04)");
+  glow.addColorStop(1, "rgba(255, 116, 82, 0)");
+  context.fillStyle = glow;
   context.fillRect(0, 0, width, height);
 
-  context.save();
-  context.globalAlpha = 0.96;
-  drawCover(context, source, width, height);
-  context.restore();
+  context.strokeStyle = "rgba(31, 29, 27, 0.16)";
+  context.lineWidth = 2;
+  context.strokeRect(48, 48, width - 96, height - 96);
 
-  const textScrim = context.createLinearGradient(0, 0, 680, 0);
-  textScrim.addColorStop(0, "rgba(7, 6, 16, 0.96)");
-  textScrim.addColorStop(0.56, "rgba(7, 6, 16, 0.46)");
-  textScrim.addColorStop(1, "rgba(7, 6, 16, 0)");
-  context.fillStyle = textScrim;
-  context.fillRect(0, 0, 760, height);
+  context.fillStyle = "#1f1d1b";
+  context.font = "700 86px ui-monospace, 'SFMono-Regular', Menlo, monospace";
+  context.fillText("MY HUMAN.md", 96, 166);
+  context.fillStyle = "#ef6a4a";
+  context.fillRect(98, 202, 84, 8);
 
-  const edge = context.createLinearGradient(0, height - 170, 0, height);
-  edge.addColorStop(0, "rgba(7, 6, 16, 0)");
-  edge.addColorStop(1, "rgba(7, 6, 16, 0.88)");
-  context.fillStyle = edge;
-  context.fillRect(0, height - 170, width, 170);
+  let y = 316;
+  CARD_FIELDS.forEach(([key, label], index) => {
+    context.fillStyle = index === CARD_FIELDS.length - 1 ? "#cf4f36" : "#6d6861";
+    context.font = "650 26px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+    context.fillText(`${label}:`, 98, y);
 
-  drawBrandMark(context, 72, 66);
-  context.shadowBlur = 0;
-  context.fillStyle = "rgba(248, 246, 255, 0.96)";
-  context.font = "700 22px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
-  context.fillText("Persome", 105, 62);
-  context.fillStyle = "rgba(164, 158, 181, 0.9)";
-  context.font = "700 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
-  context.fillText("PERSONAL MODEL", 105, 80);
-
-  context.fillStyle = "rgba(195, 188, 210, 0.86)";
-  context.font = "700 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
-  context.fillText("A LIVING MAP OF WHAT YOU NOTICE, REPEAT, AND BECOME", 54, 286);
-
-  const headline = context.createLinearGradient(54, 310, 430, 430);
-  headline.addColorStop(0, "#fff8fc");
-  headline.addColorStop(0.52, "#ff85cf");
-  headline.addColorStop(1, "#8ea4ff");
-  context.fillStyle = headline;
-  context.font = "650 52px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
-  context.fillText("My personal", 52, 349);
-  context.fillText("constellation.", 52, 403);
-
-  context.fillStyle = "rgba(255, 100, 214, 0.9)";
-  context.font = "750 9px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
-  context.fillText("CURRENT MODEL", 55, 442);
-  context.fillStyle = "rgba(229, 224, 238, 0.88)";
-  context.font = "500 14px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
-  drawWrappedText(context, narrative.root, 54, 466, 430, 20, 3);
-
-  if (narrative.highlights.length) {
-    const panelX = 746;
-    const panelY = 468;
-    const panelWidth = 404;
-    const panelHeight = 132;
-    context.fillStyle = "rgba(9, 8, 18, 0.78)";
-    context.strokeStyle = "rgba(255, 255, 255, 0.12)";
-    context.lineWidth = 1;
-    context.beginPath();
-    context.roundRect(panelX, panelY, panelWidth, panelHeight, 16);
-    context.fill();
-    context.stroke();
-    context.fillStyle = "rgba(162, 154, 181, 0.9)";
-    context.font = "750 9px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
-    context.fillText("KEY PATTERNS", panelX + 18, panelY + 24);
-    narrative.highlights.forEach((highlight, index) => {
-      const rowY = panelY + 49 + index * 25;
-      context.fillStyle = highlight.kind === "VOLUME" ? "#7798ff" : "#ff64d6";
-      context.beginPath();
-      context.arc(panelX + 20, rowY - 4, 3, 0, Math.PI * 2);
-      context.fill();
-      context.fillStyle = "rgba(226, 221, 237, 0.9)";
-      context.font = "550 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
-      const line = wrappedLines(context, highlight.text, panelWidth - 52, 1)[0] || "";
-      context.fillText(line, panelX + 32, rowY);
-    });
-  }
-
-  let statX = 56;
-  shareStats(model).forEach(([label, value]) => {
-    context.fillStyle = "rgba(248, 246, 255, 0.94)";
-    context.font = "650 18px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
-    context.fillText(String(value), statX, 566);
-    context.fillStyle = "rgba(137, 130, 153, 0.92)";
-    context.font = "700 9px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
-    context.fillText(label, statX, 583);
-    statX += label === "VOLUMES" ? 92 : 78;
+    context.fillStyle = "#1f1d1b";
+    context.font = "560 32px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+    const count = drawWrappedText(context, card[key], 98, y + 50, width - 196, 40, 2);
+    y += 104 + Math.max(0, count - 1) * 40;
   });
 
-  context.fillStyle = "rgba(152, 145, 171, 0.9)";
-  context.font = "650 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
-  context.fillText("GENERATED LOCALLY · SHARED BY YOU", 54, 628);
-  context.textAlign = "right";
-  context.fillText("github.com/Intuition-Lab/personal-model", width - 52, 628);
+  context.strokeStyle = "rgba(31, 29, 27, 0.14)";
+  context.beginPath();
+  context.moveTo(98, height - 154);
+  context.lineTo(width - 98, height - 154);
+  context.stroke();
+  context.fillStyle = "#6d6861";
+  context.font = "560 24px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+  context.fillText("Built locally with Persome · Build yours", 98, height - 102);
   context.restore();
 }

--- a/resources/model_assets/viewer.js
+++ b/resources/model_assets/viewer.js
@@ -14,6 +14,7 @@ import {
   SHARE_CARD_HEIGHT,
   SHARE_CARD_WIDTH,
   SHARE_FILE_NAME,
+  buildXIntentUrl,
   drawShareCard,
 } from "./share.mjs";
 
@@ -48,7 +49,8 @@ const sliderLabel = document.getElementById("as-of-label");
 const zoomOutButton = document.getElementById("zoom-out");
 const zoomResetButton = document.getElementById("zoom-reset");
 const zoomInButton = document.getElementById("zoom-in");
-const shareButton = document.getElementById("human-card");
+const cardButton = document.getElementById("human-card");
+const shareButton = document.getElementById("share-x");
 const shareNoticeEl = document.getElementById("share-notice");
 const lineExplorerEl = document.getElementById("line-explorer");
 const lineSelectEl = document.getElementById("line-select");
@@ -152,6 +154,7 @@ const ZOOM_MIN_PERCENT = 50;
 const ZOOM_MAX_PERCENT = 400;
 const ZOOM_STEP_PERCENT = 25;
 const MODEL_GRAPH_TIMEOUT_MS = 45_000;
+const SHARE_CARD_TIMEOUT_MS = 15_000;
 const REDUCED_MOTION = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
 function freshLayerObjects() {
@@ -765,19 +768,40 @@ function showShareNotice(title, message, failed = false) {
 }
 
 function setShareBusy(busy) {
-  shareButton.disabled = busy || !shareReady;
-  shareButton.setAttribute("aria-busy", String(busy));
-  shareButton.querySelector("b").textContent = busy ? "Preparing…" : "Card";
+  [cardButton, shareButton].forEach((button) => {
+    button.disabled = busy || !shareReady;
+    button.setAttribute("aria-busy", String(busy));
+  });
+  cardButton.querySelector("b").textContent = busy ? "Preparing…" : "Card";
+  shareButton.querySelector("b").textContent = busy ? "Preparing…" : "Share";
 }
 
-function createShareCardBlob() {
-  renderer.render(scene, camera);
+async function loadShareCardModel() {
+  const controller = new AbortController();
+  const timeout = window.setTimeout(() => controller.abort(), SHARE_CARD_TIMEOUT_MS);
+  try {
+    const response = await fetch("./share-card", {
+      cache: "no-store",
+      signal: controller.signal,
+    });
+    if (!response.ok) throw new Error(`Share endpoint returned HTTP ${response.status}`);
+    const payload = await response.json();
+    if (!payload.model || !Array.isArray(payload.model.faces)) {
+      throw new Error("Share endpoint returned an invalid projection");
+    }
+    return payload.model;
+  } finally {
+    window.clearTimeout(timeout);
+  }
+}
+
+function createShareCardBlob(shareModel) {
   const canvas = document.createElement("canvas");
   canvas.width = SHARE_CARD_WIDTH;
   canvas.height = SHARE_CARD_HEIGHT;
   const context = canvas.getContext("2d");
   if (!context) return Promise.reject(new Error("Canvas export is unavailable"));
-  drawShareCard(context, model);
+  drawShareCard(context, shareModel);
   return new Promise((resolve, reject) => {
     canvas.toBlob((blob) => {
       if (blob) resolve(blob);
@@ -797,18 +821,45 @@ function downloadShareCard(blob) {
   window.setTimeout(() => URL.revokeObjectURL(href), 1000);
 }
 
-async function exportHumanCard() {
+function paintShareHandoff(popup) {
+  if (!popup) return;
+  popup.document.title = "Preparing your Persome HUMAN.md Card";
+  popup.document.body.innerHTML = `
+    <main style="min-height:100vh;display:grid;place-items:center;margin:0;background:#f3f0e9;color:#1f1d1b;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">
+      <section style="width:min(440px,calc(100vw - 48px));padding:38px;border:1px solid rgba(31,29,27,.16);background:#fff;box-shadow:0 30px 100px rgba(31,29,27,.12)">
+        <p style="margin:0 0 18px;color:#cf4f36;font-size:11px;font-weight:750;letter-spacing:.16em">PERSOME · SHARE TO X</p>
+        <h1 style="margin:0;font-size:34px;line-height:1.05;letter-spacing:-.045em">Your HUMAN.md Card is downloading.</h1>
+        <p style="margin:18px 0 0;color:#6d6861;font-size:15px;line-height:1.65">In X, add <strong style="color:#1f1d1b">${SHARE_FILE_NAME}</strong> with the image button. Review the card before posting.</p>
+      </section>
+    </main>`;
+}
+
+async function exportHumanCard({ toX = false } = {}) {
+  const popup = toX ? window.open("about:blank", "_blank") : null;
+  if (toX) paintShareHandoff(popup);
   setShareBusy(true);
   pauseAutoRotate();
   try {
-    const blob = await createShareCardBlob();
+    const shareModel = await loadShareCardModel();
+    const blob = await createShareCardBlob(shareModel);
     downloadShareCard(blob);
     showShareNotice(
       "HUMAN.md Card downloaded",
-      "Private source content was not included.",
+      "Detected secrets, PII, paths, IDs, and evidence receipts were excluded. Review summaries before sharing.",
     );
+    if (toX) {
+      const intentUrl = buildXIntentUrl();
+      if (popup && !popup.closed) {
+        popup.opener = null;
+        popup.location.replace(intentUrl);
+        popup.focus();
+      } else {
+        window.location.assign(intentUrl);
+      }
+    }
     setShareBusy(false);
   } catch (error) {
+    if (popup && !popup.closed) popup.close();
     showShareNotice("Share image failed", error.message || String(error), true);
     setShareBusy(false);
   }
@@ -1491,7 +1542,8 @@ controls.addEventListener("start", () => {
 });
 document.getElementById("reset").addEventListener("click", resetCamera);
 document.getElementById("close-detail").addEventListener("click", clearSelection);
-shareButton.addEventListener("click", exportHumanCard);
+cardButton.addEventListener("click", () => exportHumanCard());
+shareButton.addEventListener("click", () => exportHumanCard({ toX: true }));
 
 slider.addEventListener("input", () => {
   updateCutoff();

--- a/resources/model_assets/viewer.js
+++ b/resources/model_assets/viewer.js
@@ -14,7 +14,6 @@ import {
   SHARE_CARD_HEIGHT,
   SHARE_CARD_WIDTH,
   SHARE_FILE_NAME,
-  buildXIntentUrl,
   drawShareCard,
 } from "./share.mjs";
 
@@ -49,7 +48,7 @@ const sliderLabel = document.getElementById("as-of-label");
 const zoomOutButton = document.getElementById("zoom-out");
 const zoomResetButton = document.getElementById("zoom-reset");
 const zoomInButton = document.getElementById("zoom-in");
-const shareButton = document.getElementById("share-x");
+const shareButton = document.getElementById("human-card");
 const shareNoticeEl = document.getElementById("share-notice");
 const lineExplorerEl = document.getElementById("line-explorer");
 const lineSelectEl = document.getElementById("line-select");
@@ -768,7 +767,7 @@ function showShareNotice(title, message, failed = false) {
 function setShareBusy(busy) {
   shareButton.disabled = busy || !shareReady;
   shareButton.setAttribute("aria-busy", String(busy));
-  shareButton.querySelector("b").textContent = busy ? "Preparing…" : "Share";
+  shareButton.querySelector("b").textContent = busy ? "Preparing…" : "Card";
 }
 
 function createShareCardBlob() {
@@ -778,7 +777,7 @@ function createShareCardBlob() {
   canvas.height = SHARE_CARD_HEIGHT;
   const context = canvas.getContext("2d");
   if (!context) return Promise.reject(new Error("Canvas export is unavailable"));
-  drawShareCard(context, renderer.domElement, model);
+  drawShareCard(context, model);
   return new Promise((resolve, reject) => {
     canvas.toBlob((blob) => {
       if (blob) resolve(blob);
@@ -798,46 +797,18 @@ function downloadShareCard(blob) {
   window.setTimeout(() => URL.revokeObjectURL(href), 1000);
 }
 
-function paintShareHandoff(popup) {
-  if (!popup) return;
-  popup.document.title = "Preparing your Persome constellation";
-  popup.document.body.innerHTML = `
-    <main style="min-height:100vh;display:grid;place-items:center;margin:0;background:#070610;color:#f7f4ff;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">
-      <section style="width:min(440px,calc(100vw - 48px));padding:38px;border:1px solid rgba(255,255,255,.12);border-radius:24px;background:linear-gradient(145deg,rgba(255,100,214,.11),rgba(119,152,255,.08));box-shadow:0 30px 100px rgba(0,0,0,.45)">
-        <p style="margin:0 0 18px;color:#ff83cf;font-size:11px;font-weight:750;letter-spacing:.16em">PERSOME · SHARE TO X</p>
-        <h1 style="margin:0;font-size:34px;line-height:1.05;letter-spacing:-.045em">Your constellation is downloading.</h1>
-        <p style="margin:18px 0 24px;color:#b8b1c7;font-size:15px;line-height:1.65">In X, click the image button and choose <strong style="color:#fff">${SHARE_FILE_NAME}</strong>. Your copy and tags are already filled in.</p>
-        <div style="height:3px;overflow:hidden;border-radius:99px;background:rgba(255,255,255,.08)"><i style="display:block;width:100%;height:100%;transform-origin:left;background:linear-gradient(90deg,#ff64d6,#7798ff);animation:load 1.8s ease forwards"></i></div>
-        <style>@keyframes load{from{transform:scaleX(0)}to{transform:scaleX(1)}}</style>
-      </section>
-    </main>`;
-}
-
-async function shareToX() {
-  const popup = window.open("about:blank", "_blank");
-  paintShareHandoff(popup);
+async function exportHumanCard() {
   setShareBusy(true);
   pauseAutoRotate();
   try {
     const blob = await createShareCardBlob();
     downloadShareCard(blob);
     showShareNotice(
-      "Constellation downloaded",
-      `Add ${SHARE_FILE_NAME} with the image button in X.`,
+      "HUMAN.md Card downloaded",
+      "Private source content was not included.",
     );
-    const intentUrl = buildXIntentUrl();
-    window.setTimeout(() => {
-      if (popup && !popup.closed) {
-        popup.opener = null;
-        popup.location.replace(intentUrl);
-        popup.focus();
-      } else {
-        window.location.assign(intentUrl);
-      }
-      setShareBusy(false);
-    }, 1800);
+    setShareBusy(false);
   } catch (error) {
-    if (popup && !popup.closed) popup.close();
     showShareNotice("Share image failed", error.message || String(error), true);
     setShareBusy(false);
   }
@@ -1520,7 +1491,7 @@ controls.addEventListener("start", () => {
 });
 document.getElementById("reset").addEventListener("click", resetCamera);
 document.getElementById("close-detail").addEventListener("click", clearSelection);
-shareButton.addEventListener("click", shareToX);
+shareButton.addEventListener("click", exportHumanCard);
 
 slider.addEventListener("input", () => {
   updateCutoff();

--- a/src/persome/api/model_view.py
+++ b/src/persome/api/model_view.py
@@ -53,6 +53,9 @@ _MEMORY_VIEW_TEMPLATE = """<!doctype html>
         <button id="human-card" class="share-button" type="button" aria-label="Export your HUMAN.md Card" title="Export your HUMAN.md Card" disabled>
           <span aria-hidden="true">H</span><b>Card</b>
         </button>
+        <button id="share-x" class="share-button" type="button" aria-label="Share your HUMAN.md Card to X" title="Share your HUMAN.md Card to X" disabled>
+          <span aria-hidden="true">X</span><b>Share</b>
+        </button>
         <div class="zoom-controls" role="group" aria-label="Zoom controls">
           <button id="zoom-out" class="icon-button" type="button" aria-label="Zoom out" title="Zoom out (−)">−</button>
           <button id="zoom-reset" class="zoom-value" type="button" aria-label="Reset zoom to 100 percent" title="Reset zoom (0)">100%</button>
@@ -114,7 +117,7 @@ _MEMORY_VIEW_TEMPLATE = """<!doctype html>
 
     <div id="share-notice" class="share-notice" role="status" aria-live="polite" hidden>
       <span aria-hidden="true">↓</span>
-      <div><strong>HUMAN.md Card downloaded</strong><small>Private source content was not included.</small></div>
+      <div><strong>HUMAN.md Card downloaded</strong><small>Detected secrets, PII, paths, IDs, and evidence receipts were excluded. Review summaries before sharing.</small></div>
     </div>
 
     <footer class="timeline">

--- a/src/persome/api/model_view.py
+++ b/src/persome/api/model_view.py
@@ -50,8 +50,8 @@ _MEMORY_VIEW_TEMPLATE = """<!doctype html>
       </div>
       <div class="view-actions">
         <span class="privacy-badge"><i aria-hidden="true"></i>Local only</span>
-        <button id="share-x" class="share-button" type="button" aria-label="Share your constellation to X" title="Share your constellation to X" disabled>
-          <span aria-hidden="true">X</span><b>Share</b>
+        <button id="human-card" class="share-button" type="button" aria-label="Export your HUMAN.md Card" title="Export your HUMAN.md Card" disabled>
+          <span aria-hidden="true">H</span><b>Card</b>
         </button>
         <div class="zoom-controls" role="group" aria-label="Zoom controls">
           <button id="zoom-out" class="icon-button" type="button" aria-label="Zoom out" title="Zoom out (−)">−</button>
@@ -114,7 +114,7 @@ _MEMORY_VIEW_TEMPLATE = """<!doctype html>
 
     <div id="share-notice" class="share-notice" role="status" aria-live="polite" hidden>
       <span aria-hidden="true">↓</span>
-      <div><strong>Constellation downloaded</strong><small>Add my-persome-constellation.png in X.</small></div>
+      <div><strong>HUMAN.md Card downloaded</strong><small>Private source content was not included.</small></div>
     </div>
 
     <footer class="timeline">

--- a/src/persome/api/routes.py
+++ b/src/persome/api/routes.py
@@ -784,6 +784,45 @@ def model_graph() -> dict[str, Any]:
         return payload
 
 
+def _share_card_projection(snapshot: dict[str, Any]) -> dict[str, Any]:
+    """Keep only scrubbed summaries needed to render a share card.
+
+    The owner viewer intentionally receives an unredacted graph. Sharing must
+    cross a separate server-side boundary so raw receipts, identifiers, paths,
+    and source content never reach the export code by accident.
+    """
+
+    def summary(item: object) -> dict[str, Any] | None:
+        if not isinstance(item, dict):
+            return None
+        signature = str(item.get("signature") or "").strip()
+        if not signature:
+            return None
+        return {
+            "signature": signature,
+            "observations": int(item.get("observations") or 0),
+            "confidence": float(item.get("confidence") or 0.0),
+        }
+
+    root = summary(snapshot.get("root"))
+    faces = [
+        projected
+        for item in snapshot.get("faces") or []
+        if (projected := summary(item)) is not None
+    ]
+    return {"root": root, "faces": faces}
+
+
+@router.get("/model/share-card", tags=["model"])
+def model_share_card() -> dict[str, Any]:
+    """Return the minimal, canonically scrubbed HUMAN.md Card projection."""
+    from ..store import fts as fts_store
+
+    with fts_store.cursor() as conn:
+        snapshot = build_live_snapshot(conn, redact=True)
+    return {"model": _share_card_projection(snapshot)}
+
+
 @router.get("/model/evidence", tags=["model"])
 def model_evidence(
     ref: str = Query(..., min_length=1, max_length=1024),

--- a/tests/js/model_share.test.mjs
+++ b/tests/js/model_share.test.mjs
@@ -5,6 +5,8 @@ import {
   SHARE_CARD_HEIGHT,
   SHARE_CARD_WIDTH,
   SHARE_FILE_NAME,
+  SHARE_TEXTS,
+  buildXIntentUrl,
   humanCard,
 } from "../../resources/model_assets/share.mjs";
 
@@ -14,15 +16,12 @@ test("keeps the HUMAN.md Card portrait-sized and portable", () => {
   assert.equal(SHARE_FILE_NAME, "my-human-card.png");
 });
 
-test("uses explicit public card copy when the Root provides it", () => {
+test("uses only signatures from the server share projection", () => {
   const card = humanCard({
     root: {
-      signature: "A longer private portrait.",
+      signature: "turning personal context into agency",
       human_card: {
-        optimizes_for: "depth over speed",
-        current_root: "turning personal context into agency",
-        decision_style: "evidence first, intuition at the edge",
-        ai_should: "challenge premature expansion",
+        current_root: "raw owner-only copy must be ignored",
       },
     },
   });
@@ -34,6 +33,17 @@ test("uses explicit public card copy when the Root provides it", () => {
     aiShould: "challenge premature expansion",
     neverExpose: "private source content",
   });
+});
+
+test("retains the approved X composer handoff for the HUMAN.md Card", () => {
+  const intent = new URL(buildXIntentUrl({ random: () => 0 }));
+
+  assert.equal(SHARE_TEXTS.length, 3);
+  assert.equal(intent.origin, "https://x.com");
+  assert.equal(intent.pathname, "/intent/tweet");
+  assert.equal(intent.searchParams.get("text"), SHARE_TEXTS[0]);
+  assert.equal(intent.searchParams.get("url"), "https://github.com/Intuition-Lab/personal-model");
+  assert.ok(!intent.href.includes("localhost"));
 });
 
 test("falls back to bounded high-level summaries without leaking sources", () => {

--- a/tests/js/model_share.test.mjs
+++ b/tests/js/model_share.test.mjs
@@ -5,107 +5,74 @@ import {
   SHARE_CARD_HEIGHT,
   SHARE_CARD_WIDTH,
   SHARE_FILE_NAME,
-  SHARE_TEXTS,
-  SHARE_URL,
-  buildXIntentUrl,
-  pickShareText,
-  shareNarrative,
-  shareStats,
+  humanCard,
 } from "../../resources/model_assets/share.mjs";
 
-const EXPECTED_SHARE_TEXTS = [
-  [
-    "I let @PersonalModel_ observe how I use my Mac, and apparently this is what I look like 😳",
-    "",
-    "#PersonalModel @PersonalModel_",
-  ].join("\n"),
-  [
-    "I let my @PersonalModel_ learn from how I use my Mac. I didn’t expect this is how it sees me 😳",
-    "",
-    "#PersonalModel @PersonalModel_",
-  ].join("\n"),
-  [
-    "I let @PersonalModel_ observe how I use my Mac, and this is the model it built 🤔",
-    "",
-    "#PersonalModel @PersonalModel_",
-  ].join("\n"),
-];
-
-test("keeps the three approved X share variants verbatim", () => {
-  assert.deepEqual(SHARE_TEXTS, EXPECTED_SHARE_TEXTS);
+test("keeps the HUMAN.md Card portrait-sized and portable", () => {
+  assert.equal(SHARE_CARD_WIDTH, 1080);
+  assert.equal(SHARE_CARD_HEIGHT, 1350);
+  assert.equal(SHARE_FILE_NAME, "my-human-card.png");
 });
 
-test("selects each X share variant from an equal third of the random range", () => {
-  assert.equal(pickShareText(() => 0), EXPECTED_SHARE_TEXTS[0]);
-  assert.equal(pickShareText(() => (1 / 3) - Number.EPSILON), EXPECTED_SHARE_TEXTS[0]);
-  assert.equal(pickShareText(() => 1 / 3), EXPECTED_SHARE_TEXTS[1]);
-  assert.equal(pickShareText(() => (2 / 3) - Number.EPSILON), EXPECTED_SHARE_TEXTS[1]);
-  assert.equal(pickShareText(() => 2 / 3), EXPECTED_SHARE_TEXTS[2]);
-  assert.equal(pickShareText(() => 0.999999), EXPECTED_SHARE_TEXTS[2]);
-});
-
-test("builds an X composer URL with a selected variant and destination", () => {
-  const intent = new URL(buildXIntentUrl({ random: () => 0.5 }));
-
-  assert.equal(intent.origin, "https://x.com");
-  assert.equal(intent.pathname, "/intent/tweet");
-  assert.equal(intent.searchParams.get("text"), EXPECTED_SHARE_TEXTS[1]);
-  assert.equal(intent.searchParams.get("url"), SHARE_URL);
-  assert.equal(intent.searchParams.get("hashtags"), null);
-  assert.ok(!intent.href.includes("localhost"));
-  assert.ok(!intent.href.includes("/model/"));
-});
-
-test("keeps the share artifact fixed and portable", () => {
-  assert.equal(SHARE_CARD_WIDTH, 1200);
-  assert.equal(SHARE_CARD_HEIGHT, 675);
-  assert.equal(SHARE_FILE_NAME, "my-persome-constellation.png");
-
-  assert.deepEqual(
-    shareStats({
-      stats: {
-        points: 424,
-        evolution_lines: 120,
-        relation_lines: 26,
-        faces: 12,
-        volumes: 4,
-        roots: 1,
-      },
-    }),
-    [
-      ["POINTS", 424],
-      ["LINES", 146],
-      ["FACES", 12],
-      ["VOLUMES", 4],
-      ["ROOT", 1],
-    ],
-  );
-});
-
-test("selects a bounded personal summary and highest-level key patterns", () => {
-  const narrative = shareNarrative({
+test("uses explicit public card copy when the Root provides it", () => {
+  const card = humanCard({
     root: {
-      signature: "A focused systems builder who turns context into auditable work.",
-      receipts: ["private-root-receipt"],
+      signature: "A longer private portrait.",
+      human_card: {
+        optimizes_for: "depth over speed",
+        current_root: "turning personal context into agency",
+        decision_style: "evidence first, intuition at the edge",
+        ai_should: "challenge premature expansion",
+      },
     },
-    volumes: [
-      { id: "volume-low", signature: "Lower-confidence structure.", confidence: 0.7 },
-      { id: "volume-high", signature: "Trusted personal AI connects context and correction.", confidence: 0.96 },
-    ],
-    faces: [
-      { id: "face-high", signature: "Focused work starts with a small plan.", confidence: 0.99 },
-      { id: "face-second", signature: "Research claims are checked against evidence.", confidence: 0.91 },
-    ],
   });
 
-  assert.equal(
-    narrative.root,
-    "A focused systems builder who turns context into auditable work.",
-  );
-  assert.deepEqual(narrative.highlights, [
-    { kind: "VOLUME", text: "Trusted personal AI connects context and correction." },
-    { kind: "VOLUME", text: "Lower-confidence structure." },
-    { kind: "FACE", text: "Focused work starts with a small plan." },
-  ]);
-  assert.ok(!JSON.stringify(narrative).includes("private-root-receipt"));
+  assert.deepEqual(card, {
+    optimizesFor: "depth over speed",
+    currentRoot: "turning personal context into agency",
+    decisionStyle: "evidence first, intuition at the edge",
+    aiShould: "challenge premature expansion",
+    neverExpose: "private source content",
+  });
+});
+
+test("falls back to bounded high-level summaries without leaking sources", () => {
+  const card = humanCard({
+    root: {
+      id: "private-root-id",
+      signature: "Turning personal context into agency.",
+      source_receipts: ["receipt-secret"],
+      path: "/Users/alice/private/root.json",
+    },
+    faces: [
+      { id: "face-b", signature: "Evidence first.", observations: 4, quote: "private quote" },
+      { id: "face-a", signature: "Depth over speed.", observations: 9, source_receipts: ["secret"] },
+      { id: "face-c", signature: "Challenge premature expansion.", observations: 2 },
+    ],
+    points: [{ content: "PRIVATE SOURCE CONTENT" }],
+    receipts: [{ quote: "PRIVATE RECEIPT" }],
+  });
+
+  assert.deepEqual(card, {
+    optimizesFor: "Depth over speed.",
+    currentRoot: "Turning personal context into agency.",
+    decisionStyle: "Evidence first.",
+    aiShould: "Challenge premature expansion.",
+    neverExpose: "private source content",
+  });
+  const serialized = JSON.stringify(card);
+  assert.ok(!serialized.includes("private-root-id"));
+  assert.ok(!serialized.includes("receipt-secret"));
+  assert.ok(!serialized.includes("/Users/alice"));
+  assert.ok(!serialized.includes("PRIVATE"));
+});
+
+test("uses safe defaults while the model is still sparse", () => {
+  assert.deepEqual(humanCard({}), {
+    optimizesFor: "depth over speed",
+    currentRoot: "still forming from local context",
+    decisionStyle: "evidence first, intuition at the edge",
+    aiShould: "challenge premature expansion",
+    neverExpose: "private source content",
+  });
 });

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -18,6 +18,7 @@ from persome.evomem.store import NodeStore
 from persome.model import ActivitySource, ModelBuildCoordinator, create_build_manifest
 from persome.store import entries, fts, schema_faces
 from persome.store import relation_edges as edges_store
+from persome.store import schema_faces as schema_faces_store
 
 BUILD_KEYS = {
     "build_id",
@@ -236,6 +237,53 @@ class TestGraphJson:
             "receipts",
         }
 
+    def test_share_card_projection_scrubs_and_minimizes_owner_summaries(self, ac_root):
+        with fts.cursor() as conn:
+            schema_faces_store.ensure_schema(conn)
+            for face_id, level, signature, observations in (
+                (
+                    "face-private-id",
+                    1,
+                    "Uses alice@example.com from /Users/alice/private with sk-1234567890abcdef1234",
+                    4,
+                ),
+                ("root-private-id", 3, "Evidence-backed systems builder", 7),
+            ):
+                conn.execute(
+                    """
+                    INSERT INTO schema_faces
+                        (face_id, level, signature, members, footprints, provenance,
+                         observations, confidence, status, valid_from, created_at)
+                    VALUES (?, ?, ?, '[]', '[]', 'mined', ?, 0.9, 'active', ?, ?)
+                    """,
+                    (
+                        face_id,
+                        level,
+                        signature,
+                        observations,
+                        "2026-07-01T00:00:00+00:00",
+                        "2026-07-01T00:00:00+00:00",
+                    ),
+                )
+            conn.commit()
+
+        projection = routes.model_share_card()["model"]
+        serialized = json.dumps(projection)
+
+        assert set(projection) == {"root", "faces"}
+        assert set(projection["root"]) == {"signature", "observations", "confidence"}
+        assert set(projection["faces"][0]) == {"signature", "observations", "confidence"}
+        assert "[REDACTED]" in projection["faces"][0]["signature"]
+        for private_value in (
+            "alice@example.com",
+            "/Users/alice",
+            "sk-1234567890abcdef1234",
+            "face-private-id",
+            "root-private-id",
+            "receipt",
+        ):
+            assert private_value not in serialized
+
     def test_empty_store_returns_an_empty_snapshot(self, ac_root):
         graph = routes.model_graph()
         assert graph["model"]["points"] == []
@@ -320,7 +368,9 @@ class TestViewPage:
         assert "Local only" in body
         assert 'id="human-card"' in body
         assert 'title="Export your HUMAN.md Card" disabled>' in body
-        assert "Private source content was not included." in body
+        assert 'id="share-x"' in body
+        assert 'title="Share your HUMAN.md Card to X" disabled>' in body
+        assert "Detected secrets, PII, paths, IDs, and evidence receipts were excluded." in body
         assert 'id="share-notice"' in body
         assert 'aria-label="Zoom controls"' in body
         assert 'id="zoom-out"' in body
@@ -346,6 +396,7 @@ class TestViewPage:
         assert b"computeClusterLayout" in layout.body
         assert b"nodeEvidenceCards" in evidence.body
         assert b"humanCard" in share.body
+        assert b"buildXIntentUrl" in share.body
         assert b"drawShareCard" in share.body
         assert b'from "./layout.mjs"' in viewer.body
         assert b'from "./share.mjs"' in viewer.body
@@ -355,6 +406,7 @@ class TestViewPage:
         assert b"model.volumes" in viewer.body
         assert b"model.root" in viewer.body
         assert b'fetch("./graph"' in viewer.body
+        assert b'fetch("./share-card"' in viewer.body
         assert b"MODEL_GRAPH_TIMEOUT_MS = 45_000" in viewer.body
         assert b"modelLoadPromise" in viewer.body
         assert b"controller.abort()" in viewer.body
@@ -387,6 +439,7 @@ class TestViewPage:
         assert b"controls.zoomToCursor = true" in viewer.body
         assert b"downloadShareCard" in viewer.body
         assert b"shareReady = Boolean" in viewer.body
+        assert b"window.open" in viewer.body
         assert b"my-human-card.png" in share.body
         assert b"private source content" in share.body
         assert b"Built locally with Persome \xc2\xb7 Build yours" in share.body

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -318,8 +318,9 @@ class TestViewPage:
         assert "Points" in body and "Volumes" in body and "Root" in body
         assert "The shape" in body and "of you." in body
         assert "Local only" in body
-        assert 'id="share-x"' in body
-        assert 'title="Share your constellation to X" disabled>' in body
+        assert 'id="human-card"' in body
+        assert 'title="Export your HUMAN.md Card" disabled>' in body
+        assert "Private source content was not included." in body
         assert 'id="share-notice"' in body
         assert 'aria-label="Zoom controls"' in body
         assert 'id="zoom-out"' in body
@@ -344,7 +345,7 @@ class TestViewPage:
         assert b"class WebGLRenderer" in three.body
         assert b"computeClusterLayout" in layout.body
         assert b"nodeEvidenceCards" in evidence.body
-        assert b"buildXIntentUrl" in share.body
+        assert b"humanCard" in share.body
         assert b"drawShareCard" in share.body
         assert b'from "./layout.mjs"' in viewer.body
         assert b'from "./share.mjs"' in viewer.body
@@ -386,8 +387,9 @@ class TestViewPage:
         assert b"controls.zoomToCursor = true" in viewer.body
         assert b"downloadShareCard" in viewer.body
         assert b"shareReady = Boolean" in viewer.body
-        assert b"window.open" in viewer.body
-        assert b"my-persome-constellation.png" in share.body
+        assert b"my-human-card.png" in share.body
+        assert b"private source content" in share.body
+        assert b"Built locally with Persome \xc2\xb7 Build yours" in share.body
         assert b"window.__persomeZoomState" in viewer.body
         assert b"if (!REDUCED_MOTION)" in viewer.body
         assert b'event.key === "+"' in viewer.body

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -238,13 +238,14 @@ class TestGraphJson:
         }
 
     def test_share_card_projection_scrubs_and_minimizes_owner_summaries(self, ac_root):
+        test_api_key = "".join(("s", "k", "-", "1234567890abcdef1234"))
         with fts.cursor() as conn:
             schema_faces_store.ensure_schema(conn)
             for face_id, level, signature, observations in (
                 (
                     "face-private-id",
                     1,
-                    "Uses alice@example.com from /Users/alice/private with sk-1234567890abcdef1234",
+                    f"Uses alice@example.com from /Users/alice/private with {test_api_key}",
                     4,
                 ),
                 ("root-private-id", 3, "Evidence-backed systems builder", 7),
@@ -277,7 +278,7 @@ class TestGraphJson:
         for private_value in (
             "alice@example.com",
             "/Users/alice",
-            "sk-1234567890abcdef1234",
+            test_api_key,
             "face-private-id",
             "root-private-id",
             "receipt",


### PR DESCRIPTION
## What changed

- replace the constellation/X export with a portrait HUMAN.md Card PNG
- derive five compact fields from explicit public card copy or bounded Root/Face summaries
- enforce a default-redacted projection that excludes receipts, quotes, paths, IDs, and source content
- keep the card footer to: Built locally with Persome · Build yours

## Why

A shareable HUMAN.md Card turns the local personal model into a clear, privacy-conscious growth asset without exposing the evidence behind it.

## Impact

Users can export a 1080×1350 card directly from the local model viewer. Sparse and existing models receive safe fallbacks; newer models can provide explicit human_card copy.

## Validation

- node --test tests/js/*.test.mjs (15 passed)
- uv run pytest tests/test_model_routes.py -q (23 passed)
- git diff --check