### PR TITLE
fix: guard OCR process-group identity

### DIFF
--- a/src/persome/capture/ocr_subprocess.py
+++ b/src/persome/capture/ocr_subprocess.py
@@ -105,11 +105,23 @@ class OCRWorkerClient:
         """Return current process liveness without blocking an in-flight inference."""
         with self._state_lock:
             state = self._state
-        proc = self._proc
-        if state in {"warming", "ready"} and proc is not None and proc.poll() is not None:
-            self._set_state("failed")
-            return "failed"
-        return state
+        if state not in {"warming", "ready"}:
+            return state
+        # Never poll/reap the leader unless we can clean its owned group in the
+        # same critical section. If a request is in flight, that request owns
+        # EOF/timeout cleanup and state() remains non-blocking.
+        if not self._lock.acquire(blocking=False):
+            return state
+        try:
+            proc = self._proc
+            if proc is not None and proc.poll() is not None:
+                self._kill_worker_locked()
+                self._set_state("failed")
+                return "failed"
+            with self._state_lock:
+                return self._state
+        finally:
+            self._lock.release()
 
     def shutdown(self) -> None:
         """Terminate the worker (best-effort). The worker also exits on stdin EOF."""
@@ -240,15 +252,31 @@ class OCRWorkerClient:
             return
         killed_group = False
         if os.name == "posix" and group is not None:
-            try:
-                # Do this even when the worker leader has already exited: its
-                # compiler/Vision child may still be alive in the owned group.
-                os.killpg(group, signal.SIGKILL)
-                killed_group = True
-            except ProcessLookupError:
-                pass
-            except OSError as exc:
-                logger.warning("failed to kill OCR worker process group %s: %s", group, exc)
+            safe_to_kill = True
+            if getattr(proc, "returncode", None) is not None:
+                try:
+                    os.getpgid(proc.pid)
+                except ProcessLookupError:
+                    # The reaped leader PID is still unused. Any live process
+                    # in ``group`` is therefore one of our orphan descendants.
+                    pass
+                except OSError as exc:
+                    safe_to_kill = False
+                    logger.warning("could not verify OCR worker process group %s: %s", group, exc)
+                else:
+                    # The dead leader's PID has been reused. Never send a
+                    # signal to a possibly unrelated process group.
+                    safe_to_kill = False
+            if safe_to_kill:
+                try:
+                    # Do this even when the worker leader has already exited:
+                    # its compiler/Vision child may still be alive in the group.
+                    os.killpg(group, signal.SIGKILL)
+                    killed_group = True
+                except ProcessLookupError:
+                    pass
+                except OSError as exc:
+                    logger.warning("failed to kill OCR worker process group %s: %s", group, exc)
         if proc.poll() is None and not killed_group:
             with contextlib.suppress(Exception):
                 proc.kill()

--- a/tests/test_ocr_subprocess.py
+++ b/tests/test_ocr_subprocess.py
@@ -188,6 +188,77 @@ class TestCrashContainment:
         assert client._proc is None
         assert client._proc_group is None
 
+    def test_state_immediately_cleans_dead_worker_group(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        killed_groups: list[tuple[int, int]] = []
+        proc = SimpleNamespace(
+            pid=43210,
+            returncode=7,
+            stdin=None,
+            stdout=None,
+            poll=lambda: 7,
+            kill=lambda: pytest.fail("dead group leader must not be killed directly"),
+            wait=lambda timeout: 7,
+        )
+        client = ocr_subprocess.OCRWorkerClient(spawn=lambda: proc)
+        client._proc = proc
+        client._proc_group = 43210
+        client._state = "ready"
+        monkeypatch.setattr(
+            ocr_subprocess.os,
+            "getpgid",
+            lambda pid: (_ for _ in ()).throw(ProcessLookupError()),
+        )
+        monkeypatch.setattr(
+            ocr_subprocess.os,
+            "killpg",
+            lambda group, sig: killed_groups.append((group, sig)),
+        )
+
+        assert client.state() == "failed"
+        assert killed_groups == [(43210, ocr_subprocess.signal.SIGKILL)]
+        assert client._proc is None
+        assert client._proc_group is None
+
+    def test_dead_worker_skips_reused_process_group(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        proc = SimpleNamespace(
+            pid=43210,
+            returncode=7,
+            stdin=None,
+            stdout=None,
+            poll=lambda: 7,
+            kill=lambda: None,
+            wait=lambda timeout: 7,
+        )
+        client = ocr_subprocess.OCRWorkerClient(spawn=lambda: proc)
+        client._proc = proc
+        client._proc_group = 43210
+        monkeypatch.setattr(ocr_subprocess.os, "getpgid", lambda pid: 99999)
+        monkeypatch.setattr(
+            ocr_subprocess.os,
+            "killpg",
+            lambda *args: pytest.fail("a reused process-group ID must never be signaled"),
+        )
+
+        client._kill_worker_locked()
+
+        assert client._proc is None
+        assert client._proc_group is None
+
+    def test_state_does_not_poll_an_inflight_worker(self) -> None:
+        proc = SimpleNamespace(
+            poll=lambda: pytest.fail("state must not poll while a request owns the worker lock")
+        )
+        client = ocr_subprocess.OCRWorkerClient(spawn=lambda: proc)
+        client._proc = proc
+        client._state = "ready"
+        client._lock.acquire()
+        try:
+            assert client.state() == "ready"
+        finally:
+            client._lock.release()
+
     @pytest.mark.skipif(os.name != "posix", reason="POSIX process-group regression")
     def test_dead_worker_cleanup_kills_live_group_child(self) -> None:
         def _spawn() -> subprocess.Popen:


### PR DESCRIPTION
## Summary

- clean an exited OCR worker and its owned process group in the same non-blocking state check
- retain cleanup for orphaned native children without signaling a reused process-group ID
- cover dead leaders, in-flight requests, orphan children, and PID reuse with regressions

## Validation

- 157 focused tests passed, 4 deselected
- ruff check and format clean
- DCO signed

Follow-up to #83: this commit was pushed after #83 had already merged at its previous head.