### PR TITLE
fix: bound MCP model snapshot responses

### DIFF
--- a/.github/releases/v0.4.0.md
+++ b/.github/releases/v0.4.0.md
@@ -1,0 +1,40 @@
+# Persome Runtime v0.4.0
+
+Persome v0.4.0 keeps growing Personal Model history within MCP client limits by
+replacing the unbounded default `get_model_snapshot` response with a bounded,
+separately versioned overview and paged model sections.
+
+## Breaking MCP response migration
+
+In v0.3.x, `get_model_snapshot(redact=...)` returned the complete canonical
+`schema_version: 1` object. Starting with v0.4.0, the same call returns a
+`projection_schema_version: 1`, `section="overview"` envelope with model/build
+statistics and compact Root, Face, and Volume objects.
+
+To migrate an MCP consumer:
+
+1. Branch on `projection_schema_version` instead of expecting canonical
+   top-level arrays from the default call.
+2. Request `points`, `lines`, `faces`, `volumes`, `root`, or `receipts` as a
+   bounded section, then follow its opaque page cursor.
+3. Use `persome model export --out ./model-snapshot.json` when one complete
+   canonical snapshot is required.
+
+An overview's missing Point, Line, and receipt arrays mean “omitted,” not
+“empty.” CLI export and owner-local `/model/graph` retain the complete canonical
+schema-v1 shape, including historical shadow Points, evolution Lines, and
+evidence receipts.
+
+The 64 KiB projection budget applies to the JSON string in the MCP result's
+`content[0].text`. JSON-RPC framing and escaping add transport bytes outside
+that payload budget.
+
+## Upgrade
+
+```bash
+uv tool upgrade --python 3.12 personal-model
+persome onboard
+```
+
+Restart editors that host a Persome stdio MCP process after upgrading so the
+client loads the v0.4.0 tool contract.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,9 @@ name: Release
 #
 # Cut a release:
 #   1. bump `version` in pyproject.toml + `__version__` in src/persome/__init__.py
-#   2. git tag vX.Y.Z && git push origin vX.Y.Z
+#   2. bump `version` + `packages[0].version` in server.json to the same value
+#   3. run `uv lock` and commit uv.lock + .github/releases/vX.Y.Z.md
+#   4. merge that release-prep commit to main, then tag and push that exact commit
 
 on:
   push:
@@ -45,9 +47,13 @@ jobs:
       - name: Check tag matches package version
         run: |
           pkg_version="$(uv run --no-project python -c 'import tomllib;print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
+          registry_version="$(jq -r '.version' server.json)"
+          registry_package_version="$(jq -r '.packages[0].version' server.json)"
           tag_version="${GITHUB_REF_NAME#v}"
-          if [ "$pkg_version" != "$tag_version" ]; then
-            echo "::error::tag $GITHUB_REF_NAME != pyproject version $pkg_version"
+          if [ "$pkg_version" != "$tag_version" ] || \
+             [ "$registry_version" != "$tag_version" ] || \
+             [ "$registry_package_version" != "$tag_version" ]; then
+            echo "::error::tag $GITHUB_REF_NAME must match pyproject ($pkg_version), server.json ($registry_version), and Registry package ($registry_package_version)"
             exit 1
           fi
           test -f ".github/releases/${GITHUB_REF_NAME}.md"

--- a/MCP.md
+++ b/MCP.md
@@ -58,7 +58,7 @@ Example client configuration:
 | `resolve_evidence` | Resolve any model ID or receipt one layer down with human labels; separates direct sources, nearby context, and Point history. |
 | `recent_activity` | Read recent durable event entries. |
 | `behavior_patterns` | Read modeled patterns and supporting evidence. |
-| `get_model_snapshot` | Return the versioned Point/Line/Face/Volume/Root model. |
+| `get_model_snapshot` | Return a bounded model overview or one paged Point/Line/Face/Volume/Root/receipt section. |
 | `entity_graph` | Compatibility graph view backed by the same model stores. |
 | `verify_fact` | Check a claim against current and superseded memory. |
 | `get_schema` | Return the Markdown memory schema. |
@@ -94,6 +94,31 @@ stable technical handle in `reference`, and separates `sources`, `context`, and
 Point predecessor/successor `history`. Consumers must not present nearby
 `context` as direct proof.
 
+## Bounded model projection
+
+`get_model_snapshot` defaults to `section="overview"`: build metadata and full
+model counts plus compact Root, Face, and Volume objects. The response has its
+own `projection_schema_version` and explicitly reports coverage; omitted
+Points, Lines, and receipts are not represented as empty canonical arrays.
+
+Use `section="points"`, `"lines"`, `"faces"`, `"volumes"`, `"root"`, or
+`"receipts"` with the returned opaque cursor. `limit` is capped at 100, or pass up to 20
+exact `ids`. Aggregate receipt arrays require
+`include_evidence_refs=true`. Every result is capped at 64 KiB and may use a
+smaller effective page to stay within that bound. An individually oversized
+item returns a `resume_cursor` when later items remain. Each page is stable for
+its own call; restart pagination if a cursor becomes stale while the model changes.
+
+The complete schema-v1 snapshot, including historical Points and receipts,
+stays available as an owner-local file:
+
+```bash
+persome model export --out ./model-snapshot.json
+```
+
+`section="full"` returns this instruction without serializing the full model
+over MCP.
+
 ## Transport configuration
 
 ```toml
@@ -118,7 +143,7 @@ use streamable HTTP or stdio.
 - MCP results contain personal data and must be treated as untrusted content by
   consuming agents; captured text may contain prompt injection.
 - Screenshots are excluded unless explicitly requested.
-- `get_model_snapshot` redacts by default.
+- `get_model_snapshot` projections redact by default and are byte-bounded.
 - `remember` and `correct_memory` are deliberate writes with audit history.
 
 The daemon HTTP endpoint also serves `/model`. Open the

--- a/MCP.md
+++ b/MCP.md
@@ -101,13 +101,18 @@ model counts plus compact Root, Face, and Volume objects. The response has its
 own `projection_schema_version` and explicitly reports coverage; omitted
 Points, Lines, and receipts are not represented as empty canonical arrays.
 
-Use `section="points"`, `"lines"`, `"faces"`, `"volumes"`, `"root"`, or
-`"receipts"` with the returned opaque cursor. `limit` is capped at 100, or pass up to 20
-exact `ids`. Aggregate receipt arrays require
-`include_evidence_refs=true`. Every result is capped at 64 KiB and may use a
-smaller effective page to stay within that bound. An individually oversized
-item returns a `resume_cursor` when later items remain. Each page is stable for
-its own call; restart pagination if a cursor becomes stale while the model changes.
+Call `section="points"`, `"lines"`, `"faces"`, `"volumes"`, `"root"`, or
+`"receipts"` without a cursor for the first page, then pass that page's opaque
+`next_cursor` as `cursor` for the next page. The overview itself does not return
+a page cursor. `limit` is capped at 100, or pass up to 20 exact `ids`.
+Aggregate receipt arrays require `include_evidence_refs=true`.
+
+The JSON string in the MCP result's `content[0].text` is capped at 64 KiB and
+may contain a smaller effective page to stay within that bound. JSON-RPC
+framing and escaping add transport bytes outside this payload budget. An
+individually oversized item returns a `resume_cursor` when later items remain.
+Each page is stable for its own call; restart pagination if a cursor becomes
+stale while the model changes.
 
 The complete schema-v1 snapshot, including historical Points and receipts,
 stays available as an owner-local file:
@@ -118,6 +123,20 @@ persome model export --out ./model-snapshot.json
 
 `section="full"` returns this instruction without serializing the full model
 over MCP.
+
+### Compatibility and migration
+
+This bounded default is a breaking response-contract migration targeted for
+the next minor release, v0.4.0; it must not ship as a v0.3.x patch. In v0.3.x,
+`get_model_snapshot(redact=...)` returned the complete canonical
+`schema_version: 1` object. Starting with v0.4.0, the same call returns the
+separately versioned `section="overview"` envelope.
+
+Consumers must branch on `projection_schema_version`, page only the sections
+they need, and use `persome model export` when they require the complete
+canonical object. Missing Point, Line, or receipt arrays in an overview mean
+“omitted,” not “empty.” CLI export and owner-local `/model/graph` retain the
+complete canonical schema-v1 contract.
 
 ## Transport configuration
 

--- a/MODEL_FORMAT.md
+++ b/MODEL_FORMAT.md
@@ -50,10 +50,12 @@ Use the `points`, `lines`, `faces`, `volumes`, `root`, or `receipts` sections
 with the opaque `cursor` and a limit of at most 100. Up to 20 exact `ids` can replace a
 cursor for a focused read. Aggregate member and receipt arrays are summarized
 by default; `include_evidence_refs=true` opts into them while retaining the
-same hard 64 KiB JSON-result budget. A page may therefore return fewer items
-than requested, and one individually oversized object returns an explicit
-bounded error with a `resume_cursor` when later items remain. Each call is
-transactionally stable; pages do not claim a
+same hard 64 KiB budget for the JSON string in the MCP result's
+`content[0].text`; JSON-RPC framing and escaping are outside that payload
+budget. A page may therefore return fewer items than requested, and one
+individually oversized object returns an explicit bounded error with a
+`resume_cursor` when later items remain. Each call is transactionally stable;
+pages do not claim a
 cross-call frozen database revision.
 
 `section="full"` never serializes the full object over MCP. It returns the
@@ -66,6 +68,13 @@ persome model export --out ./model-snapshot.json
 This projection does not change canonical `schema_version: 1`: CLI export and
 `/model/graph` still include historical Points, evolution Lines, and complete
 receipts.
+
+The bounded envelope replaces the v0.3.x default MCP response starting with
+the next minor release, v0.4.0. Existing integrations that parsed canonical
+top-level arrays from `get_model_snapshot()` must migrate to
+`projection_schema_version`, request the needed section pages, or use
+`persome model export` for one complete canonical object. This breaking
+response change must not be published as a v0.3.x patch.
 
 The `build` object has one fixed key set in every state. While a build is in
 progress or no valid completed build exists, unavailable identity fields are

--- a/MODEL_FORMAT.md
+++ b/MODEL_FORMAT.md
@@ -1,10 +1,13 @@
 # Personal model format
 
 The public personal model is a versioned, read-only JSON projection of local
-Runtime state. CLI export, MCP `get_model_snapshot`, and the `model` object
-inside `/model/graph` expose the same schema; consumers must not import internal
-DAOs or query SQLite tables directly. Redaction policy differs: export and MCP
-redact by default, while the owner-only loopback viewer uses raw local content.
+Runtime state. CLI export and the `model` object inside `/model/graph` expose
+the complete schema below; consumers must not import internal DAOs or query
+SQLite tables directly. MCP `get_model_snapshot` overview/page reads use the
+same live model generation but return a separately versioned, bounded projection so a growing
+audit history cannot overflow an MCP client. Redaction policy differs: export
+and MCP redact by default, while the owner-only loopback viewer uses raw local
+content.
 
 `<PERSOME_ROOT>/HUMAN.md` (`~/.persome/HUMAN.md` by default) is a separate,
 deterministic reading view of that snapshot, not another model or import
@@ -33,6 +36,36 @@ an explicit still-forming placeholder rather than a fabricated identity.
 
 Consumers must branch on `schema_version`. Package versions do not substitute
 for a schema check.
+
+## MCP bounded projection
+
+`get_model_snapshot(section="overview")` is the default agent-facing read. It
+returns `projection_schema_version`, `model_schema_version`, build metadata,
+canonical `model_stats`, and compact Root/Face/Volume objects. It deliberately
+omits `points`, `lines`, and `receipts` instead of returning empty arrays that
+could be mistaken for an empty model. `coverage` states what was returned and
+the full canonical totals.
+
+Use the `points`, `lines`, `faces`, `volumes`, `root`, or `receipts` sections
+with the opaque `cursor` and a limit of at most 100. Up to 20 exact `ids` can replace a
+cursor for a focused read. Aggregate member and receipt arrays are summarized
+by default; `include_evidence_refs=true` opts into them while retaining the
+same hard 64 KiB JSON-result budget. A page may therefore return fewer items
+than requested, and one individually oversized object returns an explicit
+bounded error with a `resume_cursor` when later items remain. Each call is
+transactionally stable; pages do not claim a
+cross-call frozen database revision.
+
+`section="full"` never serializes the full object over MCP. It returns the
+local, redacted-by-default export instruction instead:
+
+```bash
+persome model export --out ./model-snapshot.json
+```
+
+This projection does not change canonical `schema_version: 1`: CLI export and
+`/model/graph` still include historical Points, evolution Lines, and complete
+receipts.
 
 The `build` object has one fixed key set in every state. While a build is in
 progress or no valid completed build exists, unavailable identity fields are

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ After connecting an MCP client, try one of these recipes:
 
 > Help me continue where I left off on **[project]**. Search recent Personal Model context, distinguish observed facts from inferences, and show the receipts behind the proposed next step.
 
-> Review my current Personal Model with `get_model_snapshot`. Summarize my active priorities and unresolved work, cite supporting evidence, and call out anything sparse, stale, or conflicted.
+> Review my current Personal Model with the default `get_model_snapshot` overview. Page only the specific model sections needed for the answer, cite supporting evidence, and call out anything sparse, stale, or conflicted.
 
 Active work is reduced every five minutes by default. With valid capture and a working semantic provider, a first useful recall is operationally expected within about ten minutes—not guaranteed as a benchmark result.
 

--- a/SECURITY_PRIVACY.md
+++ b/SECURITY_PRIVACY.md
@@ -142,8 +142,9 @@ model stages report degradation rather than silently claiming success.
   expiring, revocable device sessions.
 - MCP tool execution itself has no provider egress, but a connected agent may
   send returned personal data to its own model provider.
-- `/model/graph` is a raw owner-local inspection surface. Default CLI/MCP model
-  export is redacted; the browser viewer is not a safe publication artifact.
+- `/model/graph` is a raw owner-local inspection surface. CLI model export and
+  bounded MCP model projections redact by default; the browser viewer is not a
+  safe publication artifact.
 - `HUMAN.md` is also a raw owner-local inspection surface, despite its readable
   format and `0600` mode. Do not publish or attach it as though it were a
   redacted export.

--- a/docs/api.md
+++ b/docs/api.md
@@ -77,8 +77,8 @@ exposes only compact OCR state because it is the unauthenticated liveness route.
 
 ## Model contract
 
-`GET /model/graph` wraps a `model` object with the same schema returned by the
-MCP `get_model_snapshot` tool and CLI `persome model export`:
+`GET /model/graph` wraps a complete `model` object with the same schema written
+by CLI `persome model export`:
 
 ```text
 schema_version, generated_at, build,
@@ -90,9 +90,14 @@ Every Line derived from activity carries `source_kind`, `source_id`, and
 `event:intent:<id>` and are read only when an old `intents` table exists.
 
 The loopback viewer receives raw local graph/model detail so its owner can
-inspect the real person model. `persome model export` and MCP
-`get_model_snapshot` apply deterministic redaction by default; `/model/graph`
-is not a publication endpoint.
+inspect the real person model. `persome model export` applies deterministic
+redaction by default; `/model/graph` is not a publication endpoint.
+
+MCP `get_model_snapshot` reads the same live generation but returns a separate
+bounded envelope: the default overview carries compact Root/Face/Volume data
+and canonical totals, while Points, Lines, Faces, Volumes, and receipts are
+available in 64 KiB-bounded pages or by exact ID. Full snapshots are exported
+to a local file instead of being placed in one MCP result.
 
 The authenticated viewer polls for model changes, but the Runtime keeps one
 owner-local graph payload in memory for at most 15 seconds and makes refresh

--- a/docs/api.md
+++ b/docs/api.md
@@ -95,9 +95,11 @@ redaction by default; `/model/graph` is not a publication endpoint.
 
 MCP `get_model_snapshot` reads the same live generation but returns a separate
 bounded envelope: the default overview carries compact Root/Face/Volume data
-and canonical totals, while Points, Lines, Faces, Volumes, and receipts are
-available in 64 KiB-bounded pages or by exact ID. Full snapshots are exported
-to a local file instead of being placed in one MCP result.
+and canonical totals, while Points, Lines, Faces, Volumes, Root, and receipts are
+available in pages or by exact ID. Each page's `content[0].text` JSON payload is
+capped at 64 KiB; JSON-RPC framing and escaping are outside that payload
+budget. Full snapshots are exported to a local file instead of being placed in
+one MCP result.
 
 The authenticated viewer polls for model changes, but the Runtime keeps one
 owner-local graph payload in memory for at most 15 seconds and makes refresh

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -124,17 +124,22 @@ coverage, paging, full_export
 Root, Face, and Volume objects retain their high-level meaning and evidence
 counts, while unbounded member/receipt arrays are summarized. Points, Lines,
 Faces, Volumes, Root, and receipt objects can be read with their section name, a
-maximum `limit` of 100, and the returned opaque `cursor`. Pass up to 20 exact
-`ids` instead of a cursor for a focused selection. Set
+maximum `limit` of 100. Subsequent pages use the returned opaque `cursor`. Pass
+up to 20 exact `ids` instead of a cursor for a focused selection. Set
 `include_evidence_refs=true` only when the full aggregate references are
 needed; the byte budget still applies.
 
-Every serialized result is capped at 64 KiB. The server reduces the effective
-page before serialization and returns a small explicit error if one object by
-itself cannot fit. When later items remain, that error includes a
-`resume_cursor` that explicitly skips the oversized object. One call is
-transactionally stable, but a page sequence is not a frozen database revision;
-restart if a cursor is stale. Default redaction applies before projection.
+Call a paged section without `cursor` for its first page, then pass that page's
+opaque `next_cursor` as `cursor` for the next page. The overview does not return
+a page cursor. The JSON string in the MCP result's `content[0].text` is capped
+at 64 KiB. JSON-RPC framing and escaping add transport bytes outside this
+payload budget. The server reduces the effective page before serialization and
+returns a small explicit error if one object by itself cannot fit. When later
+items remain, that error includes a `resume_cursor` that explicitly skips the
+oversized object. One call is transactionally stable, but a page sequence is
+not a frozen database revision; restart if a cursor is stale. Default redaction
+applies before projection.
+
 To avoid rebuilding a large canonical object for every page, one redaction
 variant is retained in process memory for at most 15 seconds; explicit MCP
 memory/model writes clear it, and it is never written to another file.
@@ -149,6 +154,20 @@ persome model export --out ./model-snapshot.json --raw  # explicit local opt-out
 `section="full"` returns a bounded export hint and never constructs an
 unbounded MCP response. CLI export and owner-local `/model/graph` retain the
 complete historical/audit contract.
+
+### v0.4.0 response migration
+
+The bounded default is a breaking MCP response-contract change scheduled for
+the next minor release, v0.4.0, rather than a v0.3.x patch. In v0.3.x,
+`get_model_snapshot(redact=...)` returned the complete canonical
+`schema_version: 1` snapshot. In v0.4.0, the same call returns the separately
+versioned `section="overview"` envelope.
+
+Client integrations must detect `projection_schema_version`, treat omitted
+overview sections as omitted rather than empty, and request the required page
+explicitly. Integrations that need one complete canonical object must use
+`persome model export`; owner-local `/model/graph` and CLI export retain the
+canonical schema-v1 shape.
 
 ## Transport
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -57,7 +57,7 @@ Example stdio client configuration:
 | `resolve_evidence` | Resolve model, memory, activity, and capture references through one progressive evidence contract. |
 | `recent_activity` | Read recent durable event entries. |
 | `behavior_patterns` | Read modeled behavioral patterns plus evidence-backed observed workflow playbooks. |
-| `get_model_snapshot` | Return the versioned Point/Line/Face/Volume/Root model snapshot. |
+| `get_model_snapshot` | Return a bounded model overview or one paged Point/Line/Face/Volume/Root/receipt section. |
 | `entity_graph` | Read the entity/relation graph; retained as a compatibility model view. |
 | `verify_fact` | Check a claim's freshness and explain existing open contradiction ledger rows. |
 | `remember` | Append an explicit, auditable memory. |
@@ -108,6 +108,48 @@ true. When a recalled entry participates in an open contradiction ledger row,
 the result includes the recorded reason and bounded competing claim. Resolved or
 dismissed rows are not replayed.
 
+## Bounded model projection
+
+The canonical model snapshot contains every non-archived historical Point,
+evolution Line, and evidence receipt, so it grows with the audit history. MCP
+does not put that complete object in one result. `get_model_snapshot` defaults
+to an explicit `overview` envelope containing:
+
+```text
+projection_schema_version, model_schema_version, section,
+generated_at, build, model_stats, root, faces, volumes,
+coverage, paging, full_export
+```
+
+Root, Face, and Volume objects retain their high-level meaning and evidence
+counts, while unbounded member/receipt arrays are summarized. Points, Lines,
+Faces, Volumes, Root, and receipt objects can be read with their section name, a
+maximum `limit` of 100, and the returned opaque `cursor`. Pass up to 20 exact
+`ids` instead of a cursor for a focused selection. Set
+`include_evidence_refs=true` only when the full aggregate references are
+needed; the byte budget still applies.
+
+Every serialized result is capped at 64 KiB. The server reduces the effective
+page before serialization and returns a small explicit error if one object by
+itself cannot fit. When later items remain, that error includes a
+`resume_cursor` that explicitly skips the oversized object. One call is
+transactionally stable, but a page sequence is not a frozen database revision;
+restart if a cursor is stale. Default redaction applies before projection.
+To avoid rebuilding a large canonical object for every page, one redaction
+variant is retained in process memory for at most 15 seconds; explicit MCP
+memory/model writes clear it, and it is never written to another file.
+
+Use the CLI for the complete schema-v1 object:
+
+```bash
+persome model export --out ./model-snapshot.json
+persome model export --out ./model-snapshot.json --raw  # explicit local opt-out
+```
+
+`section="full"` returns a bounded export hint and never constructs an
+unbounded MCP response. CLI export and owner-local `/model/graph` retain the
+complete historical/audit contract.
+
 ## Transport
 
 ```toml
@@ -136,7 +178,7 @@ port = 8742
   to the originating trusted client through MCP Sampling; the client remains in
   control of its model, authentication, approval policy, and allowance.
 - Screenshots are excluded unless a tool call explicitly requests one.
-- `get_model_snapshot` redacts detectable secrets and local paths by default.
+- `get_model_snapshot` projections redact detectable secrets and local paths by default and are byte-bounded.
 - Write tools are explicit and auditable; the removed computer-use tools are
   not part of this server.
 

--- a/docs/model-contract.md
+++ b/docs/model-contract.md
@@ -2,8 +2,9 @@
 
 `persome.model` is the public, read-only projection of the model stored by the Runtime.
 It does not define a second model or run capture/build jobs. It turns the current SQLite state into
-one versioned JSON object that a viewer, MCP adapter, or external client can consume without importing
-internal DAOs.
+one versioned JSON object that the local viewer and CLI export can consume without importing internal
+DAOs. The MCP adapter reads that same live generation through a separately versioned, bounded
+overview/page envelope; it does not serialize the complete object into one tool result.
 
 The operator surface is:
 
@@ -62,8 +63,8 @@ from package releases.
 Every `build` object records the core commit, stage model names, prompt hashes, a config hash, input
 window, mock/real mode, timing, and degraded stages. Configuration values themselves are not copied
 into the manifest. Fixed inputs and timestamps produce the same `build_id`.
-The live HTTP, MCP, and CLI-export projections preserve that persisted manifest
-exactly. The manifest `build_id` must match the stable hash of every other manifest field, and
+The live HTTP and CLI-export snapshots, plus each successful MCP overview/page
+projection, preserve that persisted manifest exactly. The manifest `build_id` must match the stable hash of every other manifest field, and
 `complete`/`degraded` must agree with an empty/non-empty `degraded_stages` list. If there is no valid
 completed or degraded manifest, the projection reports
 `status: not_built`, `trigger: no_completed_build`, and a null `build_id`
@@ -71,6 +72,28 @@ instead of synthesizing a completed build from the current database contents.
 The `not_built` and `building` states keep the same fixed build-object keys;
 unavailable commit, config hash, mode, and timestamps are null, model and prompt
 maps are empty, and the input-window bounds are null.
+
+## MCP projection contract
+
+`get_model_snapshot` defaults to an `overview` envelope with
+`projection_schema_version: 1`, the underlying `model_schema_version`, build
+metadata, canonical totals in `model_stats`, compact Root/Face/Volume objects,
+and explicit coverage. Missing `points`, `lines`, or `receipts` mean “omitted
+from this bounded response,” never “the model has none.”
+
+The six Point/Line/Face/Volume/Root/receipt sections are cursor-paged with a maximum of 100 items, and
+up to 20 exact IDs can be selected. Aggregate evidence arrays are counts unless
+explicitly requested. Every serialized MCP projection is at most 64 KiB; a
+smaller effective page or a bounded oversized-item error preserves that limit.
+The error includes a `resume_cursor` when later page items remain.
+The consistency guarantee covers one call, not a sequence of pages while the
+Runtime continues writing.
+
+Full schema-v1 data remains available through `persome model export` and the
+owner-local `/model/graph`. Asking MCP for `section="full"` returns that CLI
+instruction without constructing or sending an unbounded result. This keeps
+historical shadow Points and their evolution/receipt chain in the canonical
+contract while keeping transport behavior safe.
 
 A Face becomes active only after mined and emergent signals agree across stable footprints. A
 Volume has one honest producer (the cross-domain sweeper), so it becomes active after two stable

--- a/docs/model-contract.md
+++ b/docs/model-contract.md
@@ -83,9 +83,10 @@ from this bounded response,” never “the model has none.”
 
 The six Point/Line/Face/Volume/Root/receipt sections are cursor-paged with a maximum of 100 items, and
 up to 20 exact IDs can be selected. Aggregate evidence arrays are counts unless
-explicitly requested. Every serialized MCP projection is at most 64 KiB; a
-smaller effective page or a bounded oversized-item error preserves that limit.
-The error includes a `resume_cursor` when later page items remain.
+explicitly requested. The JSON string in the MCP result's `content[0].text` is
+at most 64 KiB; JSON-RPC framing and escaping are outside that payload budget.
+A smaller effective page or a bounded oversized-item error preserves the text
+payload limit. The error includes a `resume_cursor` when later page items remain.
 The consistency guarantee covers one call, not a sequence of pages while the
 Runtime continues writing.
 

--- a/scripts/verify_sample_mcp.py
+++ b/scripts/verify_sample_mcp.py
@@ -41,6 +41,16 @@ async def verify(url: str) -> dict:
             if receipt[key] != top[key]:
                 raise RuntimeError(f"receipt mismatch for {key}")
 
+        model_result = await session.call_tool("get_model_snapshot", {})
+        model_text = model_result.content[0].text
+        model = json.loads(model_text)
+        if model.get("section") != "overview" or model.get("projection_schema_version") != 1:
+            raise RuntimeError("get_model_snapshot did not return the bounded overview contract")
+        if len(model_text.encode("utf-8")) > 64 * 1024:
+            raise RuntimeError("get_model_snapshot exceeded the documented MCP result budget")
+        if model_result.structuredContent is not None:
+            raise RuntimeError("get_model_snapshot duplicated its JSON as structured output")
+
         return {
             "endpoint": url,
             "tool_count": len(tool_names),
@@ -52,6 +62,7 @@ async def verify(url: str) -> dict:
                 "content": top["content"],
             },
             "receipt_verified": True,
+            "model_projection_verified": True,
         }
 
 

--- a/src/persome/mcp/model_projection.py
+++ b/src/persome/mcp/model_projection.py
@@ -1,0 +1,467 @@
+"""Bounded MCP projections of the canonical Personal Model snapshot.
+
+The canonical model snapshot is intentionally complete: it retains historical
+Points, evolution Lines, and every evidence receipt.  That object can grow far
+beyond the message and context limits of stdio MCP clients.  This module keeps
+the canonical schema unchanged and publishes an explicitly partial, byte-bounded
+MCP envelope instead.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+from typing import Any
+
+from ..model.snapshot import SCHEMA_VERSION, validate_snapshot
+
+PROJECTION_SCHEMA_VERSION = 1
+DEFAULT_SECTION = "overview"
+DEFAULT_PAGE_LIMIT = 50
+MAX_PAGE_LIMIT = 100
+MAX_RESULT_BYTES = 64 * 1024
+
+PAGE_SECTIONS = ("points", "lines", "faces", "volumes", "root", "receipts")
+_COMPACT_TEXT_CHARS = 4_000
+_COMPACT_ANCHOR_CHARS = 512
+_COMPACT_ANCHORS = 20
+
+
+def dumps(payload: dict[str, Any]) -> str:
+    """Serialize one projection using the same representation used for its byte budget."""
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+
+
+def result_bytes(payload: dict[str, Any]) -> int:
+    return len(dumps(payload).encode("utf-8"))
+
+
+def full_export_response(*, redact: bool) -> dict[str, Any]:
+    """Return a small response for callers that request an unbounded full section."""
+    return {
+        "projection_schema_version": PROJECTION_SCHEMA_VERSION,
+        "model_schema_version": SCHEMA_VERSION,
+        "section": "full",
+        "canonical_snapshot_complete": False,
+        "redacted": redact,
+        "error": {
+            "code": "full_snapshot_not_available_over_mcp",
+            "message": "Full model snapshots are exported to a local file, not returned in one MCP result.",
+        },
+        "full_export": _full_export_hint(redact),
+    }
+
+
+def project_snapshot(
+    snapshot: dict[str, Any],
+    *,
+    redact: bool,
+    section: str = DEFAULT_SECTION,
+    cursor: str | None = None,
+    limit: int = DEFAULT_PAGE_LIMIT,
+    ids: list[str] | None = None,
+    include_evidence_refs: bool = False,
+) -> dict[str, Any]:
+    """Project a validated canonical snapshot into one bounded MCP response."""
+    validate_snapshot(snapshot)
+    validate_request(section=section, cursor=cursor, ids=ids)
+    if section == "full":
+        return full_export_response(redact=redact)
+    if section == DEFAULT_SECTION:
+        return _overview(snapshot, redact=redact)
+    return _page(
+        snapshot,
+        redact=redact,
+        section=section,
+        cursor=cursor,
+        limit=limit,
+        ids=ids,
+        include_evidence_refs=include_evidence_refs,
+    )
+
+
+def validate_request(*, section: str, cursor: str | None, ids: list[str] | None) -> None:
+    """Reject invalid projection combinations before the expensive live snapshot build."""
+    if section not in {DEFAULT_SECTION, *PAGE_SECTIONS, "full"}:
+        allowed = ", ".join((DEFAULT_SECTION, *PAGE_SECTIONS, "full"))
+        raise ValueError(f"section must be one of: {allowed}")
+    if section in {DEFAULT_SECTION, "full"} and (cursor is not None or ids is not None):
+        raise ValueError("cursor and ids require a paged model section")
+    if cursor is not None and ids is not None:
+        raise ValueError("cursor and ids are mutually exclusive")
+
+
+def _full_export_hint(redact: bool) -> dict[str, Any]:
+    command = "persome model export --out ./model-snapshot.json"
+    if not redact:
+        command += " --raw"
+    return {
+        "command": command,
+        "redacted": redact,
+        "note": "The file is owner-local and must be reviewed before sharing.",
+    }
+
+
+def _common(snapshot: dict[str, Any], *, redact: bool, section: str) -> dict[str, Any]:
+    return {
+        "projection_schema_version": PROJECTION_SCHEMA_VERSION,
+        "model_schema_version": snapshot["schema_version"],
+        "section": section,
+        "canonical_snapshot_complete": False,
+        "redacted": redact,
+        "generated_at": snapshot["generated_at"],
+        "build": snapshot["build"],
+        "model_stats": snapshot["stats"],
+        "consistency": "transactionally_stable_per_call",
+        "full_export": _full_export_hint(redact),
+    }
+
+
+def _trim(value: Any, maximum: int) -> tuple[Any, bool]:
+    if value is None:
+        return None, False
+    text = str(value)
+    if len(text) <= maximum:
+        return text, False
+    return text[: maximum - 1] + "…", True
+
+
+def _compact_geometry(item: dict[str, Any]) -> dict[str, Any]:
+    compact = {
+        key: item.get(key)
+        for key in (
+            "id",
+            "level",
+            "parent_id",
+            "provenance",
+            "observations",
+            "confidence",
+            "status",
+            "valid_from",
+            "created_at",
+        )
+    }
+    truncated: list[str] = []
+    compact["signature"], signature_truncated = _trim(item.get("signature"), _COMPACT_TEXT_CHARS)
+    if signature_truncated:
+        truncated.append("signature")
+
+    anchors: list[str] = []
+    raw_anchors = item.get("anchors") if isinstance(item.get("anchors"), list) else []
+    for value in raw_anchors[:_COMPACT_ANCHORS]:
+        anchor, anchor_truncated = _trim(value, _COMPACT_ANCHOR_CHARS)
+        anchors.append(str(anchor or ""))
+        if anchor_truncated:
+            truncated.append("anchors")
+    if len(raw_anchors) > _COMPACT_ANCHORS:
+        truncated.append("anchors")
+    compact["anchors"] = anchors
+
+    compact["member_count"] = len(item.get("members") or [])
+    compact["member_receipt_count"] = len(item.get("member_receipts") or [])
+    compact["source_receipt_count"] = len(item.get("source_receipts") or [])
+    if truncated:
+        compact["truncated_fields"] = sorted(set(truncated))
+    return compact
+
+
+def _overview(snapshot: dict[str, Any], *, redact: bool) -> dict[str, Any]:
+    payload = _common(snapshot, redact=redact, section=DEFAULT_SECTION)
+    faces = [_compact_geometry(item) for item in snapshot["faces"]]
+    volumes = [_compact_geometry(item) for item in snapshot["volumes"]]
+    root = _compact_geometry(snapshot["root"]) if snapshot["root"] is not None else None
+    payload.update(
+        {
+            "root": root,
+            "faces": [],
+            "volumes": [],
+            "coverage": {
+                "root": {"returned": 1 if root else 0, "total": 1 if root else 0},
+                "faces": {"returned": 0, "total": len(faces)},
+                "volumes": {"returned": 0, "total": len(volumes)},
+                "points": {"returned": 0, "total": len(snapshot["points"])},
+                "lines": {"returned": 0, "total": len(snapshot["lines"])},
+                "receipts": {"returned": 0, "total": len(snapshot["receipts"])},
+            },
+            "omitted_model_sections": ["points", "lines", "receipts"],
+            "paging": {
+                "sections": list(PAGE_SECTIONS),
+                "default_limit": DEFAULT_PAGE_LIMIT,
+                "max_limit": MAX_PAGE_LIMIT,
+            },
+        }
+    )
+    if result_bytes(payload) > MAX_RESULT_BYTES:
+        return _metadata_too_large(snapshot, redact=redact, section=DEFAULT_SECTION)
+
+    indexes = {"faces": 0, "volumes": 0}
+    collections = {"faces": faces, "volumes": volumes}
+    blocked: set[str] = set()
+    while len(blocked) < len(collections):
+        progressed = False
+        for name in ("faces", "volumes"):
+            if name in blocked:
+                continue
+            index = indexes[name]
+            items = collections[name]
+            if index >= len(items):
+                blocked.add(name)
+                continue
+            payload[name].append(items[index])
+            payload["coverage"][name]["returned"] = index + 1
+            if result_bytes(payload) <= MAX_RESULT_BYTES:
+                indexes[name] += 1
+                progressed = True
+            else:
+                payload[name].pop()
+                payload["coverage"][name]["returned"] = index
+                blocked.add(name)
+        if not progressed and all(name in blocked for name in collections):
+            break
+
+    if result_bytes(payload) > MAX_RESULT_BYTES:
+        return _metadata_too_large(snapshot, redact=redact, section=DEFAULT_SECTION)
+    return payload
+
+
+def _item_key(section: str, item: dict[str, Any]) -> Any:
+    if section == "lines":
+        return [str(item.get("kind") or ""), str(item.get("id") or "")]
+    if section == "receipts":
+        return str(item.get("receipt") or "")
+    return str(item.get("id") or "")
+
+
+def _lookup_id(section: str, item: dict[str, Any]) -> str:
+    if section == "receipts":
+        return str(item.get("receipt") or "")
+    return str(item.get("id") or "")
+
+
+def _encode_cursor(section: str, key: Any) -> str:
+    raw = json.dumps([PROJECTION_SCHEMA_VERSION, section, key], separators=(",", ":")).encode()
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def _decode_cursor(section: str, cursor: str) -> Any:
+    try:
+        padded = cursor + "=" * (-len(cursor) % 4)
+        raw = base64.urlsafe_b64decode(padded.encode())
+        version, encoded_section, key = json.loads(raw)
+    except (binascii.Error, UnicodeDecodeError, ValueError, TypeError) as exc:
+        raise ValueError("invalid model pagination cursor") from exc
+    if version != PROJECTION_SCHEMA_VERSION or encoded_section != section:
+        raise ValueError("model pagination cursor belongs to a different response or section")
+    return key
+
+
+def _prepare_item(
+    section: str, item: dict[str, Any], *, include_evidence_refs: bool
+) -> dict[str, Any]:
+    if section in {"faces", "volumes", "root"} and not include_evidence_refs:
+        return _compact_geometry(item)
+    return item
+
+
+def _page(
+    snapshot: dict[str, Any],
+    *,
+    redact: bool,
+    section: str,
+    cursor: str | None,
+    limit: int,
+    ids: list[str] | None,
+    include_evidence_refs: bool,
+) -> dict[str, Any]:
+    all_items = (
+        [snapshot["root"]]
+        if section == "root" and snapshot["root"] is not None
+        else ([] if section == "root" else snapshot[section])
+    )
+    if ids is not None:
+        by_id = {_lookup_id(section, item): item for item in all_items}
+        raw_items = [by_id[value] for value in ids if value in by_id]
+        missing_ids = [value for value in ids if value not in by_id]
+        return _bounded_selected_items(
+            snapshot,
+            redact=redact,
+            section=section,
+            raw_items=raw_items,
+            requested_ids=ids,
+            missing_ids=missing_ids,
+            include_evidence_refs=include_evidence_refs,
+        )
+
+    start = 0
+    if cursor is not None:
+        cursor_key = _decode_cursor(section, cursor)
+        for index, item in enumerate(all_items):
+            if _item_key(section, item) == cursor_key:
+                start = index + 1
+                break
+        else:
+            raise ValueError("model pagination cursor is stale; restart from the first page")
+
+    raw_items = all_items[start : start + limit]
+    payload = _common(snapshot, redact=redact, section=section)
+    payload.update(
+        {
+            "items": [
+                _prepare_item(section, item, include_evidence_refs=include_evidence_refs)
+                for item in raw_items
+            ],
+            "page": {
+                "requested_limit": limit,
+                "returned": len(raw_items),
+                "total": len(all_items),
+                "has_more": start + len(raw_items) < len(all_items),
+                "next_cursor": None,
+            },
+            "include_evidence_refs": include_evidence_refs,
+        }
+    )
+    _set_next_cursor(payload, section=section, raw_items=raw_items)
+    while payload["items"] and result_bytes(payload) > MAX_RESULT_BYTES:
+        payload["items"].pop()
+        raw_items.pop()
+        payload["page"]["returned"] = len(raw_items)
+        payload["page"]["has_more"] = start + len(raw_items) < len(all_items)
+        _set_next_cursor(payload, section=section, raw_items=raw_items)
+    if raw_items or start >= len(all_items):
+        if result_bytes(payload) <= MAX_RESULT_BYTES:
+            return payload
+        return _metadata_too_large(snapshot, redact=redact, section=section)
+    return _oversized_item(
+        snapshot,
+        redact=redact,
+        section=section,
+        item_id=_lookup_id(section, all_items[start]),
+        resume_cursor=(
+            _encode_cursor(section, _item_key(section, all_items[start]))
+            if start + 1 < len(all_items)
+            else None
+        ),
+        has_more=start + 1 < len(all_items),
+    )
+
+
+def _set_next_cursor(
+    payload: dict[str, Any], *, section: str, raw_items: list[dict[str, Any]]
+) -> None:
+    has_more = bool(payload["page"]["has_more"])
+    if has_more and raw_items:
+        payload["page"]["next_cursor"] = _encode_cursor(section, _item_key(section, raw_items[-1]))
+    else:
+        payload["page"]["next_cursor"] = None
+
+
+def _bounded_selected_items(
+    snapshot: dict[str, Any],
+    *,
+    redact: bool,
+    section: str,
+    raw_items: list[dict[str, Any]],
+    requested_ids: list[str],
+    missing_ids: list[str],
+    include_evidence_refs: bool,
+) -> dict[str, Any]:
+    payload = _common(snapshot, redact=redact, section=section)
+    payload.update(
+        {
+            "items": [],
+            "selection": {
+                "requested": len(requested_ids),
+                "returned": 0,
+                "missing_ids": missing_ids,
+                "omitted_ids_due_to_size": [],
+                "oversized_ids": [],
+            },
+            "include_evidence_refs": include_evidence_refs,
+        }
+    )
+    if result_bytes(payload) > MAX_RESULT_BYTES:
+        return _metadata_too_large(snapshot, redact=redact, section=section)
+
+    for raw_item in raw_items:
+        prepared = _prepare_item(section, raw_item, include_evidence_refs=include_evidence_refs)
+        payload["items"].append(prepared)
+        payload["selection"]["returned"] = len(payload["items"])
+        if result_bytes(payload) <= MAX_RESULT_BYTES:
+            continue
+        payload["items"].pop()
+        payload["selection"]["returned"] = len(payload["items"])
+        item_id, _ = _trim(_lookup_id(section, raw_item), 512)
+        single = _common(snapshot, redact=redact, section=section)
+        single.update(
+            {
+                "items": [prepared],
+                "selection": {"requested": 1, "returned": 1},
+                "include_evidence_refs": include_evidence_refs,
+            }
+        )
+        bucket = (
+            "oversized_ids"
+            if result_bytes(single) > MAX_RESULT_BYTES
+            else "omitted_ids_due_to_size"
+        )
+        payload["selection"][bucket].append(item_id)
+
+    oversized_ids = payload["selection"]["oversized_ids"]
+    if not payload["items"] and oversized_ids:
+        return _oversized_item(
+            snapshot,
+            redact=redact,
+            section=section,
+            item_id=str(oversized_ids[0]),
+        )
+    if result_bytes(payload) <= MAX_RESULT_BYTES:
+        return payload
+    return _metadata_too_large(snapshot, redact=redact, section=section)
+
+
+def _oversized_item(
+    snapshot: dict[str, Any],
+    *,
+    redact: bool,
+    section: str,
+    item_id: str,
+    resume_cursor: str | None = None,
+    has_more: bool | None = None,
+) -> dict[str, Any]:
+    safe_id, _ = _trim(item_id, 512)
+    payload = {
+        "projection_schema_version": PROJECTION_SCHEMA_VERSION,
+        "model_schema_version": snapshot["schema_version"],
+        "section": section,
+        "canonical_snapshot_complete": False,
+        "redacted": redact,
+        "error": {
+            "code": "model_item_exceeds_mcp_budget",
+            "item_id": safe_id,
+            "max_result_bytes": MAX_RESULT_BYTES,
+        },
+        "full_export": _full_export_hint(redact),
+    }
+    if has_more is not None:
+        payload["pagination"] = {
+            "skipped_oversized_item": True,
+            "has_more": has_more,
+            "resume_cursor": resume_cursor,
+        }
+    return payload
+
+
+def _metadata_too_large(snapshot: dict[str, Any], *, redact: bool, section: str) -> dict[str, Any]:
+    return {
+        "projection_schema_version": PROJECTION_SCHEMA_VERSION,
+        "model_schema_version": snapshot.get("schema_version", SCHEMA_VERSION),
+        "section": section,
+        "canonical_snapshot_complete": False,
+        "redacted": redact,
+        "error": {
+            "code": "model_projection_metadata_exceeds_mcp_budget",
+            "max_result_bytes": MAX_RESULT_BYTES,
+        },
+        "full_export": _full_export_hint(redact),
+    }

--- a/src/persome/mcp/model_projection.py
+++ b/src/persome/mcp/model_projection.py
@@ -11,7 +11,10 @@ from __future__ import annotations
 
 import base64
 import binascii
+import hashlib
+import hmac
 import json
+import struct
 from typing import Any
 
 from ..model.snapshot import SCHEMA_VERSION, validate_snapshot
@@ -27,6 +30,14 @@ _COMPACT_TEXT_CHARS = 4_000
 _COMPACT_ANCHOR_CHARS = 512
 _COMPACT_ANCHORS = 20
 
+# Cursors must stay small even when a canonical identifier is very large.  The
+# token carries the exact ordinal of the item it follows plus a digest of that
+# item's ordering key.  The ordinal distinguishes duplicate evolution Lines;
+# the digest detects a changed/reordered snapshot without embedding the key.
+_CURSOR_SECTION_CODES = {name: index for index, name in enumerate(PAGE_SECTIONS, start=1)}
+_CURSOR_STRUCT = struct.Struct(">BBQ32s")
+_CURSOR_TEXT_CHARS = 56  # 42 packed bytes encode to exactly 56 unpadded base64 chars.
+
 
 def dumps(payload: dict[str, Any]) -> str:
     """Serialize one projection using the same representation used for its byte budget."""
@@ -35,6 +46,11 @@ def dumps(payload: dict[str, Any]) -> str:
 
 def result_bytes(payload: dict[str, Any]) -> int:
     return len(dumps(payload).encode("utf-8"))
+
+
+def _value_bytes(value: Any) -> int:
+    """Return the exact UTF-8 size of a value embedded in a projection JSON object."""
+    return len(json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode("utf-8"))
 
 
 def full_export_response(*, redact: bool) -> dict[str, Any]:
@@ -90,6 +106,14 @@ def validate_request(*, section: str, cursor: str | None, ids: list[str] | None)
         raise ValueError("cursor and ids require a paged model section")
     if cursor is not None and ids is not None:
         raise ValueError("cursor and ids are mutually exclusive")
+    validate_cursor_shape(section=section, cursor=cursor)
+
+
+def validate_cursor_shape(*, section: str, cursor: str | None) -> None:
+    """Validate an opaque cursor without opening or projecting the model snapshot."""
+    if cursor is None:
+        return
+    _decode_cursor(section, cursor)
 
 
 def _full_export_hint(redact: bool) -> dict[str, Any]:
@@ -168,18 +192,18 @@ def _compact_geometry(item: dict[str, Any]) -> dict[str, Any]:
 
 def _overview(snapshot: dict[str, Any], *, redact: bool) -> dict[str, Any]:
     payload = _common(snapshot, redact=redact, section=DEFAULT_SECTION)
-    faces = [_compact_geometry(item) for item in snapshot["faces"]]
-    volumes = [_compact_geometry(item) for item in snapshot["volumes"]]
-    root = _compact_geometry(snapshot["root"]) if snapshot["root"] is not None else None
     payload.update(
         {
-            "root": root,
+            "root": None,
             "faces": [],
             "volumes": [],
             "coverage": {
-                "root": {"returned": 1 if root else 0, "total": 1 if root else 0},
-                "faces": {"returned": 0, "total": len(faces)},
-                "volumes": {"returned": 0, "total": len(volumes)},
+                "root": {
+                    "returned": 0,
+                    "total": 1 if snapshot["root"] is not None else 0,
+                },
+                "faces": {"returned": 0, "total": len(snapshot["faces"])},
+                "volumes": {"returned": 0, "total": len(snapshot["volumes"])},
                 "points": {"returned": 0, "total": len(snapshot["points"])},
                 "lines": {"returned": 0, "total": len(snapshot["lines"])},
                 "receipts": {"returned": 0, "total": len(snapshot["receipts"])},
@@ -192,35 +216,39 @@ def _overview(snapshot: dict[str, Any], *, redact: bool) -> dict[str, Any]:
             },
         }
     )
-    if result_bytes(payload) > MAX_RESULT_BYTES:
+    current_bytes = result_bytes(payload)
+    if current_bytes > MAX_RESULT_BYTES:
         return _metadata_too_large(snapshot, redact=redact, section=DEFAULT_SECTION)
 
+    if snapshot["root"] is not None:
+        root = _compact_geometry(snapshot["root"])
+        candidate_bytes = current_bytes - _value_bytes(None) + _value_bytes(root)
+        if candidate_bytes <= MAX_RESULT_BYTES:
+            payload["root"] = root
+            payload["coverage"]["root"]["returned"] = 1
+            current_bytes = candidate_bytes
+
     indexes = {"faces": 0, "volumes": 0}
-    collections = {"faces": faces, "volumes": volumes}
-    blocked: set[str] = set()
-    while len(blocked) < len(collections):
-        progressed = False
+    collections = {"faces": snapshot["faces"], "volumes": snapshot["volumes"]}
+    while any(indexes[name] < len(collections[name]) for name in collections):
         for name in ("faces", "volumes"):
-            if name in blocked:
-                continue
             index = indexes[name]
             items = collections[name]
             if index >= len(items):
-                blocked.add(name)
                 continue
-            payload[name].append(items[index])
-            payload["coverage"][name]["returned"] = index + 1
-            if result_bytes(payload) <= MAX_RESULT_BYTES:
-                indexes[name] += 1
-                progressed = True
-            else:
-                payload[name].pop()
-                payload["coverage"][name]["returned"] = index
-                blocked.add(name)
-        if not progressed and all(name in blocked for name in collections):
-            break
+            indexes[name] += 1
+            compact = _compact_geometry(items[index])
+            returned = int(payload["coverage"][name]["returned"])
+            list_delta = _value_bytes(compact) + (1 if payload[name] else 0)
+            count_delta = _value_bytes(returned + 1) - _value_bytes(returned)
+            candidate_bytes = current_bytes + list_delta + count_delta
+            if candidate_bytes > MAX_RESULT_BYTES:
+                continue
+            payload[name].append(compact)
+            payload["coverage"][name]["returned"] = returned + 1
+            current_bytes = candidate_bytes
 
-    if result_bytes(payload) > MAX_RESULT_BYTES:
+    if result_bytes(payload) > MAX_RESULT_BYTES:  # pragma: no cover - accounting backstop
         return _metadata_too_large(snapshot, redact=redact, section=DEFAULT_SECTION)
     return payload
 
@@ -239,21 +267,46 @@ def _lookup_id(section: str, item: dict[str, Any]) -> str:
     return str(item.get("id") or "")
 
 
-def _encode_cursor(section: str, key: Any) -> str:
-    raw = json.dumps([PROJECTION_SCHEMA_VERSION, section, key], separators=(",", ":")).encode()
-    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+def _cursor_digest(section: str, key: Any) -> bytes:
+    encoded_key = json.dumps(
+        [section, key],
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded_key).digest()
 
 
-def _decode_cursor(section: str, cursor: str) -> Any:
+def _encode_cursor(section: str, index: int, key: Any) -> str:
+    section_code = _CURSOR_SECTION_CODES.get(section)
+    if section_code is None or not 0 <= index < 2**64:
+        raise ValueError("invalid model pagination cursor")
+    raw = _CURSOR_STRUCT.pack(
+        PROJECTION_SCHEMA_VERSION,
+        section_code,
+        index,
+        _cursor_digest(section, key),
+    )
+    cursor = base64.urlsafe_b64encode(raw).decode("ascii")
+    if len(cursor) != _CURSOR_TEXT_CHARS:  # pragma: no cover - structural invariant
+        raise RuntimeError("model pagination cursor encoding changed unexpectedly")
+    return cursor
+
+
+def _decode_cursor(section: str, cursor: str) -> tuple[int, bytes]:
+    if not isinstance(cursor, str) or len(cursor) != _CURSOR_TEXT_CHARS:
+        raise ValueError("invalid model pagination cursor")
     try:
-        padded = cursor + "=" * (-len(cursor) % 4)
-        raw = base64.urlsafe_b64decode(padded.encode())
-        version, encoded_section, key = json.loads(raw)
-    except (binascii.Error, UnicodeDecodeError, ValueError, TypeError) as exc:
+        raw = base64.b64decode(cursor.encode("ascii"), altchars=b"-_", validate=True)
+        if len(raw) != _CURSOR_STRUCT.size:
+            raise ValueError("invalid cursor length")
+        version, encoded_section, index, digest = _CURSOR_STRUCT.unpack(raw)
+    except (binascii.Error, UnicodeEncodeError, ValueError, struct.error) as exc:
         raise ValueError("invalid model pagination cursor") from exc
-    if version != PROJECTION_SCHEMA_VERSION or encoded_section != section:
+    if version != PROJECTION_SCHEMA_VERSION or encoded_section != _CURSOR_SECTION_CODES.get(
+        section
+    ):
         raise ValueError("model pagination cursor belongs to a different response or section")
-    return key
+    return index, digest
 
 
 def _prepare_item(
@@ -295,65 +348,86 @@ def _page(
 
     start = 0
     if cursor is not None:
-        cursor_key = _decode_cursor(section, cursor)
-        for index, item in enumerate(all_items):
-            if _item_key(section, item) == cursor_key:
-                start = index + 1
-                break
-        else:
+        cursor_index, cursor_digest = _decode_cursor(section, cursor)
+        if cursor_index >= len(all_items) or not hmac.compare_digest(
+            _cursor_digest(section, _item_key(section, all_items[cursor_index])),
+            cursor_digest,
+        ):
             raise ValueError("model pagination cursor is stale; restart from the first page")
+        start = cursor_index + 1
 
-    raw_items = all_items[start : start + limit]
     payload = _common(snapshot, redact=redact, section=section)
+    base_page = {
+        "requested_limit": limit,
+        "returned": 0,
+        "total": len(all_items),
+        "has_more": False,
+        "next_cursor": None,
+    }
     payload.update(
         {
-            "items": [
-                _prepare_item(section, item, include_evidence_refs=include_evidence_refs)
-                for item in raw_items
-            ],
-            "page": {
-                "requested_limit": limit,
-                "returned": len(raw_items),
-                "total": len(all_items),
-                "has_more": start + len(raw_items) < len(all_items),
-                "next_cursor": None,
-            },
+            "items": [],
+            "page": base_page,
             "include_evidence_refs": include_evidence_refs,
         }
     )
-    _set_next_cursor(payload, section=section, raw_items=raw_items)
-    while payload["items"] and result_bytes(payload) > MAX_RESULT_BYTES:
-        payload["items"].pop()
-        raw_items.pop()
-        payload["page"]["returned"] = len(raw_items)
-        payload["page"]["has_more"] = start + len(raw_items) < len(all_items)
-        _set_next_cursor(payload, section=section, raw_items=raw_items)
-    if raw_items or start >= len(all_items):
-        if result_bytes(payload) <= MAX_RESULT_BYTES:
-            return payload
+    base_payload_bytes = result_bytes(payload)
+    if base_payload_bytes > MAX_RESULT_BYTES:
         return _metadata_too_large(snapshot, redact=redact, section=section)
-    return _oversized_item(
-        snapshot,
-        redact=redact,
-        section=section,
-        item_id=_lookup_id(section, all_items[start]),
-        resume_cursor=(
-            _encode_cursor(section, _item_key(section, all_items[start]))
-            if start + 1 < len(all_items)
-            else None
-        ),
-        has_more=start + 1 < len(all_items),
-    )
+    if start >= len(all_items):
+        return payload
 
+    base_page_bytes = _value_bytes(base_page)
+    packed_items_bytes = 0
+    end = min(start + limit, len(all_items))
+    for index in range(start, end):
+        raw_item = all_items[index]
+        prepared = _prepare_item(
+            section,
+            raw_item,
+            include_evidence_refs=include_evidence_refs,
+        )
+        has_more = index + 1 < len(all_items)
+        next_cursor = (
+            _encode_cursor(section, index, _item_key(section, raw_item)) if has_more else None
+        )
+        candidate_page = {
+            "requested_limit": limit,
+            "returned": len(payload["items"]) + 1,
+            "total": len(all_items),
+            "has_more": has_more,
+            "next_cursor": next_cursor,
+        }
+        item_delta = _value_bytes(prepared) + (1 if payload["items"] else 0)
+        candidate_bytes = (
+            base_payload_bytes
+            + packed_items_bytes
+            + item_delta
+            + _value_bytes(candidate_page)
+            - base_page_bytes
+        )
+        if candidate_bytes > MAX_RESULT_BYTES:
+            if not payload["items"]:
+                return _oversized_item(
+                    snapshot,
+                    redact=redact,
+                    section=section,
+                    item_id=_lookup_id(section, raw_item),
+                    resume_cursor=(
+                        _encode_cursor(section, index, _item_key(section, raw_item))
+                        if has_more
+                        else None
+                    ),
+                    has_more=has_more,
+                )
+            break
+        payload["items"].append(prepared)
+        payload["page"] = candidate_page
+        packed_items_bytes += item_delta
 
-def _set_next_cursor(
-    payload: dict[str, Any], *, section: str, raw_items: list[dict[str, Any]]
-) -> None:
-    has_more = bool(payload["page"]["has_more"])
-    if has_more and raw_items:
-        payload["page"]["next_cursor"] = _encode_cursor(section, _item_key(section, raw_items[-1]))
-    else:
-        payload["page"]["next_cursor"] = None
+    if result_bytes(payload) > MAX_RESULT_BYTES:  # pragma: no cover - accounting backstop
+        return _metadata_too_large(snapshot, redact=redact, section=section)
+    return payload
 
 
 def _bounded_selected_items(
@@ -380,32 +454,44 @@ def _bounded_selected_items(
             "include_evidence_refs": include_evidence_refs,
         }
     )
-    if result_bytes(payload) > MAX_RESULT_BYTES:
+    current_bytes = result_bytes(payload)
+    if current_bytes > MAX_RESULT_BYTES:
         return _metadata_too_large(snapshot, redact=redact, section=section)
+
+    single_base = _common(snapshot, redact=redact, section=section)
+    single_base.update(
+        {
+            "items": [],
+            "selection": {"requested": 1, "returned": 1},
+            "include_evidence_refs": include_evidence_refs,
+        }
+    )
+    single_base_bytes = result_bytes(single_base)
 
     for raw_item in raw_items:
         prepared = _prepare_item(section, raw_item, include_evidence_refs=include_evidence_refs)
-        payload["items"].append(prepared)
-        payload["selection"]["returned"] = len(payload["items"])
-        if result_bytes(payload) <= MAX_RESULT_BYTES:
+        prepared_bytes = _value_bytes(prepared)
+        returned = int(payload["selection"]["returned"])
+        item_delta = prepared_bytes + (1 if payload["items"] else 0)
+        count_delta = _value_bytes(returned + 1) - _value_bytes(returned)
+        if current_bytes + item_delta + count_delta <= MAX_RESULT_BYTES:
+            payload["items"].append(prepared)
+            payload["selection"]["returned"] = returned + 1
+            current_bytes += item_delta + count_delta
             continue
-        payload["items"].pop()
-        payload["selection"]["returned"] = len(payload["items"])
+
         item_id, _ = _trim(_lookup_id(section, raw_item), 512)
-        single = _common(snapshot, redact=redact, section=section)
-        single.update(
-            {
-                "items": [prepared],
-                "selection": {"requested": 1, "returned": 1},
-                "include_evidence_refs": include_evidence_refs,
-            }
-        )
         bucket = (
             "oversized_ids"
-            if result_bytes(single) > MAX_RESULT_BYTES
+            if single_base_bytes + prepared_bytes > MAX_RESULT_BYTES
             else "omitted_ids_due_to_size"
         )
+        bucket_values = payload["selection"][bucket]
+        bucket_delta = _value_bytes(item_id) + (1 if bucket_values else 0)
+        if current_bytes + bucket_delta > MAX_RESULT_BYTES:
+            return _metadata_too_large(snapshot, redact=redact, section=section)
         payload["selection"][bucket].append(item_id)
+        current_bytes += bucket_delta
 
     oversized_ids = payload["selection"]["oversized_ids"]
     if not payload["items"] and oversized_ids:
@@ -415,7 +501,7 @@ def _bounded_selected_items(
             section=section,
             item_id=str(oversized_ids[0]),
         )
-    if result_bytes(payload) <= MAX_RESULT_BYTES:
+    if result_bytes(payload) <= MAX_RESULT_BYTES:  # final accounting backstop
         return payload
     return _metadata_too_large(snapshot, redact=redact, section=section)
 
@@ -449,7 +535,9 @@ def _oversized_item(
             "has_more": has_more,
             "resume_cursor": resume_cursor,
         }
-    return payload
+    if result_bytes(payload) <= MAX_RESULT_BYTES:
+        return payload
+    return _metadata_too_large(snapshot, redact=redact, section=section)
 
 
 def _metadata_too_large(snapshot: dict[str, Any], *, redact: bool, section: str) -> dict[str, Any]:

--- a/src/persome/mcp/server.py
+++ b/src/persome/mcp/server.py
@@ -37,6 +37,7 @@ from ..store import fts, health_events
 from ..timeline import attention_trajectory as attention_traj
 from ..timeline import store as timeline_store
 from . import captures as captures_mod
+from . import model_projection
 from .limits import (
     bounded_float,
     bounded_int,
@@ -46,6 +47,54 @@ from .limits import (
 )
 
 logger = get("persome.mcp")
+
+_MCP_MODEL_SNAPSHOT_CACHE_TTL_SECONDS = 15.0
+
+
+class _ModelSnapshotCache:
+    """Keep one short-lived canonical snapshot for an MCP overview/page sequence."""
+
+    def __init__(self, *, ttl_seconds: float = _MCP_MODEL_SNAPSHOT_CACHE_TTL_SECONDS) -> None:
+        self._ttl_seconds = ttl_seconds
+        self._lock = threading.Lock()
+        self._entry: tuple[bool, float, dict[str, Any]] | None = None
+        self._expiry_timer: threading.Timer | None = None
+
+    def get(self, conn, *, redact: bool) -> dict[str, Any]:  # type: ignore[no-untyped-def]
+        from ..model import build_live_snapshot
+
+        with self._lock:
+            now = time.monotonic()
+            if self._entry is not None:
+                cached_redact, created_at, snapshot = self._entry
+                if cached_redact == redact and now - created_at < self._ttl_seconds:
+                    return snapshot
+            snapshot = build_live_snapshot(conn, redact=redact)
+            created_at = time.monotonic()
+            self._entry = (redact, created_at, snapshot)
+            if self._expiry_timer is not None:
+                self._expiry_timer.cancel()
+            self._expiry_timer = threading.Timer(
+                self._ttl_seconds,
+                self._expire,
+                args=(created_at,),
+            )
+            self._expiry_timer.daemon = True
+            self._expiry_timer.start()
+            return snapshot
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entry = None
+            if self._expiry_timer is not None:
+                self._expiry_timer.cancel()
+                self._expiry_timer = None
+
+    def _expire(self, created_at: float) -> None:
+        with self._lock:
+            if self._entry is not None and self._entry[1] == created_at:
+                self._entry = None
+                self._expiry_timer = None
 
 
 def _parse_iso_opt(value: str | None) -> datetime | None:
@@ -140,11 +189,32 @@ def _read_memory(  # type: ignore[no-untyped-def]
     }
 
 
-def _get_model_snapshot(conn, *, redact: bool = True) -> dict[str, Any]:  # type: ignore[no-untyped-def]
-    """Project the live personal model through the same versioned contract as CLI export."""
+def _get_model_snapshot(  # type: ignore[no-untyped-def]
+    conn,
+    *,
+    redact: bool = True,
+    section: str = "overview",
+    cursor: str | None = None,
+    limit: int = model_projection.DEFAULT_PAGE_LIMIT,
+    ids: list[str] | None = None,
+    include_evidence_refs: bool = False,
+) -> dict[str, Any]:
+    """Return one bounded MCP projection of the live, versioned personal model."""
+    model_projection.validate_request(section=section, cursor=cursor, ids=ids)
+    if section == "full":
+        return model_projection.full_export_response(redact=redact)
     from ..model import build_live_snapshot
 
-    return build_live_snapshot(conn, redact=redact)
+    snapshot = build_live_snapshot(conn, redact=redact)
+    return model_projection.project_snapshot(
+        snapshot,
+        redact=redact,
+        section=section,
+        cursor=cursor,
+        limit=limit,
+        ids=ids,
+        include_evidence_refs=include_evidence_refs,
+    )
 
 
 def _search(  # type: ignore[no-untyped-def]
@@ -1027,6 +1097,7 @@ def build_server(
     # FastMCP otherwise reports the SDK version in the MCP initialize response.
     # The server contract must identify the Persome Runtime release instead.
     server._mcp_server.version = __version__  # noqa: SLF001
+    model_snapshot_cache = _ModelSnapshotCache()
 
     @server.tool()
     def list_memories(include_dormant: bool = False, include_archived: bool = False) -> str:
@@ -1100,6 +1171,7 @@ def build_server(
         correction = bounded_text("correction", correction, maximum=20_000)
         with fts.cursor() as conn:
             res = correct_mod.update_memory(cfg, conn, correction, source="agent")
+        model_snapshot_cache.clear()
         return json.dumps(
             {"kind": res.kind, "applied": res.applied, "reason": res.reason, "ok": res.ok},
             ensure_ascii=False,
@@ -1218,17 +1290,52 @@ def build_server(
         with fts.cursor() as conn:
             return json.dumps(_behavior_patterns(conn), ensure_ascii=False)
 
-    @server.tool()
-    def get_model_snapshot(redact: bool = True) -> str:
-        """Return the versioned Point/Line/Face/Volume/Root personal-model snapshot.
+    @server.tool(structured_output=False)
+    def get_model_snapshot(
+        redact: bool = True,
+        section: str = "overview",
+        cursor: str | None = None,
+        limit: int = model_projection.DEFAULT_PAGE_LIMIT,
+        ids: list[str] | None = None,
+        include_evidence_refs: bool = False,
+    ) -> str:
+        """Return a bounded projection of the versioned Personal Model.
 
-        This is the stable Runtime boundary used by viewers and external clients. It includes
-        build metadata, provenance receipts, geometry counts, and the singleton Root. The call
-        is local, read-only, and uncached. ``redact=true`` is the safe default; pass false only
-        when the user explicitly needs their unredacted local model.
+        The default ``section=overview`` returns model/build stats plus compact Root, Face, and
+        Volume objects. Use ``points``, ``lines``, ``faces``, ``volumes``, ``root``, or
+        ``receipts`` for bounded pages; pass the returned opaque ``cursor`` for the next page,
+        or up to 20 exact ``ids`` for a focused selection. Aggregate evidence-reference arrays
+        stay summarized unless ``include_evidence_refs=true`` on their paged section, and still
+        cannot exceed the result byte budget.
+        ``section=full`` returns a small CLI-export instruction because an unbounded snapshot is
+        unsafe for MCP transports. ``redact=true`` is the safe default; pass false only when the
+        user explicitly needs unredacted local model data.
         """
+        section = bounded_text("section", section, maximum=32)
+        cursor = bounded_optional_text("cursor", cursor, maximum=2048)
+        limit = bounded_int(limit, minimum=1, maximum=100)
+        ids = bounded_text_list(
+            "ids",
+            ids,
+            maximum_items=20,
+            maximum_item_chars=1024,
+        )
+        model_projection.validate_request(section=section, cursor=cursor, ids=ids)
+        if section == "full":
+            return model_projection.dumps(model_projection.full_export_response(redact=redact))
         with fts.cursor() as conn:
-            return json.dumps(_get_model_snapshot(conn, redact=redact), ensure_ascii=False)
+            snapshot = model_snapshot_cache.get(conn, redact=redact)
+            return model_projection.dumps(
+                model_projection.project_snapshot(
+                    snapshot,
+                    redact=redact,
+                    section=section,
+                    cursor=cursor,
+                    limit=limit,
+                    ids=ids,
+                    include_evidence_refs=include_evidence_refs,
+                )
+            )
 
     @server.tool()
     def resolve_evidence(reference: str) -> str:
@@ -1725,7 +1832,10 @@ def build_server(
             with use_bridge(bridge):
                 return writer_agent.run(cfg, limit=max_sessions)
 
-        result = await run_request_scoped(bridge, _run)
+        try:
+            result = await run_request_scoped(bridge, _run)
+        finally:
+            model_snapshot_cache.clear()
         status = "aborted" if bridge.cancelled else "completed"
         return json.dumps(
             {
@@ -1768,10 +1878,9 @@ def build_server(
             maximum_item_chars=128,
         )
         with fts.cursor() as conn:
-            return json.dumps(
-                _memory_write.remember(conn, content=content, tags=tag_list, run_id=run_id),
-                ensure_ascii=False,
-            )
+            result = _memory_write.remember(conn, content=content, tags=tag_list, run_id=run_id)
+        model_snapshot_cache.clear()
+        return json.dumps(result, ensure_ascii=False)
 
     if include_http_routes:
         from ..api import register_routes

--- a/src/persome/mcp/server.py
+++ b/src/persome/mcp/server.py
@@ -25,7 +25,9 @@ import threading
 import time
 from collections.abc import Callable
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Annotated, Any, Literal
+
+from pydantic import Field
 
 from .. import __version__, index_health
 from ..config import Config
@@ -49,6 +51,21 @@ from .limits import (
 logger = get("persome.mcp")
 
 _MCP_MODEL_SNAPSHOT_CACHE_TTL_SECONDS = 15.0
+
+_ModelSnapshotSection = Literal[
+    "overview",
+    "points",
+    "lines",
+    "faces",
+    "volumes",
+    "root",
+    "receipts",
+    "full",
+]
+_ModelSnapshotCursor = Annotated[str | None, Field(max_length=2048)]
+_ModelSnapshotLimit = Annotated[int, Field(ge=1, le=100)]
+_ModelSnapshotId = Annotated[str, Field(min_length=1, max_length=1024)]
+_ModelSnapshotIds = Annotated[list[_ModelSnapshotId] | None, Field(max_length=20)]
 
 
 class _ModelSnapshotCache:
@@ -1293,10 +1310,10 @@ def build_server(
     @server.tool(structured_output=False)
     def get_model_snapshot(
         redact: bool = True,
-        section: str = "overview",
-        cursor: str | None = None,
-        limit: int = model_projection.DEFAULT_PAGE_LIMIT,
-        ids: list[str] | None = None,
+        section: _ModelSnapshotSection = "overview",
+        cursor: _ModelSnapshotCursor = None,
+        limit: _ModelSnapshotLimit = model_projection.DEFAULT_PAGE_LIMIT,
+        ids: _ModelSnapshotIds = None,
         include_evidence_refs: bool = False,
     ) -> str:
         """Return a bounded projection of the versioned Personal Model.

--- a/src/persome/model/human.py
+++ b/src/persome/model/human.py
@@ -260,7 +260,7 @@ def render_human_markdown(snapshot: dict[str, Any], *, redacted: bool = False) -
             f"{int(stats.get('roots') or 0)} Root",
             f"- Evidence receipts: {int(stats.get('receipts') or 0)}",
             f"- Degraded stages: {_safe_markdown(', '.join(map(str, degraded))) or 'none'}",
-            "- Full evidence: `persome model export` or MCP `get_model_snapshot`",
+            "- Full evidence: `persome model export`; MCP provides bounded overview/pages",
             "",
         ]
     )

--- a/tests/test_mcp_model_projection.py
+++ b/tests/test_mcp_model_projection.py
@@ -1,0 +1,490 @@
+"""Adversarial and traversal tests for the bounded MCP model projection."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from persome.mcp import model_projection
+
+
+def _snapshot(
+    *,
+    points: list[dict] | None = None,
+    lines: list[dict] | None = None,
+    faces: list[dict] | None = None,
+    volumes: list[dict] | None = None,
+    root: dict | None = None,
+    receipts: list[dict] | None = None,
+    build: dict | None = None,
+) -> dict:
+    points = [] if points is None else points
+    lines = [] if lines is None else lines
+    faces = [] if faces is None else faces
+    volumes = [] if volumes is None else volumes
+    receipts = [] if receipts is None else receipts
+    return {
+        "schema_version": 1,
+        "generated_at": "2026-08-03T00:00:00+00:00",
+        "build": {"status": "complete", "build_id": "fixture"} if build is None else build,
+        "points": points,
+        "lines": lines,
+        "faces": faces,
+        "volumes": volumes,
+        "root": root,
+        "receipts": receipts,
+        "stats": {
+            "points": len(points),
+            "active_points": len(points),
+            "evolution_lines": sum(line.get("kind") == "evolution" for line in lines),
+            "relation_lines": sum(line.get("kind") == "relation" for line in lines),
+            "faces": len(faces),
+            "volumes": len(volumes),
+            "roots": int(root is not None),
+            "receipts": len(receipts),
+            "redactions": {},
+        },
+    }
+
+
+def _receipt(value: str) -> dict:
+    return {"receipt": value, "source_kind": "point", "source_id": "point-fixture"}
+
+
+def _geometry(identifier: str, *, large: bool, level: int = 1) -> dict:
+    return {
+        "id": identifier,
+        "level": level,
+        "parent_id": None,
+        "signature": "s" * (4_000 if large else 8),
+        "members": [],
+        "member_receipts": [],
+        "source_receipts": [],
+        "anchors": ["a" * 512] * 20 if large else [],
+        "provenance": "mined",
+        "observations": 2,
+        "confidence": 0.8,
+        "status": "active",
+        "valid_from": "2026-08-03T00:00:00+00:00",
+        "created_at": "2026-08-03T00:00:00+00:00",
+    }
+
+
+def _assert_bounded(payload: dict) -> None:
+    assert model_projection.result_bytes(payload) <= model_projection.MAX_RESULT_BYTES
+    json.loads(model_projection.dumps(payload))
+
+
+def test_thirteen_mib_receipt_key_keeps_error_and_resume_cursor_bounded() -> None:
+    huge_key = "r" * (13 * 1024 * 1024)
+    snapshot = _snapshot(receipts=[_receipt(huge_key), _receipt("receipt-later")])
+
+    blocked = model_projection.project_snapshot(
+        snapshot,
+        redact=True,
+        section="receipts",
+        limit=2,
+    )
+    cursor = blocked["pagination"]["resume_cursor"]
+
+    assert blocked["error"]["code"] == "model_item_exceeds_mcp_budget"
+    assert len(cursor) == 56
+    model_projection.validate_cursor_shape(section="receipts", cursor=cursor)
+    _assert_bounded(blocked)
+
+    resumed = model_projection.project_snapshot(
+        snapshot,
+        redact=True,
+        section="receipts",
+        cursor=cursor,
+        limit=2,
+    )
+    assert [item["receipt"] for item in resumed["items"]] == ["receipt-later"]
+    _assert_bounded(resumed)
+
+
+@pytest.mark.parametrize("huge_key", ["k" * 100_000, "🙂" * 100_000])
+def test_large_ascii_and_unicode_keys_return_fixed_size_cursors(huge_key: str) -> None:
+    snapshot = _snapshot(receipts=[_receipt(huge_key), _receipt("receipt-later")])
+
+    blocked = model_projection.project_snapshot(
+        snapshot,
+        redact=True,
+        section="receipts",
+        limit=1,
+    )
+    cursor = blocked["pagination"]["resume_cursor"]
+
+    assert blocked["error"]["code"] == "model_item_exceeds_mcp_budget"
+    assert len(cursor) == 56
+    model_projection.validate_cursor_shape(section="receipts", cursor=cursor)
+    _assert_bounded(blocked)
+
+
+def test_fitting_unicode_key_returns_reusable_fixed_size_next_cursor() -> None:
+    unicode_key = "🙂" * 1_024
+    snapshot = _snapshot(receipts=[_receipt(unicode_key), _receipt("receipt-later")])
+
+    first = model_projection.project_snapshot(
+        snapshot,
+        redact=True,
+        section="receipts",
+        limit=1,
+    )
+    cursor = first["page"]["next_cursor"]
+
+    assert [item["receipt"] for item in first["items"]] == [unicode_key]
+    assert len(cursor) == 56
+    model_projection.validate_cursor_shape(section="receipts", cursor=cursor)
+    _assert_bounded(first)
+
+    second = model_projection.project_snapshot(
+        snapshot,
+        redact=True,
+        section="receipts",
+        cursor=cursor,
+        limit=1,
+    )
+    assert [item["receipt"] for item in second["items"]] == ["receipt-later"]
+    _assert_bounded(second)
+
+
+def test_duplicate_line_keys_page_by_exact_occurrence_and_terminate() -> None:
+    duplicate_lines = [
+        {
+            "id": "evolution:old:new",
+            "kind": "evolution",
+            "source": "old",
+            "target": "new",
+            "predicate": "supersedes",
+            "marker": marker,
+        }
+        for marker in ("first", "second", "third")
+    ]
+    lines = [
+        *duplicate_lines,
+        {
+            "id": "relation-later",
+            "kind": "relation",
+            "source": "self",
+            "target": "project",
+            "predicate": "works_on",
+            "marker": "later",
+        },
+    ]
+    snapshot = _snapshot(lines=lines)
+    cursor = None
+    markers: list[str] = []
+    cursors: list[str] = []
+
+    for _ in range(10):
+        page = model_projection.project_snapshot(
+            snapshot,
+            redact=True,
+            section="lines",
+            cursor=cursor,
+            limit=1,
+        )
+        _assert_bounded(page)
+        markers.extend(item["marker"] for item in page["items"])
+        if not page["page"]["has_more"]:
+            break
+        cursor = page["page"]["next_cursor"]
+        cursors.append(cursor)
+    else:  # pragma: no cover - explicit infinite-loop guard
+        pytest.fail("duplicate-key pagination did not terminate")
+
+    assert markers == ["first", "second", "third", "later"]
+    assert len(set(cursors)) == len(cursors)
+
+
+def test_multiple_oversized_items_can_each_be_skipped_before_small_item() -> None:
+    points = [{"id": f"point-huge-{index}", "content": "x" * (2 * 64 * 1024)} for index in range(3)]
+    points.append({"id": "point-small", "content": "reachable"})
+    snapshot = _snapshot(points=points)
+    cursor = None
+
+    for index in range(3):
+        blocked = model_projection.project_snapshot(
+            snapshot,
+            redact=True,
+            section="points",
+            cursor=cursor,
+            limit=100,
+        )
+        assert blocked["error"]["item_id"] == f"point-huge-{index}"
+        cursor = blocked["pagination"]["resume_cursor"]
+        assert len(cursor) == 56
+        _assert_bounded(blocked)
+
+    page = model_projection.project_snapshot(
+        snapshot,
+        redact=True,
+        section="points",
+        cursor=cursor,
+        limit=100,
+    )
+    assert [item["id"] for item in page["items"]] == ["point-small"]
+    assert page["page"]["has_more"] is False
+    _assert_bounded(page)
+
+
+def test_exact_id_selection_accounts_for_multiple_oversized_items_incrementally() -> None:
+    points = [{"id": f"point-huge-{index}", "content": "x" * (2 * 64 * 1024)} for index in range(3)]
+    points.append({"id": "point-small", "content": "reachable"})
+    snapshot = _snapshot(points=points)
+
+    selected = model_projection.project_snapshot(
+        snapshot,
+        redact=True,
+        section="points",
+        ids=[item["id"] for item in points],
+    )
+
+    assert [item["id"] for item in selected["items"]] == ["point-small"]
+    assert selected["selection"]["oversized_ids"] == [
+        "point-huge-0",
+        "point-huge-1",
+        "point-huge-2",
+    ]
+    _assert_bounded(selected)
+
+
+def test_page_reports_metadata_overflow_before_examining_small_item() -> None:
+    snapshot = _snapshot(
+        points=[{"id": "point-small", "content": "small"}],
+        build={"status": "complete", "build_id": "fixture", "future": "z" * (70 * 1024)},
+    )
+
+    page = model_projection.project_snapshot(
+        snapshot,
+        redact=True,
+        section="points",
+        limit=1,
+    )
+
+    assert page["error"]["code"] == "model_projection_metadata_exceeds_mcp_budget"
+    assert "item_id" not in page["error"]
+    _assert_bounded(page)
+
+
+def test_overview_skips_nonfitting_geometry_and_keeps_later_small_item() -> None:
+    faces = [_geometry(f"face-large-{index}", large=True) for index in range(5)]
+    faces.append(_geometry("face-small-later", large=False))
+    snapshot = _snapshot(faces=faces)
+
+    overview = model_projection.project_snapshot(snapshot, redact=True)
+    returned_ids = [item["id"] for item in overview["faces"]]
+
+    assert "face-small-later" in returned_ids
+    assert len(returned_ids) < len(faces)
+    assert overview["coverage"]["faces"] == {
+        "returned": len(returned_ids),
+        "total": len(faces),
+    }
+    _assert_bounded(overview)
+
+
+def test_page_stops_after_first_oversized_item_without_serializing_later_items() -> None:
+    snapshot = _snapshot(
+        points=[
+            {"id": "point-huge", "content": "x" * (2 * 64 * 1024)},
+            {"id": "point-not-visited", "content": object()},
+        ]
+    )
+
+    page = model_projection.project_snapshot(
+        snapshot,
+        redact=True,
+        section="points",
+        limit=100,
+    )
+
+    assert page["error"]["item_id"] == "point-huge"
+    _assert_bounded(page)
+
+
+def test_cursor_shape_validation_rejects_malformed_and_wrong_section_tokens() -> None:
+    changed_snapshot = _snapshot(points=[{"id": "point-changed", "content": "zero"}])
+    page = model_projection.project_snapshot(
+        _snapshot(
+            points=[
+                {"id": "point-0", "content": "zero"},
+                {"id": "point-1", "content": "one"},
+            ]
+        ),
+        redact=True,
+        section="points",
+        limit=1,
+    )
+    cursor = page["page"]["next_cursor"]
+
+    model_projection.validate_cursor_shape(section="points", cursor=None)
+    model_projection.validate_cursor_shape(section="points", cursor=cursor)
+    with pytest.raises(ValueError, match="invalid model pagination cursor"):
+        model_projection.validate_cursor_shape(section="points", cursor="!")
+    with pytest.raises(ValueError, match="different response or section"):
+        model_projection.validate_cursor_shape(section="lines", cursor=cursor)
+    with pytest.raises(ValueError, match="stale"):
+        model_projection.project_snapshot(
+            changed_snapshot,
+            redact=True,
+            section="points",
+            cursor=cursor,
+            limit=1,
+        )
+
+
+def test_every_section_pages_to_completion_without_loss() -> None:
+    points = [
+        {"id": f"point-{index:03}", "content": "x" * ((index % 7) * 700)} for index in range(123)
+    ]
+    lines = [
+        {
+            "id": f"line-{index:03}",
+            "kind": "relation",
+            "source": "self",
+            "target": f"project-{index}",
+            "predicate": "works_on",
+        }
+        for index in range(111)
+    ]
+    faces = [_geometry(f"face-{index:03}", large=index % 9 == 0) for index in range(33)]
+    volumes = [
+        _geometry(f"volume-{index:03}", large=index % 7 == 0, level=2) for index in range(29)
+    ]
+    root = _geometry("root-000", large=False, level=3)
+    receipts = [_receipt(f"receipt-{index:03}") for index in range(127)]
+    snapshot = _snapshot(
+        points=points,
+        lines=lines,
+        faces=faces,
+        volumes=volumes,
+        root=root,
+        receipts=receipts,
+    )
+
+    for section in model_projection.PAGE_SECTIONS:
+        expected = [root] if section == "root" else snapshot[section]
+        cursor = None
+        returned: list[dict] = []
+        for _ in range(100):
+            page = model_projection.project_snapshot(
+                snapshot,
+                redact=True,
+                section=section,
+                cursor=cursor,
+                limit=17,
+            )
+            assert "error" not in page
+            _assert_bounded(page)
+            returned.extend(page["items"])
+            if not page["page"]["has_more"]:
+                break
+            cursor = page["page"]["next_cursor"]
+            assert len(cursor) == 56
+        else:  # pragma: no cover - explicit infinite-loop guard
+            pytest.fail(f"{section} pagination did not terminate")
+
+        if section in {"faces", "volumes", "root"}:
+            assert [item["id"] for item in returned] == [item["id"] for item in expected]
+        else:
+            assert returned == expected
+
+
+def test_projection_envelope_key_sets_are_stable() -> None:
+    common_keys = {
+        "projection_schema_version",
+        "model_schema_version",
+        "section",
+        "canonical_snapshot_complete",
+        "redacted",
+        "generated_at",
+        "build",
+        "model_stats",
+        "consistency",
+        "full_export",
+    }
+    points = [
+        {"id": "point-0", "content": "zero"},
+        {"id": "point-1", "content": "one"},
+    ]
+    snapshot = _snapshot(points=points, faces=[_geometry("face-0", large=False)])
+
+    overview = model_projection.project_snapshot(snapshot, redact=True)
+    page = model_projection.project_snapshot(
+        snapshot,
+        redact=True,
+        section="points",
+        limit=1,
+    )
+    selection = model_projection.project_snapshot(
+        snapshot,
+        redact=True,
+        section="points",
+        ids=["point-1", "missing"],
+    )
+    oversized = model_projection.project_snapshot(
+        _snapshot(
+            points=[
+                {"id": "point-huge", "content": "x" * (2 * 64 * 1024)},
+                {"id": "point-later", "content": "later"},
+            ]
+        ),
+        redact=True,
+        section="points",
+        limit=1,
+    )
+    full = model_projection.full_export_response(redact=True)
+
+    assert set(overview) == common_keys | {
+        "root",
+        "faces",
+        "volumes",
+        "coverage",
+        "omitted_model_sections",
+        "paging",
+    }
+    assert set(page) == common_keys | {"items", "page", "include_evidence_refs"}
+    assert set(page["page"]) == {
+        "requested_limit",
+        "returned",
+        "total",
+        "has_more",
+        "next_cursor",
+    }
+    assert set(selection) == common_keys | {"items", "selection", "include_evidence_refs"}
+    assert set(selection["selection"]) == {
+        "requested",
+        "returned",
+        "missing_ids",
+        "omitted_ids_due_to_size",
+        "oversized_ids",
+    }
+    assert set(oversized) == {
+        "projection_schema_version",
+        "model_schema_version",
+        "section",
+        "canonical_snapshot_complete",
+        "redacted",
+        "error",
+        "full_export",
+        "pagination",
+    }
+    assert set(oversized["error"]) == {"code", "item_id", "max_result_bytes"}
+    assert set(oversized["pagination"]) == {
+        "skipped_oversized_item",
+        "has_more",
+        "resume_cursor",
+    }
+    assert set(full) == {
+        "projection_schema_version",
+        "model_schema_version",
+        "section",
+        "canonical_snapshot_complete",
+        "redacted",
+        "error",
+        "full_export",
+    }
+    assert set(full["error"]) == {"code", "message"}

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -2,8 +2,15 @@
 
 import asyncio
 import json
+import os
+import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
+import pytest
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
 from mcp.types import CallToolResult
 
 from persome import __version__, paths
@@ -291,6 +298,64 @@ def test_registered_get_model_snapshot_bounds_large_default_result(
     assert len(wire) < 2 * model_projection.MAX_RESULT_BYTES + 4096
 
 
+def test_stdio_get_model_snapshot_bounds_17_mib_canonical_snapshot(ac_root: Path) -> None:
+    fts.initialize_runtime_schema()
+    child_code = """
+from persome.config import Config
+from persome.mcp.server import build_server
+import persome.model as model
+
+marker = "transport-private-marker-" + "x" * (17 * 1024 * 1024)
+snapshot = {
+    "schema_version": 1,
+    "generated_at": "2026-08-03T00:00:00+00:00",
+    "build": {},
+    "points": [{"id": "point-large", "content": marker}],
+    "lines": [],
+    "faces": [],
+    "volumes": [],
+    "root": None,
+    "receipts": [],
+    "stats": {
+        "points": 1,
+        "active_points": 1,
+        "evolution_lines": 0,
+        "relation_lines": 0,
+        "faces": 0,
+        "volumes": 0,
+        "roots": 0,
+        "receipts": 0,
+        "redactions": {},
+    },
+}
+model.build_live_snapshot = lambda conn, redact=True: snapshot
+build_server(Config(), auth_enabled=False, include_http_routes=False).run()
+"""
+
+    async def call_snapshot() -> CallToolResult:
+        env = os.environ.copy()
+        env["PERSOME_ROOT"] = str(ac_root)
+        env["PERSOME_LLM_MOCK"] = "1"
+        params = StdioServerParameters(command=sys.executable, args=["-c", child_code], env=env)
+        async with (
+            stdio_client(params) as (read, write),
+            ClientSession(read, write) as session,
+        ):
+            await session.initialize()
+            return await session.call_tool("get_model_snapshot", {})
+
+    result = asyncio.run(asyncio.wait_for(call_snapshot(), timeout=30.0))
+    assert result.isError is False
+    assert result.structuredContent is None
+    assert len(result.content) == 1
+    raw = result.content[0].text
+    parsed = json.loads(raw)
+    assert parsed["section"] == "overview"
+    assert parsed["model_stats"]["points"] == 1
+    assert "transport-private-marker" not in raw
+    assert len(raw.encode("utf-8")) <= model_projection.MAX_RESULT_BYTES
+
+
 def test_registered_get_model_snapshot_pages_points_with_opaque_cursor(
     ac_root: Path, monkeypatch
 ) -> None:
@@ -316,6 +381,113 @@ def test_registered_get_model_snapshot_pages_points_with_opaque_cursor(
     assert second["page"]["has_more"] is False
     assert second["page"]["next_cursor"] is None
     assert build_calls == [True]
+
+
+def test_registered_get_model_snapshot_rejects_malformed_cursor_before_build(
+    ac_root: Path, monkeypatch
+) -> None:
+    build_calls = []
+
+    def fake_live_snapshot(conn, *, redact=True):  # type: ignore[no-untyped-def]
+        build_calls.append(redact)
+        return _synthetic_snapshot()
+
+    monkeypatch.setattr(model_mod, "build_live_snapshot", fake_live_snapshot)
+    server = mcp_server.build_server(auth_enabled=False)
+    tool = server._tool_manager.get_tool("get_model_snapshot")
+    assert tool is not None
+
+    with pytest.raises(ValueError, match="invalid model pagination cursor"):
+        tool.fn(section="points", cursor="not-a-model-cursor")
+
+    assert build_calls == []
+
+
+def test_model_snapshot_cache_ttl_and_stale_timer_guard(monkeypatch) -> None:
+    now = [100.0]
+    build_calls: list[bool] = []
+    timers = []
+
+    class FakeTimer:
+        def __init__(self, interval, function, args=()):  # type: ignore[no-untyped-def]
+            self.interval = interval
+            self.function = function
+            self.args = args
+            self.cancelled = False
+            self.daemon = False
+            timers.append(self)
+
+        def start(self) -> None:
+            pass
+
+        def cancel(self) -> None:
+            self.cancelled = True
+
+        def fire(self) -> None:
+            self.function(*self.args)
+
+    def fake_live_snapshot(conn, *, redact=True):  # type: ignore[no-untyped-def]
+        build_calls.append(redact)
+        return {"redact": redact, "generation": len(build_calls)}
+
+    monkeypatch.setattr(mcp_server.time, "monotonic", lambda: now[0])
+    monkeypatch.setattr(mcp_server.threading, "Timer", FakeTimer)
+    monkeypatch.setattr(model_mod, "build_live_snapshot", fake_live_snapshot)
+    cache = mcp_server._ModelSnapshotCache(ttl_seconds=15.0)
+
+    first = cache.get(None, redact=True)
+    now[0] = 114.999
+    assert cache.get(None, redact=True) is first
+    now[0] = 115.0
+    second = cache.get(None, redact=True)
+
+    assert second is not first
+    assert build_calls == [True, True]
+    assert timers[0].cancelled is True
+    timers[0].fire()
+    assert cache._entry is not None
+    timers[1].fire()
+    assert cache._entry is None
+
+
+def test_model_snapshot_cache_single_flight_and_redaction_isolation(monkeypatch) -> None:
+    build_calls: list[bool] = []
+    calls_lock = threading.Lock()
+    start = threading.Barrier(8)
+    build_started = threading.Event()
+    release_build = threading.Event()
+
+    def fake_live_snapshot(conn, *, redact=True):  # type: ignore[no-untyped-def]
+        with calls_lock:
+            build_calls.append(redact)
+        build_started.set()
+        assert release_build.wait(timeout=10.0)
+        return {"redact": redact, "generation": len(build_calls)}
+
+    monkeypatch.setattr(model_mod, "build_live_snapshot", fake_live_snapshot)
+    cache = mcp_server._ModelSnapshotCache(ttl_seconds=15.0)
+
+    def get_redacted(_index: int) -> dict:
+        start.wait()
+        return cache.get(None, redact=True)
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        futures = [pool.submit(get_redacted, index) for index in range(8)]
+        assert build_started.wait(timeout=10.0)
+        release_build.set()
+        redacted = [future.result(timeout=10.0) for future in futures]
+
+    assert build_calls == [True]
+    assert len({id(snapshot) for snapshot in redacted}) == 1
+    raw = cache.get(None, redact=False)
+    raw_again = cache.get(None, redact=False)
+    redacted_again = cache.get(None, redact=True)
+
+    assert raw["redact"] is False
+    assert raw_again is raw
+    assert redacted_again["redact"] is True
+    assert redacted_again is not redacted[0]
+    assert build_calls == [True, False, True]
 
 
 def test_registered_get_model_snapshot_pages_shadow_evolution_history(
@@ -498,6 +670,58 @@ def test_registered_get_model_snapshot_redacts_real_model_pages(ac_root: Path) -
     assert home_path in raw_points
 
 
+def test_registered_model_writes_invalidate_snapshot_cache(ac_root: Path, monkeypatch) -> None:
+    from persome.writer import agent as writer_agent
+    from persome.writer import correct as correct_mod
+
+    build_calls: list[bool] = []
+
+    def fake_live_snapshot(conn, *, redact=True):  # type: ignore[no-untyped-def]
+        build_calls.append(redact)
+        return _synthetic_snapshot()
+
+    monkeypatch.setattr(model_mod, "build_live_snapshot", fake_live_snapshot)
+    monkeypatch.setattr(
+        correct_mod,
+        "update_memory",
+        lambda *args, **kwargs: correct_mod.UpdateResult("noop", reason="fixture"),
+    )
+    server = mcp_server.build_server(auth_enabled=False)
+    model_tool = server._tool_manager.get_tool("get_model_snapshot")
+    remember_tool = server._tool_manager.get_tool("remember")
+    correct_tool = server._tool_manager.get_tool("correct_memory")
+    process_tool = server._tool_manager.get_tool("process_pending_model_work")
+    assert model_tool is not None
+    assert remember_tool is not None
+    assert correct_tool is not None
+    assert process_tool is not None
+
+    model_tool.fn()
+    model_tool.fn(section="points")
+    assert build_calls == [True]
+
+    remember_tool.fn(content="A durable test finding")
+    model_tool.fn()
+    assert build_calls == [True, True]
+
+    correct_tool.fn(correction="The prior fixture is wrong")
+    model_tool.fn()
+    assert build_calls == [True, True, True]
+
+    class FakeSession:
+        @staticmethod
+        def check_client_capability(capability) -> bool:  # type: ignore[no-untyped-def]
+            return True
+
+    class FakeContext:
+        session = FakeSession()
+
+    monkeypatch.setattr(writer_agent, "run", lambda cfg, *, limit: writer_agent.WriterRunResult())
+    asyncio.run(process_tool.fn(FakeContext()))
+    model_tool.fn()
+    assert build_calls == [True, True, True, True]
+
+
 def test_registered_get_model_snapshot_full_returns_cli_hint_without_build(
     ac_root: Path, monkeypatch
 ) -> None:
@@ -534,6 +758,27 @@ def test_server_reports_runtime_version(ac_root: Path) -> None:
         "redact",
         "section",
     }
+    properties = model_tool.parameters["properties"]
+    assert properties["section"]["enum"] == [
+        "overview",
+        "points",
+        "lines",
+        "faces",
+        "volumes",
+        "root",
+        "receipts",
+        "full",
+    ]
+    assert properties["limit"]["minimum"] == 1
+    assert properties["limit"]["maximum"] == 100
+    cursor_string = next(
+        item for item in properties["cursor"]["anyOf"] if item.get("type") == "string"
+    )
+    assert cursor_string["maxLength"] == 2048
+    ids_array = next(item for item in properties["ids"]["anyOf"] if item.get("type") == "array")
+    assert ids_array["maxItems"] == 20
+    assert ids_array["items"]["minLength"] == 1
+    assert ids_array["items"]["maxLength"] == 1024
 
 
 def test_stdio_server_skips_daemon_http_routes(ac_root: Path) -> None:

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1,16 +1,22 @@
 """Test MCP tool functions directly (bypassing FastMCP wiring)."""
 
+import asyncio
 import json
 from pathlib import Path
+
+from mcp.types import CallToolResult
 
 from persome import __version__, paths
 from persome import model as model_mod
 from persome.capture import s1_parser
+from persome.evomem.models import MemoryLayer, MemoryNode
+from persome.evomem.store import NodeStore
 from persome.mcp import captures as captures_mod
+from persome.mcp import model_projection
 from persome.mcp import server as mcp_server
 from persome.model import ModelBuildCoordinator, create_build_manifest
 from persome.store import entries as entries_mod
-from persome.store import fts, health_events
+from persome.store import fts, health_events, schema_faces
 from persome.timeline import store as timeline_store
 
 BUILD_KEYS = {
@@ -28,6 +34,45 @@ BUILD_KEYS = {
     "status",
     "trigger",
 }
+
+
+def _synthetic_snapshot(
+    *,
+    points: list[dict] | None = None,
+    lines: list[dict] | None = None,
+    faces: list[dict] | None = None,
+    volumes: list[dict] | None = None,
+    root: dict | None = None,
+    receipts: list[dict] | None = None,
+    generated_at: str = "2026-08-03T00:00:00+00:00",
+) -> dict:
+    points = points or []
+    lines = lines or []
+    faces = faces or []
+    volumes = volumes or []
+    receipts = receipts or []
+    return {
+        "schema_version": 1,
+        "generated_at": generated_at,
+        "build": {"status": "complete", "build_id": "fixture-build"},
+        "points": points,
+        "lines": lines,
+        "faces": faces,
+        "volumes": volumes,
+        "root": root,
+        "receipts": receipts,
+        "stats": {
+            "points": len(points),
+            "active_points": len(points),
+            "evolution_lines": sum(1 for line in lines if line.get("kind") == "evolution"),
+            "relation_lines": sum(1 for line in lines if line.get("kind") == "relation"),
+            "faces": len(faces),
+            "volumes": len(volumes),
+            "roots": 1 if root else 0,
+            "receipts": len(receipts),
+            "redactions": {},
+        },
+    }
 
 
 def test_list_memories(ac_root: Path) -> None:
@@ -129,10 +174,14 @@ def test_query_health_events_filters_and_orders(ac_root: Path) -> None:
 def test_get_model_snapshot_uses_versioned_contract(ac_root: Path) -> None:
     with fts.cursor() as conn:
         out = mcp_server._get_model_snapshot(conn)
-    assert out["schema_version"] == 1
-    assert out["points"] == []
+    assert out["projection_schema_version"] == 1
+    assert out["model_schema_version"] == 1
+    assert out["section"] == "overview"
+    assert out["canonical_snapshot_complete"] is False
+    assert "points" not in out
     assert out["root"] is None
-    assert out["stats"]["roots"] == 0
+    assert out["model_stats"]["roots"] == 0
+    assert out["coverage"]["points"] == {"returned": 0, "total": 0}
     assert set(out["build"]) == BUILD_KEYS
     assert out["build"]["status"] == "not_built"
     assert out["build"]["trigger"] == "no_completed_build"
@@ -142,7 +191,7 @@ def test_get_model_snapshot_uses_versioned_contract(ac_root: Path) -> None:
 def test_get_model_snapshot_uses_transactionally_stable_live_reader(
     ac_root: Path, monkeypatch
 ) -> None:
-    sentinel = {"schema_version": 1, "source": "live-reader"}
+    sentinel = _synthetic_snapshot(generated_at="2026-08-03T01:02:03+00:00")
     calls = []
 
     def fake_live_snapshot(conn, *, redact=True):  # type: ignore[no-untyped-def]
@@ -153,7 +202,8 @@ def test_get_model_snapshot_uses_transactionally_stable_live_reader(
     with fts.cursor() as conn:
         out = mcp_server._get_model_snapshot(conn, redact=False)
 
-    assert out is sentinel
+    assert out["generated_at"] == "2026-08-03T01:02:03+00:00"
+    assert out["redacted"] is False
     assert len(calls) == 1
     assert calls[0][1] is False
 
@@ -200,12 +250,290 @@ def test_get_model_snapshot_preserves_saved_manifest(ac_root: Path) -> None:
     assert out["build"] == manifest
 
 
+def test_registered_get_model_snapshot_bounds_large_default_result(
+    ac_root: Path, monkeypatch
+) -> None:
+    marker = "oversized-private-marker-" + "x" * (17 * 1024 * 1024)
+    huge_refs = [f"receipt-{index}" for index in range(20_000)]
+    snapshot = _synthetic_snapshot(
+        points=[{"id": "point-large", "content": marker}],
+        faces=[
+            {
+                "id": "face-large",
+                "signature": "A compact high-level pattern",
+                "members": huge_refs,
+                "member_receipts": huge_refs,
+                "source_receipts": huge_refs,
+            }
+        ],
+    )
+    monkeypatch.setattr(model_mod, "build_live_snapshot", lambda conn, *, redact=True: snapshot)
+    server = mcp_server.build_server(auth_enabled=False)
+    tool = server._tool_manager.get_tool("get_model_snapshot")
+    assert tool is not None
+
+    converted = asyncio.run(
+        server._tool_manager.call_tool("get_model_snapshot", {}, convert_result=True)
+    )
+    assert isinstance(converted, list)
+    call_result = CallToolResult(content=converted)
+    raw = converted[0].text
+    parsed = json.loads(raw)
+    wire = call_result.model_dump_json().encode("utf-8")
+
+    assert parsed["section"] == "overview"
+    assert parsed["model_stats"]["points"] == 1
+    assert parsed["faces"][0]["source_receipt_count"] == len(huge_refs)
+    assert "points" not in parsed
+    assert "oversized-private-marker" not in raw
+    assert len(raw.encode("utf-8")) <= model_projection.MAX_RESULT_BYTES
+    assert call_result.structuredContent is None
+    assert len(wire) < 2 * model_projection.MAX_RESULT_BYTES + 4096
+
+
+def test_registered_get_model_snapshot_pages_points_with_opaque_cursor(
+    ac_root: Path, monkeypatch
+) -> None:
+    points = [{"id": f"point-{index}", "content": f"content-{index}"} for index in range(3)]
+    snapshot = _synthetic_snapshot(points=points)
+    build_calls = []
+
+    def fake_live_snapshot(conn, *, redact=True):  # type: ignore[no-untyped-def]
+        build_calls.append(redact)
+        return snapshot
+
+    monkeypatch.setattr(model_mod, "build_live_snapshot", fake_live_snapshot)
+    server = mcp_server.build_server(auth_enabled=False)
+    tool = server._tool_manager.get_tool("get_model_snapshot")
+    assert tool is not None
+
+    first = json.loads(tool.fn(section="points", limit=2))
+    second = json.loads(tool.fn(section="points", cursor=first["page"]["next_cursor"], limit=2))
+
+    assert [item["id"] for item in first["items"]] == ["point-0", "point-1"]
+    assert first["page"]["has_more"] is True
+    assert [item["id"] for item in second["items"]] == ["point-2"]
+    assert second["page"]["has_more"] is False
+    assert second["page"]["next_cursor"] is None
+    assert build_calls == [True]
+
+
+def test_registered_get_model_snapshot_pages_shadow_evolution_history(
+    ac_root: Path, monkeypatch
+) -> None:
+    points = [
+        {"id": "point-old", "content": "old", "status": "shadow", "is_latest": False},
+        {"id": "point-new", "content": "new", "status": "active", "is_latest": True},
+    ]
+    lines = [
+        {
+            "id": "evolution:point-old:point-new",
+            "kind": "evolution",
+            "source": "point-old",
+            "target": "point-new",
+            "predicate": "supersedes",
+        }
+    ]
+    snapshot = _synthetic_snapshot(points=points, lines=lines)
+    monkeypatch.setattr(model_mod, "build_live_snapshot", lambda conn, *, redact=True: snapshot)
+    server = mcp_server.build_server(auth_enabled=False)
+    tool = server._tool_manager.get_tool("get_model_snapshot")
+    assert tool is not None
+
+    point_page = json.loads(tool.fn(section="points"))
+    line_page = json.loads(tool.fn(section="lines"))
+
+    returned_points = {item["id"]: item for item in point_page["items"]}
+    assert returned_points["point-old"]["status"] == "shadow"
+    assert returned_points["point-new"]["status"] == "active"
+    assert line_page["items"][0]["source"] in returned_points
+    assert line_page["items"][0]["target"] in returned_points
+
+
+def test_registered_get_model_snapshot_selects_exact_ids(ac_root: Path, monkeypatch) -> None:
+    points = [{"id": f"point-{index}", "content": f"content-{index}"} for index in range(3)]
+    snapshot = _synthetic_snapshot(points=points)
+    monkeypatch.setattr(model_mod, "build_live_snapshot", lambda conn, *, redact=True: snapshot)
+    server = mcp_server.build_server(auth_enabled=False)
+    tool = server._tool_manager.get_tool("get_model_snapshot")
+    assert tool is not None
+
+    selected = json.loads(tool.fn(section="points", ids=["point-2", "missing"]))
+    empty = json.loads(tool.fn(section="points", ids=[]))
+
+    assert [item["id"] for item in selected["items"]] == ["point-2"]
+    assert selected["selection"]["missing_ids"] == ["missing"]
+    assert empty["items"] == []
+    assert empty["selection"]["requested"] == 0
+
+
+def test_registered_get_model_snapshot_rejects_single_oversized_item(
+    ac_root: Path, monkeypatch
+) -> None:
+    marker = "single-private-marker-" + "z" * (model_projection.MAX_RESULT_BYTES * 2)
+    snapshot = _synthetic_snapshot(points=[{"id": "point-large", "content": marker}])
+    monkeypatch.setattr(model_mod, "build_live_snapshot", lambda conn, *, redact=True: snapshot)
+    server = mcp_server.build_server(auth_enabled=False)
+    tool = server._tool_manager.get_tool("get_model_snapshot")
+    assert tool is not None
+
+    raw = tool.fn(section="points", limit=1)
+    parsed = json.loads(raw)
+
+    assert parsed["error"]["code"] == "model_item_exceeds_mcp_budget"
+    assert "single-private-marker" not in raw
+    assert len(raw.encode("utf-8")) <= model_projection.MAX_RESULT_BYTES
+
+
+def test_registered_get_model_snapshot_can_resume_after_oversized_item(
+    ac_root: Path, monkeypatch
+) -> None:
+    marker = "blocked-item-marker-" + "q" * (model_projection.MAX_RESULT_BYTES * 2)
+    snapshot = _synthetic_snapshot(
+        points=[
+            {"id": "point-large", "content": marker},
+            {"id": "point-small", "content": "reachable"},
+        ]
+    )
+    monkeypatch.setattr(model_mod, "build_live_snapshot", lambda conn, *, redact=True: snapshot)
+    server = mcp_server.build_server(auth_enabled=False)
+    tool = server._tool_manager.get_tool("get_model_snapshot")
+    assert tool is not None
+
+    blocked = json.loads(tool.fn(section="points", limit=2))
+    resumed = json.loads(
+        tool.fn(section="points", cursor=blocked["pagination"]["resume_cursor"], limit=2)
+    )
+    selected = json.loads(tool.fn(section="points", ids=["point-large", "point-small"]))
+
+    assert blocked["error"]["code"] == "model_item_exceeds_mcp_budget"
+    assert blocked["pagination"]["skipped_oversized_item"] is True
+    assert [item["id"] for item in resumed["items"]] == ["point-small"]
+    assert [item["id"] for item in selected["items"]] == ["point-small"]
+    assert selected["selection"]["oversized_ids"] == ["point-large"]
+
+
+def test_registered_get_model_snapshot_bounds_expanded_root_evidence(
+    ac_root: Path, monkeypatch
+) -> None:
+    refs = [f"root-private-receipt-{index}" for index in range(20_000)]
+    root = {
+        "id": "root-large",
+        "signature": "Current owner model",
+        "members": refs,
+        "member_receipts": refs,
+        "source_receipts": refs,
+    }
+    snapshot = _synthetic_snapshot(root=root)
+    monkeypatch.setattr(model_mod, "build_live_snapshot", lambda conn, *, redact=True: snapshot)
+    server = mcp_server.build_server(auth_enabled=False)
+    tool = server._tool_manager.get_tool("get_model_snapshot")
+    assert tool is not None
+
+    compact = json.loads(tool.fn(section="root"))
+    expanded_raw = tool.fn(section="root", include_evidence_refs=True)
+    expanded = json.loads(expanded_raw)
+
+    assert compact["items"][0]["source_receipt_count"] == len(refs)
+    assert "source_receipts" not in compact["items"][0]
+    assert expanded["error"]["code"] == "model_item_exceeds_mcp_budget"
+    assert "root-private-receipt" not in expanded_raw
+    assert len(expanded_raw.encode("utf-8")) <= model_projection.MAX_RESULT_BYTES
+
+
+def test_registered_get_model_snapshot_redacts_real_model_pages(ac_root: Path) -> None:
+    email = "alice.private" + "@" + "example.test"
+    home_path = "/" + "Users" + "/alice/private"
+    sensitive = f"Contact {email}; workspace {home_path}"
+    NodeStore().save(
+        MemoryNode(
+            node_id="point-sensitive",
+            content=sensitive,
+            layer=MemoryLayer.L2_FACT,
+            file_name=f"{home_path}/work.md",
+        )
+    )
+    with fts.cursor() as conn:
+        face_id = schema_faces.record_face(
+            conn,
+            source=schema_faces.PROVENANCE_MINED,
+            signature=sensitive,
+            members=["point-sensitive"],
+            anchors=[sensitive],
+        )
+        schema_faces.record_face(
+            conn,
+            source=schema_faces.PROVENANCE_EMERGENT,
+            signature=sensitive,
+            members=["point-sensitive"],
+            anchors=[sensitive],
+        )
+        assert schema_faces.maybe_promote(conn, face_id)
+        schema_faces.upsert_root(
+            conn,
+            signature=sensitive,
+            members=[face_id],
+            anchors=[sensitive],
+        )
+        conn.commit()
+
+    server = mcp_server.build_server(auth_enabled=False)
+    tool = server._tool_manager.get_tool("get_model_snapshot")
+    assert tool is not None
+
+    redacted = tool.fn()
+    redacted_points = tool.fn(section="points")
+    raw = tool.fn(redact=False)
+    raw_points = tool.fn(redact=False, section="points")
+
+    assert email not in redacted
+    assert home_path not in redacted
+    assert email not in redacted_points
+    assert home_path not in redacted_points
+    assert "[REDACTED]" in redacted
+    assert "[REDACTED]" in redacted_points
+    assert email in raw
+    assert home_path in raw
+    assert email in raw_points
+    assert home_path in raw_points
+
+
+def test_registered_get_model_snapshot_full_returns_cli_hint_without_build(
+    ac_root: Path, monkeypatch
+) -> None:
+    def fail_if_built(conn, *, redact=True):  # type: ignore[no-untyped-def]
+        raise AssertionError("full MCP request must not build or serialize a snapshot")
+
+    monkeypatch.setattr(model_mod, "build_live_snapshot", fail_if_built)
+    server = mcp_server.build_server(auth_enabled=False)
+    tool = server._tool_manager.get_tool("get_model_snapshot")
+    assert tool is not None
+
+    parsed = json.loads(tool.fn(section="full"))
+    direct = model_projection.project_snapshot(_synthetic_snapshot(), redact=True, section="full")
+
+    assert parsed["error"]["code"] == "full_snapshot_not_available_over_mcp"
+    assert parsed["full_export"]["command"].startswith("persome model export")
+    assert direct["error"]["code"] == "full_snapshot_not_available_over_mcp"
+
+
 def test_server_reports_runtime_version(ac_root: Path) -> None:
     server = mcp_server.build_server(auth_enabled=False)
     assert server._mcp_server.version == __version__
     tool = server._tool_manager.get_tool("process_pending_model_work")
     assert tool is not None
     assert "ctx" not in tool.parameters["properties"]
+    model_tool = server._tool_manager.get_tool("get_model_snapshot")
+    assert model_tool is not None
+    assert model_tool.output_schema is None
+    assert set(model_tool.parameters["properties"]) == {
+        "cursor",
+        "ids",
+        "include_evidence_refs",
+        "limit",
+        "redact",
+        "section",
+    }
 
 
 def test_stdio_server_skips_daemon_http_routes(ac_root: Path) -> None:


### PR DESCRIPTION
## What changed

- replace the unbounded default `get_model_snapshot` result with a separately versioned, byte-bounded MCP overview
- add paged and exact-ID reads for Point, Line, Face, Volume, Root, and receipt sections
- use fixed-size opaque cursors with section/version/ordinal/digest checks, including safe progress across duplicate keys and oversized items
- pack pages incrementally against the exact 64 KiB `content[0].text` budget, with a final serialized-size backstop
- validate tool inputs in the published MCP schema and reject malformed cursors before building a snapshot
- cache one redaction-specific canonical snapshot for at most 15 seconds with single-flight builds and write invalidation
- keep full canonical snapshots on `persome model export` and owner-local `/model/graph`
- document the v0.4.0 breaking migration and make release CI require PyPI and MCP Registry versions to match the tag

## Root cause

The tool returned the complete schema-v1 snapshot in one stdio message. Canonical snapshots intentionally retain shadow Points, evolution Lines, and evidence receipts, so audit history makes the response grow without a transport bound. At 16 MiB Claude Code disconnects the stdio server even though snapshot construction and serialization themselves succeed.

## Compatibility

The canonical schema-v1 model, CLI export, HTTP viewer, shadow history, evolution Lines, and receipts are unchanged. Only the MCP projection contract changes. The migration is targeted for v0.4.0; this PR intentionally does not bump package versions before the release-prep commit.

## Validation

- Python 3.12 and 3.13 full default suites: `2190 passed, 17 deselected` on each runtime
- MCP projection/tool tests: `54 passed`; broader targeted model/MCP suite: `145 passed`
- macOS marker: 2 passed, 2 skipped; integration marker: 2 passed, 11 environment-dependent skips
- Swift package: 19 tests passed; generic iOS build succeeded
- OpenAPI and DB schema drift tests: 4 passed
- Ruff, format, lock, shell syntax, secret, PII, language, docs-link, and pip-audit checks passed
- source and PyPI wheel/sdist builds plus installed CLI and synthetic HTTP MCP smoke passed
- actual 17 MiB stdio regression passed repeatedly with no orphan process
- live read-only model traversal returned all 5,263 Points, 2,858 Lines, 12 Faces, 59 Volumes, one Root, and 5,263 receipts; largest page was 65,532 bytes
- independent adversarial oracles covered 100,000-item pagination, Unicode/control characters, duplicate keys, stale/tampered cursors, exact-ID reads, and oversized-item recovery
- three independent final reviews found no P0, P1, or P2 issues
