### PR TITLE
Turn overlooked signals into evidence-backed personal behavior

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -417,6 +417,11 @@ as structured error logs. The old runtime SSE event bus no longer exists.
 `freeze_writes_on_failure` is intentionally off because a false positive under
 Markdown authority should not halt observation.
 
+`contradiction_check_enabled` remains off by default because generation spends
+nightly LLM calls. This does not disable the read contract: `verify_fact`
+explains any existing open ledger rows, while resolved or dismissed rows remain
+historical and are not returned.
+
 ## Retrieval
 
 ```toml

--- a/docs/config.md
+++ b/docs/config.md
@@ -301,6 +301,22 @@ owner-only `.index-health.json` sidecar and surface through `persome status`,
 [`runtime-internals.md`](runtime-internals.md) and
 [`capture.md`](capture.md).
 
+## Timeline skill matching
+
+```toml
+[skill_check]
+enabled = true
+max_registered = 20
+token_budget = 1000
+```
+
+When skill matching is enabled, each timeline call receives only the most
+relevant active flat or nested skill paths. `max_registered` limits the number
+of complete registry rows, while `token_budget` caps the whole Registered Skills
+prompt section using a deterministic local estimate. Oversized rows are skipped
+without truncation, and returned hints are accepted only for paths that were
+actually included in that call's prompt.
+
 ## Higher geometry
 
 ```toml

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -56,7 +56,7 @@ Example stdio client configuration:
 | `related_events` | Retrieve time-adjacent context around one memory entry: overlapping timeline blocks plus nearest captures, anchored on parseable `occurred_at` else write time. Context is observed data, not evidence for the entry. |
 | `resolve_evidence` | Resolve model, memory, activity, and capture references through one progressive evidence contract. |
 | `recent_activity` | Read recent durable event entries. |
-| `behavior_patterns` | Read modeled behavioral patterns and their support. |
+| `behavior_patterns` | Read modeled behavioral patterns plus evidence-backed observed workflow playbooks. |
 | `get_model_snapshot` | Return the versioned Point/Line/Face/Volume/Root model snapshot. |
 | `entity_graph` | Read the entity/relation graph; retained as a compatibility model view. |
 | `verify_fact` | Check a claim against current and superseded memory. |
@@ -97,6 +97,11 @@ as direct proof. Display `label` as the human-readable card title and keep
 are returned separately in `history`. Follow each returned `reference` to move
 down one layer; a retained receipt whose payload is no longer available returns
 `status=missing`.
+
+`behavior_patterns` includes only active skill files with a current
+evidence-backed observed-pattern entry. Later trigger echoes do not replace the
+playbook. A playbook can guide personalization and imitation, but it never grants
+a client permission to execute the observed actions.
 
 ## Transport
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -59,7 +59,7 @@ Example stdio client configuration:
 | `behavior_patterns` | Read modeled behavioral patterns plus evidence-backed observed workflow playbooks. |
 | `get_model_snapshot` | Return the versioned Point/Line/Face/Volume/Root model snapshot. |
 | `entity_graph` | Read the entity/relation graph; retained as a compatibility model view. |
-| `verify_fact` | Check a claim against current and superseded memory. |
+| `verify_fact` | Check a claim's freshness and explain existing open contradiction ledger rows. |
 | `remember` | Append an explicit, auditable memory. |
 | `correct_memory` | Supersede or revoke memory through the correction workflow. |
 | `process_pending_model_work` | Process a bounded number of pending sessions with the connected client's model allowance through MCP Sampling. |
@@ -102,6 +102,11 @@ down one layer; a retained receipt whose payload is no longer available returns
 evidence-backed observed-pattern entry. Later trigger echoes do not replace the
 playbook. A playbook can guide personalization and imitation, but it never grants
 a client permission to execute the observed actions.
+
+`verify_fact` remains a deterministic read: it does not judge whether a claim is
+true. When a recalled entry participates in an open contradiction ledger row,
+the result includes the recorded reason and bounded competing claim. Resolved or
+dismissed rows are not replayed.
 
 ## Transport
 

--- a/docs/writer.md
+++ b/docs/writer.md
@@ -111,9 +111,10 @@ delta apply.
 candidate filtering, and an LLM validation pass. Confirmed observations land in
 `skills/skill-*.md` with evidence and `stage: observed`. A single occurrence is
 insufficient. Timeline skill echoes are deduplicated by session, so repeated
-minute blocks inside one continuous episode count as one observation. The stage
-models a person's recurring behavior; it does not propose scripts or execute
-automation.
+minute blocks inside one continuous episode count as one observation. MCP
+`behavior_patterns` exposes the latest active evidence-backed playbooks beside
+the resident Root and Faces. The stage models a person's recurring behavior; it
+does not propose scripts, grant permission, or execute automation.
 
 ## Higher-level build
 

--- a/src/persome/config.py
+++ b/src/persome/config.py
@@ -247,6 +247,8 @@ class MemoryDecayConfig:
 class SkillCheckConfig:
     # Detect skill matches inside the per-minute timeline LLM call.
     enabled: bool = True
+    max_registered: int = 20  # relevance-ranked skills exposed to one timeline call
+    token_budget: int = 1000  # deterministic proxy cap for the whole registry section
 
 
 @dataclass
@@ -751,6 +753,8 @@ port = 8742
 
 [skill_check]
 enabled = true                    # detect skill matches inside the per-minute timeline LLM call
+max_registered = 20              # maximum relevance-ranked skills exposed to one call
+token_budget = 1000              # deterministic cap for the Registered Skills section
 
 
 [schema]

--- a/src/persome/mcp/server.py
+++ b/src/persome/mcp/server.py
@@ -296,9 +296,52 @@ def _behavior_patterns(conn) -> dict[str, Any]:  # type: ignore[no-untyped-def]
 
     root_row = faces_store.resident_root(conn)
     faces = faces_store.resident_faces(conn, top_k=8)
+    skill_rows = conn.execute(
+        """
+        SELECT f.path, f.description, f.updated, e.id, e.timestamp, e.content
+          FROM files AS f
+          JOIN entries AS e
+            ON e.rowid = (
+                SELECT latest.rowid
+                  FROM entries AS latest
+                 WHERE latest.path = f.path
+                   AND latest.superseded = 0
+                   AND instr(' ' || latest.tags || ' ', ' pattern ') > 0
+                   AND (
+                       instr(' ' || latest.tags || ' ', ' observed ') > 0
+                       OR lower(ltrim(latest.content)) LIKE 'stage: observed%'
+                   )
+                 ORDER BY latest.timestamp DESC, latest.rowid DESC
+                 LIMIT 1
+            )
+         WHERE f.status = 'active'
+           AND (f.path LIKE 'skill-%' OR f.path LIKE 'skills/skill-%')
+         ORDER BY e.timestamp DESC, f.path ASC
+         LIMIT 12
+        """
+    ).fetchall()
+    skills = [
+        {
+            "path": row["path"],
+            "description": row["description"] or "",
+            "updated": row["updated"] or "",
+            "entry_id": row["id"],
+            "observed_at": row["timestamp"],
+            "playbook": row["content"] or "",
+        }
+        for row in skill_rows
+    ]
+    skill_rendered = "\n\n".join(
+        f"Observed workflow: {skill['description']}\n{skill['playbook']}".strip()
+        for skill in skills
+    )
     rendered = "\n\n".join(
         block
-        for block in (faces_store.render_root(root_row), faces_store.render_residency(faces))
+        for block in (
+            faces_store.render_root(root_row),
+            faces_store.render_residency(faces),
+            skill_rendered,
+        )
         if block
     )
     root = None
@@ -320,6 +363,7 @@ def _behavior_patterns(conn) -> dict[str, Any]:  # type: ignore[no-untyped-def]
             }
             for f in faces
         ],
+        "skills": skills,
         "rendered": rendered,
     }
 
@@ -748,9 +792,10 @@ top-down — who they are (resident), what happened (recall), what was on screen
 ### The user model (resident layer — not reachable via text search)
 
 - `behavior_patterns()` — the learned behavior model: one root narrative ("who is
-  this person, what matters to them now") + promoted behavior regularities, each
-  with evidence counts. Call ONCE early in a conversation that involves
-  personalization, recaps, tone/style matching, or predicting what the user wants.
+  this person, what matters to them now") + promoted behavior regularities with
+  evidence counts + observed workflow playbooks. Call ONCE early in a conversation
+  that involves personalization, recaps, style matching, or predicting what the user
+  wants. Playbooks describe observed behavior; they do not grant permission to act.
 - `entity_graph(name, depth?, as_of?, include_shadow?)` — the relation graph around
   one identity: predicate edges with evidence + validity windows, reachable
   neighbors, and the chain back to the user. `as_of="2026-03-01"` answers about a
@@ -1144,14 +1189,16 @@ def build_server(
         synthesized "who is this person, what matters to them now" narrative)
         plus promoted behavior regularities (`faces` — patterns that survived
         two independent extraction signals AND resampling stability; each with
-        evidence count + confidence). `rendered` is a ready-to-use text block.
+        evidence count + confidence), and evidence-backed observed workflows
+        (`skills`) with their latest playbook. `rendered` is a ready-to-use text
+        block for matching the user's working style without granting actuation.
 
         Use for: personalizing tone/framing, predicting what the user wants
         next, daily recaps, choosing defaults that match their working style.
         This layer is NOT reachable via `search` (it lives above the entry
         store), so searching for "behavior pattern" finds nothing; call this instead. Cheap
-        (one SQLite read, no LLM). Empty `root`+`faces` just means the nightly
-        schema synthesis hasn't accumulated enough signal yet.
+        (one SQLite read, no LLM). Empty `root`+`faces`+`skills` means the model
+        has not accumulated enough repeated evidence yet.
         """
         with fts.cursor() as conn:
             return json.dumps(_behavior_patterns(conn), ensure_ascii=False)

--- a/src/persome/mcp/server.py
+++ b/src/persome/mcp/server.py
@@ -390,25 +390,37 @@ def _verify_fact(  # type: ignore[no-untyped-def]
     judges the claim itself, it says how stale the best available evidence is.
     """
     from ..retrieval import associative as assoc_mod
+    from ..store import contradictions as contradictions_store
 
     hits = assoc_mod.associative_read(conn, query=claim, top_k=top_k)
     metas = fts.entry_metadata_map(conn, [h.id for h in hits])
+    conflicts = contradictions_store.open_for_entries(conn, [h.id for h in hits])
     now = datetime.now().astimezone()
     evidence = []
     for h in hits:
         m = metas.get(h.id) or {}
-        evidence.append(
-            {
-                "id": h.id,
-                "path": h.path,
-                "timestamp": h.timestamp,
-                "age_days": _age_days(h.timestamp, now=now),
-                "content": h.content,
-                "confidence": m.get("confidence"),
-                "conflicted": m.get("conflicted", False),
-                "occurred_at": m.get("occurred_at"),
-            }
-        )
+        item = {
+            "id": h.id,
+            "path": h.path,
+            "timestamp": h.timestamp,
+            "age_days": _age_days(h.timestamp, now=now),
+            "content": h.content,
+            "confidence": m.get("confidence"),
+            "conflicted": m.get("conflicted", False),
+            "occurred_at": m.get("occurred_at"),
+        }
+        if h.id in conflicts:
+            item["conflicted"] = True
+            item["contradictions"] = [
+                {
+                    "pair_key": conflict["pair_key"],
+                    "reason": conflict["reason"],
+                    "competing_id": conflict["competing_id"],
+                    "competing_claim": (conflict["competing_body"] or "")[:280],
+                }
+                for conflict in conflicts[h.id]
+            ]
+        evidence.append(item)
     ages = [e["age_days"] for e in evidence if e["age_days"] is not None]
     freshest = min(ages) if ages else None
     stale = freshest is None or freshest > fresh_within_days
@@ -432,6 +444,8 @@ def _verify_fact(  # type: ignore[no-untyped-def]
             f"Evidence exists within {freshest} day(s). Read each item to confirm that "
             "it supports the claim; this tool checks freshness, not semantics."
         )
+    if any(item.get("contradictions") for item in evidence):
+        note += " One or more evidence items have an unresolved contradiction; do not present them as settled."
     return {
         "claim": claim,
         "evidence": evidence,
@@ -813,7 +827,8 @@ top-down — who they are (resident), what happened (recall), what was on screen
   - `include_bodies=true` to also attach higher-level cross-domain patterns.
 - `verify_fact(claim, top_k?, fresh_within_days?)` — freshness check for ONE claim.
   Call before stating time-sensitive facts (versions, task status, who-does-what,
-  schedules) as current. It judges TIME only; read the evidence yourself.
+  schedules) as current. It judges TIME only, but explains any existing open
+  contradiction ledger rows so they are not presented as settled.
 - `read_receipt(entry_id)` — dereference a `⟨entry_id:path⟩` receipt (from `chains`
   or any hit id) into the full entry + nearby-capture breadcrumbs. The audit trail
   from any memory down to the on-screen moment it came from.
@@ -1338,9 +1353,10 @@ def build_server(
         `verify_fact(claim="the current version is 0.3.9")`). Returns the freshest live
         evidence with per-entry `age_days`, plus `stale` (no evidence within
         `fresh_within_days`) and a `note` telling you how to treat it. The tool
-        judges TIME only — read the evidence to judge semantics yourself: if the
-        freshest evidence contradicts or postdates your claim, follow the
-        evidence; if everything is stale, state it as past status or ask.
+        judges TIME only — read the evidence to judge semantics yourself. An
+        evidence item with an open ledger row includes `contradictions` with the
+        recorded reason and competing claim; do not present either side as
+        settled. If everything is stale, state it as past status or ask.
         """
         claim = bounded_text("claim", claim, maximum=20_000)
         top_k = bounded_int(top_k, minimum=1, maximum=50)

--- a/src/persome/prompts/timeline_block.system.md
+++ b/src/persome/prompts/timeline_block.system.md
@@ -138,7 +138,7 @@ Each record uses this exact shape:
 
 Field rules:
 
-- `skill`: exact filename from the Registered Skills list. No other values are valid.
+- `skill`: exact path from the Registered Skills list. It may include a `skills/` prefix. No other values are valid.
 - `confidence`: float in `[0.0, 1.0]`. Only emit when ≥ 0.65.
 - `rationale`: one short clause that references specific evidence from `entries` above (app name, action, time). Do NOT quote skills that aren't in the registered list.
 

--- a/src/persome/store/contradictions.py
+++ b/src/persome/store/contradictions.py
@@ -82,6 +82,48 @@ def list_rows(conn: sqlite3.Connection, *, status: str | None = "open") -> list[
     )
 
 
+def open_for_entries(conn: sqlite3.Connection, entry_ids: list[str]) -> dict[str, list[dict]]:
+    """Return open ledger rows touching the requested entries, keyed by entry id.
+
+    Each result is oriented from the requested entry's side of the pair so a
+    read client can explain the ``conflicted`` flag without making another
+    semantic judgment.
+    """
+    ids = sorted({entry_id for entry_id in entry_ids if entry_id})
+    if not ids:
+        return {}
+    ensure_schema(conn)
+    conn.row_factory = sqlite3.Row
+    placeholders = ",".join("?" for _ in ids)
+    rows = conn.execute(
+        "SELECT pair_key, a_id, b_id, path, a_body, b_body, reason"
+        " FROM memory_contradictions WHERE status = 'open'"
+        f" AND (a_id IN ({placeholders}) OR b_id IN ({placeholders}))"  # noqa: S608
+        " ORDER BY created_at DESC, pair_key ASC",
+        (*ids, *ids),
+    ).fetchall()
+    wanted = set(ids)
+    out: dict[str, list[dict]] = {}
+    for row in rows:
+        sides = (
+            (row["a_id"], row["b_id"], row["b_body"]),
+            (row["b_id"], row["a_id"], row["a_body"]),
+        )
+        for current_id, competing_id, competing_body in sides:
+            if current_id not in wanted:
+                continue
+            out.setdefault(current_id, []).append(
+                {
+                    "pair_key": row["pair_key"],
+                    "reason": row["reason"],
+                    "competing_id": competing_id,
+                    "competing_body": competing_body,
+                    "path": row["path"],
+                }
+            )
+    return out
+
+
 def close(
     conn: sqlite3.Connection,
     key: str,

--- a/src/persome/timeline/aggregator.py
+++ b/src/persome/timeline/aggregator.py
@@ -499,8 +499,14 @@ def produce_block_for_window(
 
     skill_rows: list = []
     if cfg.skill_check.enabled:
+        # Pattern detection writes nested skills/skill-*.md files while legacy
+        # user-authored skills can still be flat. Register both active layouts.
         with fts_store.cursor() as conn:
-            skill_rows = [f for f in fts_store.list_files(conn) if f.path.startswith("skill-")]
+            skill_rows = [
+                f
+                for f in fts_store.list_files(conn)
+                if f.path.startswith("skill-") or f.path.startswith("skills/skill-")
+            ]
     skill_paths = {r.path for r in skill_rows}
     if skill_rows:
         skill_index_section = "\n\n## Registered Skills\n\n" + "\n".join(

--- a/src/persome/timeline/aggregator.py
+++ b/src/persome/timeline/aggregator.py
@@ -14,6 +14,7 @@ fields are back-rendered via ``ax_tree_to_markdown`` as a fallback.
 from __future__ import annotations
 
 import json
+import re
 from datetime import datetime, tzinfo
 from pathlib import Path
 
@@ -456,6 +457,54 @@ def _echo_skill_hints(block: store.TimelineBlock, skill_hints: list[dict]) -> No
             logger.warning("timeline: failed to echo skill hint to %s: %s", hint["skill"], exc)
 
 
+def _estimate_tokens(text: str) -> int:
+    """Return a cheap deterministic prompt-budget proxy.
+
+    CJK characters count individually; other text uses a conservative 4:1
+    character ratio. This is a hard local cap, not a provider tokenizer claim.
+    """
+    cjk = sum(1 for char in text if "\u4e00" <= char <= "\u9fff")
+    return cjk + (len(text) - cjk + 3) // 4
+
+
+def _registered_skills_section(
+    rows: list,
+    *,
+    events_text: str,
+    max_registered: int,
+    token_budget: int,
+) -> tuple[str, set[str]]:
+    """Render only relevance-ranked skills that fit the configured hard caps."""
+    if max_registered <= 0 or token_budget <= 0:
+        return "", set()
+
+    terms = set(re.findall(r"[a-z0-9_-]+|[\u4e00-\u9fff]", events_text.casefold()))
+
+    def rank(row: object) -> tuple[int, str]:
+        text = f"{row.path} {row.description}".casefold()
+        row_terms = set(re.findall(r"[a-z0-9_-]+|[\u4e00-\u9fff]", text))
+        return (-len(terms & row_terms), row.path)
+
+    header = "\n\n## Registered Skills\n\n"
+    selected: list[str] = []
+    selected_paths: set[str] = set()
+    used = _estimate_tokens(header)
+    for row in sorted(rows, key=rank):
+        if len(selected) >= max_registered:
+            break
+        description = " ".join(str(row.description).split())
+        line = f"- {row.path}" + (f": {description}" if description else "")
+        cost = _estimate_tokens(line + "\n")
+        if used + cost > token_budget:
+            continue
+        selected.append(line)
+        selected_paths.add(row.path)
+        used += cost
+    if not selected:
+        return "", set()
+    return header + "\n".join(selected), selected_paths
+
+
 def produce_block_for_window(
     cfg: Config,
     *,
@@ -507,13 +556,12 @@ def produce_block_for_window(
                 for f in fts_store.list_files(conn)
                 if f.path.startswith("skill-") or f.path.startswith("skills/skill-")
             ]
-    skill_paths = {r.path for r in skill_rows}
-    if skill_rows:
-        skill_index_section = "\n\n## Registered Skills\n\n" + "\n".join(
-            f"- {r.path}: {r.description}" for r in skill_rows
-        )
-    else:
-        skill_index_section = ""
+    skill_index_section, skill_paths = _registered_skills_section(
+        skill_rows,
+        events_text=events_text,
+        max_registered=cfg.skill_check.max_registered,
+        token_budget=cfg.skill_check.token_budget,
+    )
 
     system_text = load_prompt("timeline_block.system.md")
     user_text = load_prompt("timeline_block.user.md").format(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,9 @@ def test_defaults_when_no_file(tmp_path: Path) -> None:
     assert cfg.timeline.max_parallel_windows == 4
     assert cfg.attention_digest_enabled is False
     assert cfg.relation_extraction_enabled is False
+    assert cfg.evomem.contradiction_check_enabled is False
+    assert cfg.skill_check.max_registered == 20
+    assert cfg.skill_check.token_budget == 1000
     default = cfg.model_for("reducer")
     assert default.model == "deepseek-v4-flash"
 
@@ -131,6 +134,9 @@ def test_write_default_creates_file(tmp_path: Path) -> None:
     assert "PERSOME_LLM_API_KEY" in text
     assert "attention_digest_enabled = false" in text
     assert "relation_extraction_enabled = false" in text
+    assert "contradiction_check_enabled = false" in text
+    assert "max_registered = 20" in text
+    assert "token_budget = 1000" in text
     # idempotent
     assert not config.write_default_if_missing(p)
 

--- a/tests/test_recall_recency_and_labels.py
+++ b/tests/test_recall_recency_and_labels.py
@@ -219,6 +219,66 @@ def test_verify_fact_passes_fresh_evidence(ac_root, _restore_fts_gates):
         assert out["freshest_age_days"] <= 2
 
 
+def test_verify_fact_explains_open_contradictions(ac_root, _restore_fts_gates):
+    from persome.store import contradictions as contradictions_store
+
+    with fts.cursor() as conn:
+        conn.executescript(fts.SCHEMA)
+        fresh_ts = (datetime.now().astimezone() - timedelta(days=1)).isoformat()
+        _insert(conn, id="e-a", ts=fresh_ts, content="current version 0.4.2")
+        _insert(conn, id="e-b", ts=fresh_ts, content="current version 0.5.0")
+        key = contradictions_store.record(
+            conn,
+            a_id="e-a",
+            b_id="e-b",
+            path="topic-x.md",
+            a_body="current version 0.4.2",
+            b_body="current version 0.5.0",
+            reason="both claim to be the current version",
+        )
+
+        out = mcp_server._verify_fact(conn, claim="current version")
+
+    by_id = {item["id"]: item for item in out["evidence"]}
+    assert by_id["e-a"]["conflicted"] is True
+    assert by_id["e-a"]["contradictions"] == [
+        {
+            "pair_key": key,
+            "reason": "both claim to be the current version",
+            "competing_id": "e-b",
+            "competing_claim": "current version 0.5.0",
+        }
+    ]
+    assert by_id["e-b"]["contradictions"][0]["competing_id"] == "e-a"
+    assert "unresolved contradiction" in out["note"]
+
+
+def test_verify_fact_does_not_replay_closed_contradictions(ac_root, _restore_fts_gates):
+    from persome.store import contradictions as contradictions_store
+
+    with fts.cursor() as conn:
+        conn.executescript(fts.SCHEMA)
+        fresh_ts = (datetime.now().astimezone() - timedelta(days=1)).isoformat()
+        _insert(conn, id="e-a", ts=fresh_ts, content="current version 0.4.2")
+        key = contradictions_store.record(
+            conn,
+            a_id="e-a",
+            b_id="e-retired",
+            path="topic-x.md",
+            a_body="current version 0.4.2",
+            b_body="current version 0.3.9",
+            reason="a newer version superseded the old claim",
+        )
+        contradictions_store.close(conn, key, status="resolved", keep_id="e-a")
+
+        out = mcp_server._verify_fact(conn, claim="current version")
+
+    item = next(evidence for evidence in out["evidence"] if evidence["id"] == "e-a")
+    assert item["conflicted"] is False
+    assert "contradictions" not in item
+    assert "unresolved contradiction" not in out["note"]
+
+
 def test_verify_fact_no_evidence_is_honest(ac_root, _restore_fts_gates):
     with fts.cursor() as conn:
         conn.executescript(fts.SCHEMA)

--- a/tests/test_recall_recency_and_labels.py
+++ b/tests/test_recall_recency_and_labels.py
@@ -292,13 +292,37 @@ def test_build_server_wires_the_full_read_path(ac_root, _restore_fts_gates, monk
 
 
 def test_behavior_patterns_exposes_root_and_faces(ac_root):
+    from persome.store import entries as entries_store
     from persome.store import schema_faces as faces_store
 
     with fts.cursor() as conn:
         conn.executescript(fts.SCHEMA)
         # cold start: honest empties, never an error
         out = mcp_server._behavior_patterns(conn)
-        assert out == {"root": None, "faces": [], "rendered": ""}
+        assert out == {"root": None, "faces": [], "skills": [], "rendered": ""}
+        entries_store.create_file(
+            conn,
+            name="skills/skill-morning-triage",
+            description="Triage communication before opening the active project.",
+            tags=["skill", "observed"],
+        )
+        skill_id = entries_store.append_entry(
+            conn,
+            name="skills/skill-morning-triage.md",
+            content=(
+                "stage: observed\n\n"
+                "**Trigger**: weekday start\n"
+                "**Steps**: 1. Mail. 2. Slack. 3. Project.\n"
+                "**Boundaries**: observed ordering only"
+            ),
+            tags=["pattern", "observed"],
+        )
+        echo_id = entries_store.append_entry(
+            conn,
+            name="skills/skill-morning-triage.md",
+            content="Triggered with confidence 0.91: Mail and Slack were opened.",
+            tags=["triggered", "echo"],
+        )
         faces_store.upsert_root(
             conn,
             signature="\u9ad8\u5ea6\u7cfb\u7edf\u5316\u7684\u5f00\u53d1\u8005\uff0c\u6df1\u591c\u9ad8\u4ea7",
@@ -308,3 +332,58 @@ def test_behavior_patterns_exposes_root_and_faces(ac_root):
         out = mcp_server._behavior_patterns(conn)
         assert out["root"]["signature"].startswith("\u9ad8\u5ea6\u7cfb\u7edf\u5316")
         assert "Root" in out["rendered"] and "\u9ad8\u5ea6\u7cfb\u7edf\u5316" in out["rendered"]
+        assert out["skills"][0]["entry_id"] == skill_id
+        assert out["skills"][0]["entry_id"] != echo_id
+        assert out["skills"][0]["path"] == "skills/skill-morning-triage.md"
+        assert "**Steps**: 1. Mail. 2. Slack. 3. Project." in out["skills"][0]["playbook"]
+        assert "Triggered with confidence" not in out["skills"][0]["playbook"]
+        assert "Observed workflow" in out["rendered"]
+
+
+def test_behavior_patterns_excludes_skills_without_live_observed_playbook(ac_root):
+    from persome.store import entries as entries_store
+
+    with fts.cursor() as conn:
+        conn.executescript(fts.SCHEMA)
+        entries_store.create_file(
+            conn,
+            name="skill-echo-only",
+            description="Has an activation echo but no admitted playbook.",
+            tags=["skill"],
+        )
+        entries_store.append_entry(
+            conn,
+            name="skill-echo-only.md",
+            content="Triggered with confidence 0.88: matching activity.",
+            tags=["triggered", "echo"],
+        )
+        entries_store.create_file(
+            conn,
+            name="skills/skill-unobserved",
+            description="A candidate that has not passed observation gates.",
+            tags=["skill"],
+        )
+        entries_store.append_entry(
+            conn,
+            name="skills/skill-unobserved.md",
+            content="stage: candidate\n\n**Pattern**: one possible sequence",
+            tags=["pattern"],
+        )
+        entries_store.create_file(
+            conn,
+            name="skills/skill-dormant",
+            description="An observed playbook that is no longer active.",
+            tags=["skill", "observed"],
+            status="dormant",
+        )
+        entries_store.append_entry(
+            conn,
+            name="skills/skill-dormant.md",
+            content="stage: observed\n\n**Pattern**: retired workflow",
+            tags=["pattern", "observed"],
+        )
+
+        out = mcp_server._behavior_patterns(conn)
+
+    assert out["skills"] == []
+    assert out["rendered"] == ""

--- a/tests/test_skill_hints.py
+++ b/tests/test_skill_hints.py
@@ -151,6 +151,76 @@ def test_skill_prefix_allowed_in_create_file(ac_root: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# bounded Registered Skills prompt section
+# ---------------------------------------------------------------------------
+
+
+def test_registered_skills_section_applies_top_k_by_relevance() -> None:
+    class Row:
+        def __init__(self, path: str, description: str) -> None:
+            self.path = path
+            self.description = description
+
+    rows = [
+        Row("skill-code-review.md", "Use for reviewing a GitHub pull request."),
+        Row("skill-standup.md", "Use for a weekday Lark standup status update."),
+        Row("skill-calendar.md", "Use for calendar scheduling."),
+    ]
+    section, paths = aggregator._registered_skills_section(
+        rows,
+        events_text="User typed a status update in the Lark standup channel",
+        max_registered=1,
+        token_budget=1000,
+    )
+    assert paths == {"skill-standup.md"}
+    assert "skill-standup.md" in section
+    assert "skill-code-review.md" not in section
+
+
+def test_registered_skills_section_honors_token_cap_without_partial_lines() -> None:
+    class Row:
+        path = "skill-standup.md"
+        description = "Use for Lark standup updates."
+
+    full, paths = aggregator._registered_skills_section(
+        [Row()], events_text="Lark standup", max_registered=10, token_budget=1000
+    )
+    exact_budget = aggregator._estimate_tokens(full)
+    capped, capped_paths = aggregator._registered_skills_section(
+        [Row()], events_text="Lark standup", max_registered=10, token_budget=exact_budget - 1
+    )
+    assert paths == {"skill-standup.md"}
+    assert aggregator._estimate_tokens(full) <= exact_budget
+    assert capped == ""
+    assert capped_paths == set()
+
+
+def test_registered_skills_section_backfills_after_oversized_relevant_row() -> None:
+    class Row:
+        def __init__(self, path: str, description: str) -> None:
+            self.path = path
+            self.description = description
+
+    short = Row("skill-short.md", "Use for Lark updates.")
+    short_section, _ = aggregator._registered_skills_section(
+        [short], events_text="Lark standup", max_registered=1, token_budget=1000
+    )
+    budget = aggregator._estimate_tokens(short_section)
+    oversized = Row("skill-oversized.md", "Lark standup " * 500)
+
+    section, paths = aggregator._registered_skills_section(
+        [oversized, short],
+        events_text="Lark standup",
+        max_registered=1,
+        token_budget=budget,
+    )
+
+    assert paths == {"skill-short.md"}
+    assert "skill-oversized.md" not in section
+    assert aggregator._estimate_tokens(section) <= budget
+
+
+# ---------------------------------------------------------------------------
 # produce_block_for_window — skill_hints round-trip
 # ---------------------------------------------------------------------------
 
@@ -343,6 +413,46 @@ def test_produce_block_drops_unregistered_skill_hints(ac_root: Path, fake_llm) -
     fake_llm.set_default("timeline", _SKILL_HINTS_PAYLOAD)
 
     cfg = config_mod.load(ac_root / "config.toml")
+    block = aggregator.produce_block_for_window(cfg, start=win_start, end=win_end)
+
+    assert block is not None
+    assert block.skill_hints == []
+
+
+def test_produce_block_drops_registered_skill_hidden_by_prompt_cap(ac_root: Path, fake_llm) -> None:
+    with fts.cursor() as conn:
+        entries_mod.create_file(
+            conn,
+            name="skill-morning-standup",
+            description="Use for a weekday Lark standup status update.",
+            tags=["skill"],
+        )
+        entries_mod.create_file(
+            conn,
+            name="skill-code-review",
+            description="Use for reviewing a GitHub pull request.",
+            tags=["skill"],
+        )
+
+    hidden_hint = json.dumps(
+        {
+            "entries": ["[Lark] standup channel: user typed a status update. Involving: —."],
+            "skill_hints": [
+                {
+                    "skill": "skill-code-review.md",
+                    "confidence": 0.92,
+                    "rationale": "model returned a registered path that was not shown",
+                }
+            ],
+        },
+        ensure_ascii=False,
+    )
+    start = datetime(2026, 5, 21, 9, 10, tzinfo=_TZ)
+    win_start, win_end = _seed_window(start)
+    fake_llm.set_default("timeline", hidden_hint)
+    cfg = config_mod.load(ac_root / "config.toml")
+    cfg.skill_check.max_registered = 1
+
     block = aggregator.produce_block_for_window(cfg, start=win_start, end=win_end)
 
     assert block is not None

--- a/tests/test_skill_hints.py
+++ b/tests/test_skill_hints.py
@@ -219,6 +219,53 @@ def test_produce_block_empty_skill_hints_when_no_skills_registered(ac_root: Path
     assert block.skill_hints == []
 
 
+def test_nested_skill_registry_composes_with_session_dedupe(ac_root: Path, fake_llm) -> None:
+    with fts.cursor() as conn:
+        path = entries_mod.create_file(
+            conn,
+            name="skills/skill-morning-standup",
+            description="Use when user is doing a weekday morning standup in Lark.",
+            tags=["skill"],
+        )
+        session_store.insert(
+            conn,
+            session_store.SessionRow(
+                id="sess-nested",
+                start_time=datetime(2026, 5, 21, 9, 6, 30, tzinfo=_TZ),
+            ),
+        )
+
+    payload = json.dumps(
+        {
+            "entries": ["[Lark] standup channel: user typed a status update. Involving: —."],
+            "skill_hints": [
+                {
+                    "skill": "skills/skill-morning-standup.md",
+                    "confidence": 0.82,
+                    "rationale": "entries show Lark standup activity",
+                }
+            ],
+        },
+        ensure_ascii=False,
+    )
+    fake_llm.set_default("timeline", payload)
+    cfg = config_mod.load(ac_root / "config.toml")
+
+    for minute in (6, 7):
+        start = datetime(2026, 5, 21, 9, minute, tzinfo=_TZ)
+        win_start, win_end = _seed_window(start)
+        block = aggregator.produce_block_for_window(cfg, start=win_start, end=win_end)
+        assert block is not None
+        assert block.skill_hints[0]["skill"] == "skills/skill-morning-standup.md"
+
+    assert path.read_text(encoding="utf-8").count("Triggered with confidence 0.82") == 1
+    with fts.cursor() as conn:
+        rows = conn.execute("SELECT session_id, skill_path FROM skill_observations").fetchall()
+    assert [(row["session_id"], row["skill_path"]) for row in rows] == [
+        ("sess-nested", "skills/skill-morning-standup.md")
+    ]
+
+
 def test_skill_echo_is_deduplicated_within_session(ac_root: Path, fake_llm) -> None:
     with fts.cursor() as conn:
         path = entries_mod.create_file(

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1048,6 +1048,7 @@ def test_client_mcp_read_cannot_mutate_schema(
         assert mcp_server._behavior_patterns(client) == {
             "root": None,
             "faces": [],
+            "skills": [],
             "rendered": "",
         }
         assert int(client.execute("PRAGMA schema_version").fetchone()[0]) == before


### PR DESCRIPTION
## What changed

- promote underused attention, relation, contradiction, and health signals into the auditable personal-model pipeline
- add an owner-local Apple Health connector and idempotent health-event import boundary
- turn repeated behavior into evidence-backed skill playbooks with triggers, ordered steps, success signals, boundaries, and receipts
- relevance-rank Registered Skills and cap each timeline prompt by configurable top-K and token budgets
- expose active observed skills through `behavior_patterns()` for downstream personalization and imitation without granting actuation
- expand the local model viewer around daily activity, evidence trails, keyboard exploration, responsive layout, and build-state clarity
- require a verified personal-data snapshot before update activation

## Why

Persome already captures far more than it promotes. This change follows the repository's existing pipeline instead of adding a parallel learner:

`attention selects → evidence admits → memory learns → agents imitate`

Attention and external observations remain candidates. They only enter durable behavior after independent repetition, receipt preservation, confidence gates, deterministic apply, and correction-compatible storage. Bounding the Registered Skills section prevents a growing skill registry from consuming unbounded timeline context while preserving the most relevant candidates.

## Impact

Connected agents can retrieve concrete observed workflows alongside Root and Faces, making personalization actionable while keeping Runtime read-only with respect to computer actuation. Health observations enter through a trusted, bearer-authenticated and idempotent ingest path. Timeline skill matching defaults to the 20 most relevant registered skills within an approximately 1,000-token section, with both limits configurable.

## Validation

- full non-macOS/non-integration suite: 1965 passed; the single viewer asset-order failure found in this run was fixed
- focused Python contract suite: 63 passed
- Registered Skills/config/timeline regression suite: 62 passed
- JavaScript model asset suite: 16 passed
- `uv run ruff check .`
- secret, PII, and language scans
- `git diff --check`

Known environment note: one legacy updater handoff test depends on the parent process command line being `persome update`; it reports `0` under this PTY wrapper when run in isolation. The same test passed in the full suite before the viewer failure.
