### PR TITLE
fix: exec background runtime safely

### DIFF
--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -236,8 +236,9 @@ validation, one-operation directory exchange, crash recovery before/after that
 exchange, rejection of absolute candidate shebangs, execution of the relocated
 CLI after old-venv cleanup, signal-safe rollback, and final
 background/LaunchAgent ownership.
-Lifecycle tests also cover daemon lifetime locking, PID reuse, malformed live
-generation state, and owner-marker handoff. `tests/test_onboarding.py`,
+Lifecycle tests also cover real daemon lifetime-lock transfer across background
+exec, spawned-PID readiness binding, pre-receipt child cleanup, PID reuse,
+malformed live generation state, and owner-marker handoff. `tests/test_onboarding.py`,
 `tests/test_launchagent.py`, `tests/test_ax_capture.py`, and
 `tests/test_ocr_subprocess.py` cover the permission/mode cross-product,
 source-versioned helper reuse, durable `ocr_policy`, progress reporting, and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,8 +57,9 @@ flowchart LR
 ### Runtime readiness and ownership
 
 The control path is generation-bound. `.daemon.lock` is acquired before start
-preflight and inherited for the complete foreground or double-forked daemon
-lifetime. The daemon publishes `.runtime-state.json` with `starting`/`ready`
+preflight and held for the complete foreground or background daemon lifetime;
+background start transfers it into a fresh spawn/exec process. The daemon
+publishes `.runtime-state.json` with `starting`/`ready`
 phase, random generation, current permission probes, OCR policy/worker state,
 and its last fresh-capture, ingest-readiness, paused, or locked receipt. HTTP
 onboarding reads the same data through authenticated endpoints; HTTP-disabled

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -78,7 +78,7 @@ and old helper path.
 | `.integrity-recovery.pending.json` | crash-resumable full-database quarantine/replay journal |
 | `.integrity-config-recovery.pending.json` | config-quarantine intent retained until database authority is reconciled |
 | `.pid`, `.runtime-state.json` | compatibility PID plus owner-only generation, phase, permission, OCR-worker, and capture/privacy receipt |
-| `.daemon.lock` | lifetime single-Runtime lock inherited across background forks |
+| `.daemon.lock` | lifetime single-Runtime lock transferred into the background exec |
 | `.launchagent-owner` | durable intent that launchd owns Runtime lifecycle |
 | `.update.lock`, `.update-state.json` | exclusive update lock and crash-recovery phase metadata |
 | `native/<source-digest>/` | immutable machine-local AX and Vision OCR binaries; code, not personal data |

--- a/docs/runtime-internals.md
+++ b/docs/runtime-internals.md
@@ -63,8 +63,10 @@ call. Reconciliation emits a forming placeholder when no Root exists and
 refuses to replace an unmarked file at that path.
 
 `start` holds `<PERSOME_ROOT>/.daemon.lock` from preflight through the entire
-foreground or double-forked daemon lifetime. This prevents two concurrent
-starters from both passing the PID check. The daemon writes a numeric `.pid` for
+foreground or background daemon lifetime. Background start transfers that held
+lock into a fresh `posix_spawn`/exec process instead of running Runtime code in a
+fork-cloned Python/SQLite process. This prevents two concurrent starters from
+both passing the PID check. The daemon writes a numeric `.pid` for
 one-release compatibility plus an owner-only `.runtime-state.json` containing
 its random generation, start/update times, readiness phase, effective capture
 and OCR policy, native permission probes, and the last capture/privacy receipt.
@@ -105,7 +107,7 @@ labels, ports, and data roots do not belong in core.
 | `config.toml` | runtime configuration |
 | `.pid` | compatibility PID receipt; never sufficient by itself for signaling |
 | `.runtime-state.json` | owner-only generation, phase, permission, OCR, and capture receipt |
-| `.daemon.lock` | lifetime single-Runtime lock inherited across background forks |
+| `.daemon.lock` | lifetime single-Runtime lock transferred into the background exec |
 | `.launchagent-owner` | durable launchd lifecycle intent |
 | `.update.lock`, `.update-state.json` | exclusive updater lock and crash-recovery transaction |
 | `venv/` | active installed Runtime |

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -17,6 +17,7 @@ import fcntl
 import json
 import shutil
 import signal
+import stat
 import subprocess
 import sys
 import tempfile
@@ -53,6 +54,7 @@ _DAEMON_STARTUP_RETRY_SECONDS = 0.1
 _DAEMON_STARTUP_HTTP_TIMEOUT_SECONDS = 1.0
 _DAEMON_STARTUP_STOP_TIMEOUT_SECONDS = 5.0
 _DAEMON_STARTUP_KILL_TIMEOUT_SECONDS = 2.0
+_BACKGROUND_DAEMON_LOCK_FD_ENV = "PERSOME_DAEMON_LOCK_FD"
 
 
 def _fail_if_runtime_state_is_ambiguous() -> None:
@@ -77,6 +79,115 @@ def _acquire_daemon_lock():  # type: ignore[no-untyped-def]
             handle.close()
         raise RuntimeError("another Persome Runtime is already starting or running") from exc
     return handle
+
+
+def _adopt_daemon_lock_fd(lock_fd: int):  # type: ignore[no-untyped-def]
+    """Adopt the canonical lifetime lock handed across a background exec."""
+    try:
+        inherited = os.fstat(lock_fd)
+        linked = paths.daemon_lock_file().lstat()
+        if (
+            lock_fd <= 2
+            or not stat.S_ISREG(inherited.st_mode)
+            or inherited.st_uid != os.getuid()
+            or inherited.st_nlink != 1
+            or not stat.S_ISREG(linked.st_mode)
+            or linked.st_uid != os.getuid()
+            or linked.st_nlink != 1
+            or (inherited.st_dev, inherited.st_ino) != (linked.st_dev, linked.st_ino)
+        ):
+            raise RuntimeError("inherited daemon lock does not name the canonical private lock")
+        os.fchmod(lock_fd, 0o600)
+        # This is a no-op for the inherited open-file description, but fails
+        # closed if an invalid launcher handed us a competing descriptor.
+        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        # POSIX_SPAWN_DUP2 deliberately clears close-on-exec for this handoff.
+        # Restore it now so OCR/native subprocesses cannot extend the daemon's
+        # lifetime lock after the Runtime owner exits.
+        descriptor_flags = fcntl.fcntl(lock_fd, fcntl.F_GETFD)
+        fcntl.fcntl(lock_fd, fcntl.F_SETFD, descriptor_flags | fcntl.FD_CLOEXEC)
+        return os.fdopen(lock_fd, "a+b")
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.close(lock_fd)
+        raise
+
+
+def _background_daemon_command(*, capture_only: bool) -> list[str]:
+    """Return the same-package command used for the fresh daemon exec."""
+    if getattr(sys, "frozen", False):
+        command = [sys.executable, "start", "--foreground"]
+    else:
+        command = [sys.executable, "-m", "persome.cli", "start", "--foreground"]
+    if capture_only:
+        command.append("--capture-only")
+    return command
+
+
+def _spawn_background_runtime(daemon_lock, *, capture_only: bool) -> int:  # type: ignore[no-untyped-def]
+    """Spawn a fresh interpreter while transferring the held lifetime lock.
+
+    ``posix_spawn`` keeps all Python and SQLite work on the parent side of the
+    process boundary. The child begins only after ``exec``, so it cannot run
+    daemon code inside a fork-cloned SQLite/WAL state.
+    """
+    parent_lock_fd = daemon_lock.fileno()
+    child_lock_fd = 4 if parent_lock_fd == 3 else 3
+    command = _background_daemon_command(capture_only=capture_only)
+    env = dict(os.environ)
+    # Unlike ``start --foreground`` owned by the Desktop app, plain background
+    # start has always outlived its launching shell/app. Do not let the fresh
+    # exec accidentally opt into the foreground parent-death watcher.
+    env.pop("PERSOME_PARENT_PID", None)
+    env[_BACKGROUND_DAEMON_LOCK_FD_ENV] = str(child_lock_fd)
+    file_actions: list[tuple] = [
+        # Duplicate first: the lock can occupy fd 0 when a caller starts with
+        # closed stdio, and the following devnull action intentionally replaces it.
+        (os.POSIX_SPAWN_DUP2, parent_lock_fd, child_lock_fd),
+    ]
+    if parent_lock_fd > 2:
+        file_actions.append((os.POSIX_SPAWN_CLOSE, parent_lock_fd))
+    file_actions.extend(
+        [
+            (os.POSIX_SPAWN_OPEN, 0, os.devnull, os.O_RDWR, 0o666),
+            (os.POSIX_SPAWN_DUP2, 0, 1),
+            (os.POSIX_SPAWN_DUP2, 0, 2),
+        ]
+    )
+    return os.posix_spawn(
+        command[0],
+        command,
+        env,
+        file_actions=file_actions,
+        setsid=True,
+    )
+
+
+def _inherited_background_lock_fd() -> int | None:
+    """Consume the private marker used only by the background daemon exec."""
+    raw = os.environ.pop(_BACKGROUND_DAEMON_LOCK_FD_ENV, None)
+    if raw is None:
+        return None
+    try:
+        lock_fd = int(raw)
+    except ValueError as exc:
+        raise RuntimeError("invalid inherited daemon lock descriptor") from exc
+    if lock_fd <= 2:
+        raise RuntimeError("invalid inherited daemon lock descriptor")
+    return lock_fd
+
+
+def _run_background_exec_child(lock_fd: int, *, capture_only: bool) -> None:
+    """Run the daemon after a fresh exec without repeating mutable DB recovery."""
+    daemon_lock = _adopt_daemon_lock_fd(lock_fd)
+    try:
+        cfg = _init(starting_runtime=True, recover_integrity=False)
+        from . import daemon
+
+        daemon.run(cfg, capture_only=capture_only)
+    finally:
+        daemon_lock.close()
+    os._exit(0)
 
 
 def _daemon_lock_is_held() -> bool:
@@ -336,6 +447,8 @@ def _same_runtime_process(
 def _probe_background_runtime(
     cfg: config_mod.Config,
     expected_process: runtime_pid.ProcessIdentity | None = None,
+    *,
+    spawned_pid: int | None = None,
 ) -> tuple[str, str, runtime_pid.ProcessIdentity | None]:
     """Probe one background-start attempt.
 
@@ -349,6 +462,14 @@ def _probe_background_runtime(
         if expected_process is not None:
             return "fatal", "the new Runtime process exited during startup", expected_process
         return "retry", "waiting for the new Runtime process receipt", None
+    if spawned_pid is not None and process.pid != spawned_pid:
+        # Never hand another process to failed-start cleanup. The caller owns
+        # only the direct child returned by posix_spawn.
+        return (
+            "fatal",
+            f"the Runtime receipt names pid {process.pid}, not spawned pid {spawned_pid}",
+            None,
+        )
     if process.generation is None or process.runtime_started_at is None:
         return "retry", "waiting for the generation-bound Runtime receipt", process
     if expected_process is not None and not _same_runtime_process(process, expected_process):
@@ -417,6 +538,7 @@ def _probe_background_runtime(
 def _wait_for_background_start(
     cfg: config_mod.Config,
     *,
+    spawned_pid: int | None = None,
     timeout_seconds: float = _DAEMON_STARTUP_TIMEOUT_SECONDS,
 ) -> tuple[bool, str, runtime_pid.ProcessIdentity | None]:
     """Wait a bounded time for one exact daemon generation to become usable."""
@@ -425,7 +547,18 @@ def _wait_for_background_start(
     last_process: runtime_pid.ProcessIdentity | None = None
     detail = "the Runtime did not publish a readiness receipt"
     while True:
-        state, detail, process = _probe_background_runtime(cfg, expected_process)
+        if spawned_pid is not None:
+            exit_detail = _reap_exited_background_child(spawned_pid)
+            if exit_detail is not None:
+                return False, exit_detail, expected_process or last_process
+        if spawned_pid is None:
+            state, detail, process = _probe_background_runtime(cfg, expected_process)
+        else:
+            state, detail, process = _probe_background_runtime(
+                cfg,
+                expected_process,
+                spawned_pid=spawned_pid,
+            )
         if process is not None:
             last_process = process
         if (
@@ -445,12 +578,57 @@ def _wait_for_background_start(
         time.sleep(min(_DAEMON_STARTUP_RETRY_SECONDS, remaining))
 
 
+def _reap_exited_background_child(pid: int) -> str | None:
+    """Reap a direct spawn child that exited before publishing readiness."""
+    try:
+        reaped_pid, status = os.waitpid(pid, os.WNOHANG)
+    except ChildProcessError:
+        return None
+    if reaped_pid == 0:
+        return None
+    if os.WIFEXITED(status):
+        return f"the background Runtime exited before readiness (status {os.WEXITSTATUS(status)})"
+    if os.WIFSIGNALED(status):
+        signum = os.WTERMSIG(status)
+        with contextlib.suppress(ValueError):
+            return (
+                "the background Runtime exited before readiness "
+                f"(signal {signum} {signal.Signals(signum).name})"
+            )
+        return f"the background Runtime exited before readiness (signal {signum})"
+    return "the background Runtime exited before readiness"
+
+
 def _terminate_failed_background_start(
     process: runtime_pid.ProcessIdentity | None,
+    *,
+    spawned_pid: int | None = None,
 ) -> bool:
     """Stop only the generation observed during this failed start attempt."""
     if process is None:
+        if spawned_pid is not None:
+            return _terminate_spawned_background_child(spawned_pid)
         return not _daemon_lock_is_held()
+    if spawned_pid is not None and process.pid != spawned_pid:
+        # Defensive boundary: even if a future probe accidentally returns a
+        # concurrent Runtime identity, this start owns only its direct child.
+        return _terminate_spawned_background_child(spawned_pid)
+    cleaned = _terminate_recorded_background_start(process)
+    if spawned_pid is not None and process.pid == spawned_pid:
+        if cleaned:
+            # The identity-bound wait proved exit; reap the direct child if it
+            # has become waitable so it cannot linger as a zombie until CLI
+            # exit. If the kernel still reports it alive, direct child
+            # ownership is the final authority and cleanup must continue.
+            if not _wait_for_spawned_child_exit(spawned_pid, 0.0):
+                cleaned = _terminate_spawned_background_child(spawned_pid)
+        else:
+            cleaned = _terminate_spawned_background_child(spawned_pid)
+    return cleaned
+
+
+def _terminate_recorded_background_start(process: runtime_pid.ProcessIdentity) -> bool:
+    """Stop a failed start through its generation-bound Runtime receipt."""
     if not runtime_pid.signal_process(process, signal.SIGTERM):
         return runtime_pid.resolve_recorded_process() is None and _clear_failed_background_receipts(
             process
@@ -469,6 +647,43 @@ def _terminate_failed_background_start(
     if not runtime_pid.wait_for_exit(process, _DAEMON_STARTUP_KILL_TIMEOUT_SECONDS):
         return False
     return _clear_failed_background_receipts(process)
+
+
+def _wait_for_spawned_child_exit(pid: int, timeout_seconds: float) -> bool:
+    """Wait for and reap one direct spawn child without admitting PID reuse."""
+    deadline = time.monotonic() + max(0.0, timeout_seconds)
+    while True:
+        try:
+            reaped_pid, _status = os.waitpid(pid, os.WNOHANG)
+        except ChildProcessError:
+            return True
+        if reaped_pid == pid:
+            return True
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        time.sleep(min(_DAEMON_STARTUP_RETRY_SECONDS, remaining))
+
+
+def _terminate_spawned_background_child(pid: int) -> bool:
+    """Stop a receipt-less direct child, whose unreaped PID cannot be reused."""
+    if _wait_for_spawned_child_exit(pid, 0.0):
+        return True
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return _wait_for_spawned_child_exit(pid, _DAEMON_STARTUP_RETRY_SECONDS)
+    except OSError:
+        return False
+    if _wait_for_spawned_child_exit(pid, _DAEMON_STARTUP_STOP_TIMEOUT_SECONDS):
+        return True
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return _wait_for_spawned_child_exit(pid, _DAEMON_STARTUP_RETRY_SECONDS)
+    except OSError:
+        return False
+    return _wait_for_spawned_child_exit(pid, _DAEMON_STARTUP_KILL_TIMEOUT_SECONDS)
 
 
 def _clear_failed_background_receipts(process: runtime_pid.ProcessIdentity) -> bool:
@@ -519,6 +734,15 @@ def start(
     capture_only: bool = typer.Option(False, "--capture-only", help="Skip the writer loop."),
 ) -> None:
     """Start the Persome daemon."""
+    inherited_lock_fd = _inherited_background_lock_fd()
+    if inherited_lock_fd is not None:
+        if not foreground:
+            with contextlib.suppress(OSError):
+                os.close(inherited_lock_fd)
+            raise RuntimeError("background daemon exec must use foreground process ownership")
+        _run_background_exec_child(inherited_lock_fd, capture_only=capture_only)
+        return
+
     # Avoid even configuration/integrity writes when the caller only asked to
     # start an already-running daemon. This is also the cross-process guard for
     # editor-launched MCP clients that share the same local database.
@@ -542,9 +766,9 @@ def start(
         console.print(f"[yellow]Already running (pid {pid})[/yellow]")
         raise typer.Exit(1)
 
-    from . import daemon
-
     if foreground:
+        from . import daemon
+
         console.print("[bold]Persome starting in foreground[/bold] — Ctrl+C to stop.")
         _watch_parent_death()  # exit if the Persome app that spawned us (--foreground child) dies
         daemon.run(cfg, capture_only=capture_only)
@@ -562,58 +786,54 @@ def start(
         # below already hard-exits for the same reason; mirror it here.
         os._exit(0)
 
-    # Background: double-fork. The parent stays alive just long enough to prove
-    # that this exact new generation owns its PID receipt and authenticated HTTP
-    # endpoint. Its copy of the lifetime lock is closed before polling; the
-    # grandchild retains the inherited file description for its whole life.
-    first_child_pid = os.fork()
-    if first_child_pid != 0:
+    # Background: start a new session through spawn+exec. The parent stays alive
+    # just long enough to prove that this exact new generation owns its PID
+    # receipt and authenticated HTTP endpoint. The exec child adopts the same
+    # held open-file description, so there is no unlocked takeover window.
+    spawned_pid: int | None = None
+    try:
+        spawned_pid = _spawn_background_runtime(daemon_lock, capture_only=capture_only)
+    except OSError as exc:
+        daemon_lock.close()
+        ready = False
+        detail = f"could not spawn the background Runtime ({type(exc).__name__})"
+        process = None
+    else:
         daemon_lock.close()
         try:
-            ready, detail, process = _wait_for_background_start(cfg)
+            ready, detail, process = _wait_for_background_start(cfg, spawned_pid=spawned_pid)
         except Exception as exc:  # noqa: BLE001 - startup still needs safe cleanup
             ready = False
             detail = f"startup verification failed ({type(exc).__name__})"
             process = None
             with contextlib.suppress(Exception):
-                process = runtime_pid.resolve_recorded_process()
-        if ready:
-            console.print("[green]Persome started in background.[/green]")
-            console.print(f"Logs: {paths.logs_dir()}")
-            return
-        try:
-            cleaned = _terminate_failed_background_start(process)
-        except Exception:  # noqa: BLE001 - preserve the actionable failure path
-            cleaned = False
-        console.print(f"[red]Persome did not start correctly:[/red] {detail}")
-        if cleaned:
-            console.print("[yellow]The incomplete background Runtime was stopped.[/yellow]")
-        else:
-            console.print(
-                "[yellow]Persome could not confirm that the incomplete Runtime stopped; "
-                "run `persome stop` before retrying.[/yellow]"
-            )
-        if cfg.mcp.auto_start and cfg.mcp.transport in {"sse", "streamable-http"}:
-            console.print(
-                f"Check port {cfg.mcp.port} with "
-                f"`lsof -nP -iTCP:{cfg.mcp.port} -sTCP:LISTEN`, then retry."
-            )
+                observed = runtime_pid.resolve_recorded_process()
+                if observed is not None and observed.pid == spawned_pid:
+                    process = observed
+    if ready:
+        console.print("[green]Persome started in background.[/green]")
         console.print(f"Logs: {paths.logs_dir()}")
-        console.print("Next: persome doctor")
-        raise typer.Exit(1)
-    os.setsid()
-    if os.fork() != 0:
-        os._exit(0)
-    # Redirect stdio to /dev/null. After dup2 the original fd is no longer
-    # needed; closing it avoids leaking one descriptor per daemon start.
-    devnull = os.open(os.devnull, os.O_RDWR)
-    for fd in (0, 1, 2):
-        os.dup2(devnull, fd)
-    if devnull > 2:
-        os.close(devnull)
-    daemon.run(cfg, capture_only=capture_only)
-    daemon_lock.close()
-    os._exit(0)
+        return
+    try:
+        cleaned = _terminate_failed_background_start(process, spawned_pid=spawned_pid)
+    except Exception:  # noqa: BLE001 - preserve the actionable failure path
+        cleaned = False
+    console.print(f"[red]Persome did not start correctly:[/red] {detail}")
+    if cleaned:
+        console.print("[yellow]The incomplete background Runtime was stopped.[/yellow]")
+    else:
+        console.print(
+            "[yellow]Persome could not confirm that the incomplete Runtime stopped; "
+            "run `persome stop` before retrying.[/yellow]"
+        )
+    if cfg.mcp.auto_start and cfg.mcp.transport in {"sse", "streamable-http"}:
+        console.print(
+            f"Check port {cfg.mcp.port} with "
+            f"`lsof -nP -iTCP:{cfg.mcp.port} -sTCP:LISTEN`, then retry."
+        )
+    console.print(f"Logs: {paths.logs_dir()}")
+    console.print("Next: persome doctor")
+    raise typer.Exit(1)
 
 
 @app.command()
@@ -3411,12 +3631,13 @@ def model_open(
                 )
                 break
             except httpx.ConnectError:
-                # `persome start` returns after forking, just before uvicorn has
-                # necessarily bound its loopback socket. Retry only that
-                # connection-refused startup race. Any HTTP response (notably
-                # 401/403) is handled below immediately instead of being hidden
-                # behind retries. A genuinely stopped Runtime fails
-                # immediately instead of looking like another CLI hang.
+                # Another concurrent start can hold the lifetime lock and
+                # publish its PID before uvicorn has bound the loopback socket.
+                # Retry only that connection-refused startup race. Any HTTP
+                # response (notably 401/403) is handled below immediately
+                # instead of being hidden behind retries. A genuinely stopped
+                # Runtime fails immediately instead of looking like another
+                # CLI hang.
                 runtime_starting = _read_pid() is not None or _daemon_lock_is_held()
                 if not runtime_starting or attempt + 1 == _MODEL_VIEWER_STARTUP_ATTEMPTS:
                     raise

--- a/src/persome/env_file.py
+++ b/src/persome/env_file.py
@@ -4,7 +4,7 @@ Runtime secrets live in ``~/.persome/env``. A user may edit that owner-only
 file directly, or an embedding product may mirror secrets from its own secure
 store. Business code stays on ``os.environ.get(...)``; initialized CLI commands
 merge the file's contents into ``os.environ`` before doing work, and ``start``
-does so before forking.
+does so before spawning the daemon process.
 
 Semantics:
 
@@ -33,7 +33,7 @@ LOCAL_API_TOKEN_ENV = "PERSOME_LOCAL_API_TOKEN"
 _LOCAL_API_TOKEN_MIN_BYTES = 32
 _LOCAL_API_TOKEN_MAX_BYTES = 512
 _LOCAL_API_TOKEN_RE = re.compile(r"[A-Za-z0-9_-]+\Z")
-_OWNER_ENV_BLOCKED_KEYS = frozenset({"PERSOME_ROOT"})
+_OWNER_ENV_BLOCKED_KEYS = frozenset({"PERSOME_ROOT", "PERSOME_DAEMON_LOCK_FD"})
 
 ScreenshotKeyStatus = Literal["existing", "generated"]
 LocalAPITokenStatus = Literal["existing", "generated"]

--- a/src/persome/launchagent.py
+++ b/src/persome/launchagent.py
@@ -56,8 +56,8 @@ def build_plist(binary: str) -> dict[str, object]:
     """Return the plist dict for the daemon, parameterised by the daemon
     ``binary`` path (the bundled ``persome`` executable).
 
-    ``--foreground`` keeps the process in launchd's control group (no
-    double-fork); ``KeepAlive=true`` provides crash-relaunch; ``RunAtLoad=true``
+    ``--foreground`` keeps the process directly owned by launchd without
+    detaching; ``KeepAlive=true`` provides crash-relaunch; ``RunAtLoad=true``
     starts it as soon as the agent is bootstrapped and on every login.
     """
     env: dict[str, str] = {}

--- a/src/persome/paths.py
+++ b/src/persome/paths.py
@@ -84,7 +84,7 @@ def config_file() -> Path:
 
 
 def env_file() -> Path:
-    """Owner-only dotenv secret store sourced before the daemon forks."""
+    """Owner-only dotenv secret store sourced before daemon spawn."""
     return root() / "env"
 
 
@@ -102,7 +102,7 @@ def runtime_state_file() -> Path:
 
 
 def daemon_lock_file() -> Path:
-    """Lifetime single-writer lock inherited by the foreground/background daemon."""
+    """Lifetime single-writer lock retained by foreground or background exec."""
     return root() / ".daemon.lock"
 
 

--- a/tests/test_cli_lifecycle.py
+++ b/tests/test_cli_lifecycle.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
+import shlex
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -12,8 +15,12 @@ from persome import cli
 
 
 class _FakeLock:
-    def __init__(self) -> None:
+    def __init__(self, fd: int = 91) -> None:
         self.closed = False
+        self.fd = fd
+
+    def fileno(self) -> int:
+        return self.fd
 
     def close(self) -> None:
         self.closed = True
@@ -113,7 +120,331 @@ def test_daemon_lifetime_lock_excludes_a_second_start(ac_root) -> None:
     replacement.close()
 
 
-def test_start_lock_failure_never_initializes_or_forks(
+def test_background_exec_adopts_the_same_canonical_lifetime_lock(ac_root) -> None:
+    original = cli._acquire_daemon_lock()
+    inherited_fd = cli.os.dup(original.fileno())
+    adopted = cli._adopt_daemon_lock_fd(inherited_fd)
+    original.close()
+    try:
+        assert cli.fcntl.fcntl(adopted.fileno(), cli.fcntl.F_GETFD) & cli.fcntl.FD_CLOEXEC
+        with pytest.raises(RuntimeError, match="already starting or running"):
+            cli._acquire_daemon_lock()
+    finally:
+        adopted.close()
+
+    replacement = cli._acquire_daemon_lock()
+    replacement.close()
+
+
+def test_background_exec_rejects_a_noncanonical_lock_descriptor(ac_root) -> None:
+    canonical = cli._acquire_daemon_lock()
+    wrong_path = ac_root / "wrong-daemon.lock"
+    wrong_fd = cli.os.open(wrong_path, cli.os.O_CREAT | cli.os.O_RDWR, 0o600)
+    try:
+        with pytest.raises(RuntimeError, match="canonical private lock"):
+            cli._adopt_daemon_lock_fd(wrong_fd)
+        with pytest.raises(OSError):
+            cli.os.fstat(wrong_fd)
+    finally:
+        canonical.close()
+
+
+def test_background_lock_marker_is_private_and_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(cli._BACKGROUND_DAEMON_LOCK_FD_ENV, "not-a-descriptor")
+
+    with pytest.raises(RuntimeError, match="invalid inherited daemon lock"):
+        cli._inherited_background_lock_fd()
+
+    assert cli._BACKGROUND_DAEMON_LOCK_FD_ENV not in cli.os.environ
+
+
+def test_background_spawn_execs_fresh_interpreter_and_transfers_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lock = _FakeLock(fd=91)
+    seen: dict[str, object] = {}
+
+    def fake_posix_spawn(
+        executable: str,
+        command: list[str],
+        env: dict[str, str],
+        **kwargs: object,
+    ) -> int:
+        seen.update(executable=executable, command=command, env=env, **kwargs)
+        return 4242
+
+    monkeypatch.delattr(cli.sys, "frozen", raising=False)
+    monkeypatch.setenv("PERSOME_PARENT_PID", "1234")
+    monkeypatch.setattr(cli.os, "posix_spawn", fake_posix_spawn)
+
+    assert cli._spawn_background_runtime(lock, capture_only=True) == 4242
+    command = seen["command"]
+    assert command == [
+        cli.sys.executable,
+        "-m",
+        "persome.cli",
+        "start",
+        "--foreground",
+        "--capture-only",
+    ]
+    assert seen["executable"] == cli.sys.executable
+    assert seen["setsid"] is True
+    assert seen["env"][cli._BACKGROUND_DAEMON_LOCK_FD_ENV] == "3"
+    assert "PERSOME_PARENT_PID" not in seen["env"]
+    assert seen["file_actions"] == [
+        (cli.os.POSIX_SPAWN_DUP2, 91, 3),
+        (cli.os.POSIX_SPAWN_CLOSE, 91),
+        (cli.os.POSIX_SPAWN_OPEN, 0, cli.os.devnull, cli.os.O_RDWR, 0o666),
+        (cli.os.POSIX_SPAWN_DUP2, 0, 1),
+        (cli.os.POSIX_SPAWN_DUP2, 0, 2),
+    ]
+
+
+def test_background_spawn_uses_fd_four_when_parent_lock_is_fd_three(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: dict[str, object] = {}
+
+    def fake_posix_spawn(
+        _executable: str,
+        _command: list[str],
+        env: dict[str, str],
+        **kwargs: object,
+    ) -> int:
+        seen.update(env=env, **kwargs)
+        return 4242
+
+    monkeypatch.setattr(cli.os, "posix_spawn", fake_posix_spawn)
+
+    assert cli._spawn_background_runtime(_FakeLock(fd=3), capture_only=False) == 4242
+    assert seen["env"][cli._BACKGROUND_DAEMON_LOCK_FD_ENV] == "4"
+    assert seen["file_actions"][:2] == [
+        (cli.os.POSIX_SPAWN_DUP2, 3, 4),
+        (cli.os.POSIX_SPAWN_CLOSE, 3),
+    ]
+
+
+def test_background_spawn_transfers_the_real_lock_across_exec(
+    ac_root, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ready_path = ac_root / "spawn-lock-ready"
+    child_code = (
+        "import os,pathlib,time;"
+        f"os.fstat(int(os.environ[{cli._BACKGROUND_DAEMON_LOCK_FD_ENV!r}]));"
+        f"pathlib.Path({str(ready_path)!r}).touch();"
+        "time.sleep(30)"
+    )
+    monkeypatch.setattr(
+        cli,
+        "_background_daemon_command",
+        lambda *, capture_only: [cli.sys.executable, "-c", child_code],
+    )
+
+    parent_lock = cli._acquire_daemon_lock()
+    spawned_pid = cli._spawn_background_runtime(parent_lock, capture_only=False)
+    parent_lock.close()
+    reaped = False
+    try:
+        deadline = time.monotonic() + 5.0
+        while not ready_path.exists():
+            observed_pid, status = cli.os.waitpid(spawned_pid, cli.os.WNOHANG)
+            if observed_pid == spawned_pid:
+                reaped = True
+                pytest.fail(f"exec child exited before lock proof (wait status {status})")
+            if time.monotonic() >= deadline:
+                pytest.fail("exec child did not publish its lock proof")
+            time.sleep(0.01)
+
+        with pytest.raises(RuntimeError, match="already starting or running"):
+            cli._acquire_daemon_lock()
+    finally:
+        if not reaped:
+            with contextlib.suppress(ProcessLookupError):
+                cli.os.kill(spawned_pid, cli.signal.SIGTERM)
+            with contextlib.suppress(ChildProcessError):
+                cli.os.waitpid(spawned_pid, 0)
+
+    replacement = cli._acquire_daemon_lock()
+    replacement.close()
+
+
+def test_background_daemon_command_reexecs_the_frozen_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cli.sys, "frozen", True, raising=False)
+
+    assert cli._background_daemon_command(capture_only=False) == [
+        cli.sys.executable,
+        "start",
+        "--foreground",
+    ]
+
+
+def test_background_daemon_command_matches_runtime_identity_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delattr(cli.sys, "frozen", raising=False)
+    command = cli._background_daemon_command(capture_only=False)
+
+    assert cli.runtime_pid.is_runtime_command(
+        shlex.join(command),
+        executable=command[0],
+    )
+
+
+def test_background_exec_child_skips_mutable_integrity_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lock = _FakeLock()
+    cfg = object()
+    init_kwargs: list[dict[str, bool]] = []
+    runs: list[tuple[object, bool]] = []
+    exits: list[int] = []
+    monkeypatch.setattr(cli, "_adopt_daemon_lock_fd", lambda _fd: lock)
+    monkeypatch.setattr(
+        cli,
+        "_init",
+        lambda **kwargs: init_kwargs.append(kwargs) or cfg,
+    )
+
+    from persome import daemon
+
+    monkeypatch.setattr(
+        daemon,
+        "run",
+        lambda value, *, capture_only: runs.append((value, capture_only)),
+    )
+    monkeypatch.setattr(cli.os, "_exit", lambda code: exits.append(code))
+
+    cli._run_background_exec_child(91, capture_only=True)
+
+    assert init_kwargs == [{"starting_runtime": True, "recover_integrity": False}]
+    assert runs == [(cfg, True)]
+    assert lock.closed is True
+    assert exits == [0]
+
+
+def test_background_probe_rejects_receipt_from_a_different_pid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    other = SimpleNamespace(pid=9002)
+    monkeypatch.setattr(cli.runtime_pid, "resolve_recorded_process", lambda: other)
+
+    state, detail, process = cli._probe_background_runtime(
+        _http_config(),
+        spawned_pid=9001,
+    )
+
+    assert state == "fatal"
+    assert "pid 9002, not spawned pid 9001" in detail
+    assert process is None
+
+
+def test_background_wait_reaps_and_reports_pre_receipt_sigbus(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        cli.os,
+        "waitpid",
+        lambda pid, options: (pid, int(cli.signal.SIGBUS)),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_probe_background_runtime",
+        lambda *_args, **_kwargs: pytest.fail("an exited child must be reported before probing"),
+    )
+
+    ready, detail, process = cli._wait_for_background_start(
+        _http_config(),
+        spawned_pid=9001,
+    )
+
+    assert ready is False
+    assert "SIGBUS" in detail
+    assert process is None
+
+
+def test_receiptless_spawned_child_is_terminated_and_reaped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    waits = iter([False, True])
+    signals: list[tuple[int, int]] = []
+    monkeypatch.setattr(
+        cli,
+        "_wait_for_spawned_child_exit",
+        lambda _pid, _timeout: next(waits),
+    )
+    monkeypatch.setattr(cli.os, "kill", lambda pid, sig: signals.append((pid, sig)))
+
+    assert cli._terminate_failed_background_start(None, spawned_pid=9001) is True
+    assert signals == [(9001, cli.signal.SIGTERM)]
+
+
+def test_recorded_cleanup_still_requires_direct_child_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = SimpleNamespace(pid=9001)
+    direct_children: list[int] = []
+    monkeypatch.setattr(cli, "_terminate_recorded_background_start", lambda _process: True)
+    monkeypatch.setattr(cli, "_wait_for_spawned_child_exit", lambda _pid, _timeout: False)
+    monkeypatch.setattr(
+        cli,
+        "_terminate_spawned_background_child",
+        lambda pid: direct_children.append(pid) or True,
+    )
+
+    assert cli._terminate_failed_background_start(process, spawned_pid=9001) is True
+    assert direct_children == [9001]
+
+
+def test_failed_start_never_signals_a_mismatched_runtime_receipt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    other_process = SimpleNamespace(pid=9002)
+    direct_children: list[int] = []
+    monkeypatch.setattr(
+        cli,
+        "_terminate_recorded_background_start",
+        lambda _process: pytest.fail("a foreign Runtime receipt must not be signaled"),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_terminate_spawned_background_child",
+        lambda pid: direct_children.append(pid) or True,
+    )
+
+    assert cli._terminate_failed_background_start(other_process, spawned_pid=9001) is True
+    assert direct_children == [9001]
+
+
+def test_background_wait_timeout_keeps_spawned_pid_for_receiptless_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cli.os, "waitpid", lambda _pid, _options: (0, 0))
+    monkeypatch.setattr(
+        cli,
+        "_probe_background_runtime",
+        lambda _cfg, _expected=None, *, spawned_pid: (
+            "retry",
+            f"waiting for spawned pid {spawned_pid}",
+            None,
+        ),
+    )
+
+    ready, detail, process = cli._wait_for_background_start(
+        _http_config(),
+        spawned_pid=9001,
+        timeout_seconds=0,
+    )
+
+    assert ready is False
+    assert "startup timed out" in detail
+    assert process is None
+
+
+def test_start_lock_failure_never_initializes_or_spawns(
     ac_root, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(cli, "_read_pid", lambda: None)
@@ -236,11 +567,20 @@ def test_background_start_reports_success_only_after_readiness(
     monkeypatch.setattr(cli, "_acquire_daemon_lock", lambda: lock)
     monkeypatch.setattr(cli.env_file_mod, "ensure_local_api_token", lambda _path: "existing")
     monkeypatch.setattr(cli, "_init", lambda **_kwargs: cfg)
-    monkeypatch.setattr(cli.os, "fork", lambda: 4321)
+    spawned: list[tuple[object, bool]] = []
+    monkeypatch.setattr(
+        cli,
+        "_spawn_background_runtime",
+        lambda value, *, capture_only: spawned.append((value, capture_only)) or 4321,
+    )
     monkeypatch.setattr(
         cli,
         "_wait_for_background_start",
-        lambda _cfg: (observed.append("ready") or True, "ready", SimpleNamespace(pid=4242)),
+        lambda _cfg, *, spawned_pid: (
+            observed.append(f"ready:{spawned_pid}") or True,
+            "ready",
+            SimpleNamespace(pid=spawned_pid),
+        ),
     )
     monkeypatch.setattr(
         cli,
@@ -251,7 +591,8 @@ def test_background_start_reports_success_only_after_readiness(
     result = CliRunner().invoke(cli.app, ["start"])
 
     assert result.exit_code == 0, result.output
-    assert observed == ["ready"]
+    assert observed == ["ready:4321"]
+    assert spawned == [(lock, False)]
     assert lock.closed is True
     assert "Persome started in background." in result.output
 
@@ -261,39 +602,111 @@ def test_background_start_failure_stops_child_and_reports_port_owner(
 ) -> None:
     lock = _FakeLock()
     cfg = _http_config()
-    process = SimpleNamespace(pid=4242)
+    process = SimpleNamespace(pid=4321)
     terminated: list[object] = []
     monkeypatch.setattr(cli, "_fail_if_runtime_state_is_ambiguous", lambda: None)
     monkeypatch.setattr(cli, "_read_pid", lambda: None)
     monkeypatch.setattr(cli, "_acquire_daemon_lock", lambda: lock)
     monkeypatch.setattr(cli.env_file_mod, "ensure_local_api_token", lambda _path: "existing")
     monkeypatch.setattr(cli, "_init", lambda **_kwargs: cfg)
-    monkeypatch.setattr(cli.os, "fork", lambda: 4321)
+    monkeypatch.setattr(cli, "_spawn_background_runtime", lambda *_args, **_kwargs: 4321)
     monkeypatch.setattr(
         cli,
         "_wait_for_background_start",
-        lambda _cfg: (
+        lambda _cfg, *, spawned_pid: (
             False,
-            "port 8742 is in use by a different or incompatible service",
+            f"spawned pid {spawned_pid} did not own port 8742",
             process,
         ),
     )
     monkeypatch.setattr(
         cli,
         "_terminate_failed_background_start",
-        lambda value: terminated.append(value) or True,
+        lambda value, *, spawned_pid: terminated.append((value, spawned_pid)) or True,
     )
 
     result = CliRunner().invoke(cli.app, ["start"])
 
     assert result.exit_code == 1, result.output
     assert lock.closed is True
-    assert terminated == [process]
+    assert terminated == [(process, 4321)]
     assert "Persome started in background." not in result.output
     assert "did not start correctly" in result.output
     assert "incomplete background Runtime was stopped" in result.output
     assert "lsof -nP -iTCP:8742 -sTCP:LISTEN" in result.output
     assert "persome doctor" in result.output
+
+
+def test_background_spawn_failure_is_reported_without_waiting(
+    ac_root, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    lock = _FakeLock()
+    cfg = _http_config()
+    terminated: list[object] = []
+    monkeypatch.setattr(cli, "_fail_if_runtime_state_is_ambiguous", lambda: None)
+    monkeypatch.setattr(cli, "_read_pid", lambda: None)
+    monkeypatch.setattr(cli, "_acquire_daemon_lock", lambda: lock)
+    monkeypatch.setattr(cli.env_file_mod, "ensure_local_api_token", lambda _path: "existing")
+    monkeypatch.setattr(cli, "_init", lambda **_kwargs: cfg)
+    monkeypatch.setattr(
+        cli,
+        "_spawn_background_runtime",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("spawn failed")),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_wait_for_background_start",
+        lambda _cfg: pytest.fail("a failed spawn must not enter readiness polling"),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_terminate_failed_background_start",
+        lambda process, *, spawned_pid: terminated.append((process, spawned_pid)) or True,
+    )
+
+    result = CliRunner().invoke(cli.app, ["start"])
+
+    assert result.exit_code == 1, result.output
+    assert lock.closed is True
+    assert terminated == [(None, None)]
+    assert "could not spawn the background Runtime" in result.output
+    assert "OSError" in result.output
+
+
+def test_background_verification_exception_never_targets_another_receipt(
+    ac_root, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    lock = _FakeLock()
+    cfg = _http_config()
+    other_process = SimpleNamespace(pid=9999)
+    terminated: list[tuple[object, int | None]] = []
+    monkeypatch.setattr(cli, "_fail_if_runtime_state_is_ambiguous", lambda: None)
+    monkeypatch.setattr(cli, "_read_pid", lambda: None)
+    monkeypatch.setattr(cli, "_acquire_daemon_lock", lambda: lock)
+    monkeypatch.setattr(cli.env_file_mod, "ensure_local_api_token", lambda _path: "existing")
+    monkeypatch.setattr(cli, "_init", lambda **_kwargs: cfg)
+    monkeypatch.setattr(cli, "_spawn_background_runtime", lambda *_args, **_kwargs: 4321)
+    monkeypatch.setattr(
+        cli,
+        "_wait_for_background_start",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("probe failed")),
+    )
+    monkeypatch.setattr(
+        cli.runtime_pid,
+        "resolve_recorded_process",
+        lambda: other_process,
+    )
+    monkeypatch.setattr(
+        cli,
+        "_terminate_failed_background_start",
+        lambda process, *, spawned_pid: terminated.append((process, spawned_pid)) or True,
+    )
+
+    result = CliRunner().invoke(cli.app, ["start"])
+
+    assert result.exit_code == 1, result.output
+    assert terminated == [(None, 4321)]
+    assert "startup verification failed" in result.output
 
 
 def test_failed_background_cleanup_escalates_only_the_observed_generation(

--- a/tests/test_env_file.py
+++ b/tests/test_env_file.py
@@ -34,20 +34,24 @@ def test_does_not_overwrite_existing(tmp_path: Path, monkeypatch: pytest.MonkeyP
     assert os.environ["KEEP_ME"] == "shell-wins"
 
 
-def test_owner_env_cannot_redirect_persome_root(
+def test_owner_env_cannot_set_process_bootstrap_authority(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A file under one root cannot redirect initialization to another root."""
+    """The owner file cannot redirect the root or forge an internal lock handoff."""
     monkeypatch.delenv("PERSOME_ROOT", raising=False)
+    monkeypatch.delenv("PERSOME_DAEMON_LOCK_FD", raising=False)
     monkeypatch.delenv("SAFE_OWNER_KEY", raising=False)
     path = tmp_path / "env"
     path.write_text(
-        f"PERSOME_ROOT={tmp_path / 'different-root'}\nSAFE_OWNER_KEY=loaded\n",
+        f"PERSOME_ROOT={tmp_path / 'different-root'}\n"
+        "PERSOME_DAEMON_LOCK_FD=3\n"
+        "SAFE_OWNER_KEY=loaded\n",
         encoding="utf-8",
     )
 
     assert load_env_file(path) == 1
     assert "PERSOME_ROOT" not in os.environ
+    assert "PERSOME_DAEMON_LOCK_FD" not in os.environ
     assert os.environ["SAFE_OWNER_KEY"] == "loaded"
 
 


### PR DESCRIPTION
## Summary\n- replace the post-initialization Python double-fork with a fresh posix_spawn/exec Runtime\n- transfer and validate the held lifetime lock across exec without an unlocked takeover window\n- bind readiness and failed-start cleanup to the exact spawned PID, including early SIGBUS exit and TERM/KILL reaping\n- preserve background parent-independence, frozen builds, capture-only mode, LaunchAgent ownership, and runtime command identity\n- update lifecycle documentation and add a real cross-exec lock regression\n\n## Root cause\nOn macOS, background start forked after configuration, logging, integrity, SQLite/WAL, and threaded native state had already initialized. The child continued running Python before exec and could crash in SQLite WAL access with SIGBUS. Foreground start never took that path and remained stable.\n\n## Validation\n- 2212 passed, 17 deselected\n- 119 focused lifecycle, env, local access, and LaunchAgent tests passed\n- real posix_spawn/exec lock-transfer regression passed on macOS Python 3.12\n- Ruff check and format clean\n- secret, PII, and language scans clean\n- OpenAPI/schema drift, updater, and onboarding tests clean