### PR TITLE
fix: restore constellation export for X sharing

### DIFF
--- a/docs/model-contract.md
+++ b/docs/model-contract.md
@@ -101,6 +101,9 @@ Persome branding, downloads it, and opens an X composer with one of three standa
 each carrying the Personal Model tag and official account mention. Individual
 Point labels, receipts, source names, timestamps, and viewer credentials are excluded from the share
 artifact; the owner attaches the downloaded image and confirms the post in X.
+Both share actions take their written summaries and aggregate counts from the canonically scrubbed
+`/model/share-card` projection rather than the owner-only graph. The adjacent `Card` action remains
+a separate renderer that downloads the portrait `my-human-card.png` without opening X.
 
 Visible node labels and their Point, Face, Volume, Root, or context meshes open the same provenance
 detail panel. Overview summarizes the evidence footprint, Evidence presents human-readable source

--- a/openapi.json
+++ b/openapi.json
@@ -331,7 +331,7 @@
           "model"
         ],
         "summary": "Model Share Card",
-        "description": "Return the minimal, canonically scrubbed HUMAN.md Card projection.",
+        "description": "Return the minimal, canonically scrubbed public share projection.",
         "operationId": "model_share_card_model_share_card_get",
         "responses": {
           "200": {

--- a/resources/model_assets/share.mjs
+++ b/resources/model_assets/share.mjs
@@ -1,6 +1,9 @@
-export const SHARE_CARD_WIDTH = 1080;
-export const SHARE_CARD_HEIGHT = 1350;
-export const SHARE_FILE_NAME = "my-human-card.png";
+export const HUMAN_CARD_WIDTH = 1080;
+export const HUMAN_CARD_HEIGHT = 1350;
+export const HUMAN_CARD_FILE_NAME = "my-human-card.png";
+export const CONSTELLATION_CARD_WIDTH = 1200;
+export const CONSTELLATION_CARD_HEIGHT = 675;
+export const CONSTELLATION_FILE_NAME = "my-persome-constellation.png";
 export const SHARE_URL = "https://github.com/Intuition-Lab/personal-model";
 export const SHARE_TEXTS = Object.freeze([
   [
@@ -107,9 +110,9 @@ function drawWrappedText(context, text, x, y, maxWidth, lineHeight, maxLines) {
   return lines.length;
 }
 
-export function drawShareCard(context, model = {}) {
-  const width = SHARE_CARD_WIDTH;
-  const height = SHARE_CARD_HEIGHT;
+export function drawHumanCard(context, model = {}) {
+  const width = HUMAN_CARD_WIDTH;
+  const height = HUMAN_CARD_HEIGHT;
   const card = humanCard(model);
 
   context.save();
@@ -153,5 +156,208 @@ export function drawShareCard(context, model = {}) {
   context.fillStyle = "#6d6861";
   context.font = "560 24px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
   context.fillText("Built locally with Persome · Build yours", 98, height - 102);
+  context.restore();
+}
+
+export function shareStats(model = {}) {
+  const stats = model.stats || {};
+  const lineCount = (stats.evolution_lines || 0) + (stats.relation_lines || 0);
+  return [
+    ["POINTS", stats.points || model.points?.length || 0],
+    ["LINES", lineCount || model.lines?.length || 0],
+    ["FACES", stats.faces || model.faces?.length || 0],
+    ["VOLUMES", stats.volumes || model.volumes?.length || 0],
+    ["ROOT", stats.roots || Number(Boolean(model.root))],
+  ];
+}
+
+function cleanNarrative(value, limit = 220) {
+  const text = String(value || "").replace(/\s+/g, " ").trim();
+  if (text.length <= limit) return text;
+  return `${text.slice(0, Math.max(0, limit - 1)).trimEnd()}…`;
+}
+
+function narrativeStrength(item) {
+  const evidence = item.observations
+    || item.source_receipts?.length
+    || item.member_receipts?.length
+    || 0;
+  return (Number(item.confidence) || 0) * 1000 + evidence;
+}
+
+export function shareNarrative(model = {}) {
+  const candidates = [
+    ...(model.volumes || []).map((item) => ({ ...item, kind: "VOLUME" })),
+    ...(model.faces || []).map((item) => ({ ...item, kind: "FACE" })),
+  ].filter((item) => item.signature);
+  candidates.sort((left, right) => {
+    const kindDelta = Number(right.kind === "VOLUME") - Number(left.kind === "VOLUME");
+    if (kindDelta) return kindDelta;
+    return narrativeStrength(right) - narrativeStrength(left)
+      || String(left.id || "").localeCompare(String(right.id || ""));
+  });
+  return {
+    root: cleanNarrative(model.root?.signature, 240)
+      || "A living personal model, shaped by real context over time.",
+    highlights: candidates.slice(0, 3).map((item) => ({
+      kind: item.kind,
+      text: cleanNarrative(item.signature, 110),
+    })),
+  };
+}
+
+function drawCover(context, source, width, height) {
+  const sourceWidth = source.width || source.videoWidth || width;
+  const sourceHeight = source.height || source.videoHeight || height;
+  const scale = Math.max(width / sourceWidth, height / sourceHeight);
+  const drawWidth = sourceWidth * scale;
+  const drawHeight = sourceHeight * scale;
+  context.drawImage(
+    source,
+    (width - drawWidth) / 2,
+    (height - drawHeight) / 2,
+    drawWidth,
+    drawHeight,
+  );
+}
+
+function drawBrandMark(context, x, y) {
+  context.save();
+  context.strokeStyle = "rgba(255, 255, 255, 0.22)";
+  context.lineWidth = 1;
+  context.beginPath();
+  context.arc(x, y, 18, 0, Math.PI * 2);
+  context.stroke();
+
+  const nodes = [
+    [0, -6, "#ff6b8a"],
+    [-6, 5, "#ff64d6"],
+    [7, 5, "#7798ff"],
+  ];
+  context.strokeStyle = "rgba(255, 255, 255, 0.19)";
+  context.beginPath();
+  context.moveTo(x, y - 6);
+  context.lineTo(x - 6, y + 5);
+  context.lineTo(x + 7, y + 5);
+  context.closePath();
+  context.stroke();
+  nodes.forEach(([dx, dy, color]) => {
+    context.fillStyle = color;
+    context.shadowColor = color;
+    context.shadowBlur = 10;
+    context.beginPath();
+    context.arc(x + dx, y + dy, 3, 0, Math.PI * 2);
+    context.fill();
+  });
+  context.restore();
+}
+
+export function drawConstellationCard(context, source, model = {}) {
+  const width = CONSTELLATION_CARD_WIDTH;
+  const height = CONSTELLATION_CARD_HEIGHT;
+  const narrative = shareNarrative(model);
+
+  context.save();
+  context.fillStyle = "#070610";
+  context.fillRect(0, 0, width, height);
+
+  const aura = context.createRadialGradient(760, 300, 20, 760, 300, 610);
+  aura.addColorStop(0, "rgba(105, 92, 210, 0.24)");
+  aura.addColorStop(0.46, "rgba(49, 35, 91, 0.13)");
+  aura.addColorStop(1, "rgba(7, 6, 16, 0)");
+  context.fillStyle = aura;
+  context.fillRect(0, 0, width, height);
+
+  context.save();
+  context.globalAlpha = 0.96;
+  drawCover(context, source, width, height);
+  context.restore();
+
+  const textScrim = context.createLinearGradient(0, 0, 680, 0);
+  textScrim.addColorStop(0, "rgba(7, 6, 16, 0.96)");
+  textScrim.addColorStop(0.56, "rgba(7, 6, 16, 0.46)");
+  textScrim.addColorStop(1, "rgba(7, 6, 16, 0)");
+  context.fillStyle = textScrim;
+  context.fillRect(0, 0, 760, height);
+
+  const edge = context.createLinearGradient(0, height - 170, 0, height);
+  edge.addColorStop(0, "rgba(7, 6, 16, 0)");
+  edge.addColorStop(1, "rgba(7, 6, 16, 0.88)");
+  context.fillStyle = edge;
+  context.fillRect(0, height - 170, width, 170);
+
+  drawBrandMark(context, 72, 66);
+  context.shadowBlur = 0;
+  context.fillStyle = "rgba(248, 246, 255, 0.96)";
+  context.font = "700 22px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+  context.fillText("Persome", 105, 62);
+  context.fillStyle = "rgba(164, 158, 181, 0.9)";
+  context.font = "700 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+  context.fillText("PERSONAL MODEL", 105, 80);
+
+  context.fillStyle = "rgba(195, 188, 210, 0.86)";
+  context.font = "700 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+  context.fillText("A LIVING MAP OF WHAT YOU NOTICE, REPEAT, AND BECOME", 54, 286);
+
+  const headline = context.createLinearGradient(54, 310, 430, 430);
+  headline.addColorStop(0, "#fff8fc");
+  headline.addColorStop(0.52, "#ff85cf");
+  headline.addColorStop(1, "#8ea4ff");
+  context.fillStyle = headline;
+  context.font = "650 52px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+  context.fillText("My personal", 52, 349);
+  context.fillText("constellation.", 52, 403);
+
+  context.fillStyle = "rgba(255, 100, 214, 0.9)";
+  context.font = "750 9px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+  context.fillText("CURRENT MODEL", 55, 442);
+  context.fillStyle = "rgba(229, 224, 238, 0.88)";
+  context.font = "500 14px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+  drawWrappedText(context, narrative.root, 54, 466, 430, 20, 3);
+
+  if (narrative.highlights.length) {
+    const panelX = 746;
+    const panelY = 468;
+    const panelWidth = 404;
+    const panelHeight = 132;
+    context.fillStyle = "rgba(9, 8, 18, 0.78)";
+    context.strokeStyle = "rgba(255, 255, 255, 0.12)";
+    context.lineWidth = 1;
+    context.beginPath();
+    context.roundRect(panelX, panelY, panelWidth, panelHeight, 16);
+    context.fill();
+    context.stroke();
+    context.fillStyle = "rgba(162, 154, 181, 0.9)";
+    context.font = "750 9px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+    context.fillText("KEY PATTERNS", panelX + 18, panelY + 24);
+    narrative.highlights.forEach((highlight, index) => {
+      const rowY = panelY + 49 + index * 25;
+      context.fillStyle = highlight.kind === "VOLUME" ? "#7798ff" : "#ff64d6";
+      context.beginPath();
+      context.arc(panelX + 20, rowY - 4, 3, 0, Math.PI * 2);
+      context.fill();
+      context.fillStyle = "rgba(226, 221, 237, 0.9)";
+      context.font = "550 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+      const line = wrappedLines(context, highlight.text, panelWidth - 52, 1)[0] || "";
+      context.fillText(line, panelX + 32, rowY);
+    });
+  }
+
+  let statX = 56;
+  shareStats(model).forEach(([label, value]) => {
+    context.fillStyle = "rgba(248, 246, 255, 0.94)";
+    context.font = "650 18px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+    context.fillText(String(value), statX, 566);
+    context.fillStyle = "rgba(137, 130, 153, 0.92)";
+    context.font = "700 9px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+    context.fillText(label, statX, 583);
+    statX += label === "VOLUMES" ? 92 : 78;
+  });
+
+  context.fillStyle = "rgba(152, 145, 171, 0.9)";
+  context.font = "650 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+  context.fillText("GENERATED LOCALLY · SHARED BY YOU", 54, 628);
+  context.textAlign = "right";
+  context.fillText("github.com/Intuition-Lab/personal-model", width - 52, 628);
   context.restore();
 }

--- a/resources/model_assets/viewer.js
+++ b/resources/model_assets/viewer.js
@@ -11,11 +11,15 @@ import {
   relationLabel,
 } from "./evidence.mjs";
 import {
-  SHARE_CARD_HEIGHT,
-  SHARE_CARD_WIDTH,
-  SHARE_FILE_NAME,
+  CONSTELLATION_CARD_HEIGHT,
+  CONSTELLATION_CARD_WIDTH,
+  CONSTELLATION_FILE_NAME,
+  HUMAN_CARD_HEIGHT,
+  HUMAN_CARD_WIDTH,
+  HUMAN_CARD_FILE_NAME,
   buildXIntentUrl,
-  drawShareCard,
+  drawConstellationCard,
+  drawHumanCard,
 } from "./share.mjs";
 
 const COLORS = {
@@ -776,7 +780,7 @@ function setShareBusy(busy) {
   shareButton.querySelector("b").textContent = busy ? "Preparing…" : "Share";
 }
 
-async function loadShareCardModel() {
+async function loadShareProjection() {
   const controller = new AbortController();
   const timeout = window.setTimeout(() => controller.abort(), SHARE_CARD_TIMEOUT_MS);
   try {
@@ -786,7 +790,13 @@ async function loadShareCardModel() {
     });
     if (!response.ok) throw new Error(`Share endpoint returned HTTP ${response.status}`);
     const payload = await response.json();
-    if (!payload.model || !Array.isArray(payload.model.faces)) {
+    if (
+      !payload.model
+      || !Array.isArray(payload.model.faces)
+      || !Array.isArray(payload.model.volumes)
+      || !payload.model.stats
+      || typeof payload.model.stats !== "object"
+    ) {
       throw new Error("Share endpoint returned an invalid projection");
     }
     return payload.model;
@@ -795,13 +805,29 @@ async function loadShareCardModel() {
   }
 }
 
-function createShareCardBlob(shareModel) {
+function createHumanCardBlob(shareModel) {
   const canvas = document.createElement("canvas");
-  canvas.width = SHARE_CARD_WIDTH;
-  canvas.height = SHARE_CARD_HEIGHT;
+  canvas.width = HUMAN_CARD_WIDTH;
+  canvas.height = HUMAN_CARD_HEIGHT;
   const context = canvas.getContext("2d");
   if (!context) return Promise.reject(new Error("Canvas export is unavailable"));
-  drawShareCard(context, shareModel);
+  drawHumanCard(context, shareModel);
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) resolve(blob);
+      else reject(new Error("The HUMAN.md Card could not be encoded"));
+    }, "image/png");
+  });
+}
+
+function createConstellationBlob(shareModel) {
+  renderer.render(scene, camera);
+  const canvas = document.createElement("canvas");
+  canvas.width = CONSTELLATION_CARD_WIDTH;
+  canvas.height = CONSTELLATION_CARD_HEIGHT;
+  const context = canvas.getContext("2d");
+  if (!context) return Promise.reject(new Error("Canvas export is unavailable"));
+  drawConstellationCard(context, renderer.domElement, shareModel);
   return new Promise((resolve, reject) => {
     canvas.toBlob((blob) => {
       if (blob) resolve(blob);
@@ -810,52 +836,68 @@ function createShareCardBlob(shareModel) {
   });
 }
 
-function downloadShareCard(blob) {
+function downloadShareImage(blob, fileName) {
   const href = URL.createObjectURL(blob);
   const anchor = document.createElement("a");
   anchor.href = href;
-  anchor.download = SHARE_FILE_NAME;
+  anchor.download = fileName;
   document.body.appendChild(anchor);
   anchor.click();
   anchor.remove();
   window.setTimeout(() => URL.revokeObjectURL(href), 1000);
 }
 
-function paintShareHandoff(popup) {
+function paintConstellationHandoff(popup) {
   if (!popup) return;
-  popup.document.title = "Preparing your Persome HUMAN.md Card";
+  popup.document.title = "Preparing your Persome constellation";
   popup.document.body.innerHTML = `
-    <main style="min-height:100vh;display:grid;place-items:center;margin:0;background:#f3f0e9;color:#1f1d1b;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">
-      <section style="width:min(440px,calc(100vw - 48px));padding:38px;border:1px solid rgba(31,29,27,.16);background:#fff;box-shadow:0 30px 100px rgba(31,29,27,.12)">
-        <p style="margin:0 0 18px;color:#cf4f36;font-size:11px;font-weight:750;letter-spacing:.16em">PERSOME · SHARE TO X</p>
-        <h1 style="margin:0;font-size:34px;line-height:1.05;letter-spacing:-.045em">Your HUMAN.md Card is downloading.</h1>
-        <p style="margin:18px 0 0;color:#6d6861;font-size:15px;line-height:1.65">In X, add <strong style="color:#1f1d1b">${SHARE_FILE_NAME}</strong> with the image button. Review the card before posting.</p>
+    <main style="min-height:100vh;display:grid;place-items:center;margin:0;background:#070610;color:#f7f4ff;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">
+      <section style="width:min(440px,calc(100vw - 48px));padding:38px;border:1px solid rgba(255,255,255,.12);border-radius:24px;background:linear-gradient(145deg,rgba(255,100,214,.11),rgba(119,152,255,.08));box-shadow:0 30px 100px rgba(0,0,0,.45)">
+        <p style="margin:0 0 18px;color:#ff83cf;font-size:11px;font-weight:750;letter-spacing:.16em">PERSOME · SHARE TO X</p>
+        <h1 style="margin:0;font-size:34px;line-height:1.05;letter-spacing:-.045em">Your constellation is downloading.</h1>
+        <p style="margin:18px 0 0;color:#b8b1c7;font-size:15px;line-height:1.65">In X, add <strong style="color:#fff">${CONSTELLATION_FILE_NAME}</strong> with the image button. Review the image before posting.</p>
       </section>
     </main>`;
 }
 
-async function exportHumanCard({ toX = false } = {}) {
-  const popup = toX ? window.open("about:blank", "_blank") : null;
-  if (toX) paintShareHandoff(popup);
+async function exportHumanCard() {
   setShareBusy(true);
   pauseAutoRotate();
   try {
-    const shareModel = await loadShareCardModel();
-    const blob = await createShareCardBlob(shareModel);
-    downloadShareCard(blob);
+    const shareModel = await loadShareProjection();
+    const blob = await createHumanCardBlob(shareModel);
+    downloadShareImage(blob, HUMAN_CARD_FILE_NAME);
     showShareNotice(
       "HUMAN.md Card downloaded",
       "Detected secrets, PII, paths, IDs, and evidence receipts were excluded. Review summaries before sharing.",
     );
-    if (toX) {
-      const intentUrl = buildXIntentUrl();
-      if (popup && !popup.closed) {
-        popup.opener = null;
-        popup.location.replace(intentUrl);
-        popup.focus();
-      } else {
-        window.location.assign(intentUrl);
-      }
+    setShareBusy(false);
+  } catch (error) {
+    showShareNotice("Share image failed", error.message || String(error), true);
+    setShareBusy(false);
+  }
+}
+
+async function shareConstellationToX() {
+  const popup = window.open("about:blank", "_blank");
+  paintConstellationHandoff(popup);
+  setShareBusy(true);
+  pauseAutoRotate();
+  try {
+    const shareModel = await loadShareProjection();
+    const blob = await createConstellationBlob(shareModel);
+    downloadShareImage(blob, CONSTELLATION_FILE_NAME);
+    showShareNotice(
+      "Constellation downloaded",
+      `Add ${CONSTELLATION_FILE_NAME} with the image button in X.`,
+    );
+    const intentUrl = buildXIntentUrl();
+    if (popup && !popup.closed) {
+      popup.opener = null;
+      popup.location.replace(intentUrl);
+      popup.focus();
+    } else {
+      window.location.assign(intentUrl);
     }
     setShareBusy(false);
   } catch (error) {
@@ -1542,8 +1584,8 @@ controls.addEventListener("start", () => {
 });
 document.getElementById("reset").addEventListener("click", resetCamera);
 document.getElementById("close-detail").addEventListener("click", clearSelection);
-cardButton.addEventListener("click", () => exportHumanCard());
-shareButton.addEventListener("click", () => exportHumanCard({ toX: true }));
+cardButton.addEventListener("click", exportHumanCard);
+shareButton.addEventListener("click", shareConstellationToX);
 
 slider.addEventListener("input", () => {
   updateCutoff();

--- a/src/persome/api/model_view.py
+++ b/src/persome/api/model_view.py
@@ -53,7 +53,7 @@ _MEMORY_VIEW_TEMPLATE = """<!doctype html>
         <button id="human-card" class="share-button" type="button" aria-label="Export your HUMAN.md Card" title="Export your HUMAN.md Card" disabled>
           <span aria-hidden="true">H</span><b>Card</b>
         </button>
-        <button id="share-x" class="share-button" type="button" aria-label="Share your HUMAN.md Card to X" title="Share your HUMAN.md Card to X" disabled>
+        <button id="share-x" class="share-button" type="button" aria-label="Share your constellation to X" title="Share your constellation to X" disabled>
           <span aria-hidden="true">X</span><b>Share</b>
         </button>
         <div class="zoom-controls" role="group" aria-label="Zoom controls">

--- a/src/persome/api/routes.py
+++ b/src/persome/api/routes.py
@@ -823,7 +823,7 @@ def model_graph() -> dict[str, Any]:
 
 
 def _share_card_projection(snapshot: dict[str, Any]) -> dict[str, Any]:
-    """Keep only scrubbed summaries needed to render a share card.
+    """Keep only scrubbed summaries and counts needed by public share artifacts.
 
     The owner viewer intentionally receives an unredacted graph. Sharing must
     cross a separate server-side boundary so raw receipts, identifiers, paths,
@@ -848,12 +848,29 @@ def _share_card_projection(snapshot: dict[str, Any]) -> dict[str, Any]:
         for item in snapshot.get("faces") or []
         if (projected := summary(item)) is not None
     ]
-    return {"root": root, "faces": faces}
+    volumes = [
+        projected
+        for item in snapshot.get("volumes") or []
+        if (projected := summary(item)) is not None
+    ]
+    raw_stats = snapshot.get("stats") if isinstance(snapshot.get("stats"), dict) else {}
+    stats = {
+        key: int(raw_stats.get(key) or 0)
+        for key in (
+            "points",
+            "evolution_lines",
+            "relation_lines",
+            "faces",
+            "volumes",
+            "roots",
+        )
+    }
+    return {"root": root, "faces": faces, "volumes": volumes, "stats": stats}
 
 
 @router.get("/model/share-card", tags=["model"])
 def model_share_card() -> dict[str, Any]:
-    """Return the minimal, canonically scrubbed HUMAN.md Card projection."""
+    """Return the minimal, canonically scrubbed public share projection."""
     from ..store import fts as fts_store
 
     with fts_store.cursor() as conn:

--- a/tests/js/model_share.test.mjs
+++ b/tests/js/model_share.test.mjs
@@ -2,18 +2,34 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
-  SHARE_CARD_HEIGHT,
-  SHARE_CARD_WIDTH,
-  SHARE_FILE_NAME,
+  CONSTELLATION_CARD_HEIGHT,
+  CONSTELLATION_CARD_WIDTH,
+  CONSTELLATION_FILE_NAME,
+  HUMAN_CARD_HEIGHT,
+  HUMAN_CARD_WIDTH,
+  HUMAN_CARD_FILE_NAME,
   SHARE_TEXTS,
+  SHARE_URL,
   buildXIntentUrl,
+  drawConstellationCard,
+  drawHumanCard,
   humanCard,
+  pickShareText,
+  shareNarrative,
+  shareStats,
 } from "../../resources/model_assets/share.mjs";
 
 test("keeps the HUMAN.md Card portrait-sized and portable", () => {
-  assert.equal(SHARE_CARD_WIDTH, 1080);
-  assert.equal(SHARE_CARD_HEIGHT, 1350);
-  assert.equal(SHARE_FILE_NAME, "my-human-card.png");
+  assert.equal(HUMAN_CARD_WIDTH, 1080);
+  assert.equal(HUMAN_CARD_HEIGHT, 1350);
+  assert.equal(HUMAN_CARD_FILE_NAME, "my-human-card.png");
+});
+
+test("keeps the X share artifact constellation-sized and distinct", () => {
+  assert.equal(CONSTELLATION_CARD_WIDTH, 1200);
+  assert.equal(CONSTELLATION_CARD_HEIGHT, 675);
+  assert.equal(CONSTELLATION_FILE_NAME, "my-persome-constellation.png");
+  assert.notEqual(CONSTELLATION_FILE_NAME, HUMAN_CARD_FILE_NAME);
 });
 
 test("uses only signatures from the server share projection", () => {
@@ -35,15 +51,137 @@ test("uses only signatures from the server share projection", () => {
   });
 });
 
-test("retains the approved X composer handoff for the HUMAN.md Card", () => {
+const EXPECTED_SHARE_TEXTS = [
+  [
+    "I let @PersonalModel_ observe how I use my Mac, and apparently this is what I look like 😳",
+    "",
+    "#PersonalModel @PersonalModel_",
+  ].join("\n"),
+  [
+    "I let my @PersonalModel_ learn from how I use my Mac. I didn’t expect this is how it sees me 😳",
+    "",
+    "#PersonalModel @PersonalModel_",
+  ].join("\n"),
+  [
+    "I let @PersonalModel_ observe how I use my Mac, and this is the model it built 🤔",
+    "",
+    "#PersonalModel @PersonalModel_",
+  ].join("\n"),
+];
+
+test("keeps the three approved X share variants verbatim", () => {
+  assert.deepEqual(SHARE_TEXTS, EXPECTED_SHARE_TEXTS);
+});
+
+test("selects each X share variant from an equal third of the random range", () => {
+  assert.equal(pickShareText(() => 0), EXPECTED_SHARE_TEXTS[0]);
+  assert.equal(pickShareText(() => (1 / 3) - Number.EPSILON), EXPECTED_SHARE_TEXTS[0]);
+  assert.equal(pickShareText(() => 1 / 3), EXPECTED_SHARE_TEXTS[1]);
+  assert.equal(pickShareText(() => (2 / 3) - Number.EPSILON), EXPECTED_SHARE_TEXTS[1]);
+  assert.equal(pickShareText(() => 2 / 3), EXPECTED_SHARE_TEXTS[2]);
+  assert.equal(pickShareText(() => 0.999999), EXPECTED_SHARE_TEXTS[2]);
+});
+
+test("retains the approved X composer handoff for the constellation", () => {
   const intent = new URL(buildXIntentUrl({ random: () => 0 }));
 
   assert.equal(SHARE_TEXTS.length, 3);
   assert.equal(intent.origin, "https://x.com");
   assert.equal(intent.pathname, "/intent/tweet");
   assert.equal(intent.searchParams.get("text"), SHARE_TEXTS[0]);
-  assert.equal(intent.searchParams.get("url"), "https://github.com/Intuition-Lab/personal-model");
+  assert.equal(intent.searchParams.get("url"), SHARE_URL);
   assert.ok(!intent.href.includes("localhost"));
+});
+
+test("keeps aggregate constellation counts separate from private source data", () => {
+  assert.deepEqual(
+    shareStats({
+      stats: {
+        points: 424,
+        evolution_lines: 120,
+        relation_lines: 26,
+        faces: 12,
+        volumes: 4,
+        roots: 1,
+      },
+    }),
+    [
+      ["POINTS", 424],
+      ["LINES", 146],
+      ["FACES", 12],
+      ["VOLUMES", 4],
+      ["ROOT", 1],
+    ],
+  );
+});
+
+test("selects a bounded constellation narrative and highest-level patterns", () => {
+  const narrative = shareNarrative({
+    root: {
+      signature: "A focused systems builder who turns context into auditable work.",
+      receipts: ["private-root-receipt"],
+    },
+    volumes: [
+      { id: "volume-low", signature: "Lower-confidence structure.", confidence: 0.7 },
+      { id: "volume-high", signature: "Trusted personal AI connects context and correction.", confidence: 0.96 },
+    ],
+    faces: [
+      { id: "face-high", signature: "Focused work starts with a small plan.", confidence: 0.99 },
+      { id: "face-second", signature: "Research claims are checked against evidence.", confidence: 0.91 },
+    ],
+  });
+
+  assert.equal(
+    narrative.root,
+    "A focused systems builder who turns context into auditable work.",
+  );
+  assert.deepEqual(narrative.highlights, [
+    { kind: "VOLUME", text: "Trusted personal AI connects context and correction." },
+    { kind: "VOLUME", text: "Lower-confidence structure." },
+    { kind: "FACE", text: "Focused work starts with a small plan." },
+  ]);
+  assert.ok(!JSON.stringify(narrative).includes("private-root-receipt"));
+});
+
+function recordingContext() {
+  const drawImages = [];
+  const gradient = { addColorStop() {} };
+  const context = {
+    drawImages,
+    measureText(value) {
+      return { width: String(value).length * 7 };
+    },
+    createLinearGradient() {
+      return gradient;
+    },
+    createRadialGradient() {
+      return gradient;
+    },
+    drawImage(...args) {
+      drawImages.push(args);
+    },
+  };
+  return new Proxy(context, {
+    get(target, property) {
+      if (property in target) return target[property];
+      return () => {};
+    },
+  });
+}
+
+test("draws the live WebGL canvas into the X constellation artifact only", () => {
+  const source = { width: 1600, height: 900 };
+  const constellationContext = recordingContext();
+  drawConstellationCard(constellationContext, source, {
+    root: { signature: "A test constellation." },
+  });
+
+  assert.equal(constellationContext.drawImages.length, 1);
+  assert.equal(constellationContext.drawImages[0][0], source);
+
+  const humanContext = recordingContext();
+  drawHumanCard(humanContext, { root: { signature: "A test HUMAN.md Card." } });
+  assert.equal(humanContext.drawImages.length, 0);
 });
 
 test("falls back to bounded high-level summaries without leaking sources", () => {

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -248,7 +248,18 @@ class TestGraphJson:
                     f"Uses alice@example.com from /Users/alice/private with {test_api_key}",
                     4,
                 ),
-                ("root-private-id", 3, "Evidence-backed systems builder", 7),
+                (
+                    "volume-private-id",
+                    2,
+                    "Coordinates alice@example.com work from /Users/alice/private",
+                    5,
+                ),
+                (
+                    "root-private-id",
+                    3,
+                    f"Evidence-backed systems builder for alice@example.com with {test_api_key}",
+                    7,
+                ),
             ):
                 conn.execute(
                     """
@@ -271,15 +282,31 @@ class TestGraphJson:
         projection = routes.model_share_card()["model"]
         serialized = json.dumps(projection)
 
-        assert set(projection) == {"root", "faces"}
+        assert set(projection) == {"root", "faces", "volumes", "stats"}
         assert set(projection["root"]) == {"signature", "observations", "confidence"}
         assert set(projection["faces"][0]) == {"signature", "observations", "confidence"}
+        assert set(projection["volumes"][0]) == {
+            "signature",
+            "observations",
+            "confidence",
+        }
+        assert "[REDACTED]" in projection["root"]["signature"]
         assert "[REDACTED]" in projection["faces"][0]["signature"]
+        assert "[REDACTED]" in projection["volumes"][0]["signature"]
+        assert projection["stats"] == {
+            "points": 0,
+            "evolution_lines": 0,
+            "relation_lines": 0,
+            "faces": 1,
+            "volumes": 1,
+            "roots": 1,
+        }
         for private_value in (
             "alice@example.com",
             "/Users/alice",
             test_api_key,
             "face-private-id",
+            "volume-private-id",
             "root-private-id",
             "receipt",
         ):
@@ -370,7 +397,7 @@ class TestViewPage:
         assert 'id="human-card"' in body
         assert 'title="Export your HUMAN.md Card" disabled>' in body
         assert 'id="share-x"' in body
-        assert 'title="Share your HUMAN.md Card to X" disabled>' in body
+        assert 'title="Share your constellation to X" disabled>' in body
         assert "Detected secrets, PII, paths, IDs, and evidence receipts were excluded." in body
         assert 'id="share-notice"' in body
         assert 'aria-label="Zoom controls"' in body
@@ -398,7 +425,8 @@ class TestViewPage:
         assert b"nodeEvidenceCards" in evidence.body
         assert b"humanCard" in share.body
         assert b"buildXIntentUrl" in share.body
-        assert b"drawShareCard" in share.body
+        assert b"drawHumanCard" in share.body
+        assert b"drawConstellationCard" in share.body
         assert b'from "./layout.mjs"' in viewer.body
         assert b'from "./share.mjs"' in viewer.body
         assert b"model.points" in viewer.body
@@ -438,10 +466,17 @@ class TestViewPage:
         assert b"--build-color: var(--root)" in css.body
         assert b"--build-color: var(--point)" in css.body
         assert b"controls.zoomToCursor = true" in viewer.body
-        assert b"downloadShareCard" in viewer.body
+        assert b"downloadShareImage" in viewer.body
         assert b"shareReady = Boolean" in viewer.body
         assert b"window.open" in viewer.body
         assert b"my-human-card.png" in share.body
+        assert b"my-persome-constellation.png" in share.body
+        assert b'cardButton.addEventListener("click", exportHumanCard)' in viewer.body
+        assert b'shareButton.addEventListener("click", shareConstellationToX)' in viewer.body
+        assert b"exportHumanCard({ toX: true })" not in viewer.body
+        assert viewer.body.count(b"await loadShareProjection()") == 2
+        assert b"drawConstellationCard(context, renderer.domElement, shareModel)" in viewer.body
+        assert b"drawConstellationCard(context, renderer.domElement, model)" not in viewer.body
         assert b"private source content" in share.body
         assert b"Built locally with Persome \xc2\xb7 Build yours" in share.body
         assert b"window.__persomeZoomState" in viewer.body


### PR DESCRIPTION
## What changed

- restore the X Share path to export the 1200x675 WebGL model constellation as `my-persome-constellation.png`
- keep the H Card button as a separate 1080x1350 `my-human-card.png` export
- keep all Root, Volume, Face copy and aggregate counts behind the server-side redacted share projection
- restore the constellation handoff copy and accessible button label
- add distinct renderer, filename, event-binding, pixel-source, privacy-projection, and OpenAPI regression coverage

## Root cause

PR #78 replaced the original constellation renderer with the HUMAN.md Card renderer. When the X button was restored, it was wired to `exportHumanCard({ toX: true })`, so the X action deterministically downloaded the wrong artifact. The existing tests were updated to assert that incorrect behavior.

## User impact

`H / Card` still downloads the privacy-safe HUMAN.md Card. `X / Share` now downloads the actual model constellation and opens the existing X composer. The WebGL geometry remains unlabeled, while all written summaries and counts come from the canonically scrubbed server projection.

## Validation

- real local sample-demo browser smoke and visual inspection of the rendered 1200x675 constellation PNG
- independent privacy-focused review, followed by a clean re-review
- `PERSOME_LLM_MOCK=1 uv run pytest -m "not macos and not integration"`: 2124 passed, 17 deselected
- `node --test tests/js/*.test.mjs`: 22 passed
- `uv run pytest tests/test_model_routes.py tests/test_openapi_drift.py -q`: 28 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- secret, PII, and language scans
- `git diff --check`
