### PR TITLE
docs: add README demo video

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Persome: Build your Personal Model
 
+<p align="center">
+  <a href="https://github.com/Intuition-Lab/personal-model/releases/download/v0.3.2/demo.mp4"><strong>▶ Watch the Personal Model demo</strong></a>
+</p>
+
 <!-- mcp-name: io.github.Intuition-Lab/personal-model -->
 
 **The open-source Personal Model that makes every AI yours.**


### PR DESCRIPTION
## What

- Add a prominent demo-video link at the top of the README.
- Point it to the full-quality `demo.mp4` hosted as a v0.3.2 release asset.

## Why

Give repository visitors immediate access to the Personal Model product demo.

## How verified

- Confirmed the release asset is 62.1 MB.
- Confirmed its SHA-256 matches the provided local video: `c15ac6704926ead3e96114be137d1af762a56bb9fd490540f513e5d85b6e8b6c`.
- Confirmed the README change is limited to the new link at the top.
- No code changed; automated tests were not run.

---

- [x] Commits are signed off (`git commit -s`) — DCO required, see CONTRIBUTING.md
- [x] No real names / emails / tokens in code or test fixtures (synthetic data only)
- [ ] Secret scan passes (`scripts/secret_scan.py`) — not run; documentation-only change
- [x] Human-authored repository text is English (`scripts/language_scan.py` passes)