### PR TITLE
feat: import Apple Health through a secure local relay

### DIFF
--- a/connectors/apple-health/Package.swift
+++ b/connectors/apple-health/Package.swift
@@ -6,9 +6,14 @@ let package = Package(
     platforms: [.iOS(.v17), .macOS(.v14)],
     products: [
         .library(name: "PersomeAppleHealth", targets: ["PersomeAppleHealth"]),
+        .executable(name: "persome-health-relay", targets: ["PersomeHealthRelay"]),
     ],
     targets: [
         .target(name: "PersomeAppleHealth"),
+        .executableTarget(
+            name: "PersomeHealthRelay",
+            dependencies: ["PersomeAppleHealth"]
+        ),
         .testTarget(name: "PersomeAppleHealthTests", dependencies: ["PersomeAppleHealth"]),
     ]
 )

--- a/connectors/apple-health/README.md
+++ b/connectors/apple-health/README.md
@@ -30,3 +30,79 @@ The first slice reads steps, heart rate, resting heart rate, active energy,
 sleep analysis, and workouts. Anchored queries use 500-operation pages rather
 than materializing an unlimited history. Interrupted syncs safely replay the
 last unacknowledged page and rely on server-side idempotency.
+
+## Run the Mac relay
+
+The package includes a real Mac relay host. It owns the Runtime bearer, accepts
+encrypted Multipeer frames, authenticates and decrypts them, and forwards only
+to the loopback `POST /health-events/import` route:
+
+```bash
+cd connectors/apple-health
+set -a
+source "${PERSOME_ROOT:-$HOME/.persome}/env"
+set +a
+swift run persome-health-relay
+```
+
+The command prints a six-digit comparison code and a short-lived base64 pairing
+payload suitable for a QR code. `PERSOME_RUNTIME_URL` may override the default
+`http://127.0.0.1:8742`, but non-loopback URLs are rejected. The long-lived
+`PERSOME_LOCAL_API_TOKEN` is used only by `LoopbackHealthRuntimeForwarder`; it is
+never encoded into a pairing offer, credential, relay request, or phone client.
+
+## Pair and upload from the phone
+
+The iPhone app scans the host payload, connects to the peer named by the offer,
+and runs both confirmed handshake flights over `MultipeerRelayTransport`:
+
+```swift
+let offerData = Data(base64Encoded: scannedPayload)!
+let offer = try RelayPairingOfferCodec.decode(offerData)
+let transport = MultipeerRelayTransport(displayName: phonePeerID)
+transport.start()
+
+// Use onDiscoveredPeer/onStateChange to invite offer.responderPeerID and wait
+// for .connected. Ask the owner to confirm the code displayed by the Mac,
+// then run the authenticated handshake on that same channel.
+try await SecureHealthRelayPairer.pair(
+    offer: offer,
+    confirmedPairingCode: userConfirmedCode,
+    ownPeerID: phonePeerID,
+    credentialStore: KeychainRelayCredentialStore(),
+    channel: transport
+)
+let secureRelayClient = SecureHealthRelayClient(
+    macPeerID: offer.responderPeerID,
+    credentialStore: KeychainRelayCredentialStore(),
+    channel: transport
+)
+let connector = AppleHealthConnector(client: secureRelayClient)
+```
+
+The QR payload carries a random 32-byte pairing secret. The six-digit code is a
+human comparison value, not the session's entropy. Each pairing also creates
+fresh P-256 keys, nonces, and a session ID. ECDH + HKDF-SHA256 binds those values
+to a canonical transcript; the Mac and phone must present separate HMAC key
+confirmations before either stores a session.
+
+Health payloads and Runtime receipts use directional AES-256-GCM keys. The
+session ID, direction, version, and sequence are authenticated. Send counters
+are persisted before encryption, and receive watermarks are persisted after
+authentication but before Runtime forwarding, preventing nonce reuse and
+replay across process restarts. Credentials expire after 30 days and are stored
+as `AfterFirstUnlockThisDeviceOnly`, non-synchronizing Keychain items. A new
+pairing replaces the old session for that peer.
+
+Multipeer itself uses required transport encryption, while the relay protocol
+provides endpoint authentication and end-to-end payload protection. Frames are
+bounded to 3 MiB for the Runtime's 2 MiB plaintext ceiling, allow one in-flight
+request per peer, and time out after 30 seconds.
+
+iOS host apps must add `NSLocalNetworkUsageDescription` and
+`_persome-health._tcp` under `NSBonjourServices` in `Info.plist`.
+
+The deterministic protocol, restart, replay, bound, and loopback-forwarding
+paths run under `swift test`. HealthKit authorization, entitlements, real
+Multipeer discovery, background execution, and a scanned-QR UI still require
+physical iPhone/Apple Watch plus Xcode validation by the embedding app.

--- a/connectors/apple-health/Sources/PersomeAppleHealth/HealthRelay.swift
+++ b/connectors/apple-health/Sources/PersomeAppleHealth/HealthRelay.swift
@@ -1,0 +1,331 @@
+import Foundation
+
+public enum HealthRelayError: Error, Equatable {
+    case invalidPairingPayload
+    case pairingCodeMismatch
+    case pairingRejected(String)
+    case payloadTooLarge
+    case requestMismatch
+    case runtimeRejected(String)
+    case unexpectedFrame
+}
+
+public enum RelayPairingOfferCodec {
+    public static let maximumPayloadBytes = 4 * 1024
+
+    public static func encode(_ offer: RelayPairingOffer) throws -> Data {
+        let data = try JSONEncoder.persome.encode(offer)
+        guard data.count <= maximumPayloadBytes else { throw HealthRelayError.payloadTooLarge }
+        return data
+    }
+
+    public static func decode(_ data: Data, now: Date = Date()) throws -> RelayPairingOffer {
+        guard data.count <= maximumPayloadBytes else { throw HealthRelayError.payloadTooLarge }
+        do {
+            let offer = try JSONDecoder.persome.decode(RelayPairingOffer.self, from: data)
+            guard offer.isValid, offer.expiresAt > now else {
+                throw HealthRelayError.invalidPairingPayload
+            }
+            return offer
+        } catch let error as HealthRelayError {
+            throw error
+        } catch {
+            throw HealthRelayError.invalidPairingPayload
+        }
+    }
+}
+
+public struct HealthRelayImportRequest: Codable, Sendable, Equatable {
+    public let version: Int
+    public let requestID: String
+    public let body: HealthEventsImport
+
+    public init(version: Int = 1, requestID: String, body: HealthEventsImport) {
+        self.version = version
+        self.requestID = requestID
+        self.body = body
+    }
+}
+
+public struct HealthRelayImportResponse: Codable, Sendable, Equatable {
+    public let version: Int
+    public let requestID: String
+    public let result: HealthImportResult?
+    public let errorCode: String?
+
+    enum CodingKeys: String, CodingKey {
+        case version, result
+        case requestID = "request_id"
+        case errorCode = "error_code"
+    }
+
+    public init(
+        version: Int = 1,
+        requestID: String,
+        result: HealthImportResult? = nil,
+        errorCode: String? = nil
+    ) {
+        self.version = version
+        self.requestID = requestID
+        self.result = result
+        self.errorCode = errorCode
+    }
+}
+
+extension HealthEventsImport: Equatable {
+    public static func == (lhs: HealthEventsImport, rhs: HealthEventsImport) -> Bool {
+        lhs.events == rhs.events && lhs.deletedEvents == rhs.deletedEvents
+    }
+}
+
+public protocol HealthRuntimeForwarding: Sendable {
+    func importChanges(_ body: HealthEventsImport) async throws -> HealthImportResult
+}
+
+/// The only component that owns the Runtime bearer. Initialization rejects LAN
+/// URLs, so relay plaintext can only be forwarded into the Mac's loopback API.
+public actor LoopbackHealthRuntimeForwarder: HealthRuntimeForwarding {
+    private let client: PersomeHealthClient
+
+    public init(
+        runtimeURL: URL = URL(string: "http://127.0.0.1:8742")!,
+        bearerToken: String,
+        session: URLSession = .shared
+    ) throws {
+        guard !bearerToken.isEmpty else { throw HealthRelayError.runtimeRejected("missing_token") }
+        client = try PersomeHealthClient(
+            runtimeURL: runtimeURL,
+            bearerToken: bearerToken,
+            session: session
+        )
+    }
+
+    public func importChanges(_ body: HealthEventsImport) async throws -> HealthImportResult {
+        try await client.upload(events: body.events, deletedEvents: body.deletedEvents)
+    }
+}
+
+/// iPhone-side uploader. It contains only a paired session credential and sends
+/// an encrypted request through Multipeer; it has no Runtime URL or bearer.
+public actor SecureHealthRelayClient: HealthEventUploader {
+    public static let maximumPlaintextBytes = 2 * 1024 * 1024
+
+    private let macPeerID: String
+    private let channel: any RelayRequestChannel
+    private let session: DurableSecureRelaySession
+
+    public init(
+        macPeerID: String,
+        credentialStore: any RelayCredentialStore,
+        channel: any RelayRequestChannel
+    ) {
+        self.macPeerID = macPeerID
+        self.channel = channel
+        session = DurableSecureRelaySession(peerID: macPeerID, store: credentialStore)
+    }
+
+    public func upload(
+        events: [HealthEvent],
+        deletedEvents: [HealthEventDeletion]
+    ) async throws -> HealthImportResult {
+        guard !events.isEmpty || !deletedEvents.isEmpty,
+              events.count + deletedEvents.count <= 1_000
+        else {
+            throw HealthRelayError.payloadTooLarge
+        }
+        let requestID = UUID().uuidString.lowercased()
+        let request = HealthRelayImportRequest(
+            requestID: requestID,
+            body: HealthEventsImport(events: events, deletedEvents: deletedEvents)
+        )
+        let plaintext = try JSONEncoder.persome.encode(request)
+        guard plaintext.count <= Self.maximumPlaintextBytes else {
+            throw HealthRelayError.payloadTooLarge
+        }
+        let outgoing = try session.seal(plaintext)
+        let responseFrame = try await channel.request(.envelope(outgoing), to: macPeerID)
+        switch responseFrame {
+        case let .envelope(incoming):
+            let responseData = try session.open(incoming)
+            let response = try JSONDecoder.persome.decode(
+                HealthRelayImportResponse.self,
+                from: responseData
+            )
+            guard response.version == 1, response.requestID == requestID else {
+                throw HealthRelayError.requestMismatch
+            }
+            if let code = response.errorCode { throw HealthRelayError.runtimeRejected(code) }
+            guard let result = response.result else { throw HealthRelayError.unexpectedFrame }
+            return result
+        case let .failure(failure):
+            throw HealthRelayError.runtimeRejected(failure.code)
+        default:
+            throw HealthRelayError.unexpectedFrame
+        }
+    }
+}
+
+public enum SecureHealthRelayPairer {
+    /// Runs both transcript-confirmation flights over the same request channel
+    /// later used for health uploads, then durably stores the confirmed session.
+    public static func pair(
+        offer: RelayPairingOffer,
+        confirmedPairingCode: String,
+        ownPeerID: String,
+        credentialStore: any RelayCredentialStore,
+        channel: any RelayRequestChannel
+    ) async throws -> RelayCredential {
+        guard confirmedPairingCode == offer.pairingCode else {
+            throw HealthRelayError.pairingCodeMismatch
+        }
+        var handshake = try RelayHandshakeInitiator(offer: offer, ownPeerID: ownPeerID)
+        let first = try await channel.request(
+            .clientHello(handshake.makeClientHello()),
+            to: offer.responderPeerID
+        )
+        let serverHello: RelayServerHello
+        switch first {
+        case let .serverHello(value): serverHello = value
+        case let .failure(failure): throw HealthRelayError.pairingRejected(failure.code)
+        default: throw HealthRelayError.unexpectedFrame
+        }
+
+        let confirmation = try handshake.receive(serverHello)
+        let second = try await channel.request(
+            .clientConfirmation(confirmation),
+            to: offer.responderPeerID
+        )
+        let complete: RelayPairingComplete
+        switch second {
+        case let .pairingComplete(value): complete = value
+        case let .failure(failure): throw HealthRelayError.pairingRejected(failure.code)
+        default: throw HealthRelayError.unexpectedFrame
+        }
+        let credential = try handshake.finish(complete)
+        try credentialStore.save(credential)
+        return credential
+    }
+}
+
+/// Mac-side protocol terminus. It owns pairing responder state, durable replay
+/// state, and a loopback forwarder. The Runtime bearer never enters a wire frame.
+public actor MacHealthRelayHost {
+    private let peerID: String
+    private let credentialStore: any RelayCredentialStore
+    private let forwarder: any HealthRuntimeForwarding
+    private var handshakes: [String: RelayHandshakeResponder] = [:]
+
+    public init(
+        peerID: String,
+        credentialStore: any RelayCredentialStore,
+        forwarder: any HealthRuntimeForwarding
+    ) {
+        self.peerID = peerID
+        self.credentialStore = credentialStore
+        self.forwarder = forwarder
+    }
+
+    public func beginPairing(pairingCode: String) throws -> RelayPairingOffer {
+        let handshake = try RelayHandshakeResponder(peerID: peerID, pairingCode: pairingCode)
+        handshakes[handshake.offer.sessionID] = handshake
+        return handshake.offer
+    }
+
+    public func handle(_ frame: RelayWireFrame, from connectedPeerID: String) async -> RelayWireFrame {
+        do {
+            switch frame {
+            case let .clientHello(hello):
+                guard hello.initiatorPeerID == connectedPeerID,
+                      var handshake = handshakes[hello.sessionID]
+                else {
+                    throw SecureRelayError.invalidPairingOffer
+                }
+                let response = try handshake.receive(hello)
+                handshakes[hello.sessionID] = handshake
+                return .serverHello(response)
+
+            case let .clientConfirmation(confirmation):
+                guard var handshake = handshakes[confirmation.sessionID] else {
+                    throw SecureRelayError.handshakeOutOfOrder
+                }
+                let result = try handshake.finish(confirmation)
+                guard result.credential.peerID == connectedPeerID else {
+                    throw SecureRelayError.invalidPairingOffer
+                }
+                try credentialStore.save(result.credential)
+                handshakes.removeValue(forKey: confirmation.sessionID)
+                return .pairingComplete(result.complete)
+
+            case let .envelope(envelope):
+                return await handleEnvelope(envelope, from: connectedPeerID)
+
+            default:
+                throw HealthRelayError.unexpectedFrame
+            }
+        } catch {
+            return .failure(RelayProtocolFailure(code: "protocol_rejected"))
+        }
+    }
+
+    private func handleEnvelope(
+        _ envelope: RelayEnvelope,
+        from connectedPeerID: String
+    ) async -> RelayWireFrame {
+        do {
+            let secureSession = DurableSecureRelaySession(
+                peerID: connectedPeerID,
+                store: credentialStore
+            )
+            let plaintext = try secureSession.open(envelope)
+            guard plaintext.count <= SecureHealthRelayClient.maximumPlaintextBytes else {
+                throw HealthRelayError.payloadTooLarge
+            }
+            let request = try JSONDecoder.persome.decode(
+                HealthRelayImportRequest.self,
+                from: plaintext
+            )
+            guard request.version == 1,
+                  !request.body.events.isEmpty || !request.body.deletedEvents.isEmpty,
+                  request.body.events.count + request.body.deletedEvents.count <= 1_000
+            else {
+                throw HealthRelayError.payloadTooLarge
+            }
+            let response: HealthRelayImportResponse
+            do {
+                let result = try await forwarder.importChanges(request.body)
+                response = HealthRelayImportResponse(requestID: request.requestID, result: result)
+            } catch {
+                response = HealthRelayImportResponse(
+                    requestID: request.requestID,
+                    errorCode: "runtime_rejected"
+                )
+            }
+            let responseData = try JSONEncoder.persome.encode(response)
+            return .envelope(try secureSession.seal(responseData))
+        } catch {
+            return .failure(RelayProtocolFailure(code: "secure_session_rejected"))
+        }
+    }
+}
+
+/// Binds the async Mac host to incoming Multipeer frames. The transport sends
+/// every returned frame to the exact connected peer that originated it.
+public final class MultipeerHealthRelayHostAdapter: @unchecked Sendable {
+    private let transport: MultipeerRelayTransport
+    private let host: MacHealthRelayHost
+
+    public init(transport: MultipeerRelayTransport, host: MacHealthRelayHost) {
+        self.transport = transport
+        self.host = host
+        transport.onFrame = { [weak transport, host] peerID, frame in
+            Task {
+                let response = await host.handle(frame, from: peerID)
+                do {
+                    try transport?.send(response, to: peerID)
+                } catch {
+                    transport?.onError?(error)
+                }
+            }
+        }
+    }
+}

--- a/connectors/apple-health/Sources/PersomeAppleHealth/MultipeerRelayTransport.swift
+++ b/connectors/apple-health/Sources/PersomeAppleHealth/MultipeerRelayTransport.swift
@@ -1,0 +1,299 @@
+@preconcurrency import MultipeerConnectivity
+import Foundation
+
+public enum RelayPeerState: String, Sendable {
+    case connected
+    case connecting
+    case notConnected
+}
+
+public enum RelayTransportError: Error, Equatable {
+    case ambiguousPeer
+    case frameTooLarge
+    case invalidFrame
+    case peerNotFound
+    case requestAlreadyPending
+    case timedOut
+    case unexpectedResponse
+}
+
+public struct RelayProtocolFailure: Codable, Sendable, Equatable {
+    public let code: String
+
+    public init(code: String) {
+        self.code = code
+    }
+}
+
+public enum RelayWireFrame: Codable, Sendable, Equatable {
+    case clientHello(RelayClientHello)
+    case serverHello(RelayServerHello)
+    case clientConfirmation(RelayClientConfirmation)
+    case pairingComplete(RelayPairingComplete)
+    case envelope(RelayEnvelope)
+    case failure(RelayProtocolFailure)
+}
+
+public enum RelayFrameCodec {
+    /// A 2 MiB Runtime request expands under AES-GCM and JSON base64. Keep the
+    /// transport ceiling explicit and only large enough for that bounded case.
+    public static let maximumFrameBytes = 3 * 1024 * 1024
+
+    public static func encode(_ frame: RelayWireFrame) throws -> Data {
+        let data = try JSONEncoder.persome.encode(frame)
+        guard data.count <= maximumFrameBytes else { throw RelayTransportError.frameTooLarge }
+        return data
+    }
+
+    public static func decode(_ data: Data) throws -> RelayWireFrame {
+        guard data.count <= maximumFrameBytes else { throw RelayTransportError.frameTooLarge }
+        do {
+            return try JSONDecoder.persome.decode(RelayWireFrame.self, from: data)
+        } catch {
+            throw RelayTransportError.invalidFrame
+        }
+    }
+}
+
+public protocol RelayRequestChannel: Sendable {
+    func request(_ frame: RelayWireFrame, to peerID: String) async throws -> RelayWireFrame
+}
+
+/// Multipeer provides encrypted local discovery/transport; the relay protocol
+/// still authenticates the paired endpoints and encrypts payloads end to end.
+/// One request is in flight per peer, which preserves envelope order and keeps
+/// reply routing deterministic.
+public final class MultipeerRelayTransport: NSObject, RelayRequestChannel, @unchecked Sendable {
+    public static let serviceType = "persome-health"
+
+    public var onDiscoveredPeer: (@Sendable (String) -> Void)?
+    public var onLostPeer: (@Sendable (String) -> Void)?
+    public var onInvitation: (@Sendable (String) -> Void)?
+    public var onStateChange: (@Sendable (String, RelayPeerState) -> Void)?
+    public var onFrame: (@Sendable (String, RelayWireFrame) -> Void)?
+    public var onError: (@Sendable (Error) -> Void)?
+
+    private let localPeer: MCPeerID
+    private let session: MCSession
+    private let advertiser: MCNearbyServiceAdvertiser
+    private let browser: MCNearbyServiceBrowser
+    private let lock = NSLock()
+    private var discovered: [MCPeerID] = []
+    private var invitations: [MCPeerID: (Bool, MCSession?) -> Void] = [:]
+    private struct PendingRequest {
+        let token: UUID
+        let continuation: CheckedContinuation<RelayWireFrame, any Error>
+    }
+
+    private var pending: [String: PendingRequest] = [:]
+
+    public init(displayName: String) {
+        localPeer = MCPeerID(displayName: displayName)
+        session = MCSession(
+            peer: localPeer,
+            securityIdentity: nil,
+            encryptionPreference: .required
+        )
+        advertiser = MCNearbyServiceAdvertiser(
+            peer: localPeer,
+            discoveryInfo: ["protocol": "2"],
+            serviceType: Self.serviceType
+        )
+        browser = MCNearbyServiceBrowser(peer: localPeer, serviceType: Self.serviceType)
+        super.init()
+        session.delegate = self
+        advertiser.delegate = self
+        browser.delegate = self
+    }
+
+    public func start() {
+        advertiser.startAdvertisingPeer()
+        browser.startBrowsingForPeers()
+    }
+
+    public func stop() {
+        browser.stopBrowsingForPeers()
+        advertiser.stopAdvertisingPeer()
+        session.disconnect()
+        let state = lock.withLock { () -> (
+            invitations: [(Bool, MCSession?) -> Void],
+            pending: [CheckedContinuation<RelayWireFrame, any Error>]
+        ) in
+            defer {
+                invitations.removeAll()
+                pending.removeAll()
+            }
+            return (Array(invitations.values), pending.values.map(\.continuation))
+        }
+        for handler in state.invitations { handler(false, nil) }
+        for continuation in state.pending {
+            continuation.resume(throwing: RelayTransportError.peerNotFound)
+        }
+    }
+
+    public func invite(displayName: String, timeout: TimeInterval = 30) throws {
+        let matches = lock.withLock { discovered.filter { $0.displayName == displayName } }
+        guard !matches.isEmpty else { throw RelayTransportError.peerNotFound }
+        guard matches.count == 1, let peer = matches.first else {
+            throw RelayTransportError.ambiguousPeer
+        }
+        browser.invitePeer(peer, to: session, withContext: nil, timeout: timeout)
+    }
+
+    public func respondToInvitation(from displayName: String, accept: Bool) throws {
+        let matches = lock.withLock {
+            invitations.keys.filter { $0.displayName == displayName }
+        }
+        guard !matches.isEmpty else { throw RelayTransportError.peerNotFound }
+        guard matches.count == 1, let peer = matches.first else {
+            throw RelayTransportError.ambiguousPeer
+        }
+        let handler = lock.withLock { invitations.removeValue(forKey: peer) }
+        handler?(accept, accept ? session : nil)
+    }
+
+    public func send(_ frame: RelayWireFrame, to displayName: String) throws {
+        let matches = session.connectedPeers.filter { $0.displayName == displayName }
+        guard !matches.isEmpty else { throw RelayTransportError.peerNotFound }
+        guard matches.count == 1, let peer = matches.first else {
+            throw RelayTransportError.ambiguousPeer
+        }
+        try session.send(RelayFrameCodec.encode(frame), toPeers: [peer], with: .reliable)
+    }
+
+    public func request(
+        _ frame: RelayWireFrame,
+        to peerID: String
+    ) async throws -> RelayWireFrame {
+        try await withCheckedThrowingContinuation { continuation in
+            let token = UUID()
+            let accepted = lock.withLock { () -> Bool in
+                guard pending[peerID] == nil else { return false }
+                pending[peerID] = PendingRequest(token: token, continuation: continuation)
+                return true
+            }
+            guard accepted else {
+                continuation.resume(throwing: RelayTransportError.requestAlreadyPending)
+                return
+            }
+            do {
+                try send(frame, to: peerID)
+                Task { [weak self] in
+                    try? await Task.sleep(for: .seconds(30))
+                    self?.expireRequest(peerID: peerID, token: token)
+                }
+            } catch {
+                let waiting = lock.withLock { pending.removeValue(forKey: peerID) }
+                waiting?.continuation.resume(throwing: error)
+            }
+        }
+    }
+
+    private func expireRequest(peerID: String, token: UUID) {
+        let waiting = lock.withLock { () -> PendingRequest? in
+            guard pending[peerID]?.token == token else { return nil }
+            return pending.removeValue(forKey: peerID)
+        }
+        waiting?.continuation.resume(throwing: RelayTransportError.timedOut)
+    }
+
+    deinit {
+        browser.stopBrowsingForPeers()
+        advertiser.stopAdvertisingPeer()
+        session.disconnect()
+    }
+}
+
+extension MultipeerRelayTransport: MCNearbyServiceAdvertiserDelegate {
+    public func advertiser(
+        _: MCNearbyServiceAdvertiser,
+        didReceiveInvitationFromPeer peerID: MCPeerID,
+        withContext _: Data?,
+        invitationHandler: @escaping (Bool, MCSession?) -> Void
+    ) {
+        lock.withLock { invitations[peerID] = invitationHandler }
+        onInvitation?(peerID.displayName)
+    }
+
+    public func advertiser(
+        _: MCNearbyServiceAdvertiser,
+        didNotStartAdvertisingPeer error: any Error
+    ) {
+        onError?(error)
+    }
+}
+
+extension MultipeerRelayTransport: MCNearbyServiceBrowserDelegate {
+    public func browser(
+        _: MCNearbyServiceBrowser,
+        foundPeer peerID: MCPeerID,
+        withDiscoveryInfo info: [String: String]?
+    ) {
+        guard info?["protocol"] == "2" else { return }
+        lock.withLock {
+            if !discovered.contains(peerID) { discovered.append(peerID) }
+        }
+        onDiscoveredPeer?(peerID.displayName)
+    }
+
+    public func browser(_: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
+        lock.withLock { discovered.removeAll { $0 == peerID } }
+        onLostPeer?(peerID.displayName)
+    }
+
+    public func browser(_: MCNearbyServiceBrowser, didNotStartBrowsingForPeers error: any Error) {
+        onError?(error)
+    }
+}
+
+extension MultipeerRelayTransport: MCSessionDelegate {
+    public func session(_: MCSession, peer peerID: MCPeerID, didChange state: MCSessionState) {
+        let relayState: RelayPeerState = switch state {
+        case .connected: .connected
+        case .connecting: .connecting
+        case .notConnected: .notConnected
+        @unknown default: .notConnected
+        }
+        if state == .notConnected {
+            let waiting = lock.withLock { pending.removeValue(forKey: peerID.displayName) }
+            waiting?.continuation.resume(throwing: RelayTransportError.peerNotFound)
+        }
+        onStateChange?(peerID.displayName, relayState)
+    }
+
+    public func session(_: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
+        do {
+            let frame = try RelayFrameCodec.decode(data)
+            let waiting = lock.withLock { pending.removeValue(forKey: peerID.displayName) }
+            if let waiting {
+                waiting.continuation.resume(returning: frame)
+            } else {
+                onFrame?(peerID.displayName, frame)
+            }
+        } catch {
+            onError?(error)
+        }
+    }
+
+    public func session(
+        _: MCSession,
+        didReceive _: InputStream,
+        withName _: String,
+        fromPeer _: MCPeerID
+    ) {}
+
+    public func session(
+        _: MCSession,
+        didStartReceivingResourceWithName _: String,
+        fromPeer _: MCPeerID,
+        with _: Progress
+    ) {}
+
+    public func session(
+        _: MCSession,
+        didFinishReceivingResourceWithName _: String,
+        fromPeer _: MCPeerID,
+        at _: URL?,
+        withError _: (any Error)?
+    ) {}
+}

--- a/connectors/apple-health/Sources/PersomeAppleHealth/RelayCredentialStore.swift
+++ b/connectors/apple-health/Sources/PersomeAppleHealth/RelayCredentialStore.swift
@@ -1,0 +1,273 @@
+import Foundation
+import Security
+
+public struct RelayCredential: Codable, Sendable, Equatable {
+    public let version: Int
+    public let peerID: String
+    public let role: RelayRole
+    public let sessionID: String
+    public let rootKey: Data
+    public let createdAt: Date
+    public let expiresAt: Date
+    public let nextSendSequence: UInt64
+    public let lastReceivedSequence: UInt64?
+
+    public init(
+        version: Int = 2,
+        peerID: String,
+        role: RelayRole,
+        sessionID: String,
+        rootKey: Data,
+        createdAt: Date = Date(),
+        expiresAt: Date,
+        nextSendSequence: UInt64 = 0,
+        lastReceivedSequence: UInt64? = nil
+    ) {
+        self.version = version
+        self.peerID = peerID
+        self.role = role
+        self.sessionID = sessionID
+        self.rootKey = rootKey
+        self.createdAt = createdAt
+        self.expiresAt = expiresAt
+        self.nextSendSequence = nextSendSequence
+        self.lastReceivedSequence = lastReceivedSequence
+    }
+
+    fileprivate var isValid: Bool {
+        version == 2 && !peerID.isEmpty && !sessionID.isEmpty && rootKey.count == 32
+            && expiresAt > createdAt
+    }
+
+    fileprivate func updating(
+        nextSendSequence: UInt64? = nil,
+        lastReceivedSequence: UInt64?? = nil
+    ) -> Self {
+        Self(
+            version: version,
+            peerID: peerID,
+            role: role,
+            sessionID: sessionID,
+            rootKey: rootKey,
+            createdAt: createdAt,
+            expiresAt: expiresAt,
+            nextSendSequence: nextSendSequence ?? self.nextSendSequence,
+            lastReceivedSequence: lastReceivedSequence ?? self.lastReceivedSequence
+        )
+    }
+}
+
+public struct RelaySequenceReservation: Sendable, Equatable {
+    public let credential: RelayCredential
+    public let sequence: UInt64
+}
+
+public protocol RelayCredentialStore: AnyObject, Sendable {
+    func save(_ credential: RelayCredential) throws
+    func load(peerID: String) throws -> RelayCredential?
+    func delete(peerID: String) throws
+
+    /// Atomically persists the increment before returning a sequence. A crash
+    /// can create a harmless gap, never key+nonce reuse.
+    func reserveSendSequence(peerID: String, now: Date) throws -> RelaySequenceReservation
+
+    /// Atomically advances the replay watermark after authentication and before
+    /// a caller can act on the plaintext.
+    func acceptReceivedSequence(
+        peerID: String,
+        sessionID: String,
+        sequence: UInt64,
+        now: Date
+    ) throws
+}
+
+public final class KeychainRelayCredentialStore: RelayCredentialStore, @unchecked Sendable {
+    private static let lock = NSLock()
+    private let service: String
+
+    public init(service: String = "ai.persome.apple-health.relay.v2") {
+        self.service = service
+    }
+
+    public func save(_ credential: RelayCredential) throws {
+        try Self.lock.withLock { try saveUnlocked(credential) }
+    }
+
+    public func load(peerID: String) throws -> RelayCredential? {
+        try Self.lock.withLock { try loadUnlocked(peerID: peerID) }
+    }
+
+    public func delete(peerID: String) throws {
+        try Self.lock.withLock {
+            let status = SecItemDelete(baseQuery(peerID: peerID) as CFDictionary)
+            guard status == errSecSuccess || status == errSecItemNotFound else {
+                throw KeychainRelayError.operationFailed(status)
+            }
+        }
+    }
+
+    public func reserveSendSequence(
+        peerID: String,
+        now: Date
+    ) throws -> RelaySequenceReservation {
+        try Self.lock.withLock {
+            guard let credential = try loadUnlocked(peerID: peerID) else {
+                throw SecureRelayError.credentialNotFound
+            }
+            guard credential.expiresAt > now else { throw SecureRelayError.sessionExpired }
+            guard credential.nextSendSequence < UInt64.max else {
+                throw SecureRelayError.sequenceExhausted
+            }
+            let sequence = credential.nextSendSequence
+            let updated = credential.updating(nextSendSequence: sequence + 1)
+            try saveUnlocked(updated)
+            return RelaySequenceReservation(credential: updated, sequence: sequence)
+        }
+    }
+
+    public func acceptReceivedSequence(
+        peerID: String,
+        sessionID: String,
+        sequence: UInt64,
+        now: Date
+    ) throws {
+        try Self.lock.withLock {
+            guard let credential = try loadUnlocked(peerID: peerID) else {
+                throw SecureRelayError.credentialNotFound
+            }
+            guard credential.expiresAt > now else { throw SecureRelayError.sessionExpired }
+            guard credential.sessionID == sessionID else {
+                throw SecureRelayError.sessionMismatch
+            }
+            if let last = credential.lastReceivedSequence, sequence <= last {
+                throw SecureRelayError.replayedMessage
+            }
+            try saveUnlocked(credential.updating(lastReceivedSequence: .some(sequence)))
+        }
+    }
+
+    private func saveUnlocked(_ credential: RelayCredential) throws {
+        guard credential.isValid else { throw KeychainRelayError.invalidCredential }
+        let data = try JSONEncoder.persome.encode(credential)
+        let selector = baseQuery(peerID: credential.peerID)
+        let updateStatus = SecItemUpdate(
+            selector as CFDictionary,
+            [kSecValueData: data] as CFDictionary
+        )
+        if updateStatus == errSecSuccess { return }
+        guard updateStatus == errSecItemNotFound else {
+            throw KeychainRelayError.operationFailed(updateStatus)
+        }
+
+        var insert = selector
+        insert[kSecValueData] = data
+        insert[kSecAttrAccessible] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        insert[kSecAttrSynchronizable] = kCFBooleanFalse
+        let addStatus = SecItemAdd(insert as CFDictionary, nil)
+        guard addStatus == errSecSuccess else {
+            throw KeychainRelayError.operationFailed(addStatus)
+        }
+    }
+
+    private func loadUnlocked(peerID: String) throws -> RelayCredential? {
+        var query = baseQuery(peerID: peerID)
+        query[kSecReturnData] = kCFBooleanTrue
+        query[kSecMatchLimit] = kSecMatchLimitOne
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecItemNotFound { return nil }
+        guard status == errSecSuccess, let data = result as? Data else {
+            throw KeychainRelayError.operationFailed(status)
+        }
+        do {
+            let credential = try JSONDecoder.persome.decode(RelayCredential.self, from: data)
+            guard credential.isValid else { throw KeychainRelayError.invalidCredential }
+            return credential
+        } catch let error as KeychainRelayError {
+            throw error
+        } catch {
+            throw KeychainRelayError.invalidCredential
+        }
+    }
+
+    private func baseQuery(peerID: String) -> [CFString: Any] {
+        [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: peerID,
+        ]
+    }
+}
+
+public final class MemoryRelayCredentialStore: RelayCredentialStore, @unchecked Sendable {
+    private let lock = NSLock()
+    private var credentials: [String: RelayCredential] = [:]
+
+    public init() {}
+
+    public func save(_ credential: RelayCredential) throws {
+        guard credential.isValid else { throw KeychainRelayError.invalidCredential }
+        lock.withLock { credentials[credential.peerID] = credential }
+    }
+
+    public func load(peerID: String) throws -> RelayCredential? {
+        lock.withLock { credentials[peerID] }
+    }
+
+    public func delete(peerID: String) throws {
+        _ = lock.withLock { credentials.removeValue(forKey: peerID) }
+    }
+
+    public func reserveSendSequence(
+        peerID: String,
+        now: Date
+    ) throws -> RelaySequenceReservation {
+        try lock.withLock {
+            guard let credential = credentials[peerID] else {
+                throw SecureRelayError.credentialNotFound
+            }
+            guard credential.expiresAt > now else { throw SecureRelayError.sessionExpired }
+            guard credential.nextSendSequence < UInt64.max else {
+                throw SecureRelayError.sequenceExhausted
+            }
+            let sequence = credential.nextSendSequence
+            let updated = credential.updating(nextSendSequence: sequence + 1)
+            credentials[peerID] = updated
+            return RelaySequenceReservation(credential: updated, sequence: sequence)
+        }
+    }
+
+    public func acceptReceivedSequence(
+        peerID: String,
+        sessionID: String,
+        sequence: UInt64,
+        now: Date
+    ) throws {
+        try lock.withLock {
+            guard let credential = credentials[peerID] else {
+                throw SecureRelayError.credentialNotFound
+            }
+            guard credential.expiresAt > now else { throw SecureRelayError.sessionExpired }
+            guard credential.sessionID == sessionID else {
+                throw SecureRelayError.sessionMismatch
+            }
+            if let last = credential.lastReceivedSequence, sequence <= last {
+                throw SecureRelayError.replayedMessage
+            }
+            credentials[peerID] = credential.updating(lastReceivedSequence: .some(sequence))
+        }
+    }
+}
+
+public enum KeychainRelayError: Error, Equatable {
+    case invalidCredential
+    case operationFailed(OSStatus)
+}
+
+extension JSONDecoder {
+    static var persome: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}

--- a/connectors/apple-health/Sources/PersomeAppleHealth/SecureRelay.swift
+++ b/connectors/apple-health/Sources/PersomeAppleHealth/SecureRelay.swift
@@ -1,0 +1,625 @@
+import CryptoKit
+import Foundation
+import Security
+
+public enum RelayRole: String, Codable, Sendable {
+    case initiator
+    case responder
+}
+
+public struct RelayPublicIdentity: Codable, Sendable, Equatable {
+    public let keyAgreementKey: Data
+
+    public init(keyAgreementKey: Data) {
+        self.keyAgreementKey = keyAgreementKey
+    }
+}
+
+public struct RelayIdentity: Sendable {
+    private let privateKey: P256.KeyAgreement.PrivateKey
+
+    public var publicIdentity: RelayPublicIdentity {
+        RelayPublicIdentity(keyAgreementKey: privateKey.publicKey.x963Representation)
+    }
+
+    public init() {
+        privateKey = P256.KeyAgreement.PrivateKey()
+    }
+
+    public init(rawRepresentation: Data) throws {
+        privateKey = try P256.KeyAgreement.PrivateKey(rawRepresentation: rawRepresentation)
+    }
+
+    public var rawRepresentation: Data { privateKey.rawRepresentation }
+
+    fileprivate func sharedSecret(with peer: RelayPublicIdentity) throws -> SharedSecret {
+        let peerKey = try P256.KeyAgreement.PublicKey(x963Representation: peer.keyAgreementKey)
+        return try privateKey.sharedSecretFromKeyAgreement(with: peerKey)
+    }
+}
+
+/// One short-lived QR payload. The 32-byte secret supplies cryptographic entropy;
+/// the six-digit code is only a human key-confirmation display and is never the
+/// sole input to session key derivation.
+public struct RelayPairingOffer: Codable, Sendable, Equatable {
+    public let version: Int
+    public let sessionID: String
+    public let responderPeerID: String
+    public let responderIdentity: RelayPublicIdentity
+    public let responderNonce: Data
+    public let pairingSecret: Data
+    public let pairingCode: String
+    public let expiresAt: Date
+
+    public init(
+        version: Int = 2,
+        sessionID: String,
+        responderPeerID: String,
+        responderIdentity: RelayPublicIdentity,
+        responderNonce: Data,
+        pairingSecret: Data,
+        pairingCode: String,
+        expiresAt: Date
+    ) throws {
+        guard version == 2 else { throw SecureRelayError.unsupportedVersion }
+        guard !sessionID.isEmpty, !responderPeerID.isEmpty else {
+            throw SecureRelayError.invalidPairingOffer
+        }
+        guard responderNonce.count == 32, pairingSecret.count == 32 else {
+            throw SecureRelayError.invalidPairingOffer
+        }
+        guard Self.validPairingCode(pairingCode) else {
+            throw SecureRelayError.invalidPairingCode
+        }
+        self.version = version
+        self.sessionID = sessionID
+        self.responderPeerID = responderPeerID
+        self.responderIdentity = responderIdentity
+        self.responderNonce = responderNonce
+        self.pairingSecret = pairingSecret
+        self.pairingCode = pairingCode
+        self.expiresAt = expiresAt
+    }
+
+    fileprivate static func validPairingCode(_ code: String) -> Bool {
+        code.count == 6 && code.allSatisfy(\.isNumber)
+    }
+
+    var isValid: Bool {
+        version == 2 && !sessionID.isEmpty && !responderPeerID.isEmpty
+            && responderNonce.count == 32 && pairingSecret.count == 32
+            && Self.validPairingCode(pairingCode)
+    }
+}
+
+public struct RelayClientHello: Codable, Sendable, Equatable {
+    public let version: Int
+    public let sessionID: String
+    public let initiatorPeerID: String
+    public let responderPeerID: String
+    public let initiatorIdentity: RelayPublicIdentity
+    public let initiatorNonce: Data
+    public let offerProof: Data
+}
+
+public struct RelayServerHello: Codable, Sendable, Equatable {
+    public let version: Int
+    public let sessionID: String
+    public let transcriptHash: Data
+    public let keyConfirmation: Data
+    public let sessionExpiresAt: Date
+}
+
+public struct RelayClientConfirmation: Codable, Sendable, Equatable {
+    public let version: Int
+    public let sessionID: String
+    public let keyConfirmation: Data
+}
+
+public struct RelayPairingComplete: Codable, Sendable, Equatable {
+    public let version: Int
+    public let sessionID: String
+    public let keyConfirmation: Data
+}
+
+public struct RelayHandshakeInitiator: Sendable {
+    public let offer: RelayPairingOffer
+    public let ownPeerID: String
+
+    private let identity: RelayIdentity
+    private let initiatorNonce: Data
+    private var rootKey: Data?
+    private var transcriptHash: Data?
+    private var sessionExpiresAt: Date?
+
+    public init(offer: RelayPairingOffer, ownPeerID: String, now: Date = Date()) throws {
+        guard offer.isValid else { throw SecureRelayError.invalidPairingOffer }
+        guard offer.expiresAt > now else { throw SecureRelayError.pairingExpired }
+        guard !ownPeerID.isEmpty, ownPeerID != offer.responderPeerID else {
+            throw SecureRelayError.invalidPairingOffer
+        }
+        self.offer = offer
+        self.ownPeerID = ownPeerID
+        identity = RelayIdentity()
+        initiatorNonce = try Self.randomBytes(count: 32)
+    }
+
+    public func makeClientHello() -> RelayClientHello {
+        let unsigned = RelayClientHello(
+            version: offer.version,
+            sessionID: offer.sessionID,
+            initiatorPeerID: ownPeerID,
+            responderPeerID: offer.responderPeerID,
+            initiatorIdentity: identity.publicIdentity,
+            initiatorNonce: initiatorNonce,
+            offerProof: Data()
+        )
+        let transcript = RelayTranscript.bytes(offer: offer, hello: unsigned)
+        return RelayClientHello(
+            version: unsigned.version,
+            sessionID: unsigned.sessionID,
+            initiatorPeerID: unsigned.initiatorPeerID,
+            responderPeerID: unsigned.responderPeerID,
+            initiatorIdentity: unsigned.initiatorIdentity,
+            initiatorNonce: unsigned.initiatorNonce,
+            offerProof: RelayCrypto.confirmation(
+                key: offer.pairingSecret,
+                label: "offer-proof",
+                transcriptHash: Data(SHA256.hash(data: transcript))
+            )
+        )
+    }
+
+    public mutating func receive(_ hello: RelayServerHello) throws -> RelayClientConfirmation {
+        guard hello.version == 2 else { throw SecureRelayError.unsupportedVersion }
+        guard hello.sessionID == offer.sessionID else { throw SecureRelayError.sessionMismatch }
+        guard hello.sessionExpiresAt > Date() else { throw SecureRelayError.sessionExpired }
+        let clientHello = makeClientHello()
+        let transcript = RelayTranscript.bytes(offer: offer, hello: clientHello)
+        let expectedHash = Data(SHA256.hash(data: transcript))
+        guard hello.transcriptHash == expectedHash else {
+            throw SecureRelayError.transcriptMismatch
+        }
+        let derived = try RelayCrypto.deriveRootKey(
+            identity: identity,
+            peer: offer.responderIdentity,
+            pairingSecret: offer.pairingSecret,
+            pairingCode: offer.pairingCode,
+            sessionID: offer.sessionID,
+            transcriptHash: expectedHash
+        )
+        guard RelayCrypto.verify(
+            hello.keyConfirmation,
+            key: derived,
+            label: "server-confirm",
+            transcriptHash: expectedHash
+        ) else {
+            throw SecureRelayError.keyConfirmationFailed
+        }
+        rootKey = derived
+        transcriptHash = expectedHash
+        sessionExpiresAt = hello.sessionExpiresAt
+        return RelayClientConfirmation(
+            version: 2,
+            sessionID: offer.sessionID,
+            keyConfirmation: RelayCrypto.confirmation(
+                key: derived,
+                label: "client-confirm",
+                transcriptHash: expectedHash
+            )
+        )
+    }
+
+    public mutating func finish(
+        _ complete: RelayPairingComplete,
+        now: Date = Date()
+    ) throws -> RelayCredential {
+        guard complete.version == 2 else { throw SecureRelayError.unsupportedVersion }
+        guard complete.sessionID == offer.sessionID else {
+            throw SecureRelayError.sessionMismatch
+        }
+        guard let rootKey, let transcriptHash, let sessionExpiresAt else {
+            throw SecureRelayError.handshakeOutOfOrder
+        }
+        guard RelayCrypto.verify(
+            complete.keyConfirmation,
+            key: rootKey,
+            label: "pairing-complete",
+            transcriptHash: transcriptHash
+        ) else {
+            throw SecureRelayError.keyConfirmationFailed
+        }
+        return RelayCredential(
+            peerID: offer.responderPeerID,
+            role: .initiator,
+            sessionID: offer.sessionID,
+            rootKey: rootKey,
+            createdAt: now,
+            expiresAt: sessionExpiresAt
+        )
+    }
+
+    private static func randomBytes(count: Int) throws -> Data {
+        var bytes = [UInt8](repeating: 0, count: count)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        guard status == errSecSuccess else { throw SecureRelayError.randomGenerationFailed }
+        return Data(bytes)
+    }
+}
+
+public struct RelayHandshakeResponder: Sendable {
+    public let offer: RelayPairingOffer
+
+    private let identity: RelayIdentity
+    private var initiatorPeerID: String?
+    private var rootKey: Data?
+    private var transcriptHash: Data?
+    private var sessionExpiresAt: Date?
+
+    public init(
+        peerID: String,
+        pairingCode: String,
+        now: Date = Date(),
+        offerLifetime: TimeInterval = 5 * 60
+    ) throws {
+        guard RelayPairingOffer.validPairingCode(pairingCode) else {
+            throw SecureRelayError.invalidPairingCode
+        }
+        let identity = RelayIdentity()
+        self.identity = identity
+        offer = try RelayPairingOffer(
+            sessionID: UUID().uuidString.lowercased(),
+            responderPeerID: peerID,
+            responderIdentity: identity.publicIdentity,
+            responderNonce: try Self.randomBytes(count: 32),
+            pairingSecret: try Self.randomBytes(count: 32),
+            pairingCode: pairingCode,
+            expiresAt: now.addingTimeInterval(offerLifetime)
+        )
+    }
+
+    public mutating func receive(
+        _ hello: RelayClientHello,
+        now: Date = Date(),
+        sessionLifetime: TimeInterval = 30 * 24 * 60 * 60
+    ) throws -> RelayServerHello {
+        guard now < offer.expiresAt else { throw SecureRelayError.pairingExpired }
+        guard hello.version == 2 else { throw SecureRelayError.unsupportedVersion }
+        guard hello.sessionID == offer.sessionID else { throw SecureRelayError.sessionMismatch }
+        guard hello.responderPeerID == offer.responderPeerID,
+              !hello.initiatorPeerID.isEmpty,
+              hello.initiatorPeerID != offer.responderPeerID,
+              hello.initiatorNonce.count == 32
+        else {
+            throw SecureRelayError.invalidPairingOffer
+        }
+        let transcript = RelayTranscript.bytes(offer: offer, hello: hello)
+        let hash = Data(SHA256.hash(data: transcript))
+        guard RelayCrypto.verify(
+            hello.offerProof,
+            key: offer.pairingSecret,
+            label: "offer-proof",
+            transcriptHash: hash
+        ) else {
+            throw SecureRelayError.keyConfirmationFailed
+        }
+        let derived = try RelayCrypto.deriveRootKey(
+            identity: identity,
+            peer: hello.initiatorIdentity,
+            pairingSecret: offer.pairingSecret,
+            pairingCode: offer.pairingCode,
+            sessionID: offer.sessionID,
+            transcriptHash: hash
+        )
+        let expiration = now.addingTimeInterval(sessionLifetime)
+        initiatorPeerID = hello.initiatorPeerID
+        rootKey = derived
+        transcriptHash = hash
+        sessionExpiresAt = expiration
+        return RelayServerHello(
+            version: 2,
+            sessionID: offer.sessionID,
+            transcriptHash: hash,
+            keyConfirmation: RelayCrypto.confirmation(
+                key: derived,
+                label: "server-confirm",
+                transcriptHash: hash
+            ),
+            sessionExpiresAt: expiration
+        )
+    }
+
+    public mutating func finish(
+        _ confirmation: RelayClientConfirmation,
+        now: Date = Date()
+    ) throws -> (complete: RelayPairingComplete, credential: RelayCredential) {
+        guard confirmation.version == 2 else { throw SecureRelayError.unsupportedVersion }
+        guard confirmation.sessionID == offer.sessionID else {
+            throw SecureRelayError.sessionMismatch
+        }
+        guard let rootKey, let transcriptHash, let initiatorPeerID, let sessionExpiresAt else {
+            throw SecureRelayError.handshakeOutOfOrder
+        }
+        guard RelayCrypto.verify(
+            confirmation.keyConfirmation,
+            key: rootKey,
+            label: "client-confirm",
+            transcriptHash: transcriptHash
+        ) else {
+            throw SecureRelayError.keyConfirmationFailed
+        }
+        let credential = RelayCredential(
+            peerID: initiatorPeerID,
+            role: .responder,
+            sessionID: offer.sessionID,
+            rootKey: rootKey,
+            createdAt: now,
+            expiresAt: sessionExpiresAt
+        )
+        let complete = RelayPairingComplete(
+            version: 2,
+            sessionID: offer.sessionID,
+            keyConfirmation: RelayCrypto.confirmation(
+                key: rootKey,
+                label: "pairing-complete",
+                transcriptHash: transcriptHash
+            )
+        )
+        return (complete, credential)
+    }
+
+    private static func randomBytes(count: Int) throws -> Data {
+        var bytes = [UInt8](repeating: 0, count: count)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        guard status == errSecSuccess else { throw SecureRelayError.randomGenerationFailed }
+        return Data(bytes)
+    }
+}
+
+public struct RelayEnvelope: Codable, Sendable, Equatable {
+    public let version: Int
+    public let sessionID: String
+    public let sequence: UInt64
+    public let sealed: Data
+
+    public init(version: Int = 2, sessionID: String, sequence: UInt64, sealed: Data) {
+        self.version = version
+        self.sessionID = sessionID
+        self.sequence = sequence
+        self.sealed = sealed
+    }
+}
+
+/// A durable encrypted channel. Sequence allocation and receive-watermark
+/// advancement are committed to the credential store before ciphertext or
+/// plaintext leaves this object, so process restart cannot reuse a nonce or
+/// replay an already-authenticated request into the Runtime.
+public final class DurableSecureRelaySession: @unchecked Sendable {
+    private let peerID: String
+    private let store: any RelayCredentialStore
+
+    public init(peerID: String, store: any RelayCredentialStore) {
+        self.peerID = peerID
+        self.store = store
+    }
+
+    public func seal(_ plaintext: Data, now: Date = Date()) throws -> RelayEnvelope {
+        let reservation = try store.reserveSendSequence(peerID: peerID, now: now)
+        let credential = reservation.credential
+        let key = RelayCrypto.directionalKey(
+            rootKey: credential.rootKey,
+            sessionID: credential.sessionID,
+            role: credential.role,
+            sending: true
+        )
+        let nonce = try RelayCrypto.nonce(
+            rootKey: credential.rootKey,
+            sessionID: credential.sessionID,
+            role: credential.role,
+            sending: true,
+            sequence: reservation.sequence
+        )
+        let authenticatedData = RelayCrypto.authenticatedData(
+            version: credential.version,
+            sessionID: credential.sessionID,
+            sequence: reservation.sequence
+        )
+        let box = try AES.GCM.seal(
+            plaintext,
+            using: key,
+            nonce: nonce,
+            authenticating: authenticatedData
+        )
+        guard let combined = box.combined else { throw SecureRelayError.invalidEnvelope }
+        return RelayEnvelope(
+            version: credential.version,
+            sessionID: credential.sessionID,
+            sequence: reservation.sequence,
+            sealed: combined
+        )
+    }
+
+    public func open(_ envelope: RelayEnvelope, now: Date = Date()) throws -> Data {
+        guard envelope.version == 2 else { throw SecureRelayError.unsupportedVersion }
+        guard let credential = try store.load(peerID: peerID) else {
+            throw SecureRelayError.credentialNotFound
+        }
+        guard credential.expiresAt > now else { throw SecureRelayError.sessionExpired }
+        guard credential.sessionID == envelope.sessionID else {
+            throw SecureRelayError.sessionMismatch
+        }
+        if let last = credential.lastReceivedSequence, envelope.sequence <= last {
+            throw SecureRelayError.replayedMessage
+        }
+        let key = RelayCrypto.directionalKey(
+            rootKey: credential.rootKey,
+            sessionID: credential.sessionID,
+            role: credential.role,
+            sending: false
+        )
+        let box = try AES.GCM.SealedBox(combined: envelope.sealed)
+        let plaintext = try AES.GCM.open(
+            box,
+            using: key,
+            authenticating: RelayCrypto.authenticatedData(
+                version: envelope.version,
+                sessionID: envelope.sessionID,
+                sequence: envelope.sequence
+            )
+        )
+        try store.acceptReceivedSequence(
+            peerID: peerID,
+            sessionID: envelope.sessionID,
+            sequence: envelope.sequence,
+            now: now
+        )
+        return plaintext
+    }
+}
+
+public enum SecureRelayError: Error, Equatable {
+    case credentialNotFound
+    case handshakeOutOfOrder
+    case invalidEnvelope
+    case invalidPairingCode
+    case invalidPairingOffer
+    case keyConfirmationFailed
+    case pairingExpired
+    case randomGenerationFailed
+    case replayedMessage
+    case sequenceExhausted
+    case sessionExpired
+    case sessionMismatch
+    case transcriptMismatch
+    case unsupportedVersion
+}
+
+private enum RelayTranscript {
+    static func bytes(offer: RelayPairingOffer, hello: RelayClientHello) -> Data {
+        fields([
+            Data("persome-health-relay-handshake-v2".utf8),
+            Data(String(offer.version).utf8),
+            Data(offer.sessionID.utf8),
+            Data(offer.responderPeerID.utf8),
+            Data(hello.initiatorPeerID.utf8),
+            offer.responderIdentity.keyAgreementKey,
+            hello.initiatorIdentity.keyAgreementKey,
+            offer.responderNonce,
+            hello.initiatorNonce,
+            Data(offer.pairingCode.utf8),
+        ])
+    }
+
+    private static func fields(_ values: [Data]) -> Data {
+        var result = Data()
+        for value in values {
+            var length = UInt64(value.count).bigEndian
+            withUnsafeBytes(of: &length) { result.append(contentsOf: $0) }
+            result.append(value)
+        }
+        return result
+    }
+}
+
+private enum RelayCrypto {
+    static func deriveRootKey(
+        identity: RelayIdentity,
+        peer: RelayPublicIdentity,
+        pairingSecret: Data,
+        pairingCode: String,
+        sessionID: String,
+        transcriptHash: Data
+    ) throws -> Data {
+        let secret = try identity.sharedSecret(with: peer)
+        let key = secret.hkdfDerivedSymmetricKey(
+            using: SHA256.self,
+            salt: pairingSecret,
+            sharedInfo: RelayTranscript.fieldsForKey(
+                sessionID: sessionID,
+                pairingCode: pairingCode,
+                transcriptHash: transcriptHash
+            ),
+            outputByteCount: 32
+        )
+        return key.withUnsafeBytes { Data($0) }
+    }
+
+    static func confirmation(
+        key: Data,
+        label: String,
+        transcriptHash: Data
+    ) -> Data {
+        let input = Data("persome-relay-v2:\(label):".utf8) + transcriptHash
+        return Data(HMAC<SHA256>.authenticationCode(for: input, using: SymmetricKey(data: key)))
+    }
+
+    static func verify(
+        _ received: Data,
+        key: Data,
+        label: String,
+        transcriptHash: Data
+    ) -> Bool {
+        let expected = confirmation(key: key, label: label, transcriptHash: transcriptHash)
+        return HMAC<SHA256>.isValidAuthenticationCode(
+            received,
+            authenticating: Data("persome-relay-v2:\(label):".utf8) + transcriptHash,
+            using: SymmetricKey(data: key)
+        ) && received == expected
+    }
+
+    static func directionalKey(
+        rootKey: Data,
+        sessionID: String,
+        role: RelayRole,
+        sending: Bool
+    ) -> SymmetricKey {
+        let label = directionLabel(role: role, sending: sending)
+        return HKDF<SHA256>.deriveKey(
+            inputKeyMaterial: SymmetricKey(data: rootKey),
+            salt: Data("persome-relay-direction-v2".utf8),
+            info: Data("\(sessionID):\(label):key".utf8),
+            outputByteCount: 32
+        )
+    }
+
+    static func nonce(
+        rootKey: Data,
+        sessionID: String,
+        role: RelayRole,
+        sending: Bool,
+        sequence: UInt64
+    ) throws -> AES.GCM.Nonce {
+        let label = directionLabel(role: role, sending: sending)
+        let prefixKey = HKDF<SHA256>.deriveKey(
+            inputKeyMaterial: SymmetricKey(data: rootKey),
+            salt: Data("persome-relay-nonce-v2".utf8),
+            info: Data("\(sessionID):\(label):nonce".utf8),
+            outputByteCount: 4
+        )
+        var data = prefixKey.withUnsafeBytes { Data($0) }
+        var bigEndian = sequence.bigEndian
+        withUnsafeBytes(of: &bigEndian) { data.append(contentsOf: $0) }
+        return try AES.GCM.Nonce(data: data)
+    }
+
+    static func authenticatedData(version: Int, sessionID: String, sequence: UInt64) -> Data {
+        Data("persome-relay-envelope:\(version):\(sessionID):\(sequence)".utf8)
+    }
+
+    private static func directionLabel(role: RelayRole, sending: Bool) -> String {
+        switch (role, sending) {
+        case (.initiator, true), (.responder, false): "initiator-to-responder"
+        case (.responder, true), (.initiator, false): "responder-to-initiator"
+        }
+    }
+}
+
+private extension RelayTranscript {
+    static func fieldsForKey(sessionID: String, pairingCode: String, transcriptHash: Data) -> Data {
+        var result = Data("persome-relay-root-v2".utf8)
+        result.append(Data(sessionID.utf8))
+        result.append(Data(pairingCode.utf8))
+        result.append(transcriptHash)
+        return result
+    }
+}

--- a/connectors/apple-health/Sources/PersomeHealthRelay/main.swift
+++ b/connectors/apple-health/Sources/PersomeHealthRelay/main.swift
@@ -1,0 +1,66 @@
+import Foundation
+import PersomeAppleHealth
+
+enum RelayHostCLIError: Error {
+    case invalidRuntimeURL
+    case missingBearerToken
+}
+
+@main
+struct PersomeHealthRelayCLI {
+    static func main() async throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let token = environment["PERSOME_LOCAL_API_TOKEN"], !token.isEmpty else {
+            throw RelayHostCLIError.missingBearerToken
+        }
+        guard let runtimeURL = URL(
+            string: environment["PERSOME_RUNTIME_URL"] ?? "http://127.0.0.1:8742"
+        ) else {
+            throw RelayHostCLIError.invalidRuntimeURL
+        }
+
+        let peerID = environment["PERSOME_RELAY_NAME"] ?? "Persome Mac"
+        let store = KeychainRelayCredentialStore()
+        let forwarder = try LoopbackHealthRuntimeForwarder(
+            runtimeURL: runtimeURL,
+            bearerToken: token
+        )
+        let host = MacHealthRelayHost(
+            peerID: peerID,
+            credentialStore: store,
+            forwarder: forwarder
+        )
+        let pairingCode = String(format: "%06d", Int.random(in: 0 ... 999_999))
+        let offer = try await host.beginPairing(pairingCode: pairingCode)
+        let payload = try RelayPairingOfferCodec.encode(offer).base64EncodedString()
+
+        let transport = MultipeerRelayTransport(displayName: peerID)
+        let adapter = MultipeerHealthRelayHostAdapter(transport: transport, host: host)
+        transport.onInvitation = { [weak transport] phonePeerID in
+            do {
+                // The owner explicitly launched this five-minute pairing window;
+                // transcript authentication still requires its QR secret.
+                try transport?.respondToInvitation(from: phonePeerID, accept: true)
+            } catch {
+                transport?.onError?(error)
+            }
+        }
+        transport.onError = { error in
+            FileHandle.standardError.write(Data("relay error: \(error)\n".utf8))
+        }
+        transport.start()
+
+        print("Persome Apple Health relay is listening as \(peerID).")
+        print("Pairing code: \(pairingCode)")
+        print("Pairing payload (base64): \(payload)")
+        print("The payload expires in five minutes; existing paired sessions remain resumable.")
+
+        defer {
+            transport.stop()
+            withExtendedLifetime(adapter) {}
+        }
+        while !Task.isCancelled {
+            try? await Task.sleep(for: .seconds(60))
+        }
+    }
+}

--- a/connectors/apple-health/Tests/PersomeAppleHealthTests/HealthRelayTests.swift
+++ b/connectors/apple-health/Tests/PersomeAppleHealthTests/HealthRelayTests.swift
@@ -1,0 +1,196 @@
+import Foundation
+import Testing
+@testable import PersomeAppleHealth
+
+private actor MockHealthRuntimeForwarder: HealthRuntimeForwarding {
+    private var bodies: [HealthEventsImport] = []
+
+    func importChanges(_ body: HealthEventsImport) async throws -> HealthImportResult {
+        bodies.append(body)
+        return HealthImportResult(
+            schemaVersion: 1,
+            received: body.events.count,
+            inserted: body.events.count,
+            corrected: 2,
+            duplicates: 0,
+            deleted: body.deletedEvents.count
+        )
+    }
+
+    func snapshot() -> [HealthEventsImport] { bodies }
+}
+
+private actor InMemoryRelayChannel: RelayRequestChannel {
+    private var host: MacHealthRelayHost
+    private let phonePeerID: String
+    private var recordedEnvelope: RelayEnvelope?
+
+    init(host: MacHealthRelayHost, phonePeerID: String) {
+        self.host = host
+        self.phonePeerID = phonePeerID
+    }
+
+    func request(_ frame: RelayWireFrame, to _: String) async throws -> RelayWireFrame {
+        if case let .envelope(envelope) = frame { recordedEnvelope = envelope }
+        return await host.handle(frame, from: phonePeerID)
+    }
+
+    func replaceHost(_ newHost: MacHealthRelayHost) {
+        host = newHost
+    }
+
+    func lastEnvelope() -> RelayEnvelope? { recordedEnvelope }
+}
+
+private func sampleEvent(metadata: [String: String] = [:]) -> HealthEvent {
+    HealthEvent(
+        eventID: "sample-1",
+        source: HealthEventSource(device: "Apple Watch", deviceID: "local-watch"),
+        metric: "heart_rate",
+        value: .number(72),
+        unit: "bpm",
+        startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+        endedAt: nil,
+        timezone: "Asia/Shanghai",
+        metadata: metadata
+    )
+}
+
+@Test func phoneToMultipeerBoundaryToMacLoopbackPathIsEndToEndAndRestartSafe() async throws {
+    let phonePeerID = "owner-phone"
+    let macPeerID = "owner-mac"
+    let phoneStore = MemoryRelayCredentialStore()
+    let macStore = MemoryRelayCredentialStore()
+    let forwarder = MockHealthRuntimeForwarder()
+    let firstHost = MacHealthRelayHost(
+        peerID: macPeerID,
+        credentialStore: macStore,
+        forwarder: forwarder
+    )
+    let channel = InMemoryRelayChannel(host: firstHost, phonePeerID: phonePeerID)
+    let hostOffer = try await firstHost.beginPairing(pairingCode: "482193")
+    let offer = try RelayPairingOfferCodec.decode(RelayPairingOfferCodec.encode(hostOffer))
+
+    let phoneCredential = try await SecureHealthRelayPairer.pair(
+        offer: offer,
+        confirmedPairingCode: "482193",
+        ownPeerID: phonePeerID,
+        credentialStore: phoneStore,
+        channel: channel
+    )
+    let loadedMacCredential = try macStore.load(peerID: phonePeerID)
+    let macCredential = try #require(loadedMacCredential)
+    #expect(phoneCredential.rootKey == macCredential.rootKey)
+    #expect(phoneCredential.role == .initiator)
+    #expect(macCredential.role == .responder)
+
+    let firstClient = SecureHealthRelayClient(
+        macPeerID: macPeerID,
+        credentialStore: phoneStore,
+        channel: channel
+    )
+    let firstResult = try await firstClient.upload(
+        events: [sampleEvent()],
+        deletedEvents: [HealthEventDeletion(eventID: "deleted-1")]
+    )
+    #expect(firstResult.corrected == 2)
+    #expect(firstResult.deleted == 1)
+    #expect(await forwarder.snapshot().count == 1)
+
+    // MacHealthRelayHost creates a fresh secure-session object for each frame;
+    // replay state comes from the durable store, not process memory.
+    let replayed = try #require(await channel.lastEnvelope())
+    let replayResponse = await firstHost.handle(.envelope(replayed), from: phonePeerID)
+    guard case let .failure(failure) = replayResponse else {
+        Issue.record("replayed ciphertext should be rejected")
+        return
+    }
+    #expect(failure.code == "secure_session_rejected")
+    #expect(await forwarder.snapshot().count == 1)
+
+    // Replace the host and client objects while retaining only their credential
+    // stores. The next request uses the next durable sequence and still succeeds.
+    let restartedHost = MacHealthRelayHost(
+        peerID: macPeerID,
+        credentialStore: macStore,
+        forwarder: forwarder
+    )
+    await channel.replaceHost(restartedHost)
+    let restartedClient = SecureHealthRelayClient(
+        macPeerID: macPeerID,
+        credentialStore: phoneStore,
+        channel: channel
+    )
+    let secondResult = try await restartedClient.upload(
+        events: [],
+        deletedEvents: [HealthEventDeletion(eventID: "deleted-2")]
+    )
+    #expect(secondResult.deleted == 1)
+    #expect(await forwarder.snapshot().count == 2)
+}
+
+@Test func bearerClientAndMacForwarderRejectNonLoopbackRuntime() {
+    let lanURL = URL(string: "http://192.168.1.10:8742")!
+    #expect(throws: PersomeHealthClientError.nonLoopbackRuntime) {
+        try PersomeHealthClient(runtimeURL: lanURL, bearerToken: "owner-token")
+    }
+    #expect(throws: PersomeHealthClientError.nonLoopbackRuntime) {
+        try LoopbackHealthRuntimeForwarder(
+            runtimeURL: lanURL,
+            bearerToken: "owner-token"
+        )
+    }
+}
+
+@Test func pairingPayloadAndRelayPlaintextAreBounded() async throws {
+    let forwarder = MockHealthRuntimeForwarder()
+    let host = MacHealthRelayHost(
+        peerID: "owner-mac",
+        credentialStore: MemoryRelayCredentialStore(),
+        forwarder: forwarder
+    )
+    let offer = try await host.beginPairing(pairingCode: "482193")
+    let encodedOffer = try RelayPairingOfferCodec.encode(offer)
+    let decodedOffer = try RelayPairingOfferCodec.decode(encodedOffer)
+    #expect(decodedOffer.sessionID == offer.sessionID)
+    #expect(decodedOffer.pairingSecret == offer.pairingSecret)
+    var malformedObject = try #require(
+        JSONSerialization.jsonObject(with: encodedOffer) as? [String: Any]
+    )
+    malformedObject["pairingSecret"] = Data([1]).base64EncodedString()
+    let malformedOffer = try JSONSerialization.data(withJSONObject: malformedObject)
+    #expect(throws: HealthRelayError.invalidPairingPayload) {
+        try RelayPairingOfferCodec.decode(malformedOffer)
+    }
+
+    let phoneStore = MemoryRelayCredentialStore()
+    let channel = InMemoryRelayChannel(host: host, phonePeerID: "owner-phone")
+    _ = try await SecureHealthRelayPairer.pair(
+        offer: offer,
+        confirmedPairingCode: "482193",
+        ownPeerID: "owner-phone",
+        credentialStore: phoneStore,
+        channel: channel
+    )
+    await #expect(throws: HealthRelayError.pairingCodeMismatch) {
+        try await SecureHealthRelayPairer.pair(
+            offer: offer,
+            confirmedPairingCode: "000000",
+            ownPeerID: "other-phone",
+            credentialStore: MemoryRelayCredentialStore(),
+            channel: channel
+        )
+    }
+    let client = SecureHealthRelayClient(
+        macPeerID: "owner-mac",
+        credentialStore: phoneStore,
+        channel: channel
+    )
+    await #expect(throws: HealthRelayError.payloadTooLarge) {
+        try await client.upload(
+            events: [sampleEvent(metadata: ["blob": String(repeating: "x", count: 2_100_000)])],
+            deletedEvents: []
+        )
+    }
+    #expect(await forwarder.snapshot().isEmpty)
+}

--- a/connectors/apple-health/Tests/PersomeAppleHealthTests/RelayCredentialStoreTests.swift
+++ b/connectors/apple-health/Tests/PersomeAppleHealthTests/RelayCredentialStoreTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+@testable import PersomeAppleHealth
+
+private func credential(
+    sessionID: String = "session-1",
+    rootByte: UInt8 = 1
+) -> RelayCredential {
+    RelayCredential(
+        peerID: "owner-mac",
+        role: .initiator,
+        sessionID: sessionID,
+        rootKey: Data(repeating: rootByte, count: 32),
+        expiresAt: Date().addingTimeInterval(3_600)
+    )
+}
+
+@Test func credentialStoreRoundTripPersistsSessionState() throws {
+    let store = MemoryRelayCredentialStore()
+    let value = credential()
+    try store.save(value)
+
+    #expect(try store.load(peerID: "owner-mac") == value)
+    let reservation = try store.reserveSendSequence(peerID: "owner-mac", now: Date())
+    #expect(reservation.sequence == 0)
+    #expect(try store.load(peerID: "owner-mac")?.nextSendSequence == 1)
+
+    try store.acceptReceivedSequence(
+        peerID: "owner-mac",
+        sessionID: value.sessionID,
+        sequence: 8,
+        now: Date()
+    )
+    #expect(try store.load(peerID: "owner-mac")?.lastReceivedSequence == 8)
+    #expect(throws: SecureRelayError.replayedMessage) {
+        try store.acceptReceivedSequence(
+            peerID: "owner-mac",
+            sessionID: value.sessionID,
+            sequence: 8,
+            now: Date()
+        )
+    }
+
+    try store.delete(peerID: "owner-mac")
+    #expect(try store.load(peerID: "owner-mac") == nil)
+}
+
+@Test func savingSamePeerReplacesTheWholeSession() throws {
+    let store = MemoryRelayCredentialStore()
+    let first = credential()
+    let replacement = credential(sessionID: "session-2", rootByte: 2)
+
+    try store.save(first)
+    try store.save(replacement)
+    #expect(try store.load(peerID: "owner-mac") == replacement)
+}
+
+@Test func rejectsExpiredAndMalformedCredentials() throws {
+    let store = MemoryRelayCredentialStore()
+    let expired = RelayCredential(
+        peerID: "owner-mac",
+        role: .initiator,
+        sessionID: "expired",
+        rootKey: Data(repeating: 1, count: 32),
+        createdAt: Date().addingTimeInterval(-10),
+        expiresAt: Date().addingTimeInterval(-1)
+    )
+    try store.save(expired)
+    #expect(throws: SecureRelayError.sessionExpired) {
+        try store.reserveSendSequence(peerID: "owner-mac", now: Date())
+    }
+
+    let malformed = RelayCredential(
+        peerID: "owner-mac",
+        role: .initiator,
+        sessionID: "bad-key",
+        rootKey: Data([1, 2, 3]),
+        expiresAt: Date().addingTimeInterval(60)
+    )
+    #expect(throws: KeychainRelayError.invalidCredential) { try store.save(malformed) }
+}

--- a/connectors/apple-health/Tests/PersomeAppleHealthTests/RelayEnvelopeCodecTests.swift
+++ b/connectors/apple-health/Tests/PersomeAppleHealthTests/RelayEnvelopeCodecTests.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Testing
+@testable import PersomeAppleHealth
+
+@Test func relayFrameCodecRoundTrip() throws {
+    let envelope = RelayEnvelope(
+        sessionID: "session-1",
+        sequence: 42,
+        sealed: Data([1, 2, 3, 4])
+    )
+    let frame = RelayWireFrame.envelope(envelope)
+    #expect(try RelayFrameCodec.decode(RelayFrameCodec.encode(frame)) == frame)
+}
+
+@Test func relayFrameCodecRejectsMalformedAndOversizedFrames() {
+    #expect(throws: RelayTransportError.invalidFrame) {
+        try RelayFrameCodec.decode(Data("not-json".utf8))
+    }
+    #expect(throws: RelayTransportError.frameTooLarge) {
+        try RelayFrameCodec.decode(Data(repeating: 0, count: RelayFrameCodec.maximumFrameBytes + 1))
+    }
+}

--- a/connectors/apple-health/Tests/PersomeAppleHealthTests/SecureRelayTests.swift
+++ b/connectors/apple-health/Tests/PersomeAppleHealthTests/SecureRelayTests.swift
@@ -1,0 +1,195 @@
+import Foundation
+import Testing
+@testable import PersomeAppleHealth
+
+private struct PairedRelay {
+    let phoneStore: MemoryRelayCredentialStore
+    let macStore: MemoryRelayCredentialStore
+    let phoneCredential: RelayCredential
+    let macCredential: RelayCredential
+}
+
+private func pairRelay() throws -> PairedRelay {
+    var responder = try RelayHandshakeResponder(peerID: "owner-mac", pairingCode: "482193")
+    var initiator = try RelayHandshakeInitiator(
+        offer: responder.offer,
+        ownPeerID: "owner-phone"
+    )
+    let serverHello = try responder.receive(initiator.makeClientHello())
+    let clientConfirmation = try initiator.receive(serverHello)
+    let result = try responder.finish(clientConfirmation)
+    let phoneCredential = try initiator.finish(result.complete)
+    let phoneStore = MemoryRelayCredentialStore()
+    let macStore = MemoryRelayCredentialStore()
+    try phoneStore.save(phoneCredential)
+    try macStore.save(result.credential)
+    return PairedRelay(
+        phoneStore: phoneStore,
+        macStore: macStore,
+        phoneCredential: phoneCredential,
+        macCredential: result.credential
+    )
+}
+
+@Test func confirmedSessionsExchangeBidirectionally() throws {
+    let paired = try pairRelay()
+    let phone = DurableSecureRelaySession(peerID: "owner-mac", store: paired.phoneStore)
+    let mac = DurableSecureRelaySession(peerID: "owner-phone", store: paired.macStore)
+
+    let upload = try phone.seal(Data("health batch".utf8))
+    #expect(try mac.open(upload) == Data("health batch".utf8))
+
+    let receipt = try mac.seal(Data("inserted: 4".utf8))
+    #expect(try phone.open(receipt) == Data("inserted: 4".utf8))
+}
+
+@Test func rejectsTamperedTranscriptAndKeyConfirmation() throws {
+    var responder = try RelayHandshakeResponder(peerID: "owner-mac", pairingCode: "482193")
+    var initiator = try RelayHandshakeInitiator(
+        offer: responder.offer,
+        ownPeerID: "owner-phone"
+    )
+    let server = try responder.receive(initiator.makeClientHello())
+    let tampered = RelayServerHello(
+        version: server.version,
+        sessionID: server.sessionID,
+        transcriptHash: server.transcriptHash,
+        keyConfirmation: Data(repeating: 0, count: server.keyConfirmation.count),
+        sessionExpiresAt: server.sessionExpiresAt
+    )
+    #expect(throws: SecureRelayError.keyConfirmationFailed) {
+        try initiator.receive(tampered)
+    }
+
+    let alteredOffer = try RelayPairingOffer(
+        sessionID: responder.offer.sessionID,
+        responderPeerID: responder.offer.responderPeerID,
+        responderIdentity: responder.offer.responderIdentity,
+        responderNonce: responder.offer.responderNonce,
+        pairingSecret: Data(repeating: 7, count: 32),
+        pairingCode: responder.offer.pairingCode,
+        expiresAt: responder.offer.expiresAt
+    )
+    let attacker = try RelayHandshakeInitiator(offer: alteredOffer, ownPeerID: "attacker")
+    #expect(throws: SecureRelayError.keyConfirmationFailed) {
+        try responder.receive(attacker.makeClientHello())
+    }
+}
+
+@Test func durableCountersSurviveRestartAndRejectOldCiphertext() throws {
+    let paired = try pairRelay()
+    let firstPhoneProcess = DurableSecureRelaySession(
+        peerID: "owner-mac",
+        store: paired.phoneStore
+    )
+    let firstMacProcess = DurableSecureRelaySession(
+        peerID: "owner-phone",
+        store: paired.macStore
+    )
+    let first = try firstPhoneProcess.seal(Data("first".utf8))
+    #expect(first.sequence == 0)
+    #expect(try firstMacProcess.open(first) == Data("first".utf8))
+
+    // Simulate a process boundary by round-tripping exactly the Codable value
+    // stored by Keychain into entirely new store/session instances.
+    let loadedPersistedPhone = try paired.phoneStore.load(peerID: "owner-mac")
+    let loadedPersistedMac = try paired.macStore.load(peerID: "owner-phone")
+    let persistedPhone = try #require(loadedPersistedPhone)
+    let persistedMac = try #require(loadedPersistedMac)
+    let restartedPhoneStore = MemoryRelayCredentialStore()
+    let restartedMacStore = MemoryRelayCredentialStore()
+    try restartedPhoneStore.save(
+        JSONDecoder.persome.decode(
+            RelayCredential.self,
+            from: JSONEncoder.persome.encode(persistedPhone)
+        )
+    )
+    try restartedMacStore.save(
+        JSONDecoder.persome.decode(
+            RelayCredential.self,
+            from: JSONEncoder.persome.encode(persistedMac)
+        )
+    )
+    let restartedPhoneProcess = DurableSecureRelaySession(
+        peerID: "owner-mac",
+        store: restartedPhoneStore
+    )
+    let restartedMacProcess = DurableSecureRelaySession(
+        peerID: "owner-phone",
+        store: restartedMacStore
+    )
+    let second = try restartedPhoneProcess.seal(Data("second".utf8))
+    #expect(second.sequence == 1)
+    #expect(try restartedMacProcess.open(second) == Data("second".utf8))
+    #expect(throws: SecureRelayError.replayedMessage) {
+        try restartedMacProcess.open(first)
+    }
+
+    let loadedPhoneCredential = try restartedPhoneStore.load(peerID: "owner-mac")
+    let loadedMacCredential = try restartedMacStore.load(peerID: "owner-phone")
+    let phoneCredential = try #require(loadedPhoneCredential)
+    let macCredential = try #require(loadedMacCredential)
+    #expect(phoneCredential.nextSendSequence == 2)
+    #expect(macCredential.lastReceivedSequence == 1)
+}
+
+@Test func authenticatedHeaderBindsSessionAndSequence() throws {
+    let paired = try pairRelay()
+    let phone = DurableSecureRelaySession(peerID: "owner-mac", store: paired.phoneStore)
+    let mac = DurableSecureRelaySession(peerID: "owner-phone", store: paired.macStore)
+    let envelope = try phone.seal(Data("private health data".utf8))
+
+    let wrongSequence = RelayEnvelope(
+        sessionID: envelope.sessionID,
+        sequence: envelope.sequence + 1,
+        sealed: envelope.sealed
+    )
+    #expect(throws: (any Error).self) { try mac.open(wrongSequence) }
+
+    let wrongSession = RelayEnvelope(
+        sessionID: UUID().uuidString,
+        sequence: envelope.sequence,
+        sealed: envelope.sealed
+    )
+    #expect(throws: SecureRelayError.sessionMismatch) { try mac.open(wrongSession) }
+}
+
+@Test func everyPairingCreatesFreshSessionMaterial() throws {
+    let first = try pairRelay()
+    let second = try pairRelay()
+    #expect(first.phoneCredential.sessionID != second.phoneCredential.sessionID)
+    #expect(first.phoneCredential.rootKey != second.phoneCredential.rootKey)
+
+    let firstEnvelope = try DurableSecureRelaySession(
+        peerID: "owner-mac",
+        store: first.phoneStore
+    ).seal(Data("same".utf8))
+    let secondEnvelope = try DurableSecureRelaySession(
+        peerID: "owner-mac",
+        store: second.phoneStore
+    ).seal(Data("same".utf8))
+    #expect(firstEnvelope.sequence == secondEnvelope.sequence)
+    #expect(firstEnvelope.sessionID != secondEnvelope.sessionID)
+    #expect(firstEnvelope.sealed != secondEnvelope.sealed)
+}
+
+@Test func validatesPairingCodeAndOfferExpiry() throws {
+    #expect(throws: SecureRelayError.invalidPairingCode) {
+        try RelayHandshakeResponder(peerID: "owner-mac", pairingCode: "12345x")
+    }
+
+    let now = Date()
+    let responder = try RelayHandshakeResponder(
+        peerID: "owner-mac",
+        pairingCode: "123456",
+        now: now,
+        offerLifetime: 1
+    )
+    #expect(throws: SecureRelayError.pairingExpired) {
+        try RelayHandshakeInitiator(
+            offer: responder.offer,
+            ownPeerID: "phone",
+            now: now.addingTimeInterval(2)
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- add normalized Apple Health event import and owner-authorized metric queries
- add authenticated Multipeer relay transport with Keychain-backed credentials
- treat changed payloads using the same provider event ID as corrections, while identical replays remain duplicates
- document the Health import contract and correction counters

## Validation

- `uv run ruff check src/persome/store/health_events.py tests/test_health_events_import_api.py`
- `uv run pytest tests/test_health_events_import_api.py tests/test_openapi_drift.py tests/test_db_schema_drift.py -q` (9 passed)
- `git diff --check`