### PR TITLE
fix: bound capture index rebuild WAL

### DIFF
--- a/docs/capture.md
+++ b/docs/capture.md
@@ -264,7 +264,7 @@ Every successful capture write is also indexed into an FTS5 virtual table (`capt
 | `cleanup_buffer` time-based delete | FTS deletion is attempted before each JSON deletion; filesystem erasure remains authoritative if SQLite is temporarily unavailable, and the final reconciliation removes stale searchable rows after recovery. |
 | `cleanup_buffer` size-based eviction | Same, including hard-cap eviction of unabsorbed files when necessary and continued eviction after one unlink failure. |
 | Screenshot strip | **Untouched.** Strip only removes the base64 image; the indexed text (`visible_text`, `focused_value`, `window_title`, `app_name`, `url`) is unchanged. |
-| `persome rebuild-captures-index` | Clear stale rows, then index every surviving `~/.persome/capture-buffer/*.json`. Use `--merge` after snapshot recovery to preserve older rows whose JSON aged out. |
+| `persome rebuild-captures-index` | Atomically clear stale rows, then index every surviving `~/.persome/capture-buffer/*.json` in one rollback-safe transaction. Use `--merge` after snapshot recovery to preserve older rows whose JSON aged out. |
 
 **Indexed columns.** Only the searchable text is in FTS: `app_name`, `window_title`, `focused_value`, `visible_text`, `url`. Filterable metadata (timestamp, bundle_id, focused_role) lives on the `captures` table for `WHERE`-clause filtering. Screenshots are deliberately not duplicated — the JSON file on disk stays the authoritative copy of the raw image bytes.
 

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -3389,55 +3389,68 @@ def rebuild_captures_index(
                 "SELECT id, visible_text FROM captures WHERE visible_text != ''"
             ).fetchall()
         }
-        # Exact rebuild is reconciliation, not just an upsert pass. Recovery
-        # merge intentionally preserves older snapshot rows whose source JSON
-        # has already aged out of the bounded capture buffer.
-        if not merge:
-            conn.execute("DELETE FROM captures")
-        for p in files:
-            try:
-                data = json.loads(p.read_text())
-            except (OSError, json.JSONDecodeError) as exc:
-                skipped += 1
-                console.print(f"[yellow]skip {p.name}: {exc}[/yellow]")
-                continue
-            if not isinstance(data, dict):
-                skipped += 1
-                console.print(f"[yellow]skip {p.name}: capture is not a JSON object[/yellow]")
-                continue
-            preserve_ocr = bool(data.get("ocr_submitted")) and not str(
-                data.get("visible_text") or ""
-            )
-            data = s1_parser.sanitize_capture(data)
-            preserved_ocr = s1_parser.sanitize_ocr_text(
-                data,
-                ocr_backfills.get(p.stem, ""),
-            )
-            meta = data.get("window_meta") or {}
-            focused = data.get("focused_element") or {}
-            try:
-                fts.insert_capture(
-                    conn,
-                    id=p.stem,
-                    timestamp=data.get("timestamp", ""),
-                    app_name=meta.get("app_name") or "",
-                    bundle_id=meta.get("bundle_id") or "",
-                    window_title=meta.get("title") or "",
-                    focused_role=focused.get("role") or "",
-                    focused_value=focused.get("value") or "",
-                    visible_text=(
-                        preserved_ocr
-                        if preserve_ocr and not data.get("visible_text")
-                        else data.get("visible_text") or ""
-                    ),
-                    url=data.get("url") or "",
+        # One explicit transaction prevents each capture upsert from becoming
+        # its own FTS5 commit. On a large retained buffer, per-row autocommit
+        # can amplify a small index into a multi-gigabyte WAL and WAL-index,
+        # exposing concurrent macOS readers to a fatal mmap page-in failure.
+        # It also makes exact reconciliation interruption-safe: either the
+        # complete replacement commits or SQLite restores the prior index.
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            # Exact rebuild is reconciliation, not just an upsert pass. Recovery
+            # merge intentionally preserves older snapshot rows whose source JSON
+            # has already aged out of the bounded capture buffer.
+            if not merge:
+                conn.execute("DELETE FROM captures")
+            for p in files:
+                try:
+                    data = json.loads(p.read_text())
+                except (OSError, json.JSONDecodeError) as exc:
+                    skipped += 1
+                    console.print(f"[yellow]skip {p.name}: {exc}[/yellow]")
+                    continue
+                if not isinstance(data, dict):
+                    skipped += 1
+                    console.print(f"[yellow]skip {p.name}: capture is not a JSON object[/yellow]")
+                    continue
+                preserve_ocr = bool(data.get("ocr_submitted")) and not str(
+                    data.get("visible_text") or ""
                 )
-                indexed += 1
-            except Exception as exc:  # noqa: BLE001
-                skipped += 1
-                console.print(f"[yellow]skip {p.name}: {exc}[/yellow]")
-            if indexed % 200 == 0 and indexed > 0:
-                console.print(f"  indexed {indexed} / {len(files)}…")
+                data = s1_parser.sanitize_capture(data)
+                preserved_ocr = s1_parser.sanitize_ocr_text(
+                    data,
+                    ocr_backfills.get(p.stem, ""),
+                )
+                meta = data.get("window_meta") or {}
+                focused = data.get("focused_element") or {}
+                try:
+                    fts.insert_capture(
+                        conn,
+                        id=p.stem,
+                        timestamp=data.get("timestamp", ""),
+                        app_name=meta.get("app_name") or "",
+                        bundle_id=meta.get("bundle_id") or "",
+                        window_title=meta.get("title") or "",
+                        focused_role=focused.get("role") or "",
+                        focused_value=focused.get("value") or "",
+                        visible_text=(
+                            preserved_ocr
+                            if preserve_ocr and not data.get("visible_text")
+                            else data.get("visible_text") or ""
+                        ),
+                        url=data.get("url") or "",
+                    )
+                    indexed += 1
+                except Exception as exc:  # noqa: BLE001
+                    skipped += 1
+                    console.print(f"[yellow]skip {p.name}: {exc}[/yellow]")
+                if indexed % 200 == 0 and indexed > 0:
+                    console.print(f"  staged {indexed} / {len(files)}…")
+            conn.commit()
+        except BaseException:
+            if conn.in_transaction:
+                conn.rollback()
+            raise
 
     console.print(
         f"[green]Captures index {'merged' if merge else 'rebuilt'}: "

--- a/tests/test_cli_capture_rebuild.py
+++ b/tests/test_cli_capture_rebuild.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from persome import cli, paths
@@ -76,6 +77,48 @@ def test_rebuild_captures_default_remains_exact_buffer_reconciliation(ac_root: P
     with fts.cursor() as conn:
         ids = {row[0] for row in conn.execute("SELECT id FROM captures").fetchall()}
     assert ids == {"buffer-new"}
+
+
+def test_rebuild_captures_indexes_inside_explicit_transaction(
+    ac_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_buffer_capture()
+    original_insert = fts.insert_capture
+    transaction_states: list[bool] = []
+
+    def tracking_insert(conn, **kwargs):
+        transaction_states.append(conn.in_transaction)
+        return original_insert(conn, **kwargs)
+
+    monkeypatch.setattr(fts, "insert_capture", tracking_insert)
+
+    result = CliRunner().invoke(cli.app, ["rebuild-captures-index", "--merge"])
+
+    assert result.exit_code == 0, result.output
+    assert transaction_states == [True]
+
+
+def test_rebuild_captures_interrupt_rolls_back_exact_reconciliation(
+    ac_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_snapshot_only_capture()
+    _write_buffer_capture()
+    original_insert = fts.insert_capture
+
+    def interrupting_insert(conn, **kwargs):
+        original_insert(conn, **kwargs)
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(fts, "insert_capture", interrupting_insert)
+
+    result = CliRunner().invoke(cli.app, ["rebuild-captures-index"])
+
+    assert result.exit_code != 0
+    with fts.cursor() as conn:
+        ids = {row[0] for row in conn.execute("SELECT id FROM captures").fetchall()}
+    assert ids == {"snapshot-only"}
 
 
 def test_rebuild_captures_sanitizes_historical_placeholder_projection(ac_root: Path) -> None:


### PR DESCRIPTION
## What changed

- run `rebuild-captures-index` reconciliation inside one explicit `BEGIN IMMEDIATE` transaction
- roll back the complete rebuild on interruption instead of leaving a partially reconciled index
- report progress as `staged` until the transaction commits
- document the atomic rebuild behavior and add transaction/rollback regression coverage

## Root cause

The command previously autocommitted every capture upsert. On the reported 9k-capture store, the first 1,800 upserts alone reproduced 1.31 GB of WAL and a 2.56 MB WAL-index mapping. Under concurrent Runtime/MCP activity, the mapped WAL-index could be reset while FTS5 was flushing secure-delete segments, producing macOS `SIGBUS` (`cluster_pagein past EOF`) instead of a recoverable Python exception.

The explicit transaction removes the per-row commit amplification and closes the concurrent writer reset window. On the same 1,800-capture database copy, the patched command completed with `PRAGMA quick_check = ok`, a 14 MB WAL, and a 32 KB SHM file.

## Impact

Large capture-index rebuilds no longer create multi-gigabyte WAL/SHM state or leave exact reconciliation half-applied after interruption. `--merge` continues preserving snapshot-only rows and OCR backfills.

## Validation

- `PERSOME_LLM_MOCK=1 uv run pytest -m "not macos and not integration" -q` — 2,126 passed, 17 deselected
- focused capture/FTS/store/index-health suite — 69 passed
- real 1,800-capture isolated rebuild — success; `quick_check=ok`; WAL 14 MB; SHM 32 KB
- `uv run ruff check .`
- `uv run ruff format --check .`
- secret, PII, and language scans clean
