### PR TITLE
docs: add star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,14 +319,6 @@ client moves into the verified table only after the path is reproducible.
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow and DCO
 requirements.
 
-## Star History
-
-[View Personal Model's growth on Star History](https://www.star-history.com/#Intuition-Lab/personal-model&Date) or
-[star the repository](https://github.com/Intuition-Lab/personal-model) to follow
-new Runtime and MCP releases.
-
-<!-- A live chart embed now requires repository-owner-generated sealed-token code. -->
-
 ---
 
 <p align="center"><a href="https://github.com/Intuition-Lab/personal-model"><b>Star Personal Model on GitHub</b></a> · <a href="https://registry.modelcontextprotocol.io/?q=personal-model">Official MCP Registry</a> · <a href="https://github.com/Intuition-Lab/personal-model/blob/main/docs/mcp-clients.md">MCP client setup</a> · <a href="https://github.com/Intuition-Lab/personal-model/blob/main/SECURITY_PRIVACY.md">Security &amp; privacy</a></p>
@@ -383,3 +375,13 @@ new Runtime and MCP releases.
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 </details>
+
+## Star History
+
+<p align="center">
+  <a href="https://www.star-history.com/#Intuition-Lab/personal-model&amp;Date">
+    <img src="docs/assets/readme/star-history.svg" alt="Star history for Intuition-Lab/personal-model through July 31, 2026" width="100%">
+  </a>
+</p>
+
+<p align="center"><sub>Snapshot through July 31, 2026 · <a href="https://www.star-history.com/#Intuition-Lab/personal-model&amp;Date">Open on Star History</a></sub></p>

--- a/docs/assets/readme/star-history.svg
+++ b/docs/assets/readme/star-history.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc" viewBox="0 0 960 520">
+  <title id="title">Star History for Intuition-Lab/personal-model</title>
+  <desc id="desc">Cumulative GitHub stars increased from 7 on July 11, 2026 to 1,268 on July 31, 2026.</desc>
+  <defs>
+    <linearGradient id="area" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#2f81f7" stop-opacity="0.28"/>
+      <stop offset="1" stop-color="#2f81f7" stop-opacity="0.03"/>
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%">
+      <feDropShadow dx="0" dy="2" stdDeviation="6" flood-color="#1f2328" flood-opacity="0.08"/>
+    </filter>
+  </defs>
+
+  <rect x="8" y="8" width="944" height="504" rx="16" fill="#ffffff" stroke="#d0d7de" filter="url(#shadow)"/>
+
+  <g font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+    <text x="72" y="58" fill="#1f2328" font-size="28" font-weight="700">Star History</text>
+    <text x="72" y="84" fill="#656d76" font-size="15">Intuition-Lab/personal-model</text>
+    <text x="888" y="58" fill="#1f2328" font-size="24" font-weight="700" text-anchor="end">1,268</text>
+    <text x="888" y="82" fill="#656d76" font-size="14" text-anchor="end">GitHub stars</text>
+
+    <g stroke="#d8dee4" stroke-width="1">
+      <line x1="90" y1="450" x2="920" y2="450"/>
+      <line x1="90" y1="384.6" x2="920" y2="384.6"/>
+      <line x1="90" y1="319.2" x2="920" y2="319.2"/>
+      <line x1="90" y1="253.8" x2="920" y2="253.8"/>
+      <line x1="90" y1="188.5" x2="920" y2="188.5"/>
+      <line x1="90" y1="123.1" x2="920" y2="123.1"/>
+    </g>
+
+    <g fill="#656d76" font-size="13" text-anchor="end">
+      <text x="78" y="455">0</text>
+      <text x="78" y="389.6">250</text>
+      <text x="78" y="324.2">500</text>
+      <text x="78" y="258.8">750</text>
+      <text x="78" y="193.5">1,000</text>
+      <text x="78" y="128.1">1,250</text>
+    </g>
+
+    <path d="M90 448.2 L131.5 434.3 L173 403.7 L214.5 392.2 L256 367.6 L297.5 317.7 L339 278.2 L380.5 248.1 L422 225.6 L463.5 207 L505 186.4 L546.5 158.9 L588 144.5 L629.5 141.1 L671 136.7 L712.5 133.8 L754 129.4 L795.5 126.7 L837 122.6 L878.5 119.2 L920 118.4 L920 450 L90 450 Z" fill="url(#area)"/>
+    <polyline points="90,448.2 131.5,434.3 173,403.7 214.5,392.2 256,367.6 297.5,317.7 339,278.2 380.5,248.1 422,225.6 463.5,207 505,186.4 546.5,158.9 588,144.5 629.5,141.1 671,136.7 712.5,133.8 754,129.4 795.5,126.7 837,122.6 878.5,119.2 920,118.4" fill="none" stroke="#0969da" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="90" cy="448.2" r="5" fill="#ffffff" stroke="#0969da" stroke-width="3"/>
+    <circle cx="920" cy="118.4" r="6" fill="#0969da" stroke="#ffffff" stroke-width="3"/>
+
+    <g fill="#656d76" font-size="13">
+      <text x="90" y="482">Jul 11</text>
+      <text x="256" y="482" text-anchor="middle">Jul 15</text>
+      <text x="422" y="482" text-anchor="middle">Jul 19</text>
+      <text x="588" y="482" text-anchor="middle">Jul 23</text>
+      <text x="754" y="482" text-anchor="middle">Jul 27</text>
+      <text x="920" y="482" text-anchor="end">Jul 31</text>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
## What changed

- move the Star History section to the end of the README
- add a static SVG chart built from GitHub stargazer timestamps
- keep the chart linked to Star History without embedding a repository access token

## Why

The README previously linked to Star History but did not display the requested chart. A static asset provides a reliable preview while keeping credentials out of the public repository.

## Impact

Documentation-only change. Runtime behavior and package contents are unchanged.

## Validation

- `git diff --check`
- `xmllint --noout docs/assets/readme/star-history.svg`
- GitHub Markdown API render check
- `uv run python scripts/secret_scan.py`
- `uv run python scripts/pii_scan.py`
- `uv run python scripts/language_scan.py`
