### PR TITLE
Fix NUL-padded AX text projection

### DIFF
--- a/docs/capture.md
+++ b/docs/capture.md
@@ -200,6 +200,11 @@ producers. An exact placeholder descendant is removed only inside its owning
 editable subtree and only when its text is locally paired with that control.
 Matching text is then cleared from the parent projection. Ordinary page text
 and broad CSS classes that merely contain the word `placeholder` remain intact.
+The same copy-on-write S1 boundary removes embedded NUL code points from AX
+strings before focused-value and visible-text limits are applied. This repairs
+iTerm2-style NUL padding around CJK text without rewriting the diagnostic raw
+`ax_tree`; `focused_element.value`, its length metadata, and AX-derived
+`visible_text` are projected from the normalized copy.
 Historical timeline, MCP, and classifier chat-drill reads plus
 `rebuild-captures-index` apply the same sanitizer, so replaying an old buffer
 cannot turn input hints into authored text; index rebuilds also preserve DB-only

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -36,8 +36,8 @@ Only closed windows are produced. The current half-formed window sits as "traili
 
 `timeline/aggregator.py` reads each capture's S1 fields (`focused_element`, `visible_text`, `url`, `window_meta`) — **not** the raw AX tree during normal operation. This keeps the prompt tractable:
 
-- `visible_text` is a pre-rendered, length-capped markdown view of the AX tree (capped at 10 KB per capture by S1, then capped at 4 KB per capture by the timeline prompt).
-- `focused_element` carries the user's current cursor / input context (role, title, value, editable flag). Before this boundary, S1 removes standard AX placeholders and locally matched Chromium `.placeholder` descendants. Therefore, when `is_editable=true` and `value_length > 0`, the remaining value is user-authored content and the prompt treats it as the highest-priority signal to preserve verbatim.
+- `visible_text` is a pre-rendered, length-capped markdown view of the AX tree (capped at 10 KB per capture by S1, then capped at 4 KB per capture by the timeline prompt). S1 removes embedded AX NUL code points before applying that budget, preserving contiguous CJK terms for prompts and FTS.
+- `focused_element` carries the user's current cursor / input context (role, title, value, editable flag). Before this boundary, S1 removes embedded AX NULs, standard AX placeholders, and locally matched Chromium `.placeholder` descendants, then calculates `value_length`. Therefore, when `is_editable=true` and `value_length > 0`, the remaining value is user-authored content and the prompt treats it as the highest-priority signal to preserve verbatim.
 - `url` is regex-extracted from visible text when present.
 - When capture JSON has no AX text and `ocr_submitted=true`, the aggregator
   consults the OCR backfill in `captures` FTS before declaring the window empty.

--- a/src/persome/capture/s1_parser.py
+++ b/src/persome/capture/s1_parser.py
@@ -45,6 +45,70 @@ _CMUX_TERMINAL_MARKER = "### [cmux terminal]"
 _OCR_PLACEHOLDER_VALUES = "_persome_ocr_placeholder_values"
 
 
+def _without_embedded_nuls(value: Any) -> Any:
+    """Return a copy-on-write JSON value with embedded NUL code points removed.
+
+    Some custom AX implementations (notably iTerm2's terminal text area) expose
+    CJK values with ``\0`` padding.  Keep the persisted/raw AX tree intact for
+    diagnostics, but never let those separators enter the S1 text projection.
+    """
+    if isinstance(value, str):
+        return value if "\0" not in value else value.replace("\0", "")
+    if isinstance(value, list):
+        clean: list[Any] | None = None
+        for index, item in enumerate(value):
+            normalized = _without_embedded_nuls(item)
+            if normalized is item:
+                continue
+            if clean is None:
+                clean = list(value)
+            clean[index] = normalized
+        return value if clean is None else clean
+    if isinstance(value, dict):
+        clean_dict: dict[Any, Any] | None = None
+        for key, item in value.items():
+            normalized = _without_embedded_nuls(item)
+            if normalized is item:
+                continue
+            if clean_dict is None:
+                clean_dict = dict(value)
+            clean_dict[key] = normalized
+        return value if clean_dict is None else clean_dict
+    return value
+
+
+def _sanitize_s1_projection(capture: dict[str, Any]) -> dict[str, Any]:
+    """Remove NULs from stored S1 fields without touching forensic ``ax_tree``."""
+    clean = capture
+    focused = capture.get("focused_element")
+    if isinstance(focused, dict):
+        clean_focused = focused
+        for field in ("role", "title", "value"):
+            value = focused.get(field)
+            normalized = _without_embedded_nuls(value)
+            if normalized is value:
+                continue
+            if clean_focused is focused:
+                clean_focused = dict(focused)
+            clean_focused[field] = normalized
+        if clean_focused is not focused:
+            value = str(clean_focused.get("value") or "").strip()
+            clean_focused["has_value"] = bool(value)
+            clean_focused["value_length"] = len(value)
+            clean = dict(capture)
+            clean["focused_element"] = clean_focused
+
+    for field in ("visible_text", "url"):
+        value = clean.get(field)
+        normalized = _without_embedded_nuls(value)
+        if normalized is value:
+            continue
+        if clean is capture:
+            clean = dict(capture)
+        clean[field] = normalized
+    return clean
+
+
 @dataclass
 class FocusedElement:
     role: str = ""
@@ -71,11 +135,13 @@ def enrich(capture: dict[str, Any]) -> None:
     if not isinstance(ax_tree, dict):
         return
 
-    clean_ax_tree = placeholder.sanitize_ax_tree(ax_tree)
-    original_app = _frontmost_app(ax_tree)
+    projected_ax_tree = _without_embedded_nuls(ax_tree)
+    clean_ax_tree = placeholder.sanitize_ax_tree(projected_ax_tree)
+    original_app = _frontmost_app(projected_ax_tree)
     trigger = capture.get("trigger")
     if isinstance(trigger, dict):
-        clean_trigger = placeholder.sanitize_trigger(original_app or {}, trigger)
+        projected_trigger = _without_embedded_nuls(trigger)
+        clean_trigger = placeholder.sanitize_trigger(original_app or {}, projected_trigger)
         if clean_trigger is not trigger:
             capture["trigger"] = clean_trigger
     app_data = _frontmost_app(clean_ax_tree)
@@ -116,13 +182,21 @@ def sanitize_capture(capture: dict[str, Any], *, replace_ax_tree: bool = False) 
     """
     ax_tree = capture.get("ax_tree")
     ocr_values = ocr_placeholder_values(capture) if replace_ax_tree else ()
-    clean_ax_tree = placeholder.sanitize_ax_tree(ax_tree) if isinstance(ax_tree, dict) else ax_tree
-    original_app = _frontmost_app(ax_tree) if isinstance(ax_tree, dict) else None
+    projected_ax_tree = _without_embedded_nuls(ax_tree) if isinstance(ax_tree, dict) else ax_tree
+    clean_ax_tree = (
+        placeholder.sanitize_ax_tree(projected_ax_tree)
+        if isinstance(projected_ax_tree, dict)
+        else projected_ax_tree
+    )
+    original_app = (
+        _frontmost_app(projected_ax_tree) if isinstance(projected_ax_tree, dict) else None
+    )
     trigger = capture.get("trigger")
+    projected_trigger = _without_embedded_nuls(trigger) if isinstance(trigger, dict) else trigger
     clean_trigger = (
-        placeholder.sanitize_trigger(original_app or {}, trigger)
-        if isinstance(trigger, dict)
-        else trigger
+        placeholder.sanitize_trigger(original_app or {}, projected_trigger)
+        if isinstance(projected_trigger, dict)
+        else projected_trigger
     )
     projection_changed = clean_ax_tree is not ax_tree
     trigger_changed = clean_trigger is not trigger
@@ -130,7 +204,7 @@ def sanitize_capture(capture: dict[str, Any], *, replace_ax_tree: bool = False) 
         replace_ax_tree and bool(ocr_values) and ocr_values != capture.get(_OCR_PLACEHOLDER_VALUES)
     )
     if not projection_changed and not trigger_changed and not cache_changed:
-        return capture
+        return _sanitize_s1_projection(capture)
     clean = dict(capture)
     if replace_ax_tree and projection_changed:
         clean["ax_tree"] = clean_ax_tree
@@ -139,7 +213,7 @@ def sanitize_capture(capture: dict[str, Any], *, replace_ax_tree: bool = False) 
     if trigger_changed:
         clean["trigger"] = clean_trigger
     if not projection_changed:
-        return clean
+        return _sanitize_s1_projection(clean)
     app_data = _frontmost_app(clean_ax_tree)
     if app_data is None:
         clean["focused_element"] = FocusedElement().to_dict()
@@ -147,9 +221,8 @@ def sanitize_capture(capture: dict[str, Any], *, replace_ax_tree: bool = False) 
         clean["url"] = None
         return clean
     clean["focused_element"] = _extract_focused_element(app_data).to_dict()
-    preserve_ocr_sentinel = bool(capture.get("ocr_submitted")) and not str(
-        capture.get("visible_text") or ""
-    )
+    prior_visible = str(_without_embedded_nuls(capture.get("visible_text") or ""))
+    preserve_ocr_sentinel = bool(capture.get("ocr_submitted")) and not prior_visible
     visible_text = (
         ""
         if preserve_ocr_sentinel
@@ -166,7 +239,7 @@ def sanitize_capture(capture: dict[str, Any], *, replace_ax_tree: bool = False) 
             visible_text = f"{visible_text.rstrip()}\n\n{suffix}" if visible_text else suffix
     clean["visible_text"] = visible_text
     clean["url"] = _extract_url(app_data)
-    return clean
+    return _sanitize_s1_projection(clean)
 
 
 def _frontmost_app(ax_tree: dict[str, Any]) -> dict[str, Any] | None:
@@ -328,6 +401,9 @@ def _render_visible_text(app_data: dict[str, Any], bundle: str = "") -> str:
         md = generic_render.resolve_app(app_data)
     if md is None:
         md = ax_app_to_markdown(app_data)
+    # Normalize before applying the S1 budget. Otherwise iTerm2's NUL padding
+    # consumes the limit and can split CJK terms in the downstream FTS index.
+    md = str(_without_embedded_nuls(md))
     if len(md) > _VISIBLE_TEXT_MAX:
         md = md[:_VISIBLE_TEXT_MAX] + "\n...(truncated)"
     return md

--- a/tests/test_cli_capture_rebuild.py
+++ b/tests/test_cli_capture_rebuild.py
@@ -280,6 +280,66 @@ def test_rebuild_captures_sanitizes_historical_placeholder_projection(ac_root: P
     assert phrase not in row["visible_text"]
 
 
+def test_rebuild_captures_normalizes_historical_iterm_nuls(ac_root: Path) -> None:
+    malformed = "\0\u6d4b\0\u8bd5\0\u4e00\0\u4e0b\0:persome"
+    target = paths.capture_buffer_dir() / "iterm-nul-old.json"
+    target.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-07-17T15:00:00+00:00",
+                "window_meta": {
+                    "app_name": "iTerm2",
+                    "bundle_id": "com.googlecode.iterm2",
+                    "title": "shell",
+                },
+                "focused_element": {
+                    "role": "AXTextArea",
+                    "value": malformed,
+                    "is_editable": True,
+                    "value_length": len(malformed),
+                },
+                "visible_text": f"[TextArea] {malformed}",
+                "ax_tree": {
+                    "apps": [
+                        {
+                            "name": "iTerm2",
+                            "bundle_id": "com.googlecode.iterm2",
+                            "is_frontmost": True,
+                            "focused_element": {
+                                "role": "AXTextArea",
+                                "value": malformed,
+                                "is_editable": True,
+                            },
+                            "windows": [
+                                {
+                                    "title": "shell",
+                                    "focused": True,
+                                    "elements": [{"role": "AXTextArea", "value": malformed}],
+                                }
+                            ],
+                        }
+                    ]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(cli.app, ["rebuild-captures-index"])
+
+    assert result.exit_code == 0, result.output
+    with fts.cursor() as conn:
+        row = conn.execute(
+            "SELECT focused_value, visible_text FROM captures WHERE id='iterm-nul-old'"
+        ).fetchone()
+        hits = fts.search_captures(conn, query="\u6d4b\u8bd5\u4e00\u4e0b")
+    assert row is not None
+    assert row["focused_value"] == "\u6d4b\u8bd5\u4e00\u4e0b:persome"
+    assert "\u6d4b\u8bd5\u4e00\u4e0b:persome" in row["visible_text"]
+    assert "\0" not in row["visible_text"]
+    assert [hit.id for hit in hits] == ["iterm-nul-old"]
+
+
 def test_rebuild_captures_preserves_db_only_ocr_backfill(ac_root: Path) -> None:
     target = paths.capture_buffer_dir() / "ocr-only.json"
     target.write_text(

--- a/tests/test_s1_parser.py
+++ b/tests/test_s1_parser.py
@@ -9,11 +9,70 @@ def _ax_tree(*apps: dict) -> dict:
     return {"apps": list(apps), "timestamp": "2026-04-21T10:00:00+08:00"}
 
 
+def _iterm_capture(value: str, *, helper_focus: bool) -> dict:
+    element = {"role": "AXTextArea", "value": value}
+    app = {
+        "name": "iTerm2",
+        "bundle_id": "com.googlecode.iterm2",
+        "is_frontmost": True,
+        "windows": [
+            {
+                "title": "shell",
+                "focused": True,
+                "elements": [element],
+            }
+        ],
+    }
+    if helper_focus:
+        app["focused_element"] = {
+            "role": "AXTextArea",
+            "value": value,
+            "is_editable": True,
+        }
+    return {"ax_tree": _ax_tree(app)}
+
+
 def test_enrich_noop_without_ax_tree() -> None:
     capture = {"timestamp": "x", "window_meta": {"app_name": "A"}}
     s1_parser.enrich(capture)
     assert "focused_element" not in capture
     assert "visible_text" not in capture
+
+
+def test_enrich_removes_iterm_nuls_from_helper_focus_and_visible_text() -> None:
+    malformed = "\0\0\u6d4b\0\u8bd5\0\u4e00\0\u4e0b\0:persome\0\u7684\0current_context"
+    capture = _iterm_capture(malformed, helper_focus=True)
+    raw_ax = copy.deepcopy(capture["ax_tree"])
+
+    s1_parser.enrich(capture)
+
+    expected = "\u6d4b\u8bd5\u4e00\u4e0b:persome\u7684current_context"
+    assert capture["focused_element"]["value"] == expected
+    assert capture["focused_element"]["value_length"] == len(expected)
+    assert expected in capture["visible_text"]
+    assert "\0" not in capture["visible_text"]
+    assert capture["ax_tree"] == raw_ax
+
+
+def test_enrich_removes_iterm_nuls_from_legacy_focused_window_scan() -> None:
+    malformed = "\u6d4b\0\u8bd5\0\u4e00\0\u4e0b"
+    capture = _iterm_capture(malformed, helper_focus=False)
+
+    s1_parser.enrich(capture)
+
+    assert capture["focused_element"]["value"] == "\u6d4b\u8bd5\u4e00\u4e0b"
+    assert capture["focused_element"]["value_length"] == 4
+    assert "\u6d4b\u8bd5\u4e00\u4e0b" in capture["visible_text"]
+    assert "\0" not in capture["visible_text"]
+
+
+def test_enrich_removes_nuls_before_focused_value_limit() -> None:
+    capture = _iterm_capture("\0\u4e2d" * 2_500, helper_focus=True)
+
+    s1_parser.enrich(capture)
+
+    assert capture["focused_element"]["value"] == "\u4e2d" * 2_000
+    assert capture["focused_element"]["value_length"] == 2_000
 
 
 def test_enrich_picks_frontmost_app() -> None:
@@ -620,6 +679,67 @@ def test_sanitize_capture_repairs_historical_s1_projection() -> None:
     assert clean["focused_element"]["value"] == ""
     assert _COMPOSER_PLACEHOLDER not in clean["visible_text"]
     assert capture["focused_element"]["value"] == _COMPOSER_PLACEHOLDER
+
+
+def test_sanitize_capture_reprojects_historical_iterm_nuls_copy_on_write() -> None:
+    malformed = "\0\u6d4b\0\u8bd5\0\u4e00\0\u4e0b\0"
+    capture = _iterm_capture(malformed, helper_focus=True)
+    capture["focused_element"] = {
+        "role": "AXTextArea",
+        "value": malformed,
+        "is_editable": True,
+        "has_value": True,
+        "value_length": len(malformed),
+    }
+    capture["visible_text"] = f"[TextArea] {malformed}"
+    raw_ax = capture["ax_tree"]
+
+    clean = s1_parser.sanitize_capture(capture)
+
+    assert clean is not capture
+    assert clean["focused_element"]["value"] == "\u6d4b\u8bd5\u4e00\u4e0b"
+    assert clean["focused_element"]["value_length"] == 4
+    assert "\u6d4b\u8bd5\u4e00\u4e0b" in clean["visible_text"]
+    assert "\0" not in clean["visible_text"]
+    assert clean["ax_tree"] is raw_ax
+    assert "\0" in capture["focused_element"]["value"]
+    assert "\0" in raw_ax["apps"][0]["focused_element"]["value"]
+
+
+def test_sanitize_capture_replace_ax_tree_removes_iterm_nuls_for_legacy_replay() -> None:
+    capture = _iterm_capture("\u6d4b\0\u8bd5\0\u4e00\0\u4e0b", helper_focus=False)
+    raw_ax = capture["ax_tree"]
+
+    clean = s1_parser.sanitize_capture(capture, replace_ax_tree=True)
+
+    clean_element = clean["ax_tree"]["apps"][0]["windows"][0]["elements"][0]
+    assert clean_element["value"] == "\u6d4b\u8bd5\u4e00\u4e0b"
+    assert "\0" not in clean["visible_text"]
+    assert clean["focused_element"]["value"] == "\u6d4b\u8bd5\u4e00\u4e0b"
+    assert clean["ax_tree"] is not raw_ax
+    assert raw_ax["apps"][0]["windows"][0]["elements"][0]["value"] == (
+        "\u6d4b\0\u8bd5\0\u4e00\0\u4e0b"
+    )
+
+
+def test_sanitize_capture_removes_nuls_without_ax_tree() -> None:
+    capture = {
+        "focused_element": {
+            "role": "AXTextArea",
+            "value": "\u6d4b\0\u8bd5",
+            "has_value": True,
+            "value_length": 3,
+        },
+        "visible_text": "\u6d4b\0\u8bd5",
+    }
+
+    clean = s1_parser.sanitize_capture(capture)
+
+    assert clean is not capture
+    assert clean["focused_element"]["value"] == "\u6d4b\u8bd5"
+    assert clean["focused_element"]["value_length"] == 2
+    assert clean["visible_text"] == "\u6d4b\u8bd5"
+    assert capture["focused_element"]["value"] == "\u6d4b\0\u8bd5"
 
 
 def test_enrich_filters_matching_placeholder_title_and_description() -> None:

--- a/tests/test_timeline_blocks.py
+++ b/tests/test_timeline_blocks.py
@@ -643,6 +643,43 @@ def test_format_events_replays_placeholder_capture_without_authored_text() -> No
     assert loc is None or loc.rung != "editing"
 
 
+def test_format_events_normalizes_iterm_nuls_for_pre_v2_ax_fallback() -> None:
+    ts = datetime(2026, 7, 17, 23, 0, tzinfo=_TZ)
+    malformed = "\u6d4b\0\u8bd5\0\u4e00\0\u4e0b"
+    data = {
+        "timestamp": ts.isoformat(),
+        "window_meta": {
+            "app_name": "iTerm2",
+            "title": "shell",
+            "bundle_id": "com.googlecode.iterm2",
+        },
+        "ax_tree": {
+            "apps": [
+                {
+                    "name": "iTerm2",
+                    "bundle_id": "com.googlecode.iterm2",
+                    "is_frontmost": True,
+                    "windows": [
+                        {
+                            "title": "shell",
+                            "focused": True,
+                            "elements": [{"role": "AXTextArea", "value": malformed}],
+                        }
+                    ],
+                }
+            ]
+        },
+    }
+
+    events_text, _apps, _loc = aggregator._format_events(
+        [(Path(f"{_stem(ts)}.json"), data)], locus_enabled=False
+    )
+
+    assert "\u6d4b\u8bd5\u4e00\u4e0b" in events_text
+    assert "\0" not in events_text
+    assert data["ax_tree"]["apps"][0]["windows"][0]["elements"][0]["value"] == malformed
+
+
 def test_produce_block_replays_placeholder_without_focus_evidence(ac_root: Path, fake_llm) -> None:
     phrase = "Ask for follow-up changes"
     start = datetime(2026, 7, 12, 23, 10, tzinfo=_TZ)


### PR DESCRIPTION
## Summary

- normalize embedded NUL code points from AX-derived S1 text before focused-value and visible-text limits
- preserve the raw AX tree by using copy-on-write projection cleanup, while making historical replay and pre-v2 fallback NUL-free
- repair capture-index rebuild output so contiguous CJK terms retain their FTS5 token boundaries
- document the S1 normalization boundary

## Root cause

The Python replay sanitizer only rebuilt the S1 projection when placeholder cleanup changed the AX tree. iTerm2 AXTextArea values containing NUL padding around CJK text therefore flowed into `focused_element.value`, `visible_text`, and FTS5 unchanged. The NUL bytes also consumed projection limits and split contiguous CJK terms during tokenization.

## Validation

- `PERSOME_LLM_MOCK=1 uv run pytest -m "not macos and not integration" -q` (2160 passed, 17 deselected)
- `uv run pytest tests/test_s1_parser.py tests/test_capture_scheduler_fts.py tests/test_cli_capture_rebuild.py tests/test_timeline_blocks.py -q` (94 passed)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python scripts/secret_scan.py`
- `uv run python scripts/pii_scan.py`
- `uv run python scripts/language_scan.py`

Fixes #90
