### PR TITLE
feat: support local OCR on Intel Macs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # ubuntu-latest: the Paddle OCR deps are gated to Apple Silicon macOS,
-        # so they are skipped
-        # and the OCR-less code path is exercised.
+        # ubuntu-latest: the Paddle OCR deps are skipped and the no-runtime
+        # fail-open path is exercised.
         # macos-latest (arm64): full dependency set incl. local OCR runtime.
-        # Tests marked "macos" stay deselected on BOTH runners: CI has no
+        # macos-15-intel (x86_64): Apple Vision OCR fallback + Intel install path.
+        # Tests marked "macos" stay deselected in the default gate: CI has no
         # Accessibility (AX) permission, so AX-capture tests cannot run there.
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, macos-15-intel]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     steps:
@@ -82,6 +82,10 @@ jobs:
         env:
           PERSOME_LLM_MOCK: "1"
         run: uv run --no-sync pytest -m "not macos and not integration" -q
+
+      - name: Real Intel Vision OCR smoke
+        if: matrix.os == 'macos-15-intel'
+        run: uv run --no-sync pytest tests/test_vision_ocr.py -m macos -q
 
       - name: PII scan
         # Hard privacy gate: the whole tree (source + test fixtures) must be
@@ -158,6 +162,7 @@ jobs:
               "build-mac-ax-watcher.sh",
               "mac-ax-helper.swift",
               "mac-ax-watcher.swift",
+              "mac-vision-ocr.swift",
               "mac-url-handlers.swift",
               "model_assets/LICENSE",
               "model_assets/three.module.js",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,7 @@ jobs:
               "build-mac-ax-watcher.sh",
               "mac-ax-helper.swift",
               "mac-ax-watcher.swift",
+              "mac-vision-ocr.swift",
               "mac-url-handlers.swift",
               "model_assets/LICENSE",
               "model_assets/three.module.js",
@@ -169,6 +170,7 @@ jobs:
               raise AssertionError("PyPI wheel must be named personal-model")
           bundled = files("persome") / "_bundled"
           assert (bundled / "mac-ax-helper.swift").is_file()
+          assert (bundled / "mac-vision-ocr.swift").is_file()
           assert (bundled / "model_assets" / "viewer.js").is_file()
           assert (
               bundled / "ocr_models" / "PP-OCRv6_tiny_rec" / "inference.pdiparams"

--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ After successful interactive onboarding, the source installer schedules the one-
 - `persome onboard` explains each macOS request before it appears.
 - Accessibility is granted to the versioned `mac-ax-helper` and, only when event-driven capture is enabled, `mac-ax-watcher`.
 - Screen Recording is requested only when the effective screenshot or local-OCR policy requires pixels. Persome never requires Full Disk Access.
-- On Apple Silicon, onboarding verifies the isolated local OCR worker when OCR is enabled.
+- On Apple Silicon, local OCR uses bundled PP-OCRv6; on Intel, it uses the macOS
+  Apple Vision framework. Onboarding verifies the isolated worker on both architectures.
 - Unified localhost onboarding offers a read-only, multi-source import and builds the first model
   from existing Markdown history. Local folders are always available; Obsidian
   and Notion appear only when detected on the Mac. The same sources remain

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -144,6 +144,7 @@ required = (
     "build-mac-ax-watcher.sh",
     "mac-ax-helper.swift",
     "mac-ax-watcher.swift",
+    "mac-vision-ocr.swift",
     "mac-url-handlers.swift",
     "model_assets/LICENSE",
     "model_assets/three.module.js",
@@ -191,7 +192,7 @@ re-prove the Runtime. `persome update` detects this shape and exits with those
 instructions instead of attempting the source installer's atomic venv exchange.
 
 In an interactive macOS session, `install.sh` runs `persome onboard`. For the
-standard Apple Silicon daemon mode, onboarding separately requests Accessibility
+standard daemon mode on Apple Silicon and Intel, onboarding separately requests Accessibility
 for the source-versioned capture helper and event watcher, requests Screen
 Recording when the effective pixel policy needs it, starts the final owner,
 waits for its bundled OCR worker, polls canonical local health and authenticated
@@ -199,7 +200,7 @@ permission endpoints, and requires an exact fresh-capture receipt from the
 daemon-owned runner. Repeated runs must reuse the same source-versioned native
 binaries and ready worker rather than compile new TCC principals or spawn a
     second OCR process. The same command must also report truthfully for Intel
-    without local OCR, durable OCR/pixel opt-out, trusted ingest, paused/locked update,
+    with Apple Vision OCR, durable OCR/pixel opt-out, trusted ingest, paused/locked update,
 LaunchAgent-owned, and HTTP-disabled modes. HTTP-disabled daemon mode proves the
 same generation through owner-only `.runtime-state.json`; trusted ingest is
 rejected when its authenticated HTTP endpoint is disabled.

--- a/docs/capture.md
+++ b/docs/capture.md
@@ -85,9 +85,10 @@ and removes its worker isolation.
 The AX helper, watcher, and Intel Vision OCR helper are compiled into immutable
 `<PERSOME_ROOT>/native/<source-digest>/` directories keyed by a format version,
 architecture, and Swift source bytes. A same-version reinstall returns the exact
-existing executables, preserving their macOS TCC identity. Changed helper source
-uses a new digest path and therefore requires a deliberate new Accessibility
-grant; rollback resolves the old wheel source and old binary again.
+existing executables. For the AX helper and watcher, this preserves their macOS
+TCC identity; changed AX source uses a new digest path and therefore requires a
+deliberate new Accessibility grant. The Vision helper does not request AX access.
+Rollback resolves the old wheel source and old binaries again.
 
 ```bash
 persome onboard            # permissions + OCR + daemon + health + fresh capture

--- a/docs/capture.md
+++ b/docs/capture.md
@@ -6,9 +6,9 @@ In `source="daemon"` mode, live capture requires Accessibility for the native
 `mac-ax-helper` and, when event-driven capture is enabled, the separate
 `mac-ax-watcher` executable. The terminal and Python daemon do not read AX on
 their behalf. Screen Recording is additionally required when screenshot storage
-or effective OCR needs pixels. In a standard interactive Apple Silicon install,
+or effective OCR needs pixels. In a standard interactive macOS install,
 `persome onboard` explains and requests each required principal separately,
-verifies bundled OCR, starts the final daemon owner, checks local health, and
+verifies architecture-native OCR, starts the final daemon owner, checks local health, and
 proves one fresh capture inside that daemon before returning success. The
 authenticated `/permissions` endpoint runs the actual helper/watcher trust
 checks plus the Runtime's Screen Recording preflight. With HTTP auto-start
@@ -54,8 +54,8 @@ The same capture scheduler also invokes `SessionManager.on_event` (wired as a `p
 
 ## Local OCR fallback
 
-The installer runs `persome onboard`, whose OCR step checks the native Runtime
-and bundled weights, requests Screen Recording after an explicit explanation,
+The installer runs `persome onboard`, whose OCR step checks the architecture-native
+Runtime and required assets, requests Screen Recording after an explicit explanation,
 persists enabled intent, then starts the daemon and waits for the daemon-owned
 isolated worker to initialize. `[capture].ocr_policy` distinguishes `auto`
 (fresh/unconfigured), `enabled`, and `disabled` (explicit opt-out). Ordinary
@@ -75,12 +75,14 @@ focused screenshot bytes
   -> timeline/modeling fallback when AX text is empty
 ```
 
-The subprocess is the native-crash boundary: a Paddle fault fails the OCR call
-without killing the daemon. `PERSOME_DISABLE_OCR=1` prevents Paddle from being
-loaded at all. `PERSOME_OCR_IN_PROCESS=1` exists only for debugging and removes
-that isolation.
+The subprocess is the native-crash boundary: Apple Silicon runs bundled
+PP-OCRv6 there; Intel invokes an on-device Apple Vision helper with the same
+text, box, and confidence contract. A native fault fails the OCR call without
+killing the daemon. `PERSOME_DISABLE_OCR=1` prevents either backend from
+running. `PERSOME_OCR_IN_PROCESS=1` exists only for debugging the Paddle path
+and removes its worker isolation.
 
-The helper and watcher are compiled into immutable
+The AX helper, watcher, and Intel Vision OCR helper are compiled into immutable
 `<PERSOME_ROOT>/native/<source-digest>/` directories keyed by a format version,
 architecture, and Swift source bytes. A same-version reinstall returns the exact
 existing executables, preserving their macOS TCC identity. Changed helper source

--- a/docs/config.md
+++ b/docs/config.md
@@ -166,15 +166,16 @@ cmux_source_enabled = true
   `persome onboard --tier tiny` or `persome ocr setup` explicitly enables OCR;
   `persome ocr disable` records the opt-out. Do not toggle only
   `enable_ocr_fallback` when representing user intent.
-- Paddle inference runs in a local worker subprocess so a native crash does not
-  kill the daemon. OCR text is backfilled into capture search and consumed by
+- OCR inference runs in a local worker subprocess so a native crash does not
+  kill the daemon. Apple Silicon selects bundled PP-OCRv6; Intel selects the
+  system Apple Vision framework. OCR text is backfilled into capture search and consumed by
   timeline/modeling; pixels are not sent to an LLM stage. The source-level
   config default is `enable_ocr_fallback=false`, `ocr_policy="auto"` for
   unsupported/direct-library environments; a supported fresh macOS install
   records the enabled state shown above after explicit onboarding.
 - `PERSOME_DISABLE_OCR=1` is the deployment kill switch.
-- `PERSOME_OCR_IN_PROCESS=1` is a debugging escape hatch that gives up crash
-  isolation and should not be used for normal operation.
+- `PERSOME_OCR_IN_PROCESS=1` is a Paddle-only debugging escape hatch that gives
+  up its worker isolation and should not be used for normal operation.
 - Age-based retention only removes captures already absorbed by a closed
   timeline block. `buffer_max_mb` remains a hard cap and may evict the oldest
   unabsorbed frame to prevent unbounded disk growth.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -5,10 +5,10 @@ inspection, correction, export, erasure, and uninstall behavior.
 
 ## Support matrix
 
-| Host | AX capture | PP-OCRv6 | Daemon, MCP, model |
+| Host | AX capture | Local OCR | Daemon, MCP, model |
 |---|---|---|---|
-| macOS 13+ Apple Silicon | yes | yes, bundled and local | supported |
-| macOS 13+ Intel | yes | no compatible Paddle runtime | supported without OCR |
+| macOS 13+ Apple Silicon | yes | PP-OCRv6, bundled and local | supported |
+| macOS 13+ Intel | yes | Apple Vision, system and local | supported |
 | Linux | no | no | offline tests and development only |
 | Windows | no | no | unsupported |
 
@@ -39,8 +39,9 @@ one fresh capture through that daemon's runner. The authenticated `/permissions`
 endpoint invokes the actual helper/watcher probes and the Runtime's Screen
 Recording preflight. HTTP-disabled daemon mode publishes the same generation's
 owner-only state receipt; trusted ingest proves its authenticated runner and
-does not claim daemon-owned macOS permissions. Intel without local OCR and
-explicit OCR/pixel opt-out report their actual remaining AX/pixel capabilities.
+does not claim daemon-owned macOS permissions. Intel uses the same worker
+contract through Apple Vision; explicit OCR/pixel opt-out reports the actual
+remaining AX/pixel capabilities.
 Updates preserve paused/locked privacy state without forcing a frame. The first
 OCR load can take up to two minutes; repeated runs publish progress and normally
 reuse the worker.
@@ -80,7 +81,7 @@ and old helper path.
 | `.daemon.lock` | lifetime single-Runtime lock inherited across background forks |
 | `.launchagent-owner` | durable intent that launchd owns Runtime lifecycle |
 | `.update.lock`, `.update-state.json` | exclusive update lock and crash-recovery phase metadata |
-| `native/<source-digest>/` | immutable machine-local AX binaries; code, not personal data |
+| `native/<source-digest>/` | immutable machine-local AX and Vision OCR binaries; code, not personal data |
 | `venv.replacement.update`, `venv.previous.committed.*`, `venv.failed.update.*` | candidate, retained-old, and cleanup environments during a transaction; code, not personal data |
 | `venv/` | dedicated installer environment; code, not personal data |
 

--- a/docs/runtime-internals.md
+++ b/docs/runtime-internals.md
@@ -125,9 +125,10 @@ labels, ports, and data roots do not belong in core.
 Supported installs enable OCR through `persome ocr setup` or an explicit
 `persome onboard --tier ...`. `persome ocr disable` records a durable opt-out;
 an ordinary `persome onboard` and every update preserve that policy and tier.
-The child worker managed by `capture/ocr_subprocess.py` isolates native Paddle
-faults from the daemon. Quick health checks inspect configuration, Runtime,
-weights, kill switch, and Screen Recording without loading Paddle. Run
+The child worker managed by `capture/ocr_subprocess.py` isolates native OCR
+faults from the daemon. Apple Silicon uses bundled PP-OCRv6; Intel uses the
+system Apple Vision framework. Quick health checks inspect configuration,
+Runtime/assets, kill switch, and Screen Recording without loading an engine. Run
 `persome ocr status --check` to verify the worker engine. In trusted-ingest mode,
 the producer owns the OS permission boundary; the daemon starts no AX watcher
 and requires authenticated HTTP ingest readiness.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -110,7 +110,7 @@ fallback for old installs or a changed TCC principal.
 
 Second most common cause: **`ax_depth` too shallow for Electron apps.** See [capture.md](capture.md#ax-depth-the-1-footgun).
 
-In standard Apple Silicon daemon mode, the installer completes Accessibility,
+In standard daemon mode on Apple Silicon or Intel, the installer completes Accessibility,
 Screen Recording, local OCR, daemon health, and a fresh capture through
 `persome onboard`. Other configured modes print their own readiness receipt.
 Rerun that end-to-end gate first:

--- a/install.sh
+++ b/install.sh
@@ -535,8 +535,10 @@ PY
 }
 
 compile_bundled_binaries() {
-  log "compiling bundled AX helper binaries"
-  "${VENV_DIR}/bin/python" - <<'PY' || die "failed to compile bundled AX binaries"
+  log "compiling bundled native helper binaries"
+  "${VENV_DIR}/bin/python" - <<'PY' || die "failed to compile bundled native binaries"
+import platform
+
 from persome.capture.ax_capture import _resolve_helper_path
 from persome.capture.watcher import _resolve_watcher_path
 
@@ -548,6 +550,13 @@ if watcher is None:
     raise SystemExit("mac-ax-watcher not available after install")
 print(f"helper={helper}")
 print(f"watcher={watcher}")
+if platform.machine().lower() in {"x86_64", "amd64"}:
+    from persome.capture.vision_ocr import resolve_helper_path
+
+    vision = resolve_helper_path()
+    if vision is None:
+        raise SystemExit("mac-vision-ocr not available after Intel install")
+    print(f"vision_ocr={vision}")
 PY
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,11 @@ dependencies = [
     "uvicorn>=0.30",
     "httpx[socks]>=0.27",
     "certifi>=2024.2",
-    "cryptography>=42.0",
+    # cryptography 49 dropped macOS x86_64/universal wheels. Keep Intel on the
+    # newest line that still ships a binary so locked `--no-build` installs stay
+    # reproducible; other platforms continue receiving the current release.
+    "cryptography>=42.0,<49; platform_system == 'Darwin' and platform_machine == 'x86_64'",
+    "cryptography>=42.0; platform_system != 'Darwin' or platform_machine != 'x86_64'",
     "anthropic>=0.50",
     "openai>=1.75,<3",
     "tomlkit>=0.13,<1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     # On-device OCR for AX-poor apps (WeChat/Feishu). PP-OCRv6 via paddleocr on the
     # paddlepaddle CPU runtime; weights are vendored in ocr_models/ and loaded from a
     # local dir (no network). Paddle's macOS wheel is arm64-only; Intel installs
-    # keep the AX pipeline and degrade cleanly without local OCR.
+    # use the system Apple Vision OCR helper instead.
     "paddleocr==3.7.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
     "paddlepaddle==3.3.1; platform_system == 'Darwin' and platform_machine == 'arm64'",
     # Vector retrieval and the OCR in-process decode path import numpy directly;
@@ -90,6 +90,7 @@ packages = ["src/persome"]
 "resources/build-mac-ax-helper.sh" = "persome/_bundled/build-mac-ax-helper.sh"
 "resources/mac-ax-watcher.swift" = "persome/_bundled/mac-ax-watcher.swift"
 "resources/build-mac-ax-watcher.sh" = "persome/_bundled/build-mac-ax-watcher.sh"
+"resources/mac-vision-ocr.swift" = "persome/_bundled/mac-vision-ocr.swift"
 "resources/mac-url-handlers.swift" = "persome/_bundled/mac-url-handlers.swift"
 "resources/model_assets" = "persome/_bundled/model_assets"
 "ocr_models" = "persome/_bundled/ocr_models"

--- a/resources/mac-vision-ocr.swift
+++ b/resources/mac-vision-ocr.swift
@@ -4,6 +4,7 @@ import ImageIO
 import Vision
 
 private let maxInputBytes = 64 * 1024 * 1024
+private let inputChunkBytes = 1024 * 1024
 
 private func emit(_ payload: [String: Any]) {
     guard JSONSerialization.isValidJSONObject(payload),
@@ -20,25 +21,43 @@ private func fail(_ message: String, code: Int32 = 1) -> Never {
     exit(code)
 }
 
+private func readBoundedInput() -> Data {
+    var input = Data()
+    do {
+        while input.count <= maxInputBytes {
+            let remaining = maxInputBytes + 1 - input.count
+            guard remaining > 0 else { break }
+            let chunk = try FileHandle.standardInput.read(
+                upToCount: min(inputChunkBytes, remaining)
+            ) ?? Data()
+            guard !chunk.isEmpty else { break }
+            input.append(chunk)
+        }
+    } catch {
+        fail("could not read image input")
+    }
+    return input
+}
+
 if CommandLine.arguments.dropFirst().contains("--check") {
     _ = VNRecognizeTextRequest()
     emit(["ok": true, "texts": [], "boxes": [], "scores": []])
     exit(0)
 }
 
-let input: Data
-do {
-    // Read one byte past the contract limit so oversized input is rejected
-    // without first allocating an unbounded stdin payload.
-    input = try FileHandle.standardInput.read(upToCount: maxInputBytes + 1) ?? Data()
-} catch {
-    fail("could not read image input")
-}
+// Pipes may legally return a short read before EOF. Accumulate bounded chunks
+// so a large image is never silently truncated, while still reading one byte
+// past the contract limit to reject oversized input without unbounded memory.
+let input = readBoundedInput()
 guard !input.isEmpty else {
     fail("empty image input")
 }
 guard input.count <= maxInputBytes else {
     fail("image input exceeds 64 MiB limit")
+}
+if CommandLine.arguments.dropFirst().contains("--check-input") {
+    emit(["ok": true, "inputBytes": input.count])
+    exit(0)
 }
 guard let source = CGImageSourceCreateWithData(input as CFData, nil),
       let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {

--- a/resources/mac-vision-ocr.swift
+++ b/resources/mac-vision-ocr.swift
@@ -26,7 +26,14 @@ if CommandLine.arguments.dropFirst().contains("--check") {
     exit(0)
 }
 
-let input = FileHandle.standardInput.readDataToEndOfFile()
+let input: Data
+do {
+    // Read one byte past the contract limit so oversized input is rejected
+    // without first allocating an unbounded stdin payload.
+    input = try FileHandle.standardInput.read(upToCount: maxInputBytes + 1) ?? Data()
+} catch {
+    fail("could not read image input")
+}
 guard !input.isEmpty else {
     fail("empty image input")
 }

--- a/resources/mac-vision-ocr.swift
+++ b/resources/mac-vision-ocr.swift
@@ -1,0 +1,81 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import Vision
+
+private let maxInputBytes = 64 * 1024 * 1024
+
+private func emit(_ payload: [String: Any]) {
+    guard JSONSerialization.isValidJSONObject(payload),
+          let data = try? JSONSerialization.data(withJSONObject: payload) else {
+        FileHandle.standardOutput.write(Data("{\"ok\":false}".utf8))
+        return
+    }
+    FileHandle.standardOutput.write(data)
+}
+
+private func fail(_ message: String, code: Int32 = 1) -> Never {
+    emit(["ok": false])
+    FileHandle.standardError.write(Data((message + "\n").utf8))
+    exit(code)
+}
+
+if CommandLine.arguments.dropFirst().contains("--check") {
+    _ = VNRecognizeTextRequest()
+    emit(["ok": true, "texts": [], "boxes": [], "scores": []])
+    exit(0)
+}
+
+let input = FileHandle.standardInput.readDataToEndOfFile()
+guard !input.isEmpty else {
+    fail("empty image input")
+}
+guard input.count <= maxInputBytes else {
+    fail("image input exceeds 64 MiB limit")
+}
+guard let source = CGImageSourceCreateWithData(input as CFData, nil),
+      let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+    fail("could not decode image")
+}
+
+let request = VNRecognizeTextRequest()
+request.recognitionLevel = .accurate
+request.usesLanguageCorrection = true
+if #available(macOS 13.0, *) {
+    request.automaticallyDetectsLanguage = true
+}
+
+do {
+    try VNImageRequestHandler(cgImage: image, options: [:]).perform([request])
+} catch {
+    fail("Vision text recognition failed: \(error)")
+}
+
+let width = CGFloat(image.width)
+let height = CGFloat(image.height)
+let observations = (request.results ?? []).sorted { lhs, rhs in
+    let verticalDelta = lhs.boundingBox.midY - rhs.boundingBox.midY
+    if abs(verticalDelta) > 0.01 {
+        return verticalDelta > 0
+    }
+    return lhs.boundingBox.minX < rhs.boundingBox.minX
+}
+
+var texts: [String] = []
+var boxes: [[Int]] = []
+var scores: [Float] = []
+
+for observation in observations {
+    guard let candidate = observation.topCandidates(1).first else { continue }
+    let rect = observation.boundingBox
+    let x0 = max(0, min(image.width, Int((rect.minX * width).rounded(.down))))
+    let x1 = max(0, min(image.width, Int((rect.maxX * width).rounded(.up))))
+    // Vision coordinates start at bottom-left; Persome boxes start at top-left.
+    let y0 = max(0, min(image.height, Int(((1 - rect.maxY) * height).rounded(.down))))
+    let y1 = max(0, min(image.height, Int(((1 - rect.minY) * height).rounded(.up))))
+    texts.append(candidate.string)
+    boxes.append([x0, y0, x1, y1])
+    scores.append(candidate.confidence)
+}
+
+emit(["ok": true, "texts": texts, "boxes": boxes, "scores": scores])

--- a/src/persome/capture/ax_capture.py
+++ b/src/persome/capture/ax_capture.py
@@ -197,14 +197,15 @@ def _find_compatible_sdk() -> Path | None:
 
 def _maybe_compile(swift_path: Path, binary_path: Path) -> None:
     """Dev/first-run: compile the helper if missing or stale."""
+    helper_name = binary_path.name
     if not swift_path.is_file():
         return
     if binary_path.is_file():
         if binary_path.stat().st_mtime >= swift_path.stat().st_mtime:
             return
-        logger.info("mac-ax-helper: source newer than binary, recompiling")
+        logger.info("%s: source newer than binary, recompiling", helper_name)
     else:
-        logger.info("mac-ax-helper: binary missing, compiling from source")
+        logger.info("%s: binary missing, compiling from source", helper_name)
 
     cache = Path("/tmp/clang-module-cache")
     cache.mkdir(parents=True, exist_ok=True)
@@ -228,16 +229,17 @@ def _maybe_compile(swift_path: Path, binary_path: Path) -> None:
     sdk = _find_compatible_sdk()
     if sdk is not None:
         cmd.extend(["-sdk", str(sdk)])
-        logger.info("mac-ax-helper: using SDK %s", sdk)
+        logger.info("%s: using SDK %s", helper_name, sdk)
 
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=120, env=env)
     except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
-        logger.warning("mac-ax-helper compile failed: %s (install Xcode CLT?)", exc)
+        logger.warning("%s compile failed: %s (install Xcode CLT?)", helper_name, exc)
         return
     if result.returncode != 0:
         logger.warning(
-            "mac-ax-helper compile failed (%d): %s",
+            "%s compile failed (%d): %s",
+            helper_name,
             result.returncode,
             result.stderr.strip()[:300],
         )

--- a/src/persome/capture/ocr_health.py
+++ b/src/persome/capture/ocr_health.py
@@ -56,10 +56,11 @@ class OCRHealth:
 
 
 def inspect(cfg: CaptureConfig) -> OCRHealth:
-    """Return the effective OCR state without importing Paddle or requesting TCC access."""
+    """Return OCR state without loading an inference engine or requesting TCC access."""
     enabled = bool(cfg.enable_ocr_fallback)
     tier = cfg.ocr_tier
     runtime_ready = ocr_local.runtime_available()
+    backend = ocr_local.runtime_backend()
     models_ready = ocr_local.models_available(tier)
     env_disabled = ocr_local.disabled_by_environment()
 
@@ -81,7 +82,7 @@ def inspect(cfg: CaptureConfig) -> OCRHealth:
     elif not runtime_ready:
         state = "runtime_unavailable"
         machine = platform.machine() or "unknown architecture"
-        detail = f"Paddle OCR runtime unavailable on {machine}"
+        detail = f"local OCR runtime unavailable on {machine}"
     elif not models_ready:
         state = "models_missing"
         detail = f"bundled PP-OCRv6 {tier} weights are missing"
@@ -90,7 +91,11 @@ def inspect(cfg: CaptureConfig) -> OCRHealth:
         detail = "Screen Recording permission is required"
     else:
         state = "ready"
-        detail = f"local PP-OCRv6 {tier}, isolated worker"
+        detail = (
+            "local Apple Vision OCR, isolated worker"
+            if backend == "vision"
+            else f"local PP-OCRv6 {tier}, isolated worker"
+        )
 
     return OCRHealth(
         state=state,

--- a/src/persome/capture/ocr_local.py
+++ b/src/persome/capture/ocr_local.py
@@ -1,12 +1,14 @@
-"""On-device OCR via local PaddleOCR (PP-OCRv6).
+"""On-device OCR via PP-OCRv6 on Apple Silicon and Apple Vision on Intel.
 
 Replaces the former Baidu AI Studio cloud OCR (``ocr_client``). The focused-window
 screenshot is OCR'd **locally** — nothing leaves the machine — for apps that block
 the Accessibility API (WeChat, Feishu, NetEase Music, …).
 
 Design notes:
-- A single lazily-built ``PaddleOCR`` engine per tier is cached and reused; building it
+- Apple Silicon uses a lazily-built ``PaddleOCR`` engine per tier; building it
   is slow (loads two inference graphs) so we never construct per call.
+- Intel macOS uses a compiled Swift helper backed by the system Vision framework,
+  because PaddlePaddle publishes no macOS x86_64 wheel.
 - ``predict`` is serialized behind a module lock: the Paddle predictor is not
   guaranteed reentrant, and OCR fires at most once per window every
   ``ocr_min_gap_seconds`` (default 15s) so serialization costs nothing.
@@ -24,6 +26,7 @@ from __future__ import annotations
 
 import importlib.util
 import os
+import platform
 import sys
 import threading
 from pathlib import Path
@@ -44,34 +47,55 @@ _engines: dict[str, Any] = {}
 _lock = threading.Lock()
 
 _runtime_available: bool | None = None
+_runtime_backend: str | None = None
+
+
+def _paddle_runtime_available() -> bool:
+    try:
+        return (
+            importlib.util.find_spec("paddleocr") is not None
+            and importlib.util.find_spec("paddle") is not None
+        )
+    except (ImportError, ValueError):
+        return False
+
+
+def runtime_backend() -> str | None:
+    """Return the selected local backend: ``paddle``, ``vision``, or ``None``."""
+    if _runtime_available is None:
+        runtime_available()
+    # Tests and embedded callers historically injected only the boolean cache.
+    # Preserve that narrow compatibility by treating an injected true value as
+    # the original Paddle path unless detection selected Vision explicitly.
+    if _runtime_available and _runtime_backend is None:
+        return "paddle"
+    return _runtime_backend
 
 
 def runtime_available() -> bool:
-    """Whether the local-OCR native runtime (``paddleocr`` + ``paddlepaddle``) is installed in
-    THIS build — the honest "can we OCR at all" probe (issue #226).
+    """Whether this build has a usable architecture-native local OCR backend.
 
-    **False on Intel (x86_64) macOS by design.** PaddlePaddle publishes no macOS-Intel wheel
-    (only manylinux x86_64, win_amd64, and macos arm64), so ``pyproject.toml`` gates the paddle
-    deps to ``platform_machine == 'arm64'`` and the PyInstaller spec skips collecting them off
-    arm64. The x86_64 daemon slice therefore ships WITHOUT local OCR: AX-poor apps (WeChat /
-    Feishu) get no OCR text, but AX-based state formation and every other feature
-    work normally. This is the intended graceful degrade, not a failure.
+    Apple Silicon selects bundled PaddleOCR. Intel macOS selects an Apple Vision
+    Swift helper because PaddlePaddle has no macOS x86_64 wheel. Both stay local
+    and return the same text/geometry contract.
 
-    Cheap + side-effect-free: uses ``importlib.util.find_spec`` (no import), so it never triggers
-    paddle's slow load or its glog signal handler. Cached after the first call.
+    Cheap + side-effect-free: probes import specs or the packaged Swift source;
+    it never loads an inference engine. Cached after the first call.
     """
-    global _runtime_available
+    global _runtime_available, _runtime_backend
     if _runtime_available is None:
-        try:
-            _runtime_available = (
-                importlib.util.find_spec("paddleocr") is not None
-                and importlib.util.find_spec("paddle") is not None
-            )
-        except (
-            ImportError,
-            ValueError,
-        ):  # a missing parent package raises rather than returning None
-            _runtime_available = False
+        _runtime_backend = None
+        if _paddle_runtime_available():
+            _runtime_backend = "paddle"
+        elif platform.system() == "Darwin" and platform.machine().lower() in {
+            "x86_64",
+            "amd64",
+        }:
+            from . import vision_ocr
+
+            if vision_ocr.available():
+                _runtime_backend = "vision"
+        _runtime_available = _runtime_backend is not None
     return _runtime_available
 
 
@@ -84,11 +108,10 @@ def _ocr_disabled() -> bool:
     glog's ``FailureSignalHandler`` only *catches* the fault (and #323 already tears
     that handler out at teardown) — it cannot *prevent* the underlying native crash.
 
-    Until OCR is isolated into a crash-domain subprocess (follow-up), this flag is the
-    safe, instant stop-gap: set ``PERSOME_DISABLE_OCR=1`` (deploy-time, no config
-    rebuild) and no paddle inference runs at all — the daemon degrades to "no OCR text
-    for AX-poor apps" instead of crashing. ``warm()``/``recognize*`` all honor it, so
-    paddle is never even imported when disabled. Truthy values: 1/true/yes/on.
+    This flag is the safe, instant stop-gap: set ``PERSOME_DISABLE_OCR=1``
+    (deploy-time, no config rebuild) and no native OCR inference runs. The daemon
+    degrades to AX-only text. ``warm()``/``recognize*`` all honor it, so Paddle
+    is never imported and Vision is never invoked. Truthy values: 1/true/yes/on.
     """
     val = os.environ.get("PERSOME_DISABLE_OCR", "")
     return val.strip().lower() in {"1", "true", "yes", "on"}
@@ -102,10 +125,10 @@ def disabled_by_environment() -> bool:
 def _use_isolation() -> bool:
     """Whether OCR inference runs in the isolated crash-domain subprocess (default: yes).
 
-    Paddle can SIGSEGV natively; running it in a separate worker means such a fault kills
-    only the worker, never the daemon (see #403 + the subprocess-isolation spec). Isolation
-    is ON by default and cannot be turned off from ``config.toml`` — a normal install is
-    always crash-safe. Two escape hatches, both env-only:
+    Native inference can fail below Python; the worker boundary keeps such a
+    fault from killing the daemon (see #403 + the subprocess-isolation spec).
+    Isolation is ON by default and cannot be turned off from ``config.toml``.
+    Two escape hatches, both env-only:
 
     - ``PERSOME_OCR_WORKER=1`` — set inside the worker itself, so a routed call there
       resolves in-proc (a worker never spawns a worker).
@@ -151,9 +174,12 @@ def _model_dir(tier: str, kind: str) -> str | None:
 
 
 def models_available(tier: str = DEFAULT_TIER) -> bool:
-    """Whether both bundled model graphs required by ``tier`` are present."""
+    """Whether the selected backend has its required model assets."""
     if tier not in _VALID_TIERS:
         return False
+    if runtime_backend() == "vision":
+        # Vision's model is part of macOS; there are no Persome weight files.
+        return True
     return _model_dir(tier, "det") is not None and _model_dir(tier, "rec") is not None
 
 
@@ -209,7 +235,7 @@ def _get_engine(tier: str) -> Any | None:
     importing/building paddle, so every ``recognize*`` path fails open (no inference, no
     native-crash exposure). This is the single chokepoint all OCR entrypoints route through.
     """
-    if _ocr_disabled() or not runtime_available():
+    if _ocr_disabled() or not runtime_available() or runtime_backend() != "paddle":
         return None
     if tier not in _VALID_TIERS:
         tier = DEFAULT_TIER
@@ -224,23 +250,23 @@ def _get_engine(tier: str) -> Any | None:
 def warm(tier: str = DEFAULT_TIER) -> bool:
     """Pre-build the engine so the first real capture doesn't pay graph-load latency.
 
-    No-op when OCR is disabled (``PERSOME_DISABLE_OCR``): paddle is never imported.
-    Under isolation (default), warms the WORKER's engine (spawns it, builds its graphs);
-    only the in-process fallback builds paddle inside the daemon.
+    No-op when OCR is disabled. Under isolation (default), warms the worker's
+    selected backend. Only the Paddle debug fallback builds inside the daemon.
     """
     if _ocr_disabled():
         logger.info("local OCR disabled via PERSOME_DISABLE_OCR; skipping warm")
         return False
     if not runtime_available():
-        logger.info(
-            "local OCR runtime unavailable in this build (no paddlepaddle wheel for this arch, "
-            "e.g. x86_64 macOS); AX-poor apps run without OCR text — see #226. Skipping warm"
-        )
+        logger.info("local OCR runtime unavailable in this build; skipping warm")
         return False
     if _use_isolation():
         from . import ocr_subprocess
 
         return ocr_subprocess.get_client().warm(tier)
+    if runtime_backend() == "vision":
+        from . import vision_ocr
+
+        return vision_ocr.warm()
     with _lock:
         return _get_engine(tier) is not None
 
@@ -261,14 +287,17 @@ def recognize(image_bytes: bytes, tier: str = DEFAULT_TIER) -> str | None:
 def _recognize_detailed_inproc(
     image_bytes: bytes, tier: str = DEFAULT_TIER
 ) -> tuple[list[str], list[list[int]], list[float]] | None:
-    """The actual paddle predict — imports cv2 + builds/uses the engine IN THIS PROCESS.
+    """Run the selected native backend inside the isolated worker process.
 
-    In the daemon this only runs on the in-process fallback (``PERSOME_OCR_IN_PROCESS``);
-    in production it runs inside the isolated worker. A native SIGSEGV here is exactly what
-    isolation contains.
+    Apple Silicon imports/builds Paddle here. Intel invokes the one-shot Vision
+    helper here. A native fault is contained by the parent worker boundary.
     """
     if not image_bytes:
         return None
+    if runtime_backend() == "vision":
+        from . import vision_ocr
+
+        return vision_ocr.recognize_detailed(image_bytes)
     # Decode via PIL, not cv2: opencv is only a transitive dependency of paddle
     # (arm64-only), so cv2 is absent on hosts without the paddle wheels — while
     # this parse path must still work there under a stubbed engine (tests, and
@@ -314,11 +343,10 @@ def recognize_detailed(
     is what ``recognize`` throws away — the downstream structurer (``ocr_structure``) needs
     it to reconstruct columns/regions and drop low-confidence fragments.
 
-    Routing: the ``PERSOME_DISABLE_OCR`` kill-switch and the ``runtime_available()`` probe
-    (no paddle wheel on this arch, e.g. x86_64 macOS — #226) short-circuit first, so neither the
-    isolated worker nor the in-process path is even entered; then by default inference runs in the
-    isolated crash-domain worker (``_use_isolation``); the ``PERSOME_OCR_IN_PROCESS`` debug
-    hatch forces the legacy in-daemon predict.
+    Routing: the ``PERSOME_DISABLE_OCR`` kill-switch and ``runtime_available()``
+    short-circuit first. By default inference runs in the isolated crash-domain
+    worker; inside it Apple Silicon uses Paddle and Intel invokes Apple Vision.
+    ``PERSOME_OCR_IN_PROCESS`` is a debug hatch for the legacy Paddle path.
     """
     if _ocr_disabled() or not runtime_available():
         return None

--- a/src/persome/capture/ocr_subprocess.py
+++ b/src/persome/capture/ocr_subprocess.py
@@ -6,7 +6,7 @@ stdout, the client reads EOF, **fails open (returns ``None``)**, reaps the corps
 respawns on the next call. The daemon process itself never imports paddle/cv2, so a native
 OCR fault can never take it down.
 
-The subprocess isolates native OCR failures from the daemon.
+The subprocess isolates native OCR failures from the daemon on both architectures.
 """
 
 from __future__ import annotations

--- a/src/persome/capture/ocr_subprocess.py
+++ b/src/persome/capture/ocr_subprocess.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import contextlib
 import os
 import select
+import signal
 import struct
 import subprocess
 import sys
@@ -55,6 +56,9 @@ def _default_spawn() -> subprocess.Popen:
         env=env,
         bufsize=0,
         close_fds=True,
+        # A worker may compile or invoke a native OCR helper. Give it a private
+        # process group so timeout teardown also reaps those descendants.
+        start_new_session=os.name == "posix",
     )
 
 
@@ -216,8 +220,16 @@ class OCRWorkerClient:
         if proc is None:
             return
         if proc.poll() is None:
-            with contextlib.suppress(Exception):
-                proc.kill()
+            killed_group = False
+            if os.name == "posix":
+                with contextlib.suppress(Exception):
+                    group = os.getpgid(proc.pid)
+                    if group == proc.pid:
+                        os.killpg(group, signal.SIGKILL)
+                        killed_group = True
+            if not killed_group:
+                with contextlib.suppress(Exception):
+                    proc.kill()
         for stream in (proc.stdin, proc.stdout):
             if stream is not None:
                 with contextlib.suppress(Exception):
@@ -274,6 +286,8 @@ def _timeout_from_env() -> float:
 
 def _startup_timeout_from_env() -> float:
     try:
-        return float(os.environ.get("PERSOME_OCR_WORKER_STARTUP_TIMEOUT", "120"))
+        # First-run Intel warm-up may compile the Swift helper (120s bound) and
+        # then probe Vision (15s bound). Keep margin for process startup and I/O.
+        return float(os.environ.get("PERSOME_OCR_WORKER_STARTUP_TIMEOUT", "180"))
     except ValueError:
-        return 120.0
+        return 180.0

--- a/src/persome/capture/ocr_subprocess.py
+++ b/src/persome/capture/ocr_subprocess.py
@@ -76,6 +76,10 @@ class OCRWorkerClient:
         self._startup_timeout = timeout if startup_timeout is None else startup_timeout
         self._lock = threading.Lock()
         self._proc: subprocess.Popen | None = None
+        # The default worker owns a private POSIX process group. Record that
+        # group while the leader is alive so cleanup can still kill native
+        # descendants after the worker itself has crashed or exited.
+        self._proc_group: int | None = None
         self._state: WorkerState = "not_started"
         self._state_lock = threading.Lock()
 
@@ -159,14 +163,27 @@ class OCRWorkerClient:
             self._kill_worker_locked()
         try:
             self._proc = self._spawn()
+            self._proc_group = self._owned_process_group(self._proc)
             self._set_state("warming")
             logger.info("spawned ocr worker (pid=%s)", self._proc.pid)
             return self._proc, True
         except Exception as exc:  # noqa: BLE001
             logger.warning("ocr worker spawn failed: %s; OCR degrades to none", exc)
             self._proc = None
+            self._proc_group = None
             self._set_state("failed")
             return None, False
+
+    @staticmethod
+    def _owned_process_group(proc: subprocess.Popen) -> int | None:
+        """Return the worker's private POSIX process group, if it owns one."""
+        if os.name != "posix":
+            return None
+        try:
+            group = os.getpgid(proc.pid)
+        except (AttributeError, OSError):
+            return None
+        return group if group == proc.pid else None
 
     def _send(self, proc: subprocess.Popen, tier: str, image_bytes: bytes) -> None:
         req = ocr_protocol.encode_request(tier, image_bytes)
@@ -216,20 +233,25 @@ class OCRWorkerClient:
 
     def _kill_worker_locked(self) -> None:
         proc = self._proc
+        group = self._proc_group
         self._proc = None
+        self._proc_group = None
         if proc is None:
             return
-        if proc.poll() is None:
-            killed_group = False
-            if os.name == "posix":
-                with contextlib.suppress(Exception):
-                    group = os.getpgid(proc.pid)
-                    if group == proc.pid:
-                        os.killpg(group, signal.SIGKILL)
-                        killed_group = True
-            if not killed_group:
-                with contextlib.suppress(Exception):
-                    proc.kill()
+        killed_group = False
+        if os.name == "posix" and group is not None:
+            try:
+                # Do this even when the worker leader has already exited: its
+                # compiler/Vision child may still be alive in the owned group.
+                os.killpg(group, signal.SIGKILL)
+                killed_group = True
+            except ProcessLookupError:
+                pass
+            except OSError as exc:
+                logger.warning("failed to kill OCR worker process group %s: %s", group, exc)
+        if proc.poll() is None and not killed_group:
+            with contextlib.suppress(Exception):
+                proc.kill()
         for stream in (proc.stdin, proc.stdout):
             if stream is not None:
                 with contextlib.suppress(Exception):

--- a/src/persome/capture/ocr_worker.py
+++ b/src/persome/capture/ocr_worker.py
@@ -1,9 +1,9 @@
-"""Isolated OCR worker — the child process that owns paddle/cv2 inference.
+"""Isolated OCR worker — the child process that owns native OCR inference.
 
 Spawned by the daemon as ``Persome Backend _ocr-worker`` (frozen) / ``python -m persome.cli
-_ocr-worker`` (dev). This is the ONLY process that imports paddle: a native SIGSEGV here
-kills just this worker, and the parent (``ocr_subprocess.OCRWorkerClient``) fails open +
-respawns.
+_ocr-worker`` (dev). On Apple Silicon this is the only process that imports Paddle; on
+Intel it owns the Apple Vision helper. A native fault kills just this worker, and the
+parent (``ocr_subprocess.OCRWorkerClient``) fails open + respawns.
 
 The worker reads length-prefixed request frames on **stdin** and writes response frames on
 **stdout** (``ocr_protocol``). stdout is the data channel and MUST stay clean — all logging

--- a/src/persome/capture/scheduler.py
+++ b/src/persome/capture/scheduler.py
@@ -113,7 +113,7 @@ def _submit_ocr_async(
 ) -> None:
     """Fire-and-forget local OCR + geometry structuring. Runs on a daemon thread.
 
-    Local PP-OCRv6 inference is synchronous (~0.5s) and runs entirely on-device, so
+    Architecture-native OCR is synchronous and runs entirely on-device, so
     there is no job table / polling loop — we recognize and backfill in one shot.
     Called from `_write_capture` AFTER the capture row is indexed, so the backfill
     `UPDATE … WHERE id=?` always finds its row.

--- a/src/persome/capture/vision_ocr.py
+++ b/src/persome/capture/vision_ocr.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 from ..logger import get
 from . import ocr_protocol
-from .ax_capture import _stable_native_binary
+from .ax_capture import _native_binary_path, _stable_native_binary
 
 logger = get("persome.capture.ocr.vision")
 
@@ -52,9 +52,12 @@ def available() -> bool:
     if override:
         path = Path(override).expanduser()
         return path.is_file() and os.access(path, os.X_OK)
-    return shutil.which("swiftc") is not None and any(
-        path.is_file() for path in _source_candidates()
-    )
+    sources = [path for path in _source_candidates() if path.is_file()]
+    for source in sources:
+        compiled = _native_binary_path(source, _HELPER_NAME)
+        if compiled is not None and compiled.is_file() and os.access(compiled, os.X_OK):
+            return True
+    return shutil.which("swiftc") is not None and bool(sources)
 
 
 def resolve_helper_path() -> Path | None:

--- a/src/persome/capture/vision_ocr.py
+++ b/src/persome/capture/vision_ocr.py
@@ -1,0 +1,130 @@
+"""Apple Vision OCR adapter for Intel macOS.
+
+PaddlePaddle does not publish a macOS x86_64 wheel.  Intel installs therefore
+use a tiny Swift helper backed by Apple's on-device Vision framework.  The
+helper accepts image bytes on stdin and returns the same JSON geometry contract
+as the isolated Paddle worker, so the scheduler and app-aware structurer do not
+need an architecture-specific path.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+from pathlib import Path
+
+from ..logger import get
+from . import ocr_protocol
+from .ax_capture import _stable_native_binary
+
+logger = get("persome.capture.ocr.vision")
+
+_HELPER_NAME = "mac-vision-ocr"
+_SOURCE_NAME = f"{_HELPER_NAME}.swift"
+_TIMEOUT_SECONDS = 30
+
+
+def _source_candidates() -> list[Path]:
+    candidates: list[Path] = []
+    try:
+        from importlib.resources import files as _pkg_files
+
+        bundled = Path(str(_pkg_files("persome").joinpath("_bundled")))
+        candidates.append(bundled / _SOURCE_NAME)
+    except (ModuleNotFoundError, ValueError):
+        pass
+    candidates.append(Path(__file__).resolve().parents[3] / "resources" / _SOURCE_NAME)
+    return candidates
+
+
+def available() -> bool:
+    """Whether this host can resolve or compile the local Vision helper.
+
+    This is a side-effect-free prerequisite probe used by health checks.  The
+    installer already requires Xcode Command Line Tools for the AX helpers, so
+    an Intel install with the packaged source should satisfy it.
+    """
+    if platform.system() != "Darwin":
+        return False
+    override = os.environ.get("PERSOME_VISION_OCR")
+    if override:
+        path = Path(override).expanduser()
+        return path.is_file() and os.access(path, os.X_OK)
+    return shutil.which("swiftc") is not None and any(
+        path.is_file() for path in _source_candidates()
+    )
+
+
+def resolve_helper_path() -> Path | None:
+    """Resolve or compile the architecture-native Vision OCR executable."""
+    if platform.system() != "Darwin":
+        return None
+    override = os.environ.get("PERSOME_VISION_OCR")
+    if override:
+        path = Path(override).expanduser().resolve()
+        if path.is_file() and os.access(path, os.X_OK):
+            return path
+        logger.warning("PERSOME_VISION_OCR set but not executable: %s", path)
+        return None
+    for source in _source_candidates():
+        if source.is_file():
+            helper = _stable_native_binary(source, _HELPER_NAME)
+            if helper is not None:
+                return helper
+    return None
+
+
+def warm() -> bool:
+    """Compile the helper and prove that the Vision framework can load."""
+    helper = resolve_helper_path()
+    if helper is None:
+        return False
+    try:
+        result = subprocess.run(
+            [str(helper), "--check"],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            timeout=_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.warning("Vision OCR helper check failed: %s", exc)
+        return False
+    if result.returncode != 0:
+        logger.warning(
+            "Vision OCR helper check exited %d: %s",
+            result.returncode,
+            result.stderr.decode("utf-8", "replace")[:300],
+        )
+        return False
+    return True
+
+
+def recognize_detailed(image_bytes: bytes) -> ocr_protocol.Detailed | None:
+    """Recognize one image through the isolated, one-shot Vision helper."""
+    if not image_bytes:
+        return None
+    helper = resolve_helper_path()
+    if helper is None:
+        return None
+    try:
+        result = subprocess.run(
+            [str(helper)],
+            input=image_bytes,
+            capture_output=True,
+            check=False,
+            timeout=_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.warning("Vision OCR helper failed: %s", exc)
+        return None
+    if result.returncode != 0:
+        logger.warning(
+            "Vision OCR helper exited %d: %s",
+            result.returncode,
+            result.stderr.decode("utf-8", "replace")[:300],
+        )
+        return None
+    return ocr_protocol.decode_response(result.stdout)

--- a/src/persome/capture/vision_ocr.py
+++ b/src/persome/capture/vision_ocr.py
@@ -23,7 +23,16 @@ logger = get("persome.capture.ocr.vision")
 
 _HELPER_NAME = "mac-vision-ocr"
 _SOURCE_NAME = f"{_HELPER_NAME}.swift"
-_TIMEOUT_SECONDS = 30
+# The parent worker's normal deadline is 20 seconds. Keep the child helper's
+# deadline shorter so it is reaped here rather than surviving a worker timeout.
+_TIMEOUT_SECONDS = 15
+
+
+def _supported_host() -> bool:
+    return platform.system() == "Darwin" and platform.machine().lower() in {
+        "x86_64",
+        "amd64",
+    }
 
 
 def _source_candidates() -> list[Path]:
@@ -46,7 +55,7 @@ def available() -> bool:
     installer already requires Xcode Command Line Tools for the AX helpers, so
     an Intel install with the packaged source should satisfy it.
     """
-    if platform.system() != "Darwin":
+    if not _supported_host():
         return False
     override = os.environ.get("PERSOME_VISION_OCR")
     if override:
@@ -62,7 +71,7 @@ def available() -> bool:
 
 def resolve_helper_path() -> Path | None:
     """Resolve or compile the architecture-native Vision OCR executable."""
-    if platform.system() != "Darwin":
+    if not _supported_host():
         return None
     override = os.environ.get("PERSOME_VISION_OCR")
     if override:

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -1275,7 +1275,7 @@ def ocr_setup(
         raise typer.Exit(1)
     if not ocr_local.runtime_available():
         console.print(
-            "[red]The local Paddle OCR runtime is unavailable on this architecture.[/red] "
+            "[red]The local OCR runtime is unavailable on this architecture.[/red] "
             "AX capture remains available."
         )
         raise typer.Exit(1)
@@ -1364,7 +1364,7 @@ def ocr_selftest(
 ) -> None:
     """Run on-device OCR over an image and print the recognized text.
 
-    Verifies the bundled PP-OCRv6 runtime end-to-end (model load + inference). Exits
+    Verifies the architecture-native OCR runtime end-to-end. Exits
     non-zero on failure so it can gate a packaged build.
     """
     from pathlib import Path
@@ -1383,8 +1383,8 @@ def ocr_selftest(
 def _ocr_worker() -> None:
     """Isolated OCR worker loop (internal — spawned by the daemon, not for direct use).
 
-    Reads length-prefixed OCR requests on stdin and writes results on stdout. Paddle is
-    imported ONLY in this process, so a native SIGSEGV kills just the worker and the daemon
+    Reads length-prefixed OCR requests on stdin and writes results on stdout. Native
+    inference stays in this crash domain, so a fault kills just the worker and the daemon
     fails open + respawns (see #403 / the ocr-subprocess-isolation spec).
     """
     from .capture import ocr_worker

--- a/src/persome/config.py
+++ b/src/persome/config.py
@@ -66,13 +66,14 @@ class CaptureConfig:
     screenshot_jpeg_quality: int = 80
     ax_depth: int = 100
     ax_timeout_seconds: int = 3
-    # OCR fallback for AX-poor apps (WeChat, Feishu, etc.) — on-device PP-OCRv6.
+    # OCR fallback for AX-poor apps: PP-OCRv6 on Apple Silicon, Vision on Intel.
     enable_ocr_fallback: bool = False
     # ``auto`` = fresh/unconfigured; onboarding may enable the supported
     # default. Explicit setup/disable records durable intent so repeated
     # onboarding never silently changes the user's choice.
     ocr_policy: str = "auto"  # auto | enabled | disabled
-    ocr_tier: str = "tiny"  # tiny | small | medium (local PP-OCRv6 weights)
+    # Paddle model tier on Apple Silicon; retained for one cross-architecture config.
+    ocr_tier: str = "tiny"  # tiny | small | medium
     ocr_min_gap_seconds: float = 15.0
     # Geometry structuring of raw OCR (zero LLM, on-device): reconstruct columns/regions
     # + per-app field labels (WeChat contact/time/preview) instead of a flat noisy join.
@@ -658,12 +659,12 @@ screenshot_jpeg_quality = 80
 ax_depth = 100                # Electron apps (Claude Desktop, VS Code, Slack) have deep DOM; 8 only reaches the chrome
 ax_timeout_seconds = 3
 # OCR fallback for apps that block Accessibility API (WeChat, Feishu, NetEase Music, etc.)
-# On-device PP-OCRv6 — the focused-window screenshot is OCR'd locally; nothing leaves the machine.
+# Architecture-native OCR (PP-OCRv6 on Apple Silicon, Vision on Intel); nothing leaves the machine.
 enable_ocr_fallback = false   # install.sh verifies the worker, then writes true on supported Macs
 ocr_policy = "auto"           # auto until first setup; then enabled|disabled preserves user intent
-# Inference runs in an isolated local worker, so a native Paddle crash does not
+# Inference runs in an isolated local worker, so a native OCR crash does not
 # kill the daemon. PERSOME_DISABLE_OCR=1 is the deployment kill switch.
-ocr_tier = "tiny"             # tiny (default) | small | medium — local PP-OCRv6 weights
+ocr_tier = "tiny"             # tiny (default) | small | medium; Vision ignores the Paddle tier
 ocr_min_gap_seconds = 15.0    # minimum seconds between OCR runs for the same window
 ocr_structured = true              # geometry-structure raw OCR (zero LLM, on-device): columns/regions + per-app field labels
 # cmux signal source: real terminal text via cmux's local unix-socket RPC (GPU-rendered

--- a/src/persome/doctor.py
+++ b/src/persome/doctor.py
@@ -357,8 +357,6 @@ def check_ocr(capture: config_mod.CaptureConfig) -> Check:
         return Check("local OCR", "ok", health.detail)
     if health.state == "disabled":
         return Check("local OCR", "warn", health.detail)
-    if health.state == "runtime_unavailable" and platform.machine() != "arm64":
-        return Check("local OCR", "warn", f"{health.detail}; AX capture remains available")
     return Check("local OCR", "fail", f"{health.state}: {health.detail}")
 
 

--- a/src/persome/onboarding.py
+++ b/src/persome/onboarding.py
@@ -10,7 +10,6 @@ fresh capture; supported alternate policies return explicit mode-aware receipts.
 from __future__ import annotations
 
 import json
-import platform
 import shutil
 import subprocess
 import sys
@@ -337,7 +336,7 @@ def ensure_local_ocr(
         if preserve_policy or (tier is None and before.enable_ocr_fallback)
         else tier or before.ocr_tier or "tiny"
     )
-    ui.status(f"Checking bundled local OCR ({effective_tier})...")
+    ui.status(f"Checking local OCR ({effective_tier})...")
 
     require_worker = True
     fallback_state: str | None = None
@@ -352,12 +351,6 @@ def ensure_local_ocr(
         fallback_state = "disabled_by_environment"
         fallback_message = "disabled_by_environment"
     runtime_available = ocr_local.runtime_available() if require_worker else False
-    intel_without_runtime = platform.machine().lower() in {"x86_64", "amd64"}
-    if require_worker and not runtime_available and intel_without_runtime:
-        require_worker = False
-        fallback_state = "runtime_unavailable" if before.enable_ocr_fallback else "disabled"
-        fallback_message = "runtime_unavailable"
-
     if require_worker and effective_tier not in VALID_TIERS:
         raise OnboardingError(
             f"unsupported OCR tier {effective_tier!r}: choose {', '.join(VALID_TIERS)}"
@@ -365,7 +358,7 @@ def ensure_local_ocr(
     if require_worker and ocr_local.disabled_by_environment():
         raise OnboardingError("OCR is disabled by PERSOME_DISABLE_OCR")
     if require_worker and not runtime_available:
-        raise OnboardingError("the local Paddle OCR runtime is unavailable on this architecture")
+        raise OnboardingError("the local OCR runtime is unavailable on this architecture")
     if require_worker and not ocr_local.models_available(effective_tier):
         raise OnboardingError(f"bundled PP-OCRv6 {effective_tier} model weights are missing")
 
@@ -382,7 +375,7 @@ def ensure_local_ocr(
             ui=ui,
             explanation=(
                 "Persome uses Screen Recording for locally encrypted screenshots and, when "
-                "enabled, bundled PP-OCRv6 when an app's Accessibility text is incomplete. "
+                "enabled, on-device OCR when an app's Accessibility text is incomplete. "
                 "Pixels are not sent to an LLM or uploaded. macOS will show its own permission "
                 "request next."
             ),

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -405,6 +405,17 @@ def test_ocr_permission_block_fails(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "permission_required" in check.detail
 
 
+def test_enabled_ocr_without_architecture_backend_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ocr_local, "runtime_available", lambda: False)
+    monkeypatch.setattr(ocr_local, "models_available", lambda tier: False)
+    monkeypatch.setattr(ocr_local, "disabled_by_environment", lambda: False)
+
+    check = doctor.check_ocr(CaptureConfig(enable_ocr_fallback=True))
+
+    assert check.status == "fail"
+    assert "runtime_unavailable" in check.detail
+
+
 def test_ocr_disabled_is_visible_warning(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(ocr_health.sys, "platform", "darwin")
     monkeypatch.setattr(ocr_local, "runtime_available", lambda: True)

--- a/tests/test_ocr_local.py
+++ b/tests/test_ocr_local.py
@@ -28,13 +28,14 @@ def _force_in_process_ocr(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.fixture(autouse=True)
 def _fake_paddle_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Force the paddle runtime probe to True.
+    """Force the selected runtime to the stubbed Paddle backend.
 
     Every test here stubs the engine, so the logic under test sits BEHIND the
-    runtime gate; on hosts without paddle wheels (Linux CI, Intel macOS) the
-    gate would short-circuit recognize() to None before the stubs are reached.
+    runtime gate; on hosts without paddle wheels the gate would otherwise
+    short-circuit, while Intel may have already cached the Vision backend.
     """
     monkeypatch.setattr(ocr_local, "_runtime_available", True)
+    monkeypatch.setattr(ocr_local, "_runtime_backend", "paddle")
 
 
 def _jpeg_bytes(size=(40, 20), color=(255, 255, 255)) -> bytes:

--- a/tests/test_ocr_runtime_availability.py
+++ b/tests/test_ocr_runtime_availability.py
@@ -1,9 +1,8 @@
-"""Intel (x86_64) OCR-less degrade (issue #226).
+"""Architecture-native OCR backend selection.
 
-paddlepaddle ships no macOS-Intel wheel, so the x86_64 daemon slice runs WITHOUT local OCR.
-`ocr_local.runtime_available()` is the honest probe; when it's False every OCR entrypoint must
-fail open cleanly — no paddle import, no worker spawn, no exception — so AX-based context/intent
-keep working and only WeChat/Feishu OCR text is lost.
+PaddlePaddle ships no macOS-Intel wheel, so x86_64 selects the system Apple
+Vision helper. Hosts with neither backend still fail open without importing
+Paddle or spawning a worker.
 """
 
 from __future__ import annotations
@@ -12,15 +11,17 @@ import importlib.util
 
 import pytest
 
-from persome.capture import ocr_local
+from persome.capture import ocr_local, vision_ocr
 
 
 @pytest.fixture(autouse=True)
 def _reset_runtime_cache():
     """runtime_available() memoizes; reset it around each test so monkeypatch takes effect."""
     ocr_local._runtime_available = None
+    ocr_local._runtime_backend = None
     yield
     ocr_local._runtime_available = None
+    ocr_local._runtime_backend = None
 
 
 def _patch_specs(monkeypatch: pytest.MonkeyPatch, *, present: bool) -> None:
@@ -34,20 +35,42 @@ def _patch_specs(monkeypatch: pytest.MonkeyPatch, *, present: bool) -> None:
     monkeypatch.setattr(ocr_local.importlib.util, "find_spec", fake)
 
 
-def test_runtime_available_false_when_paddle_absent(monkeypatch: pytest.MonkeyPatch):
+def test_runtime_available_false_when_no_backend(monkeypatch: pytest.MonkeyPatch):
     _patch_specs(monkeypatch, present=False)
+    monkeypatch.setattr(ocr_local.platform, "system", lambda: "Linux")
     assert ocr_local.runtime_available() is False
 
 
 def test_runtime_available_true_when_paddle_present(monkeypatch: pytest.MonkeyPatch):
     _patch_specs(monkeypatch, present=True)
     assert ocr_local.runtime_available() is True
+    assert ocr_local.runtime_backend() == "paddle"
+
+
+def test_intel_uses_vision_when_paddle_absent(monkeypatch: pytest.MonkeyPatch):
+    _patch_specs(monkeypatch, present=False)
+    monkeypatch.setattr(ocr_local.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(ocr_local.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(vision_ocr, "available", lambda: True)
+
+    assert ocr_local.runtime_available() is True
+    assert ocr_local.runtime_backend() == "vision"
+    assert ocr_local.models_available("tiny") is True
+
+
+def test_intel_inproc_worker_routes_to_vision(monkeypatch: pytest.MonkeyPatch):
+    ocr_local._runtime_available = True
+    ocr_local._runtime_backend = "vision"
+    expected = (["Intel text"], [[1, 2, 30, 40]], [0.95])
+    monkeypatch.setattr(vision_ocr, "recognize_detailed", lambda image: expected)
+
+    assert ocr_local._recognize_detailed_inproc(b"image") == expected
 
 
 def test_ocr_entrypoints_degrade_cleanly_without_runtime(monkeypatch: pytest.MonkeyPatch):
-    """With no paddle runtime (x86_64): recognize/recognize_detailed return None and warm() is a
-    no-op — WITHOUT importing paddle or spawning the isolation worker."""
+    """With no backend, entrypoints return None without spawning the worker."""
     _patch_specs(monkeypatch, present=False)
+    monkeypatch.setattr(ocr_local.platform, "system", lambda: "Linux")
 
     # Guard: neither the in-process predict nor the isolation worker may be entered.
     def _boom(*_a, **_k):

--- a/tests/test_ocr_subprocess.py
+++ b/tests/test_ocr_subprocess.py
@@ -8,8 +8,11 @@ No paddle, hermetic, default gate.
 
 from __future__ import annotations
 
+import contextlib
+import os
 import subprocess
 import sys
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -56,6 +59,14 @@ import sys, time
 from persome.capture import ocr_protocol as p
 p.read_frame(sys.stdin.buffer)
 time.sleep(3600)
+"""
+
+# Starts a child in the worker's process group, publishes its PID, then exits.
+# Cleanup must still kill that child after the group leader is already dead.
+_EXIT_WITH_LIVE_CHILD = """
+import subprocess, sys
+child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+print(child.pid, flush=True)
 """
 
 _JPEG = b"\xff\xd8\xff\xe0fake-jpeg-bytes"
@@ -163,6 +174,7 @@ class TestCrashContainment:
         )
         client = ocr_subprocess.OCRWorkerClient(spawn=lambda: proc)
         client._proc = proc
+        client._proc_group = 43210
         monkeypatch.setattr(ocr_subprocess.os, "getpgid", lambda pid: pid)
         monkeypatch.setattr(
             ocr_subprocess.os,
@@ -174,6 +186,52 @@ class TestCrashContainment:
 
         assert killed_groups == [(43210, ocr_subprocess.signal.SIGKILL)]
         assert client._proc is None
+        assert client._proc_group is None
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX process-group regression")
+    def test_dead_worker_cleanup_kills_live_group_child(self) -> None:
+        def _spawn() -> subprocess.Popen:
+            return subprocess.Popen(
+                [sys.executable, "-c", _EXIT_WITH_LIVE_CHILD],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                bufsize=0,
+                close_fds=True,
+                start_new_session=True,
+            )
+
+        client = ocr_subprocess.OCRWorkerClient(spawn=_spawn, timeout=1)
+        proc: subprocess.Popen | None = None
+        child_pid: int | None = None
+        try:
+            proc, _ = client._ensure_worker_locked()
+            assert proc is not None and proc.stdout is not None
+            child_pid = int(proc.stdout.readline())
+            proc.wait(timeout=5)
+            assert proc.poll() is not None
+            assert client._proc_group == proc.pid
+            os.kill(child_pid, 0)  # the descendant is alive after its leader exits
+
+            client._kill_worker_locked()
+
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline:
+                try:
+                    os.kill(child_pid, 0)
+                except ProcessLookupError:
+                    break
+                time.sleep(0.05)
+            else:
+                pytest.fail("worker process-group child survived cleanup")
+        finally:
+            client._kill_worker_locked()
+            if proc is not None:
+                with contextlib.suppress(ProcessLookupError):
+                    os.killpg(proc.pid, ocr_subprocess.signal.SIGKILL)
+            if child_pid is not None:
+                with contextlib.suppress(ProcessLookupError):
+                    os.kill(child_pid, ocr_subprocess.signal.SIGKILL)
 
 
 class TestWarm:

--- a/tests/test_ocr_subprocess.py
+++ b/tests/test_ocr_subprocess.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -148,6 +149,32 @@ class TestCrashContainment:
         assert client.recognize_detailed(_JPEG, "tiny") is None
         assert client.warm("tiny") is False  # warm also fails open, never raises
 
+    def test_timeout_kills_isolated_worker_process_group(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        killed_groups: list[tuple[int, int]] = []
+        proc = SimpleNamespace(
+            pid=43210,
+            stdin=None,
+            stdout=None,
+            poll=lambda: None,
+            kill=lambda: pytest.fail("group leader must be killed through killpg"),
+            wait=lambda timeout: 0,
+        )
+        client = ocr_subprocess.OCRWorkerClient(spawn=lambda: proc)
+        client._proc = proc
+        monkeypatch.setattr(ocr_subprocess.os, "getpgid", lambda pid: pid)
+        monkeypatch.setattr(
+            ocr_subprocess.os,
+            "killpg",
+            lambda group, sig: killed_groups.append((group, sig)),
+        )
+
+        client._kill_worker_locked()
+
+        assert killed_groups == [(43210, ocr_subprocess.signal.SIGKILL)]
+        assert client._proc is None
+
 
 class TestWarm:
     def test_warm_spawns_worker(self) -> None:
@@ -164,6 +191,12 @@ class TestWarm:
         client = ocr_subprocess.OCRWorkerClient(timeout=20, startup_timeout=120)
         assert client._timeout == 20
         assert client._startup_timeout == 120
+
+    def test_default_cold_start_covers_intel_compile_and_probe(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("PERSOME_OCR_WORKER_STARTUP_TIMEOUT", raising=False)
+        assert ocr_subprocess._startup_timeout_from_env() == 180.0
 
 
 class TestRouting:

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -785,21 +785,25 @@ def test_preserve_policy_keeps_existing_ocr_tier(
     assert cfg.capture.ocr_tier == "small"
 
 
-def test_fresh_intel_onboarding_uses_supported_ax_only_mode(
+def test_fresh_intel_onboarding_enables_vision_ocr(
     ac_root: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     cfg = config.Config()
     monkeypatch.setattr(config, "load", lambda *args, **kwargs: cfg)
-    monkeypatch.setattr(onboarding.platform, "machine", lambda: "x86_64")
-    monkeypatch.setattr(ocr_local, "runtime_available", lambda: False)
+    monkeypatch.setattr(ocr_local, "runtime_available", lambda: True)
+    monkeypatch.setattr(ocr_local, "runtime_backend", lambda: "vision")
+    monkeypatch.setattr(ocr_local, "models_available", lambda tier: True)
     monkeypatch.setattr(screen_recording, "has_screen_recording", lambda: True)
+    monkeypatch.setattr(
+        ocr_health,
+        "inspect",
+        lambda capture: SimpleNamespace(ready=True, state="ready", detail="ready"),
+    )
 
     proof = onboarding.ensure_local_ocr(tier="tiny", ui=ScriptedUI())
 
-    assert proof.require_worker is False
-    # The daemon reports its effective disabled policy; the UX separately
-    # explains that Intel has no bundled OCR runtime.
-    assert proof.state == "disabled"
+    assert proof.require_worker is True
+    assert proof.state == "ready"
 
 
 def test_plain_repeated_onboarding_preserves_explicit_ocr_opt_out(

--- a/tests/test_vision_ocr.py
+++ b/tests/test_vision_ocr.py
@@ -17,6 +17,22 @@ def test_available_requires_darwin(monkeypatch: pytest.MonkeyPatch) -> None:
     assert vision_ocr.available() is False
 
 
+def test_available_reuses_compiled_helper_without_swiftc(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "mac-vision-ocr.swift"
+    source.write_text("source", encoding="utf-8")
+    helper = tmp_path / "mac-vision-ocr"
+    helper.write_text("binary", encoding="utf-8")
+    helper.chmod(0o700)
+    monkeypatch.setattr(vision_ocr.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(vision_ocr, "_source_candidates", lambda: [source])
+    monkeypatch.setattr(vision_ocr, "_native_binary_path", lambda *args: helper)
+    monkeypatch.setattr(vision_ocr.shutil, "which", lambda name: None)
+
+    assert vision_ocr.available() is True
+
+
 def test_recognize_decodes_shared_geometry_contract(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -81,5 +97,7 @@ def test_real_intel_vision_ocr_smoke(ac_root: Path, monkeypatch: pytest.MonkeyPa
         assert "PERSOME" in " ".join(texts).upper()
         assert len(texts) == len(boxes) == len(scores)
         assert all(len(box) == 4 for box in boxes)
+        assert all(0 <= x0 < x1 <= 1200 and 0 <= y0 < y1 <= 260 for x0, y0, x1, y1 in boxes)
+        assert all(0.0 <= score <= 1.0 for score in scores)
     finally:
         ocr_subprocess.get_client().shutdown()

--- a/tests/test_vision_ocr.py
+++ b/tests/test_vision_ocr.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import json
 import os
 import platform
 import subprocess
@@ -72,6 +73,26 @@ def test_recognize_fails_open_when_helper_times_out(
 
     monkeypatch.setattr(vision_ocr.subprocess, "run", timeout)
     assert vision_ocr.recognize_detailed(b"jpeg") is None
+
+
+@pytest.mark.macos
+def test_real_intel_helper_reads_large_pipe_input() -> None:
+    """The Swift helper must accumulate pipe short reads instead of truncating stdin."""
+    if platform.system() != "Darwin" or platform.machine().lower() not in {"x86_64", "amd64"}:
+        pytest.skip("Intel macOS smoke")
+
+    helper = vision_ocr.resolve_helper_path()
+    assert helper is not None
+    payload = b"x" * (2 * 1024 * 1024 + 17)
+    result = subprocess.run(
+        [str(helper), "--check-input"],
+        input=payload,
+        capture_output=True,
+        check=False,
+        timeout=vision_ocr._TIMEOUT_SECONDS,
+    )
+    assert result.returncode == 0, result.stderr.decode("utf-8", "replace")
+    assert json.loads(result.stdout) == {"ok": True, "inputBytes": len(payload)}
 
 
 @pytest.mark.macos

--- a/tests/test_vision_ocr.py
+++ b/tests/test_vision_ocr.py
@@ -17,6 +17,12 @@ def test_available_requires_darwin(monkeypatch: pytest.MonkeyPatch) -> None:
     assert vision_ocr.available() is False
 
 
+def test_available_requires_intel(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(vision_ocr.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(vision_ocr.platform, "machine", lambda: "arm64")
+    assert vision_ocr.available() is False
+
+
 def test_available_reuses_compiled_helper_without_swiftc(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -26,6 +32,7 @@ def test_available_reuses_compiled_helper_without_swiftc(
     helper.write_text("binary", encoding="utf-8")
     helper.chmod(0o700)
     monkeypatch.setattr(vision_ocr.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(vision_ocr.platform, "machine", lambda: "x86_64")
     monkeypatch.setattr(vision_ocr, "_source_candidates", lambda: [source])
     monkeypatch.setattr(vision_ocr, "_native_binary_path", lambda *args: helper)
     monkeypatch.setattr(vision_ocr.shutil, "which", lambda name: None)

--- a/tests/test_vision_ocr.py
+++ b/tests/test_vision_ocr.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import io
+import os
+import platform
+import subprocess
+from pathlib import Path
+
+import pytest
+from PIL import Image, ImageDraw, ImageFont
+
+from persome.capture import ocr_local, ocr_protocol, ocr_subprocess, vision_ocr
+
+
+def test_available_requires_darwin(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(vision_ocr.platform, "system", lambda: "Linux")
+    assert vision_ocr.available() is False
+
+
+def test_recognize_decodes_shared_geometry_contract(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    helper = tmp_path / "mac-vision-ocr"
+    helper.write_text("stub", encoding="utf-8")
+    helper.chmod(0o700)
+    expected = (["Persome Intel"], [[10, 20, 300, 80]], [0.98])
+    monkeypatch.setattr(vision_ocr, "resolve_helper_path", lambda: helper)
+    monkeypatch.setattr(
+        vision_ocr.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args[0], 0, stdout=ocr_protocol.encode_response(expected), stderr=b""
+        ),
+    )
+
+    assert vision_ocr.recognize_detailed(b"jpeg") == expected
+
+
+def test_recognize_fails_open_when_helper_times_out(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    helper = tmp_path / "mac-vision-ocr"
+    helper.write_text("stub", encoding="utf-8")
+    helper.chmod(0o700)
+    monkeypatch.setattr(vision_ocr, "resolve_helper_path", lambda: helper)
+
+    def timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(args[0], 30)
+
+    monkeypatch.setattr(vision_ocr.subprocess, "run", timeout)
+    assert vision_ocr.recognize_detailed(b"jpeg") is None
+
+
+@pytest.mark.macos
+def test_real_intel_vision_ocr_smoke(ac_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Real compile + inference gate run by the macos-15-intel CI job."""
+    if platform.system() != "Darwin" or platform.machine().lower() not in {"x86_64", "amd64"}:
+        pytest.skip("Intel macOS smoke")
+
+    monkeypatch.delenv("PERSOME_VISION_OCR", raising=False)
+    ocr_local._runtime_available = None
+    ocr_local._runtime_backend = None
+    assert vision_ocr.available()
+    assert ocr_local.runtime_available()
+    assert ocr_local.runtime_backend() == "vision"
+    assert ocr_local.warm()
+
+    image = Image.new("RGB", (1200, 260), "white")
+    draw = ImageDraw.Draw(image)
+    font_path = "/System/Library/Fonts/Supplemental/Arial.ttf"
+    assert os.path.isfile(font_path)
+    font = ImageFont.truetype(font_path, 72)
+    draw.text((40, 70), "Persome Intel OCR 2026", fill="black", font=font)
+    buf = io.BytesIO()
+    image.save(buf, format="PNG")
+
+    try:
+        detailed = ocr_local.recognize_detailed(buf.getvalue())
+        assert detailed is not None
+        texts, boxes, scores = detailed
+        assert "PERSOME" in " ".join(texts).upper()
+        assert len(texts) == len(boxes) == len(scores)
+        assert all(len(box) == 4 for box in boxes)
+    finally:
+        ocr_subprocess.get_client().shutdown()

--- a/uv.lock
+++ b/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 3
 requires-python = ">=3.12, <3.14"
 resolution-markers = [
-    "sys_platform == 'darwin'",
+    "platform_machine != 'x86_64' and sys_platform == 'darwin'",
+    "platform_machine == 'x86_64' and sys_platform == 'darwin'",
     "platform_machine == 'aarch64' and sys_platform == 'linux'",
     "sys_platform == 'win32'",
     "sys_platform == 'emscripten'",
@@ -32,14 +33,14 @@ name = "aiohttp"
 version = "3.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohappyeyeballs", marker = "sys_platform == 'darwin'" },
-    { name = "aiosignal", marker = "sys_platform == 'darwin'" },
-    { name = "attrs", marker = "sys_platform == 'darwin'" },
-    { name = "frozenlist", marker = "sys_platform == 'darwin'" },
-    { name = "multidict", marker = "sys_platform == 'darwin'" },
-    { name = "propcache", marker = "sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' and sys_platform == 'darwin'" },
-    { name = "yarl", marker = "sys_platform == 'darwin'" },
+    { name = "aiohappyeyeballs", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "aiosignal", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "attrs", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "frozenlist", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "multidict", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "propcache", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' and platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "yarl", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/82/78/8ea7308cac6934de8c74a14f3d5f65d1c89287426688be79538d0e5c013d/aiohttp-3.14.1.tar.gz", hash = "sha256:307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035", size = 7955794, upload-time = "2026-06-07T21:09:35.529Z" }
 wheels = [
@@ -56,8 +57,8 @@ name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "frozenlist", marker = "sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' and sys_platform == 'darwin'" },
+    { name = "frozenlist", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' and platform_machine != 'x86_64' and sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
@@ -69,12 +70,12 @@ name = "aistudio-sdk"
 version = "0.3.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "bce-python-sdk", marker = "sys_platform == 'darwin'" },
-    { name = "click", marker = "sys_platform == 'darwin'" },
-    { name = "prettytable", marker = "sys_platform == 'darwin'" },
-    { name = "psutil", marker = "sys_platform == 'darwin'" },
-    { name = "requests", marker = "sys_platform == 'darwin'" },
-    { name = "tqdm", marker = "sys_platform == 'darwin'" },
+    { name = "bce-python-sdk", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "click", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "prettytable", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "psutil", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "requests", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "tqdm", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/77/cd71a481bb7a76b0e9d0b6bf47711c627b1dd079001ea246893f19a9d04c/aistudio_sdk-0.3.8-py3-none-any.whl", hash = "sha256:bfc96af7243ac2ee3303014849aa4028717cce5afa622af8cfe3a1d44d1941d6", size = 62972, upload-time = "2025-09-19T11:42:39.384Z" },
@@ -144,10 +145,10 @@ name = "bce-python-sdk"
 version = "0.9.72"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "crc32c", marker = "sys_platform == 'darwin'" },
-    { name = "future", marker = "sys_platform == 'darwin'" },
-    { name = "pycryptodome", marker = "sys_platform == 'darwin'" },
-    { name = "six", marker = "sys_platform == 'darwin'" },
+    { name = "crc32c", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "future", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "pycryptodome", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "six", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/32/bb/1ccb8b28bfa0802356f8588e479adb61cfd2268b37fabc6c8a805d645cd5/bce_python_sdk-0.9.72.tar.gz", hash = "sha256:d9db568698792d74db4245252d98776eae8c9c5225fc0ba86548dfc52d478fcc", size = 302207, upload-time = "2026-06-08T12:10:32.326Z" }
 wheels = [
@@ -358,10 +359,33 @@ wheels = [
 
 [[package]]
 name = "cryptography"
+version = "48.0.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "platform_machine == 'x86_64' and sys_platform == 'darwin'",
+]
+dependencies = [
+    { name = "cffi", marker = "platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'darwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/45/870e7f4bef50e5f53b9f51d4428aee5290eedf58ba443f16b1ebb7ab8e66/cryptography-48.0.1.tar.gz", hash = "sha256:266f4ee051abb2f725b74ef8072b521ce1feacf685a3364fa6a6b45548db791a", size = 832989, upload-time = "2026-06-09T22:32:31.8Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/bc/ee4137cbbe105652c0ee4252792b78fc8e7afa4b8e61d9d5dc05a7f45731/cryptography-48.0.1-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:3e4a1a3232eef2e6c732827d5722db29a0cc8b27af2a4d865b094cf954be9ca1", size = 8008324, upload-time = "2026-06-09T22:31:00.702Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/6c/00fa2a95997164c8b2072ce327c23d4ab20809ccc323ea5fab91e53a4bba/cryptography-48.0.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:4fdc69f8e4316bcf0c8c8ec1f26f285d12e8142d88d96c876a59a03be3f6ae67", size = 7987408, upload-time = "2026-06-09T22:32:20.777Z" },
+]
+
+[[package]]
+name = "cryptography"
 version = "49.0.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "platform_machine != 'x86_64' and sys_platform == 'darwin'",
+    "platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "sys_platform == 'win32'",
+    "sys_platform == 'emscripten'",
+    "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
+]
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "cffi", marker = "(platform_machine != 'x86_64' and platform_python_implementation != 'PyPy') or (platform_python_implementation != 'PyPy' and sys_platform != 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
 wheels = [
@@ -589,15 +613,15 @@ name = "huggingface-hub"
 version = "1.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "sys_platform == 'darwin'" },
-    { name = "filelock", marker = "sys_platform == 'darwin'" },
-    { name = "fsspec", marker = "sys_platform == 'darwin'" },
-    { name = "hf-xet", marker = "(platform_machine == 'AMD64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'darwin') or (platform_machine == 'amd64' and sys_platform == 'darwin') or (platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin')" },
-    { name = "httpx", marker = "sys_platform == 'darwin'" },
-    { name = "packaging", marker = "sys_platform == 'darwin'" },
-    { name = "pyyaml", marker = "sys_platform == 'darwin'" },
-    { name = "tqdm", marker = "sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
+    { name = "click", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "filelock", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "fsspec", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "hf-xet", marker = "(platform_machine == 'AMD64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'darwin') or (platform_machine == 'amd64' and sys_platform == 'darwin') or (platform_machine == 'arm64' and sys_platform == 'darwin')" },
+    { name = "httpx", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "packaging", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "pyyaml", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "tqdm", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/77/ea/dc54b4dda5841cb3a7812a178695be776e7c15c597887c2ed892f17d015a/huggingface_hub-1.22.0.tar.gz", hash = "sha256:e2dfe5fe1ec3b87ba2709aa34555b23e3f3f6ad4d7255238e13ddb8348e6bbfa", size = 914232, upload-time = "2026-07-03T09:46:44.685Z" }
 wheels = [
@@ -761,13 +785,13 @@ name = "modelscope"
 version = "1.38.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock", marker = "sys_platform == 'darwin'" },
-    { name = "modelscope-hub", marker = "sys_platform == 'darwin'" },
-    { name = "packaging", marker = "sys_platform == 'darwin'" },
-    { name = "requests", marker = "sys_platform == 'darwin'" },
-    { name = "setuptools", marker = "sys_platform == 'darwin'" },
-    { name = "tqdm", marker = "sys_platform == 'darwin'" },
-    { name = "urllib3", marker = "sys_platform == 'darwin'" },
+    { name = "filelock", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "modelscope-hub", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "packaging", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "requests", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "setuptools", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "tqdm", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "urllib3", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/72/b37f46f8e1900c64485420b210eecda1f758cbd0fe8ade60c5bbf883b25e/modelscope-1.38.1.tar.gz", hash = "sha256:a81f3685b1545f52b415d88a763456416aa65170e622f9dcc02eadb3f8e1cfa0", size = 4542886, upload-time = "2026-07-06T15:13:56.427Z" }
 wheels = [
@@ -779,10 +803,10 @@ name = "modelscope-hub"
 version = "0.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock", marker = "sys_platform == 'darwin'" },
-    { name = "requests", marker = "sys_platform == 'darwin'" },
-    { name = "tqdm", marker = "sys_platform == 'darwin'" },
-    { name = "urllib3", marker = "sys_platform == 'darwin'" },
+    { name = "filelock", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "requests", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "tqdm", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "urllib3", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b6/cb/6b9d3fcbcd09db6cdd7f1e0fd60be2998c99db07be28f37982c0dbd14496/modelscope_hub-0.1.7.tar.gz", hash = "sha256:b78730f3923cf13d5fbc56c6224a5ba617bf111a562fe3808c03e34c3c07840f", size = 126616, upload-time = "2026-07-07T07:35:36.465Z" }
 wheels = [
@@ -917,7 +941,7 @@ name = "opencv-contrib-python"
 version = "4.10.0.84"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'darwin'" },
+    { name = "numpy", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/33/7b8ec6c4d45e678b26297e4a5e76464a93033a9adcc8c17eac01097065f6/opencv-contrib-python-4.10.0.84.tar.gz", hash = "sha256:4a3eae0ed9cadf1abe9293a6938a25a540e2fd6d7fc308595caa5896c8b36a0c", size = 150433857, upload-time = "2024-06-17T18:30:50.217Z" }
 wheels = [
@@ -929,7 +953,7 @@ name = "opt-einsum"
 version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'darwin'" },
+    { name = "numpy", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7d/bf/9257e53a0e7715bc1127e15063e831f076723c6cd60985333a1c18878fb8/opt_einsum-3.3.0.tar.gz", hash = "sha256:59f6475f77bbc37dcf7cd748519c0ec60722e91e63ca114e68821c0c54a46549", size = 73951, upload-time = "2020-07-19T22:40:32.141Z" }
 wheels = [
@@ -959,11 +983,11 @@ name = "paddleocr"
 version = "3.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp", marker = "sys_platform == 'darwin'" },
-    { name = "paddlex", extra = ["ocr-core"], marker = "sys_platform == 'darwin'" },
-    { name = "pyyaml", marker = "sys_platform == 'darwin'" },
-    { name = "requests", marker = "sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
+    { name = "aiohttp", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "paddlex", extra = ["ocr-core"], marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "pyyaml", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "requests", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/97/b1/9454e886afa925067ce51de2e513d146524645888de299d51ddc1caa3100/paddleocr-3.7.0.tar.gz", hash = "sha256:9b81eb62cf37e590d4873e60262ff56f968ff9de6ce1f565749760ceb1c422e2", size = 3082862, upload-time = "2026-06-11T12:09:52.545Z" }
 wheels = [
@@ -975,15 +999,15 @@ name = "paddlepaddle"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx", marker = "sys_platform == 'darwin'" },
-    { name = "networkx", marker = "sys_platform == 'darwin'" },
-    { name = "numpy", marker = "sys_platform == 'darwin'" },
-    { name = "opt-einsum", marker = "sys_platform == 'darwin'" },
-    { name = "pillow", marker = "sys_platform == 'darwin'" },
-    { name = "protobuf", marker = "sys_platform == 'darwin'" },
-    { name = "safetensors", marker = "sys_platform == 'darwin'" },
-    { name = "setuptools", marker = "sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
+    { name = "httpx", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "networkx", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "numpy", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "opt-einsum", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "pillow", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "protobuf", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "safetensors", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "setuptools", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/97/62d061b4700a7020506f4db80c4721100b5b2fa0709f4e999c38dc7e2293/paddlepaddle-3.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d7827d867503b502a881c718e3743d9b91648a62d01f93bcd5ba3d7846de5ab5", size = 104546703, upload-time = "2026-03-26T11:18:20.499Z" },
@@ -995,24 +1019,24 @@ name = "paddlex"
 version = "3.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aistudio-sdk", marker = "sys_platform == 'darwin'" },
-    { name = "chardet", marker = "sys_platform == 'darwin'" },
-    { name = "colorlog", marker = "sys_platform == 'darwin'" },
-    { name = "filelock", marker = "sys_platform == 'darwin'" },
-    { name = "huggingface-hub", marker = "sys_platform == 'darwin'" },
-    { name = "modelscope", marker = "sys_platform == 'darwin'" },
-    { name = "numpy", marker = "sys_platform == 'darwin'" },
-    { name = "packaging", marker = "sys_platform == 'darwin'" },
-    { name = "pandas", marker = "sys_platform == 'darwin'" },
-    { name = "pillow", marker = "sys_platform == 'darwin'" },
-    { name = "prettytable", marker = "sys_platform == 'darwin'" },
-    { name = "py-cpuinfo", marker = "sys_platform == 'darwin'" },
-    { name = "pydantic", marker = "sys_platform == 'darwin'" },
-    { name = "pyyaml", marker = "sys_platform == 'darwin'" },
-    { name = "requests", marker = "sys_platform == 'darwin'" },
-    { name = "ruamel-yaml", marker = "sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
-    { name = "ujson", marker = "sys_platform == 'darwin'" },
+    { name = "aistudio-sdk", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "chardet", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "colorlog", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "filelock", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "huggingface-hub", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "modelscope", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "numpy", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "packaging", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "pandas", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "pillow", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "prettytable", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "py-cpuinfo", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "pydantic", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "pyyaml", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "requests", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "ruamel-yaml", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "ujson", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dd/96/1e86d4056ffc1e494c53aebab7e2faf08dcf8b929180f9872ae46632e9bd/paddlex-3.7.2.tar.gz", hash = "sha256:6a60b4595e2d51460f7f51326672adca86b89ff9ecfd02ac348fb69739e0093c", size = 4415130, upload-time = "2026-06-25T05:50:53.34Z" }
 wheels = [
@@ -1021,12 +1045,12 @@ wheels = [
 
 [package.optional-dependencies]
 ocr-core = [
-    { name = "imagesize", marker = "sys_platform == 'darwin'" },
-    { name = "opencv-contrib-python", marker = "sys_platform == 'darwin'" },
-    { name = "pyclipper", marker = "sys_platform == 'darwin'" },
-    { name = "pypdfium2", marker = "sys_platform == 'darwin'" },
-    { name = "python-bidi", marker = "sys_platform == 'darwin'" },
-    { name = "shapely", marker = "sys_platform == 'darwin'" },
+    { name = "imagesize", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "opencv-contrib-python", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "pyclipper", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "pypdfium2", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "python-bidi", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "shapely", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
 ]
 
 [[package]]
@@ -1034,8 +1058,8 @@ name = "pandas"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'darwin'" },
-    { name = "python-dateutil", marker = "sys_platform == 'darwin'" },
+    { name = "numpy", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "python-dateutil", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
 wheels = [
@@ -1051,7 +1075,8 @@ source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "certifi" },
-    { name = "cryptography" },
+    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "cryptography", version = "49.0.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "fastapi" },
     { name = "httpx", extra = ["socks"] },
     { name = "mcp" },
@@ -1084,7 +1109,8 @@ dev = [
 requires-dist = [
     { name = "anthropic", specifier = ">=0.50" },
     { name = "certifi", specifier = ">=2024.2" },
-    { name = "cryptography", specifier = ">=42.0" },
+    { name = "cryptography", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'", specifier = ">=42.0" },
+    { name = "cryptography", marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'", specifier = ">=42.0,<49" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", extras = ["socks"], specifier = ">=0.27" },
     { name = "mcp", specifier = ">=1.23.0" },
@@ -1220,7 +1246,7 @@ name = "prettytable"
 version = "3.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wcwidth", marker = "sys_platform == 'darwin'" },
+    { name = "wcwidth", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/81/74/ba08d81e668ccfe8658d7520a307e63c19862c08eb4ccb26f356c5239a7a/prettytable-3.18.0.tar.gz", hash = "sha256:439217116152244369caf3d9f1caf2f9fe29b03bd79e88d2928c8e718c95d680", size = 76373, upload-time = "2026-06-22T16:07:50.174Z" }
 wheels = [
@@ -1406,7 +1432,8 @@ wheels = [
 
 [package.optional-dependencies]
 crypto = [
-    { name = "cryptography" },
+    { name = "cryptography", version = "48.0.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "cryptography", version = "49.0.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
 
 [[package]]
@@ -1485,7 +1512,7 @@ name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "six", marker = "sys_platform == 'darwin'" },
+    { name = "six", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
@@ -1698,7 +1725,7 @@ name = "shapely"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'darwin'" },
+    { name = "numpy", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4d/bc/0989043118a27cccb4e906a46b7565ce36ca7b57f5a18b78f4f1b0f72d9d/shapely-2.1.2.tar.gz", hash = "sha256:2ed4ecb28320a433db18a5bf029986aa8afcfd740745e78847e330d5d94922a9", size = 315489, upload-time = "2025-09-24T13:51:41.432Z" }
 wheels = [
@@ -1927,9 +1954,9 @@ name = "yarl"
 version = "1.24.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "idna", marker = "sys_platform == 'darwin'" },
-    { name = "multidict", marker = "sys_platform == 'darwin'" },
-    { name = "propcache", marker = "sys_platform == 'darwin'" },
+    { name = "idna", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "multidict", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
+    { name = "propcache", marker = "platform_machine != 'x86_64' and sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/79/12/1e8f37460ea0f7eb59c221fdaf0ed75e7ac43e97f8093b9c6f411df50a78/yarl-1.24.2.tar.gz", hash = "sha256:9ac374123c6fd7abf64d1fec93962b0bd4ee2c19751755a762a72dd96c0378f8", size = 210798, upload-time = "2026-05-19T21:31:05.599Z" }
 wheels = [


### PR DESCRIPTION
## What

- Add an on-device Apple Vision OCR backend for Intel macOS.
- Automatically select bundled PP-OCRv6 on Apple Silicon and Apple Vision on Intel.
- Wire Intel installation, onboarding, doctor/health, wheel packaging, documentation, and CI.
- Add a real `macos-15-intel` Vision OCR smoke test.

## Why

`paddlepaddle` does not publish a macOS x86_64 wheel. Intel installs could use Accessibility capture, but could not install and run the Paddle OCR path used when AX text is incomplete.

## Review fixes

- Keep Intel on `cryptography<49`, the latest line that still publishes a macOS x86_64/universal wheel.
- Reuse an already compiled immutable Vision helper even if `swiftc` is no longer on `PATH`.
- Bound and fully consume helper stdin without truncation.
- Reap native OCR subprocess trees on timeout.
- Pin the Paddle unit-test backend explicitly.

## How verified

- GitHub CI is green on Ubuntu, Apple Silicon, Intel macOS, and package smoke.
- The real Intel Vision OCR smoke passed on `macos-15-intel`.
- Intel dependency simulation selects `cryptography 48.0.1` and excludes Paddle/PaddleOCR.
- Focused OCR/onboarding/doctor suite: `153 passed, 4 deselected`.
- Ruff check, format check, lockfile, secret, PII, and language gates passed.

---

- [x] Commits are signed off (`git commit -s`)
- [x] No real names / emails / tokens in code or test fixtures
- [x] Secret scan passes
- [x] Human-authored repository text is English