### PR TITLE
fix: dedupe skill observations by session

### DIFF
--- a/docs/db-schema.sql
+++ b/docs/db-schema.sql
@@ -110,6 +110,14 @@ CREATE TABLE sessions (
     modeled_at TEXT
 );
 
+CREATE TABLE skill_observations (
+    session_id TEXT NOT NULL,
+    skill_path TEXT NOT NULL,
+    timeline_block_id TEXT NOT NULL,
+    observed_at TEXT NOT NULL,
+    PRIMARY KEY (session_id, skill_path)
+);
+
 CREATE TABLE sqlite_sequence(name,seq);
 
 CREATE TABLE system_state (
@@ -155,6 +163,9 @@ CREATE INDEX idx_sessions_retry ON sessions(next_retry_at)
 CREATE INDEX idx_sessions_start ON sessions(start_time);
 
 CREATE INDEX idx_sessions_status ON sessions(status);
+
+CREATE INDEX idx_skill_observations_block
+    ON skill_observations(timeline_block_id);
 
 CREATE INDEX idx_tlb_end ON timeline_blocks(end_time);
 

--- a/docs/writer.md
+++ b/docs/writer.md
@@ -110,8 +110,10 @@ delta apply.
 `writer/pattern_detector.py` uses repeated event evidence, deterministic
 candidate filtering, and an LLM validation pass. Confirmed observations land in
 `skills/skill-*.md` with evidence and `stage: observed`. A single occurrence is
-insufficient. The stage models a person's recurring behavior; it does not
-propose scripts or execute automation.
+insufficient. Timeline skill echoes are deduplicated by session, so repeated
+minute blocks inside one continuous episode count as one observation. The stage
+models a person's recurring behavior; it does not propose scripts or execute
+automation.
 
 ## Higher-level build
 

--- a/src/persome/timeline/aggregator.py
+++ b/src/persome/timeline/aggregator.py
@@ -425,7 +425,7 @@ def _validate_skill_hint(raw: object, *, skill_paths: set[str]) -> dict | None:
 
 
 def _echo_skill_hints(block: store.TimelineBlock, skill_hints: list[dict]) -> None:
-    """Append a triggered-echo entry to each matched skill file."""
+    """Append at most one triggered-echo entry per skill and session."""
     for hint in skill_hints:
         skill_name = hint["skill"].removesuffix(".md")
         content = (
@@ -434,6 +434,16 @@ def _echo_skill_hints(block: store.TimelineBlock, skill_hints: list[dict]) -> No
         )
         try:
             with fts_store.cursor() as conn:
+                if not store.claim_skill_observation(
+                    conn,
+                    block=block,
+                    skill_path=hint["skill"],
+                ):
+                    logger.debug(
+                        "timeline: skill %s already observed in block session, skipping echo",
+                        hint["skill"],
+                    )
+                    continue
                 entries_mod.append_entry(
                     conn,
                     name=skill_name,

--- a/src/persome/timeline/store.py
+++ b/src/persome/timeline/store.py
@@ -37,6 +37,16 @@ CREATE TABLE IF NOT EXISTS timeline_blocks (
 );
 CREATE INDEX IF NOT EXISTS idx_tlb_start ON timeline_blocks(start_time);
 CREATE INDEX IF NOT EXISTS idx_tlb_end ON timeline_blocks(end_time);
+
+CREATE TABLE IF NOT EXISTS skill_observations (
+    session_id TEXT NOT NULL,
+    skill_path TEXT NOT NULL,
+    timeline_block_id TEXT NOT NULL,
+    observed_at TEXT NOT NULL,
+    PRIMARY KEY (session_id, skill_path)
+);
+CREATE INDEX IF NOT EXISTS idx_skill_observations_block
+    ON skill_observations(timeline_block_id);
 """
 
 
@@ -168,6 +178,45 @@ def insert(conn: sqlite3.Connection, block: TimelineBlock) -> None:
             block.attention_rung,
         ),
     )
+
+
+def claim_skill_observation(
+    conn: sqlite3.Connection,
+    *,
+    block: TimelineBlock,
+    skill_path: str,
+) -> bool:
+    """Claim one durable skill observation per session.
+
+    Timeline classification runs once per minute, while behavioral evidence is
+    session-scoped. Without this gate a long session can append the same skill
+    echo dozens of times and make one continuous episode look like independent
+    support. If no containing session exists, preserve the legacy best-effort
+    echo rather than silently dropping the observation.
+    """
+    row = conn.execute(
+        """
+        SELECT id
+          FROM sessions
+         WHERE persome_epoch(start_time) <= persome_epoch(?)
+           AND (end_time IS NULL OR persome_epoch(end_time) > persome_epoch(?))
+         ORDER BY persome_epoch(start_time) DESC
+         LIMIT 1
+        """,
+        (block.start_time.isoformat(), block.start_time.isoformat()),
+    ).fetchone()
+    if row is None:
+        return True
+
+    cursor = conn.execute(
+        """
+        INSERT OR IGNORE INTO skill_observations
+            (session_id, skill_path, timeline_block_id, observed_at)
+        VALUES (?, ?, ?, ?)
+        """,
+        (row["id"], skill_path, block.id, block.start_time.isoformat()),
+    )
+    return cursor.rowcount == 1
 
 
 def get_latest_end(conn: sqlite3.Connection) -> datetime | None:

--- a/src/persome/timeline/store.py
+++ b/src/persome/timeline/store.py
@@ -191,19 +191,22 @@ def claim_skill_observation(
     Timeline classification runs once per minute, while behavioral evidence is
     session-scoped. Without this gate a long session can append the same skill
     echo dozens of times and make one continuous episode look like independent
-    support. If no containing session exists, preserve the legacy best-effort
-    echo rather than silently dropping the observation.
+    support. Minute blocks are wall-clock aligned while sessions may begin at
+    any second, so associate by interval overlap rather than requiring the
+    block start to fall inside the session. If no overlapping session exists,
+    preserve the legacy best-effort echo rather than silently dropping the
+    observation.
     """
     row = conn.execute(
         """
         SELECT id
           FROM sessions
-         WHERE persome_epoch(start_time) <= persome_epoch(?)
+         WHERE persome_epoch(start_time) < persome_epoch(?)
            AND (end_time IS NULL OR persome_epoch(end_time) > persome_epoch(?))
          ORDER BY persome_epoch(start_time) DESC
          LIMIT 1
         """,
-        (block.start_time.isoformat(), block.start_time.isoformat()),
+        (block.end_time.isoformat(), block.start_time.isoformat()),
     ).fetchone()
     if row is None:
         return True

--- a/tests/test_skill_hints.py
+++ b/tests/test_skill_hints.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from persome import config as config_mod
 from persome import paths
+from persome.session import store as session_store
 from persome.store import entries as entries_mod
 from persome.store import fts
 from persome.timeline import aggregator
@@ -216,6 +217,65 @@ def test_produce_block_empty_skill_hints_when_no_skills_registered(ac_root: Path
 
     assert block is not None
     assert block.skill_hints == []
+
+
+def test_skill_echo_is_deduplicated_within_session(ac_root: Path, fake_llm) -> None:
+    with fts.cursor() as conn:
+        path = entries_mod.create_file(
+            conn,
+            name="skill-morning-standup",
+            description="Use when user is doing a weekday morning standup in Lark.",
+            tags=["skill"],
+        )
+        session_store.insert(
+            conn,
+            session_store.SessionRow(
+                id="sess-one",
+                start_time=datetime(2026, 5, 21, 9, 0, tzinfo=_TZ),
+            ),
+        )
+
+    fake_llm.set_default("timeline", _SKILL_HINTS_PAYLOAD)
+    cfg = config_mod.load(ac_root / "config.toml")
+    for minute in (0, 1):
+        win_start, win_end = _seed_window(datetime(2026, 5, 21, 9, minute, tzinfo=_TZ))
+        assert aggregator.produce_block_for_window(cfg, start=win_start, end=win_end) is not None
+
+    assert path.read_text(encoding="utf-8").count("Triggered with confidence 0.82") == 1
+    with fts.cursor() as conn:
+        rows = conn.execute("SELECT session_id, skill_path FROM skill_observations").fetchall()
+    assert [(row["session_id"], row["skill_path"]) for row in rows] == [
+        ("sess-one", "skill-morning-standup.md")
+    ]
+
+
+def test_skill_echo_counts_again_in_a_new_session(ac_root: Path, fake_llm) -> None:
+    with fts.cursor() as conn:
+        path = entries_mod.create_file(
+            conn,
+            name="skill-morning-standup",
+            description="Use when user is doing a weekday morning standup in Lark.",
+            tags=["skill"],
+        )
+        first = datetime(2026, 5, 21, 9, 0, tzinfo=_TZ)
+        second = datetime(2026, 5, 21, 10, 0, tzinfo=_TZ)
+        session_store.insert(
+            conn,
+            session_store.SessionRow(id="sess-one", start_time=first),
+        )
+        session_store.mark_ended(conn, "sess-one", first + timedelta(minutes=5))
+        session_store.insert(
+            conn,
+            session_store.SessionRow(id="sess-two", start_time=second),
+        )
+
+    fake_llm.set_default("timeline", _SKILL_HINTS_PAYLOAD)
+    cfg = config_mod.load(ac_root / "config.toml")
+    for start in (first, second):
+        win_start, win_end = _seed_window(start)
+        assert aggregator.produce_block_for_window(cfg, start=win_start, end=win_end) is not None
+
+    assert path.read_text(encoding="utf-8").count("Triggered with confidence 0.82") == 2
 
 
 def test_produce_block_drops_unregistered_skill_hints(ac_root: Path, fake_llm) -> None:

--- a/tests/test_skill_hints.py
+++ b/tests/test_skill_hints.py
@@ -231,7 +231,9 @@ def test_skill_echo_is_deduplicated_within_session(ac_root: Path, fake_llm) -> N
             conn,
             session_store.SessionRow(
                 id="sess-one",
-                start_time=datetime(2026, 5, 21, 9, 0, tzinfo=_TZ),
+                # Sessions start on event timestamps, not minute boundaries.
+                # The 09:00 block overlaps this session for its final 30 seconds.
+                start_time=datetime(2026, 5, 21, 9, 0, 30, tzinfo=_TZ),
             ),
         )
 


### PR DESCRIPTION
## What changed

- add a durable `(session_id, skill_path)` uniqueness gate for timeline skill observations
- skip repeated skill echoes from minute blocks inside the same session
- preserve independent observations across different sessions
- document the session-scoped evidence behavior and update the generated database schema

## Why

Timeline classification runs once per minute, but behavioral evidence is session-scoped. Previously, a long continuous session could append the same skill echo many times and inflate one episode into multiple apparent observations.

## Impact

Skill evidence now reflects independent sessions rather than the number of timeline blocks. If no containing session can be resolved, the runtime keeps the existing best-effort echo behavior instead of dropping evidence.

## Validation

- `uv run pytest tests/test_skill_hints.py tests/test_timeline_blocks.py tests/test_timeline_parallel.py tests/test_db_schema_drift.py -q` — 54 passed
- `uv run ruff check src/persome/timeline/store.py src/persome/timeline/aggregator.py tests/test_skill_hints.py`
- `uv run ruff format --check src/persome/timeline/store.py src/persome/timeline/aggregator.py tests/test_skill_hints.py`
- `git diff --check`
