### PR TITLE
fix: unblock updates from capture index drift

### DIFF
--- a/docs/capture.md
+++ b/docs/capture.md
@@ -264,7 +264,7 @@ Every successful capture write is also indexed into an FTS5 virtual table (`capt
 | `cleanup_buffer` time-based delete | FTS deletion is attempted before each JSON deletion; filesystem erasure remains authoritative if SQLite is temporarily unavailable, and the final reconciliation removes stale searchable rows after recovery. |
 | `cleanup_buffer` size-based eviction | Same, including hard-cap eviction of unabsorbed files when necessary and continued eviction after one unlink failure. |
 | Screenshot strip | **Untouched.** Strip only removes the base64 image; the indexed text (`visible_text`, `focused_value`, `window_title`, `app_name`, `url`) is unchanged. |
-| `persome rebuild-captures-index` | Atomically clear stale rows, then index every surviving `~/.persome/capture-buffer/*.json` in one rollback-safe transaction. Use `--merge` after snapshot recovery to preserve older rows whose JSON aged out. |
+| `persome rebuild-captures-index` | Offline maintenance: run `persome stop` first. The command then holds the exclusive database gate while it atomically clears stale rows and indexes every surviving `~/.persome/capture-buffer/*.json` in one rollback-safe transaction. Use `--merge` after snapshot recovery to preserve older rows whose JSON aged out, then run `persome start`. |
 
 **Indexed columns.** Only the searchable text is in FTS: `app_name`, `window_title`, `focused_value`, `visible_text`, `url`. Filterable metadata (timestamp, bundle_id, focused_role) lives on the `captures` table for `WHERE`-clause filtering. Screenshots are deliberately not duplicated — the JSON file on disk stays the authoritative copy of the raw image bytes.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -123,9 +123,10 @@ after a completed recovery marker is durable. Snapshot recovery remains
 best-effort: the marker records its timestamp and warns that writes since that
 snapshot may be absent. Retained capture-buffer JSON can be reconciled with
 `persome rebuild-captures-index --merge` when the marker reports a pending
-replay. Recovery mode preserves older snapshot-backed captures whose buffer
-JSON has already aged out; the command without `--merge` remains an exact
-buffer-only rebuild and deletes such rows.
+replay. Stop the Runtime before running this offline reconciliation, then start
+it again afterward. Recovery mode preserves older snapshot-backed captures
+whose buffer JSON has already aged out; the command without `--merge` remains
+an exact buffer-only rebuild and deletes such rows.
 Unreadable or semantically invalid versioned journals (missing fields, unknown
 phases, or paths outside the canonical recovery namespace) are themselves moved
 to a timestamped forensic quarantine before normal integrity checks continue;

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -307,7 +307,7 @@ Fixes:
 
 1. **Check the reducer is emitting breadcrumbs.** Every sub_task should end with ` — raw: read_recent_capture(at="HH:MM", app_name="…")`. Open today's `event-YYYY-MM-DD.md` and verify. If a line has no breadcrumb, the reducer's output didn't match the canonical `[HH:MM-HH:MM, <app>]` prefix — check `logs/writer.log` for the reduced entry text.
 2. **Try `search_captures` directly.** Ask the agent *"search captures for <keyword>"* or *"what's in current_context"*. If those work, the FTS index is healthy and the issue is tool-selection, not retrieval.
-3. **Rebuild the captures index if it's empty or out of date.** Run `persome rebuild-captures-index`. Compare `SELECT COUNT(*) FROM captures` against `ls ~/.persome/capture-buffer | wc -l` — they should match modulo one active capture.
+3. **Rebuild the captures index if it's empty or out of date.** Run `persome stop`, `persome rebuild-captures-index`, then `persome start`. Compare `SELECT COUNT(*) FROM captures` against `ls ~/.persome/capture-buffer | wc -l` — they should match modulo captures retained while the Runtime was stopping.
 4. **Restart the client** after updating Persome — server-level `instructions` (which teach the two-layer model) are only read on reconnect.
 
 ## Long session got chopped in half
@@ -384,9 +384,10 @@ the retained snapshot/quarantine, then explicitly set the value to `markdown`
 or `evomem` and rerun a stopped-Runtime command. Persome reconciles the selected
 source before unfreezing; choosing evomem also replaces its conflicting
 Markdown projection.
-If the marker says `capture_buffer_replay_available: true`, run `persome
-rebuild-captures-index --merge` to upsert retained owner-only JSON without
-deleting older snapshot-backed captures before rebuilding downstream history.
+If the marker says `capture_buffer_replay_available: true`, stop the Runtime,
+run `persome rebuild-captures-index --merge` to upsert retained owner-only JSON
+without deleting older snapshot-backed captures, then start the Runtime before
+rebuilding downstream history.
 
 ## Resetting
 

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -3372,89 +3372,142 @@ def rebuild_captures_index(
 
     from .capture import s1_parser
 
+    _require_stopped_for_capture_rebuild()
     _init()
     buf = paths.capture_buffer_dir()
     files = sorted(p for p in buf.iterdir() if p.is_file() and p.suffix == ".json")
 
     indexed = 0
+    inserted = 0
+    updated = 0
+    unchanged = 0
     skipped = 0
-    with fts.cursor() as conn:
-        # OCR text is a DB-only backfill: raw JSON intentionally keeps an
-        # empty ``visible_text`` sentinel plus ``ocr_submitted=true``. Preserve
-        # those rows across both exact and merge rebuilds instead of silently
-        # replacing recognized text with the raw empty sentinel.
-        ocr_backfills = {
-            str(row["id"]): str(row["visible_text"] or "")
-            for row in conn.execute(
-                "SELECT id, visible_text FROM captures WHERE visible_text != ''"
-            ).fetchall()
-        }
-        # One explicit transaction prevents each capture upsert from becoming
-        # its own FTS5 commit. On a large retained buffer, per-row autocommit
-        # can amplify a small index into a multi-gigabyte WAL and WAL-index,
-        # exposing concurrent macOS readers to a fatal mmap page-in failure.
-        # It also makes exact reconciliation interruption-safe: either the
-        # complete replacement commits or SQLite restores the prior index.
-        conn.execute("BEGIN IMMEDIATE")
-        try:
-            # Exact rebuild is reconciliation, not just an upsert pass. Recovery
-            # merge intentionally preserves older snapshot rows whose source JSON
-            # has already aged out of the bounded capture buffer.
-            if not merge:
-                conn.execute("DELETE FROM captures")
-            for p in files:
-                try:
-                    data = json.loads(p.read_text())
-                except (OSError, json.JSONDecodeError) as exc:
-                    skipped += 1
-                    console.print(f"[yellow]skip {p.name}: {exc}[/yellow]")
-                    continue
-                if not isinstance(data, dict):
-                    skipped += 1
-                    console.print(f"[yellow]skip {p.name}: capture is not a JSON object[/yellow]")
-                    continue
-                preserve_ocr = bool(data.get("ocr_submitted")) and not str(
-                    data.get("visible_text") or ""
+    # Rebuilding every FTS segment must exclude daemon and MCP database
+    # activity for the complete transaction. A shared maintenance lock still
+    # permits another process to reset or resize the WAL index while SQLite is
+    # reading it, which can surface as an unrecoverable macOS SIGBUS rather
+    # than a catchable sqlite3 exception.
+    with fts.exclusive_database_maintenance():
+        # Close the check/start race before opening SQLite. A cooperative
+        # Runtime that starts after this point blocks on the exclusive gate.
+        _require_stopped_for_capture_rebuild()
+        with fts.cursor() as conn:
+            # One explicit transaction prevents each capture upsert from becoming
+            # its own FTS5 commit. On a large retained buffer, per-row autocommit
+            # can amplify a small index into a multi-gigabyte WAL and WAL-index,
+            # exposing concurrent macOS readers to a fatal mmap page-in failure.
+            # It also makes exact reconciliation interruption-safe: either the
+            # complete replacement commits or SQLite restores the prior index.
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                projection_fields = (
+                    "timestamp",
+                    "app_name",
+                    "bundle_id",
+                    "window_title",
+                    "focused_role",
+                    "focused_value",
+                    "visible_text",
+                    "url",
                 )
-                data = s1_parser.sanitize_capture(data)
-                preserved_ocr = s1_parser.sanitize_ocr_text(
-                    data,
-                    ocr_backfills.get(p.stem, ""),
+                existing_rows = conn.execute(
+                    "SELECT id, " + ", ".join(projection_fields) + " FROM captures"
+                ).fetchall()
+                # OCR text is a DB-only backfill: raw JSON intentionally keeps an
+                # empty ``visible_text`` sentinel plus ``ocr_submitted=true``.
+                # Preserve those rows across both exact and merge rebuilds instead
+                # of silently replacing recognized text with the raw empty sentinel.
+                ocr_backfills = {
+                    str(row["id"]): str(row["visible_text"] or "")
+                    for row in existing_rows
+                    if row["visible_text"]
+                }
+                # Startup integrity repair has already reconciled captures_fts
+                # against these authoritative rows. In merge mode, do not fire the
+                # UPDATE trigger for projections that are byte-for-byte identical:
+                # every such no-op would still delete and reinsert an FTS row.
+                existing_projections = (
+                    {
+                        str(row["id"]): tuple(row[field] for field in projection_fields)
+                        for row in existing_rows
+                    }
+                    if merge
+                    else {}
                 )
-                meta = data.get("window_meta") or {}
-                focused = data.get("focused_element") or {}
-                try:
-                    fts.insert_capture(
-                        conn,
-                        id=p.stem,
-                        timestamp=data.get("timestamp", ""),
-                        app_name=meta.get("app_name") or "",
-                        bundle_id=meta.get("bundle_id") or "",
-                        window_title=meta.get("title") or "",
-                        focused_role=focused.get("role") or "",
-                        focused_value=focused.get("value") or "",
-                        visible_text=(
+                # Exact rebuild is reconciliation, not just an upsert pass. Recovery
+                # merge intentionally preserves older snapshot rows whose source JSON
+                # has already aged out of the bounded capture buffer.
+                if not merge:
+                    conn.execute("DELETE FROM captures")
+                for p in files:
+                    try:
+                        data = json.loads(p.read_text())
+                    except (OSError, json.JSONDecodeError) as exc:
+                        skipped += 1
+                        console.print(f"[yellow]skip {p.name}: {exc}[/yellow]")
+                        continue
+                    if not isinstance(data, dict):
+                        skipped += 1
+                        console.print(
+                            f"[yellow]skip {p.name}: capture is not a JSON object[/yellow]"
+                        )
+                        continue
+                    preserve_ocr = bool(data.get("ocr_submitted")) and not str(
+                        data.get("visible_text") or ""
+                    )
+                    data = s1_parser.sanitize_capture(data)
+                    preserved_ocr = s1_parser.sanitize_ocr_text(
+                        data,
+                        ocr_backfills.get(p.stem, ""),
+                    )
+                    meta = data.get("window_meta") or {}
+                    focused = data.get("focused_element") or {}
+                    projection_kwargs = {
+                        "timestamp": data.get("timestamp", ""),
+                        "app_name": meta.get("app_name") or "",
+                        "bundle_id": meta.get("bundle_id") or "",
+                        "window_title": meta.get("title") or "",
+                        "focused_role": focused.get("role") or "",
+                        "focused_value": focused.get("value") or "",
+                        "visible_text": (
                             preserved_ocr
                             if preserve_ocr and not data.get("visible_text")
                             else data.get("visible_text") or ""
                         ),
-                        url=data.get("url") or "",
-                    )
-                    indexed += 1
-                except Exception as exc:  # noqa: BLE001
-                    skipped += 1
-                    console.print(f"[yellow]skip {p.name}: {exc}[/yellow]")
-                if indexed % 200 == 0 and indexed > 0:
-                    console.print(f"  staged {indexed} / {len(files)}…")
-            conn.commit()
-        except BaseException:
-            if conn.in_transaction:
-                conn.rollback()
-            raise
+                        "url": data.get("url") or "",
+                    }
+                    projection = tuple(projection_kwargs[field] for field in projection_fields)
+                    try:
+                        existed = p.stem in existing_projections
+                        if existed and existing_projections[p.stem] == projection:
+                            unchanged += 1
+                        else:
+                            fts.insert_capture(
+                                conn,
+                                id=p.stem,
+                                **projection_kwargs,
+                            )
+                            if existed:
+                                updated += 1
+                            else:
+                                inserted += 1
+                        indexed += 1
+                    except Exception as exc:  # noqa: BLE001
+                        skipped += 1
+                        console.print(f"[yellow]skip {p.name}: {exc}[/yellow]")
+                    if indexed % 200 == 0 and indexed > 0:
+                        console.print(f"  staged {indexed} / {len(files)}…")
+                conn.commit()
+            except BaseException:
+                if conn.in_transaction:
+                    conn.rollback()
+                raise
 
     console.print(
         f"[green]Captures index {'merged' if merge else 'rebuilt'}: "
-        f"{indexed} indexed, {skipped} skipped "
+        f"{indexed} indexed ({inserted} inserted, {updated} updated, "
+        f"{unchanged} unchanged), "
+        f"{skipped} skipped "
         f"(of {len(files)} files).[/green]"
     )
 
@@ -3476,6 +3529,19 @@ def _confirm(prompt: str, yes: bool) -> bool:
     if yes:
         return True
     return typer.confirm(prompt, default=False)
+
+
+def _require_stopped_for_capture_rebuild() -> None:
+    pid = _read_pid()
+    if pid is None and not _daemon_lock_is_held():
+        return
+    process = f" (pid {pid})" if pid is not None else ""
+    console.print(
+        f"[red]Refusing to rebuild the capture index while the Runtime is running{process}. "
+        "Run `persome stop` first. If an older editor or agent client remains connected, "
+        "restart it before retrying.[/red]"
+    )
+    raise typer.Exit(1)
 
 
 def _require_stopped_for_clean() -> None:

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -792,13 +792,15 @@ def status() -> None:
             table.add_row(
                 "Index Backlog",
                 f"[yellow]{backlog} captures not searchable yet[/yellow] "
-                "(run `persome rebuild-captures-index --merge`)",
+                "(stop Runtime, rebuild with `persome rebuild-captures-index --merge`, "
+                "then start Runtime)",
             )
         if orphaned:
             table.add_row(
                 "Index Orphans",
                 f"[yellow]{orphaned} index rows have no capture file[/yellow] "
-                "(run `persome rebuild-captures-index --merge`)",
+                "(stop Runtime, rebuild with `persome rebuild-captures-index --merge`, "
+                "then start Runtime)",
             )
         snap = health_report.get("snapshot") or {}
         if snap.get("last_ok") is False:

--- a/src/persome/index_health.py
+++ b/src/persome/index_health.py
@@ -301,7 +301,10 @@ def build_report(cfg: Config) -> dict[str, Any]:
                 "restart the daemon so startup integrity can quarantine/recover the index"
             )
         if index_drift > cfg.index_health.backlog_warn_threshold or index_failure_broken:
-            actions.append("run `persome rebuild-captures-index --merge`")
+            actions.append(
+                "run `persome stop`, then `persome rebuild-captures-index --merge`, "
+                "then `persome start`"
+            )
         if recent_queue_drop:
             actions.append(
                 "check daemon load and capture-queue warnings; dropped triggers cannot replay"
@@ -403,7 +406,6 @@ async def run_index_health_tick(cfg: Config) -> None:
     logger.info("index-health tick loop started (every %ds)", interval)
     while True:
         try:
-            await asyncio.sleep(interval)
             started = time.monotonic()
             report = await asyncio.to_thread(check_once, cfg)
             elapsed_ms = (time.monotonic() - started) * 1000
@@ -416,3 +418,4 @@ async def run_index_health_tick(cfg: Config) -> None:
             raise
         except Exception as exc:  # noqa: BLE001 - the health loop must outlive one bad pass
             logger.error("index-health tick failed: %s", exc, exc_info=True)
+        await asyncio.sleep(interval)

--- a/src/persome/mcp/captures.py
+++ b/src/persome/mcp/captures.py
@@ -333,8 +333,9 @@ def search_captures(
             raise RuntimeError(
                 "captures index unavailable (database/FTS corruption: "
                 f"{exc}); the raw-capture evidence layer is degraded and results "
-                "would be incomplete. Check `persome status`, then rebuild with "
-                "`persome rebuild-captures-index --merge`."
+                "would be incomplete. Check `persome status`, stop the Runtime, "
+                "rebuild with `persome rebuild-captures-index --merge`, then start "
+                "the Runtime again."
             ) from exc
         raise
     out: list[dict[str, Any]] = []

--- a/src/persome/onboarding.py
+++ b/src/persome/onboarding.py
@@ -590,6 +590,27 @@ def _health_payload(host: str, port: int) -> dict[str, str] | None:
     return {str(key): str(value) for key, value in data.items()}
 
 
+def _runtime_components_ready(payload: dict[str, str] | None) -> bool:
+    """Accept aggregate degradation only when the core Runtime remains ready.
+
+    ``/health.status`` also reflects repairable search drift and optional
+    snapshot failures. Those states should remain visible to the owner, but
+    must not prevent an update from installing the code that can repair them.
+    OCR policy/worker state and macOS permissions are gated separately below.
+    """
+
+    if payload is None:
+        return False
+    status = payload.get("status")
+    if status == "ok":
+        return True
+    return bool(
+        status == "degraded"
+        and payload.get("index") == "ok"
+        and payload.get("capture_pipeline") == "ok"
+    )
+
+
 def _runtime_permissions(host: str, port: int) -> dict[str, str] | None:
     """Read live probes for the Runtime and its configured native helpers."""
     import httpx
@@ -935,10 +956,7 @@ def ensure_runtime(
             )
             worker = payload.get("ocr_worker") if payload is not None else None
             ocr_state = payload.get("ocr") if payload is not None else None
-            status_ready = bool(
-                payload is not None
-                and payload.get("status") in ({"ok"} if require_ocr else {"ok", "degraded"})
-            )
+            status_ready = _runtime_components_ready(payload)
         else:
             state = _runtime_state(pid, minimum_updated_at=proof_started_at)
             permissions_payload = state.get("permissions") if state is not None else None
@@ -1157,9 +1175,8 @@ def ensure_runtime(
         raise OnboardingError("the Runtime process changed after the capture proof")
     if http_enabled:
         final_payload = _health_payload(cfg.mcp.host, cfg.mcp.port)
-        if final_payload is None or (
-            require_ocr
-            and (final_payload.get("status") != "ok" or final_payload.get("ocr_worker") != "ready")
+        if not _runtime_components_ready(final_payload) or (
+            require_ocr and final_payload.get("ocr_worker") != "ready"
         ):
             raise OnboardingError("the daemon lost health after the capture smoke test")
         if (

--- a/tests/test_cli_capture_rebuild.py
+++ b/tests/test_cli_capture_rebuild.py
@@ -66,6 +66,67 @@ def test_rebuild_captures_merge_preserves_snapshot_rows_and_upserts_buffer(ac_ro
     assert [hit.id for hit in fresh_hits] == ["buffer-new"]
 
 
+def test_rebuild_captures_merge_only_writes_missing_or_changed_rows(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def write_capture(capture_id: str, visible_text: str) -> None:
+        (paths.capture_buffer_dir() / f"{capture_id}.json").write_text(
+            json.dumps(
+                {
+                    "timestamp": "2026-07-12T00:00:00+00:00",
+                    "window_meta": {
+                        "app_name": "Browser",
+                        "bundle_id": "com.persome.browser",
+                        "title": "Retained capture",
+                    },
+                    "focused_element": {"role": "AXTextField", "value": "fresh"},
+                    "visible_text": visible_text,
+                    "url": "https://example.test/fresh",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    write_capture("identical", "same retained evidence")
+    write_capture("changed", "new retained evidence")
+    write_capture("missing", "missing retained evidence")
+    with fts.cursor() as conn:
+        for capture_id, visible_text in (
+            ("identical", "same retained evidence"),
+            ("changed", "old retained evidence"),
+        ):
+            fts.insert_capture(
+                conn,
+                id=capture_id,
+                timestamp="2026-07-12T00:00:00+00:00",
+                app_name="Browser",
+                bundle_id="com.persome.browser",
+                window_title="Retained capture",
+                focused_role="AXTextField",
+                focused_value="fresh",
+                visible_text=visible_text,
+                url="https://example.test/fresh",
+            )
+
+    original_insert = fts.insert_capture
+    written_ids: list[str] = []
+
+    def tracking_insert(conn, **kwargs):
+        written_ids.append(kwargs["id"])
+        return original_insert(conn, **kwargs)
+
+    monkeypatch.setattr(fts, "insert_capture", tracking_insert)
+    result = CliRunner().invoke(cli.app, ["rebuild-captures-index", "--merge"])
+
+    assert result.exit_code == 0, result.output
+    assert "3 indexed (1 inserted, 1 updated, 1 unchanged)" in result.output
+    assert written_ids == ["changed", "missing"]
+    with fts.cursor() as conn:
+        assert fts.search_captures(conn, query="old") == []
+        assert [hit.id for hit in fts.search_captures(conn, query="new")] == ["changed"]
+        assert [hit.id for hit in fts.search_captures(conn, query="missing")] == ["missing"]
+
+
 def test_rebuild_captures_default_remains_exact_buffer_reconciliation(ac_root: Path) -> None:
     _seed_snapshot_only_capture()
     _write_buffer_capture()
@@ -74,21 +135,47 @@ def test_rebuild_captures_default_remains_exact_buffer_reconciliation(ac_root: P
 
     assert result.exit_code == 0, result.output
     assert "Captures index rebuilt" in result.output
+    assert "1 indexed (1 inserted, 0 updated, 0 unchanged)" in result.output
     with fts.cursor() as conn:
         ids = {row[0] for row in conn.execute("SELECT id FROM captures").fetchall()}
     assert ids == {"buffer-new"}
 
 
-def test_rebuild_captures_indexes_inside_explicit_transaction(
+@pytest.mark.parametrize(("pid", "lock_held"), [(4242, False), (None, True)])
+def test_rebuild_captures_refuses_a_running_or_ambiguous_runtime_before_init(
+    ac_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    pid: int | None,
+    lock_held: bool,
+) -> None:
+    monkeypatch.setattr(cli, "_read_pid", lambda: pid)
+    monkeypatch.setattr(cli, "_daemon_lock_is_held", lambda: lock_held)
+    monkeypatch.setattr(
+        cli,
+        "_init",
+        lambda *args, **kwargs: pytest.fail("runtime refusal must happen before DB initialization"),
+    )
+
+    result = CliRunner().invoke(cli.app, ["rebuild-captures-index", "--merge"])
+
+    assert result.exit_code == 1
+    output = " ".join(result.output.split())
+    assert "Refusing to rebuild the capture index" in output
+    assert "persome stop" in output
+
+
+def test_rebuild_captures_indexes_inside_exclusive_transaction(
     ac_root: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _write_buffer_capture()
     original_insert = fts.insert_capture
     transaction_states: list[bool] = []
+    maintenance_states: list[bool] = []
 
     def tracking_insert(conn, **kwargs):
         transaction_states.append(conn.in_transaction)
+        maintenance_states.append(fts._in_exclusive_maintenance())  # noqa: SLF001
         return original_insert(conn, **kwargs)
 
     monkeypatch.setattr(fts, "insert_capture", tracking_insert)
@@ -97,6 +184,7 @@ def test_rebuild_captures_indexes_inside_explicit_transaction(
 
     assert result.exit_code == 0, result.output
     assert transaction_states == [True]
+    assert maintenance_states == [True]
 
 
 def test_rebuild_captures_interrupt_rolls_back_exact_reconciliation(
@@ -231,6 +319,56 @@ def test_rebuild_captures_preserves_db_only_ocr_backfill(ac_root: Path) -> None:
         row = conn.execute("SELECT visible_text FROM captures WHERE id='ocr-only'").fetchone()
     assert row is not None
     assert row["visible_text"] == "recognized OCR body"
+
+
+def test_rebuild_captures_merge_skips_identical_db_only_ocr_backfill(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = paths.capture_buffer_dir() / "ocr-only.json"
+    target.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-07-12T00:01:00+00:00",
+                "window_meta": {
+                    "app_name": "WeChat",
+                    "bundle_id": "com.tencent.xinWeChat",
+                    "title": "Conversation",
+                },
+                "focused_element": {},
+                "visible_text": "",
+                "ocr_submitted": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    with fts.cursor() as conn:
+        fts.insert_capture(
+            conn,
+            id=target.stem,
+            timestamp="2026-07-12T00:01:00+00:00",
+            app_name="WeChat",
+            bundle_id="com.tencent.xinWeChat",
+            window_title="Conversation",
+            focused_role="",
+            focused_value="",
+            visible_text="recognized OCR body",
+            url="",
+        )
+
+    monkeypatch.setattr(
+        fts,
+        "insert_capture",
+        lambda *args, **kwargs: pytest.fail("identical OCR projection must not be rewritten"),
+    )
+    result = CliRunner().invoke(cli.app, ["rebuild-captures-index", "--merge"])
+
+    assert result.exit_code == 0, result.output
+    assert "1 indexed (0 inserted, 0 updated, 1 unchanged)" in result.output
+    with fts.cursor() as conn:
+        row = conn.execute("SELECT visible_text FROM captures WHERE id='ocr-only'").fetchone()
+        hits = fts.search_captures(conn, query="recognized")
+    assert row is not None and row["visible_text"] == "recognized OCR body"
+    assert [hit.id for hit in hits] == ["ocr-only"]
 
 
 def test_rebuild_captures_filters_placeholder_from_db_only_ocr_backfill(

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -254,6 +254,38 @@ def test_status_renders_new_fields(ac_root: Path) -> None:
     assert "Accessibility" in result.output
 
 
+def test_status_capture_rebuild_guidance_uses_offline_sequence(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PERSOME_LLM_MOCK", "1")
+    paths.index_health_file().write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "generated_at": datetime.now().astimezone().isoformat(),
+                "status": "degraded",
+                "index": {"status": "ok", "problems": []},
+                "capture": {"state": "idle", "detail": None},
+                "backlog": {
+                    "backlog": 2,
+                    "orphaned_index_rows": 1,
+                },
+                "snapshot": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(cli.app, ["status"])
+
+    assert result.exit_code == 0, result.output
+    output = " ".join(result.output.split())
+    assert "Index Backlog" in output
+    assert "Index Orphans" in output
+    assert output.count("stop Runtime") == 2
+    assert output.count("then start Runtime") == 2
+
+
 def test_status_shows_version(ac_root: Path) -> None:
     """Status table includes the installed version string."""
     runner = CliRunner()

--- a/tests/test_index_health.py
+++ b/tests/test_index_health.py
@@ -8,6 +8,7 @@ and read surfaces must degrade explicitly instead of pretending health.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import sqlite3
 from datetime import UTC, datetime, timedelta
@@ -19,6 +20,29 @@ from persome import index_health, paths
 from persome.config import Config
 from persome.mcp import captures as captures_mod
 from persome.store import fts
+
+
+@pytest.mark.asyncio
+async def test_health_tick_publishes_before_its_first_sleep(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checked: list[Config] = []
+    cfg = Config()
+
+    async def cancel_after_check(function, passed_cfg):
+        checked.append(passed_cfg)
+        raise asyncio.CancelledError
+
+    async def unexpected_sleep(seconds: float) -> None:
+        pytest.fail(f"health tick slept for {seconds}s before its first publication")
+
+    monkeypatch.setattr(index_health.asyncio, "to_thread", cancel_after_check)
+    monkeypatch.setattr(index_health.asyncio, "sleep", unexpected_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await index_health.run_index_health_tick(cfg)
+
+    assert checked == [cfg]
 
 
 @pytest.fixture
@@ -94,7 +118,9 @@ def test_unindexed_buffer_backlog_degrades(ac_root: Path, fresh_counters: dict) 
     report = index_health.build_report(cfg)
     assert report["backlog"]["backlog"] == 3
     assert report["status"] == "degraded"
-    assert any("rebuild-captures-index" in a for a in report["recommended_actions"])
+    action = next(a for a in report["recommended_actions"] if "rebuild-captures-index" in a)
+    assert "persome stop" in action
+    assert "persome start" in action
 
 
 def test_orphaned_index_row_does_not_hide_unindexed_capture(
@@ -223,6 +249,8 @@ def test_search_captures_degrades_explicitly_on_corruption(
     message = str(excinfo.value)
     assert "evidence layer is degraded" in message
     assert "rebuild-captures-index" in message
+    assert "stop the Runtime" in message
+    assert "start the Runtime again" in message
 
 
 def test_search_captures_payload_carries_health_note(ac_root: Path) -> None:

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -240,6 +240,81 @@ def test_runtime_proof_requires_health_and_fresh_readable_capture(
     assert proof.capture_path == capture_path
 
 
+def test_runtime_proof_accepts_healthy_components_with_aggregate_degradation(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    capture_path = paths.capture_buffer_dir() / "fresh.json"
+    capture_path.parent.mkdir(parents=True, exist_ok=True)
+    capture_path.write_text(
+        '{"timestamp":"2026-07-12T00:00:00+00:00","visible_text":"ready"}',
+        encoding="utf-8",
+    )
+    health_calls = 0
+
+    def health(host: str, port: int) -> dict[str, str]:
+        nonlocal health_calls
+        health_calls += 1
+        return {
+            "status": "degraded",
+            "ocr": "ready",
+            "ocr_worker": "ready",
+            "index": "ok",
+            "capture_pipeline": "ok",
+        }
+
+    monkeypatch.setattr(onboarding, "_running_daemon_pid", lambda: 4242)
+    monkeypatch.setattr(onboarding, "_health_payload", health)
+    monkeypatch.setattr(
+        onboarding,
+        "_runtime_permissions",
+        lambda host, port: {"accessibility": "granted", "screen_recording": "granted"},
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "_request_runtime_capture",
+        lambda host, port: onboarding.CaptureRequestProof(capture_path, "daemon", "fresh-capture"),
+    )
+
+    proof = onboarding.ensure_runtime(restart=False)
+
+    assert proof.health == "degraded"
+    assert proof.ocr == "ready"
+    assert proof.capture_path == capture_path
+    assert health_calls >= 2
+
+
+@pytest.mark.parametrize(
+    ("index_state", "capture_state"),
+    [("degraded", "ok"), ("ok", "degraded"), ("unknown", "ok")],
+)
+def test_runtime_proof_rejects_degraded_core_components(
+    ac_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    index_state: str,
+    capture_state: str,
+) -> None:
+    monkeypatch.setattr(onboarding, "_running_daemon_pid", lambda: 4242)
+    monkeypatch.setattr(
+        onboarding,
+        "_health_payload",
+        lambda host, port: {
+            "status": "degraded",
+            "ocr": "ready",
+            "ocr_worker": "ready",
+            "index": index_state,
+            "capture_pipeline": capture_state,
+        },
+    )
+    monkeypatch.setattr(
+        onboarding,
+        "_runtime_permissions",
+        lambda host, port: {"accessibility": "granted", "screen_recording": "granted"},
+    )
+
+    with pytest.raises(onboarding.OnboardingError, match="status=degraded"):
+        onboarding.ensure_runtime(restart=False, timeout=0.01)
+
+
 def test_runtime_proof_rejects_degraded_ocr(ac_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(onboarding, "_running_daemon_pid", lambda: 4242)
     monkeypatch.setattr(


### PR DESCRIPTION
## What changed

- allow onboarding/update proof to accept aggregate `degraded` health only when the authoritative index and capture pipeline are both healthy; OCR, worker, permissions, PID, generation, and fresh-capture gates remain strict
- publish index health immediately after Runtime startup instead of waiting one full health interval
- require the Runtime to be stopped before capture-index rebuilds and hold exclusive database maintenance for the complete atomic transaction
- make `--merge` skip byte-identical sanitized projections, preserving DB-only OCR while only inserting missing or updating genuinely changed captures
- update recovery guidance to use the stop/rebuild/start sequence

## Root cause

Onboarding still treated the aggregate `/health.status` as a strict Runtime-readiness signal after that field was broadened to include repairable historical index drift. A retained capture backlog could therefore block the update that contained its own repair path.

The existing merge repair also ran through the ordinary shared database path and issued an UPDATE for every retained capture. Each no-op UPDATE fired the FTS delete/reinsert trigger, creating avoidable WAL/FTS churn. On the affected macOS Runtime this surfaced as a fatal SQLite WAL shared-memory `SIGBUS`, not a catchable SQLite exception.

## Impact

Updates can now complete when the live Runtime is healthy but historical search drift remains. The repair command fails closed while the daemon is active, excludes cooperating database clients, remains rollback-safe, and only rewrites projections that need repair.

## Validation

- `PERSOME_LLM_MOCK=1 uv run pytest -m "not macos and not integration"` — 2136 passed, 17 deselected
- focused onboarding/index-health/capture-rebuild/FTS/OCR tests — 120 passed
- Ruff check and format check
- secret, PII, and language scans
- live source-update proof with OCR ready and a fresh real capture
- offline reconciliation of the affected local index followed by SQLite `quick_check` and `integrity_check`; backlog returned to zero
- independent patch review found no remaining actionable findings
- GitHub CI green on Ubuntu, Apple Silicon macOS, Intel macOS, and package smoke; the Intel job passed on rerun after an unrelated 0.5-second OCR subprocess startup timeout
