### PR TITLE
feat(cli): add safe Cursor MCP registration

### DIFF
--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -76,7 +76,21 @@ The installer writes a local entry with `type: "local"` and command
 writes new JSON configs with owner-only permissions. Remove it with `persome
 uninstall opencode`.
 
-## Cursor and generic clients
+## Cursor
+
+Register Persome in the current project by default:
+
+```bash
+persome install cursor
+```
+
+This writes `.cursor/mcp.json`. Use `--scope user` to write `~/.cursor/mcp.json` instead. Cursor's
+project configuration takes precedence when both scopes define the same server name, so install in
+only one scope unless an intentional project override is needed. Both modes preserve unrelated
+keys and MCP servers and write an absolute Persome executable path. Remove the matching entry with
+`persome uninstall cursor` or `persome uninstall cursor --scope user`.
+
+## Generic clients
 
 Generate a config without touching an existing file:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -323,6 +323,8 @@ Remove MCP client entries while the CLI still exists:
 ```bash
 persome uninstall claude-code
 persome uninstall codex
+persome uninstall cursor                 # project .cursor/mcp.json
+persome uninstall cursor --scope user    # ~/.cursor/mcp.json
 persome uninstall claude-desktop
 persome uninstall opencode
 ```

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -2746,6 +2746,51 @@ def _cursor_agent_config_path() -> Path:
     return Path.home() / ".cursor" / "mcp.json"
 
 
+def _cursor_config_path(scope: str) -> Path:
+    normalized = scope.strip().lower()
+    if normalized == "project":
+        return Path.cwd() / ".cursor" / "mcp.json"
+    if normalized == "user":
+        return Path.home() / ".cursor" / "mcp.json"
+    console.print("[red]Cursor scope must be `project` or `user`.[/red]")
+    raise typer.Exit(1)
+
+
+@install_app.command("cursor")
+def install_cursor(
+    name: str = typer.Option("persome", help="MCP server name shown to the client."),
+    scope: str = typer.Option(
+        "project", help="Cursor config scope: project (.cursor) | user (~/.cursor)."
+    ),
+) -> None:
+    """Add Persome to Cursor's project or user MCP config.
+
+    Project scope is the default because Cursor gives project configuration
+    precedence over a user entry with the same server name.
+    """
+    _init()
+    cfg_path = _cursor_config_path(scope)
+    data = _load_claude_desktop_config(cfg_path)
+    servers = data.setdefault("mcpServers", {})
+    if not isinstance(servers, dict):
+        console.print(f"[red]`mcpServers` in {cfg_path} is not an object.[/red]")
+        raise typer.Exit(1)
+
+    stdio_command = _stdio_mcp_command()
+    replaced = name in servers
+    servers[name] = {"command": stdio_command[0], "args": stdio_command[1:]}
+    try:
+        _write_private_json(cfg_path, data)
+    except (OSError, RuntimeError) as exc:
+        console.print(f"[red]Could not write {cfg_path}:[/red] {exc}")
+        raise typer.Exit(1) from exc
+
+    verb = "Updated" if replaced else "Registered"
+    console.print(f"[green]{verb} {name!r} in Cursor ({scope} scope).[/green]")
+    console.print(f"  file: {cfg_path}")
+    console.print(f"  command: {' '.join(stdio_command)}")
+
+
 @install_app.command("cursor-agent")
 def install_cursor_agent(
     name: str = typer.Option("persome", help="MCP server name shown to the client."),
@@ -3011,6 +3056,35 @@ def uninstall_codex(
 
     console.print(f"[red]codex mcp remove failed:[/red]\n{result.stderr or result.stdout}")
     raise typer.Exit(result.returncode)
+
+
+@uninstall_app.command("cursor")
+def uninstall_cursor(
+    name: str = typer.Option("persome", help="MCP server name to remove."),
+    scope: str = typer.Option(
+        "project", help="Cursor config scope: project (.cursor) | user (~/.cursor)."
+    ),
+) -> None:
+    """Remove Persome from Cursor without changing unrelated configuration."""
+    cfg_path = _cursor_config_path(scope)
+    if not cfg_path.exists():
+        console.print(f"[yellow]No Cursor config at {cfg_path} — nothing to remove.[/yellow]")
+        return
+
+    data = _load_claude_desktop_config(cfg_path)
+    servers = data.get("mcpServers")
+    if not isinstance(servers, dict) or name not in servers:
+        console.print(f"[yellow]No {name!r} entry in Cursor config — nothing to remove.[/yellow]")
+        return
+
+    del servers[name]
+    try:
+        _write_private_json(cfg_path, data)
+    except (OSError, RuntimeError) as exc:
+        console.print(f"[red]Could not write {cfg_path}:[/red] {exc}")
+        raise typer.Exit(1) from exc
+
+    console.print(f"[green]Removed {name!r} from Cursor ({scope} scope).[/green]")
 
 
 @uninstall_app.command("opencode")

--- a/tests/test_cli_local_access.py
+++ b/tests/test_cli_local_access.py
@@ -473,6 +473,68 @@ def test_opencode_installer_writes_private_local_stdio_config(
     assert _mode(config_path) == 0o600
 
 
+def test_cursor_installer_defaults_to_project_and_preserves_config(
+    ac_root: Path, tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / ".cursor" / "mcp.json"
+    config_path.parent.mkdir()
+    config_path.write_text(
+        json.dumps({"theme": "dark", "mcpServers": {"keep": {"command": "keep"}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(cli, "_stdio_mcp_command", lambda: ["/opt/persome", "mcp"])
+
+    first = CliRunner().invoke(cli.app, ["install", "cursor"])
+    second = CliRunner().invoke(cli.app, ["install", "cursor"])
+
+    assert first.exit_code == 0, first.output
+    assert second.exit_code == 0, second.output
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert data["theme"] == "dark"
+    assert data["mcpServers"]["keep"] == {"command": "keep"}
+    assert data["mcpServers"]["persome"] == {"command": "/opt/persome", "args": ["mcp"]}
+    assert "Updated" in second.output
+    assert _mode(config_path) == 0o600
+
+
+def test_cursor_user_scope_and_uninstall_are_isolated(
+    ac_root: Path, tmp_path: Path, monkeypatch
+) -> None:
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    home.mkdir()
+    project.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.chdir(project)
+    monkeypatch.setattr(cli, "_stdio_mcp_command", lambda: ["/opt/persome", "mcp"])
+
+    installed = CliRunner().invoke(cli.app, ["install", "cursor", "--scope", "user"])
+    removed = CliRunner().invoke(cli.app, ["uninstall", "cursor", "--scope", "user"])
+    removed_again = CliRunner().invoke(cli.app, ["uninstall", "cursor", "--scope", "user"])
+
+    assert installed.exit_code == 0, installed.output
+    assert removed.exit_code == 0, removed.output
+    assert removed_again.exit_code == 0, removed_again.output
+    user_config = home / ".cursor" / "mcp.json"
+    assert "persome" not in json.loads(user_config.read_text(encoding="utf-8"))["mcpServers"]
+    assert not (project / ".cursor" / "mcp.json").exists()
+
+
+def test_cursor_installer_does_not_replace_malformed_config(
+    ac_root: Path, tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / ".cursor" / "mcp.json"
+    config_path.parent.mkdir()
+    config_path.write_text("{not-json", encoding="utf-8")
+
+    result = CliRunner().invoke(cli.app, ["install", "cursor"])
+
+    assert result.exit_code == 1
+    assert config_path.read_text(encoding="utf-8") == "{not-json"
+
+
 def test_http_mcp_json_is_authenticated_private_and_warned(
     ac_root: Path, tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary
- add project and user scoped Cursor MCP installers
- preserve unrelated settings and reject malformed JSON
- add idempotent uninstall support and isolated config tests
- document project precedence and removal commands

## Validation
- uv run ruff check src/persome/cli.py tests/test_cli_local_access.py
- Python compilation for changed modules
- targeted pytest collection is unavailable on this Windows host because Persome requires POSIX fcntl and directory semantics

Closes #1