### PR TITLE
fix: preserve SQLite process locks

### DIFF
--- a/docs/runtime-internals.md
+++ b/docs/runtime-internals.md
@@ -220,7 +220,11 @@ rollover, with `PASSIVE` otherwise. Every
 its complete connection lifetime; checkpoint and startup migration take the
 exclusive side. This prevents a transaction commit from racing a WAL reset on
 affected SQLite releases while still allowing normal concurrent readers and
-SQLite's single writer. A scheduled checkpoint skips a busy gate and retries
+SQLite's single writer. The owner securely precreates a missing database at
+mode `0600`; later validation of the database and its WAL/SHM sidecars is
+descriptor-free and non-mutating. Opening and closing another descriptor would
+cancel SQLite's advisory locks in the same POSIX process. A scheduled checkpoint
+skips a busy gate and retries
 on the next tick, so task cancellation cannot strand a worker waiting to reopen
 the database after shutdown. Startup integrity recovery and explicit secure
 clean operations use the same reentrant exclusive boundary. The daemon

--- a/src/persome/store/fts.py
+++ b/src/persome/store/fts.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import fcntl
 import hashlib
+import os
 import sqlite3
+import stat
 import threading
 import time
 from collections.abc import Iterable, Iterator
@@ -45,6 +47,7 @@ _SECURE_FTS_COMPACT_VERSION = 20260714
 # connection's 10s busy timeout: a loser of the migration race must defer,
 # not queue a second full-database rewrite behind the winner.
 _PURGE_BUSY_TIMEOUT_MS = 100
+_PRIVATE_SQLITE_FILE_MODE = 0o600
 # Bump whenever a daemon-owned schema step changes. This is deliberately
 # independent from PRAGMA user_version, which already tracks the secure-FTS
 # migration. Clients require an exact match: an older binary must not assume a
@@ -645,6 +648,103 @@ def _disable_checkpoint_on_close(conn: sqlite3.Connection) -> None:
         raise RuntimeError("SQLite refused to disable checkpoint-on-close")
 
 
+def _sqlite_artifacts(db_path: Path) -> tuple[Path, ...]:
+    return (
+        db_path,
+        db_path.with_name(f"{db_path.name}-wal"),
+        db_path.with_name(f"{db_path.name}-shm"),
+        db_path.with_name(f"{db_path.name}-journal"),
+    )
+
+
+def _validate_private_sqlite_artifact(path: Path, *, required: bool = False) -> bool:
+    """Validate one SQLite inode without opening or mutating it.
+
+    Closing any separately opened descriptor cancels the process's POSIX locks
+    on that inode, including locks owned by live SQLite connections.  Repeated
+    lstat calls preserve those locks while still rejecting links, special
+    files, loose permissions, and racing pathname replacement.
+    """
+    for _attempt in range(10):
+        try:
+            metadata = path.lstat()
+        except FileNotFoundError:
+            if required:
+                raise RuntimeError(f"required SQLite data file disappeared: {path}") from None
+            return False
+        if stat.S_ISLNK(metadata.st_mode):
+            raise RuntimeError(f"private data file must not be a symlink: {path}")
+        if not stat.S_ISREG(metadata.st_mode):
+            raise RuntimeError(f"private data path is not a regular file: {path}")
+        if metadata.st_nlink == 0:
+            continue
+        if metadata.st_nlink != 1:
+            raise RuntimeError(f"private data file must not be hard-linked: {path}")
+        if stat.S_IMODE(metadata.st_mode) != _PRIVATE_SQLITE_FILE_MODE:
+            raise RuntimeError(
+                f"SQLite data file must be owner-only (mode 0600): {path}. "
+                "Stop Persome before repairing it with `chmod 600`."
+            )
+        try:
+            confirmed = path.lstat()
+        except FileNotFoundError:
+            continue
+        if stat.S_ISLNK(confirmed.st_mode):
+            raise RuntimeError(f"private data file must not be a symlink: {path}")
+        if not stat.S_ISREG(confirmed.st_mode):
+            raise RuntimeError(f"private data path is not a regular file: {path}")
+        if confirmed.st_nlink == 0 or (confirmed.st_dev, confirmed.st_ino) != (
+            metadata.st_dev,
+            metadata.st_ino,
+        ):
+            continue
+        if confirmed.st_nlink != 1:
+            raise RuntimeError(f"private data file must not be hard-linked: {path}")
+        if stat.S_IMODE(confirmed.st_mode) != _PRIVATE_SQLITE_FILE_MODE:
+            continue
+        return True
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        if required:
+            raise RuntimeError(f"required SQLite data file disappeared: {path}") from None
+        return False
+    raise RuntimeError(f"SQLite data file changed during safety validation: {path}")
+
+
+def _create_private_database_file(db_path: Path) -> None:
+    """Create an owner database securely before SQLite acquires any locks."""
+    flags = (
+        os.O_RDWR
+        | os.O_CREAT
+        | os.O_EXCL
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+    try:
+        fd = os.open(db_path, flags, _PRIVATE_SQLITE_FILE_MODE)
+    except FileExistsError:
+        return
+    try:
+        metadata = os.fstat(fd)
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+            raise RuntimeError(f"private SQLite target must be one regular inode: {db_path}")
+        os.fchmod(fd, _PRIVATE_SQLITE_FILE_MODE)
+    finally:
+        os.close(fd)
+
+
+def _validate_open_database_artifacts(conn: sqlite3.Connection, db_path: Path) -> None:
+    """Fail closed, and close ``conn``, if SQLite published an unsafe artifact."""
+    try:
+        _validate_private_sqlite_artifact(db_path, required=True)
+        for artifact in _sqlite_artifacts(db_path)[1:]:
+            _validate_private_sqlite_artifact(artifact)
+    except BaseException:
+        conn.close()
+        raise
+
+
 def _prepare_database_path(db_path: Path) -> bool:
     """Validate a SQLite target before any library open; return root ownership."""
     try:
@@ -664,14 +764,12 @@ def _prepare_database_path(db_path: Path) -> bool:
     paths.ensure_private_dir(db_path.parent)
     # SQLite opens predictable sidecar names itself. Reject any pre-existing
     # link/special file before the library can follow it outside the private
-    # data root or block on a FIFO.
-    for artifact in (
-        db_path,
-        db_path.with_name(f"{db_path.name}-wal"),
-        db_path.with_name(f"{db_path.name}-shm"),
-        db_path.with_name(f"{db_path.name}-journal"),
-    ):
-        paths.ensure_private_file(artifact)
+    # data root or block on a FIFO. Never open an existing SQLite artifact here:
+    # a close in this process would cancel locks held by another live connection.
+    artifacts = _sqlite_artifacts(db_path)
+    _validate_private_sqlite_artifact(db_path)
+    for artifact in artifacts[1:]:
+        _validate_private_sqlite_artifact(artifact)
     return True
 
 
@@ -683,17 +781,25 @@ def connect(db_path: Path | None = None) -> sqlite3.Connection:
             f"Persome requires SQLite {required}+ so deleted FTS5 text cannot be reconstructed"
         )
     within_data_root = _prepare_database_path(db_path)
-    if _CLIENT_PROCESS and not db_path.exists():
+    database_exists = (
+        _validate_private_sqlite_artifact(db_path) if within_data_root else db_path.exists()
+    )
+    if _CLIENT_PROCESS and not database_exists:
         raise RuntimeError(
             "index database is missing; start the Persome daemon (`persome start`) "
             "once to create and migrate it before connecting MCP clients"
         )
-    # ``mode=rw`` is important for clients: plain sqlite3.connect() creates a
-    # missing database before the schema check below can reject it. A client
-    # must not leave behind a new, empty index that later looks like damage.
+    if within_data_root and not _CLIENT_PROCESS:
+        if not database_exists:
+            _create_private_database_file(db_path)
+        _validate_private_sqlite_artifact(db_path, required=True)
+    # ``mode=rw`` is important for every internal connection: the owner securely
+    # precreates a missing main file above, while clients must never create one.
+    # If the path disappears between validation and open, SQLite therefore
+    # fails closed instead of recreating an unvalidated database.
     target: str | Path = db_path
     connect_kwargs: dict[str, bool] = {}
-    if _CLIENT_PROCESS:
+    if _CLIENT_PROCESS or within_data_root:
         target = f"{db_path.absolute().as_uri()}?mode=rw"
         connect_kwargs["uri"] = True
     conn = sqlite3.connect(
@@ -795,7 +901,7 @@ def connect(db_path: Path | None = None) -> sqlite3.Connection:
         # accidentally attempts DDL or maintenance outside those helpers.
         conn.set_authorizer(_client_authorizer)
         if within_data_root:
-            paths.ensure_private_file(db_path)
+            _validate_open_database_artifacts(conn, db_path)
         return conn
     # Personal text must not survive ordinary DELETE operations in free pages.
     # Explicit wipe paths additionally VACUUM + truncate WAL below.
@@ -851,9 +957,7 @@ def connect(db_path: Path | None = None) -> sqlite3.Connection:
 
         entries_mod.rebuild_index(conn)
     if within_data_root:
-        paths.ensure_private_file(db_path)
-        paths.ensure_private_file(db_path.with_name(f"{db_path.name}-wal"))
-        paths.ensure_private_file(db_path.with_name(f"{db_path.name}-shm"))
+        _validate_open_database_artifacts(conn, db_path)
     return conn
 
 

--- a/tests/test_evomem_survivability.py
+++ b/tests/test_evomem_survivability.py
@@ -219,6 +219,7 @@ def test_evo_projection_mismatch_detected_when_nonempty(evo_table: Path) -> None
 def test_quick_check_on_garbage_db(ac_root: Path, alerts: list) -> None:
     garbage = ac_root / "garbage.db"
     garbage.write_bytes(b"this is not a sqlite database at all" * 64)
+    garbage.chmod(0o600)
     violations = integrity.check_and_handle(source="test", db_path=garbage)
     assert _checks_named(violations, "quick_check")
     assert any(p["check"] == "quick_check" for _, _, p in alerts)

--- a/tests/test_secure_fts_migration.py
+++ b/tests/test_secure_fts_migration.py
@@ -50,6 +50,7 @@ def _seed_legacy_db(db: Path, *, entry_secret: str, capture_secret: str) -> None
             "VALUES('live-capture','2026','TestApp','still here')"
         )
         conn.commit()
+    db.chmod(0o600)
 
 
 def _user_version(db: Path) -> int:

--- a/tests/test_storage_security.py
+++ b/tests/test_storage_security.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import fcntl
 import os
 import sqlite3
 import stat
+import subprocess
+import sys
 from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
 
@@ -145,6 +148,113 @@ def test_private_file_retries_lstat_inode_already_unlinked_by_sqlite(
     assert paths.ensure_private_file(sidecar) == sidecar
     assert calls == 1
     assert sidecar.exists()
+
+
+@pytest.mark.parametrize("suffix", ["", "-wal", "-shm", "-journal"])
+def test_sqlite_path_validation_does_not_cancel_posix_record_lock(
+    ac_root: Path, suffix: str
+) -> None:
+    database = paths.index_db()
+    database.write_bytes(b"database placeholder")
+    database.chmod(0o600)
+    locked_path = database.with_name(f"{database.name}{suffix}")
+    if suffix:
+        locked_path.write_bytes(b"sidecar placeholder")
+        locked_path.chmod(0o600)
+    probe = """
+import errno
+import fcntl
+import sys
+
+with open(sys.argv[1], "r+b") as handle:
+    try:
+        fcntl.lockf(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError as exc:
+        if exc.errno in (errno.EACCES, errno.EAGAIN):
+            raise SystemExit(0)
+        raise
+    raise SystemExit(1)
+"""
+
+    with locked_path.open("r+b") as handle:
+        fcntl.lockf(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+        assert fts._prepare_database_path(database)  # noqa: SLF001
+        result = subprocess.run(
+            [sys.executable, "-c", probe, str(locked_path)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    assert result.returncode == 0, result.stderr
+    assert _mode(locked_path) == 0o600
+
+
+def test_sqlite_path_validation_refuses_loose_mode_without_mutating(ac_root: Path) -> None:
+    database = paths.index_db()
+    database.write_bytes(b"database placeholder")
+    database.chmod(0o644)
+
+    with pytest.raises(RuntimeError, match=r"owner-only \(mode 0600\)"):
+        fts._prepare_database_path(database)  # noqa: SLF001
+
+    assert _mode(database) == 0o644
+
+
+def test_sqlite_path_validation_tolerates_disappearing_sidecar(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    database = paths.index_db()
+    database.write_bytes(b"database placeholder")
+    database.chmod(0o600)
+    sidecar = database.with_name(f"{database.name}-wal")
+    sidecar.write_bytes(b"ephemeral SQLite pages")
+    sidecar.chmod(0o600)
+    real_lstat = Path.lstat
+    calls = 0
+
+    def lstat_then_unlink(path: Path):  # noqa: ANN202
+        nonlocal calls
+        metadata = real_lstat(path)
+        if path == sidecar and calls == 0:
+            calls += 1
+            path.unlink()
+        return metadata
+
+    monkeypatch.setattr(Path, "lstat", lstat_then_unlink)
+
+    assert fts._prepare_database_path(database)  # noqa: SLF001
+    assert calls == 1
+    assert not sidecar.exists()
+
+
+def test_owner_database_is_private_before_sqlite_opens(
+    ac_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    real_connect = sqlite3.connect
+    observed_modes: list[int] = []
+
+    def connect_spy(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        observed_modes.append(_mode(paths.index_db()))
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr(fts.sqlite3, "connect", connect_spy)
+    old_umask = os.umask(0o022)
+    try:
+        with fts.cursor() as conn:
+            conn.execute("SELECT 1").fetchone()
+    finally:
+        os.umask(old_umask)
+
+    assert observed_modes and set(observed_modes) == {0o600}
+    for artifact in (
+        paths.index_db(),
+        paths.index_db().with_name(f"{paths.index_db().name}-wal"),
+        paths.index_db().with_name(f"{paths.index_db().name}-shm"),
+    ):
+        if artifact.exists():
+            assert _mode(artifact) == 0o600
 
 
 def test_permission_migration_refuses_hard_link_without_chmodding_victim(ac_root: Path) -> None:
@@ -340,6 +450,7 @@ def test_connect_purges_terms_deleted_by_legacy_fts_settings(ac_root: Path) -> N
         conn.execute("DELETE FROM captures WHERE id='legacy-capture'")
         conn.commit()
         conn.execute("VACUUM")
+    db.chmod(0o600)
     legacy_bytes = db.read_bytes()
     assert entry_secret.encode() in legacy_bytes
     assert capture_secret.encode() in legacy_bytes
@@ -574,6 +685,7 @@ def test_clean_all_removes_quarantined_personal_data(ac_root: Path) -> None:
     quarantined.write_text("private remnants", encoding="utf-8")
     journal = paths.root() / "index.db-journal"
     journal.write_text("private journal pages", encoding="utf-8")
+    journal.chmod(0o600)
 
     cli.clean_all(yes=True)
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,6 +1,7 @@
 import fcntl
 import os
 import sqlite3
+import stat
 import subprocess
 import sys
 import textwrap
@@ -65,6 +66,7 @@ def test_connect_names_recovery_path_on_corrupt_header(ac_root: Path) -> None:
     # actionable, still-catchable DatabaseError naming the recovery path.
     db = ac_root / "index.db"
     db.write_bytes(b"\x0d\x00\x00\x00" + b"\x00" * 4092)
+    db.chmod(0o600)
 
     with pytest.raises(fts.CorruptDatabaseError, match="persome start") as raised:
         fts.connect(db)
@@ -75,12 +77,25 @@ def test_connect_does_not_claim_startup_recovery_for_external_database(ac_root: 
     db = ac_root / "exports" / "damaged-snapshot.db"
     db.parent.mkdir()
     db.write_bytes(b"\x0d\x00\x00\x00" + b"\x00" * 4092)
+    db.chmod(0o600)
 
     with pytest.raises(fts.CorruptDatabaseError) as raised:
         fts.connect(db)
     message = str(raised.value)
     assert "persome start" not in message
     assert "automatic daemon-start recovery applies only to the live index.db" in message
+
+
+def test_canonical_read_cursor_initializes_a_missing_owner_database(ac_root: Path) -> None:
+    assert not paths.index_db().exists()
+
+    with fts.canonical_read_cursor() as conn:
+        assert conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='captures'"
+        ).fetchone()
+
+    assert paths.index_db().exists()
+    assert stat.S_IMODE(paths.index_db().stat().st_mode) == 0o600
 
 
 def test_create_append_search(ac_root: Path) -> None:
@@ -703,6 +718,11 @@ def test_client_connect_requires_daemon_created_schema(
     ac_root: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(fts, "_CLIENT_PROCESS", True)
+    monkeypatch.setattr(
+        fts,
+        "_create_private_database_file",
+        lambda _path: pytest.fail("a client must never create index.db"),
+    )
     with pytest.raises(RuntimeError, match="start the Persome daemon"):
         fts.connect()
     assert not paths.index_db().exists()


### PR DESCRIPTION
## Summary
- stop opening and closing live SQLite database, WAL, SHM, and journal artifacts during permission validation
- securely precreate owner databases at mode 0600 and keep clients fail-closed
- add POSIX record-lock, first-run, sidecar-race, and mode regressions

## Root cause
On POSIX, closing any file descriptor for an inode cancels every advisory lock held by that process on the same inode. Persome permission validation did exactly that while other SQLite connections remained open, allowing WAL/SHM generations to split at checkpoint time.

## Validation
- 2220 passed, 17 deselected
- ruff check and format check
- secret, PII, and language scans
- OpenAPI and DB schema drift checks

Signed-off-by: Singularity <t463zhan@uwaterloo.ca>