### PR TITLE
feat: local tool-call counting (tool_ticks) + persome stats show/export

### DIFF
--- a/SECURITY_PRIVACY.md
+++ b/SECURITY_PRIVACY.md
@@ -121,6 +121,13 @@ configured capabilities:
 Capture and BM25 retrieval work without provider credentials. LLM-dependent
 model stages report degradation rather than silently claiming success.
 
+Local usage counting is not egress: each MCP tool call appends one row (tool
+name, timestamp, client name) to the `tool_ticks` table in `index.db`. Rows
+are bounded, pruned daily, and never uploaded. `persome stats show` reads
+them locally; `persome stats export` prints bare daily call counts — no tool
+names, no client names, no content — as JSON the owner may choose to share
+by hand. Nothing transmits it.
+
 ## Local API boundary
 
 - REST and streamable HTTP MCP are restricted to loopback (`127.0.0.1` by default).

--- a/docs/db-schema.sql
+++ b/docs/db-schema.sql
@@ -363,6 +363,18 @@ CREATE INDEX ix_cross_domain_probe_age
 
 CREATE INDEX ix_faces_status ON schema_faces(status, level);
 
+-- ---- store/tool_ticks.py ----
+
+CREATE TABLE tool_ticks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts TEXT NOT NULL,              -- ISO8601 call time (local, with offset)
+    tool TEXT NOT NULL,            -- MCP tool name (e.g. 'search')
+    client TEXT NOT NULL,          -- clientInfo.name best-effort ('' unknown)
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX idx_tool_ticks_ts ON tool_ticks(ts DESC);
+
 -- ---- source_import.py ----
 
 CREATE TABLE source_imports (

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -4126,6 +4126,90 @@ def config() -> None:
     console.print(p.read_text())
 
 
+stats_app = typer.Typer(
+    help=(
+        "Local MCP usage statistics. Everything here is read from index.db on "
+        "this machine; nothing is uploaded (SECURITY_PRIVACY.md). `export` "
+        "writes bare daily call counts you may choose to share by hand."
+    ),
+    no_args_is_help=True,
+)
+app.add_typer(stats_app, name="stats")
+
+
+def _tool_tick_stats(days: int) -> tuple[dict, dict]:
+    """(windowed stats, unbounded stats) for the last ``days`` days."""
+    from datetime import date
+
+    from .store import fts
+    from .store import tool_ticks as tool_ticks_store
+
+    since = (date.today() - timedelta(days=days)).isoformat()
+    with fts.cursor() as conn:
+        window = tool_ticks_store.stats(conn, since=since)
+        whole = tool_ticks_store.stats(conn)
+    return window, whole
+
+
+@stats_app.command("show")
+def stats_show(
+    days: int = typer.Option(30, min=1, help="Window size in days."),
+) -> None:
+    """Summarize local MCP tool usage for the last N days."""
+    window, whole = _tool_tick_stats(days)
+    first = (whole["first_ts"] or "")[:10] or "(no calls recorded yet)"
+    typer.echo(f"tool calls, last {days}d: {window['total']} (recording since {first})")
+    typer.echo(f"active days: {len(window['by_day'])}/{days}")
+    for tool, count in sorted(window["by_tool"].items(), key=lambda kv: -kv[1]):
+        typer.echo(f"  {count:6d}  {tool}")
+    if window["by_client"]:
+        clients = ", ".join(
+            f"{name or '(unknown)'}={count}"
+            for name, count in sorted(window["by_client"].items(), key=lambda kv: -kv[1])
+        )
+        typer.echo(f"clients: {clients}")
+
+
+@stats_app.command("export")
+def stats_export(
+    days: int = typer.Option(30, min=1, help="Window size in days."),
+    out: str = typer.Option("", help="Write JSON here instead of stdout."),
+) -> None:
+    """Export bare daily call counts as JSON — for sharing you choose to do.
+
+    The payload contains ONLY: version, the export window, first recorded
+    date, and one integer per day. No tool names, no client names, no
+    content. Zero-days are written explicitly so retention math downstream
+    is unambiguous.
+    """
+    import json as _json
+    from datetime import date
+    from pathlib import Path
+
+    from . import __version__
+
+    window, whole = _tool_tick_stats(days)
+    today = date.today()
+    daily: dict[str, int] = {}
+    for offset in range(days - 1, -1, -1):
+        day = (today - timedelta(days=offset)).isoformat()
+        daily[day] = window["by_day"].get(day, 0)
+    payload = {
+        "persome_version": __version__,
+        "generated_at": datetime.now().astimezone().isoformat(timespec="seconds"),
+        "window_days": days,
+        "first_recorded": (whole["first_ts"] or "")[:10] or None,
+        "days_active": sum(1 for v in daily.values() if v),
+        "daily_calls": daily,
+    }
+    text = _json.dumps(payload, ensure_ascii=False, indent=2)
+    if out:
+        paths.atomic_write_private_text(Path(out), text)
+        typer.echo(f"wrote {out}")
+    else:
+        typer.echo(text)
+
+
 clean_app = typer.Typer(help="Delete past data. Destructive — use with care.")
 app.add_typer(clean_app, name="clean")
 

--- a/src/persome/mcp/server.py
+++ b/src/persome/mcp/server.py
@@ -18,6 +18,7 @@ depending on `[mcp] transport`. Exposes:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import signal
@@ -1020,6 +1021,24 @@ def _protect_http_app(app: Any, *, host: str, auth_enabled: bool) -> Any:
     return add_local_api_auth_middleware(app, enabled=auth_enabled)
 
 
+def _record_tool_tick(tool: str, client: str) -> None:
+    """Best-effort local usage tick — one row in ``index.db``, nothing leaves
+    the machine (SECURITY_PRIVACY.md). Never raises: a telemetry failure must
+    not break the tool call it describes."""
+    try:
+        from ..store import tool_ticks
+
+        with fts.cursor() as conn:
+            tool_ticks.record_tick(
+                conn,
+                ts=datetime.now().astimezone().isoformat(timespec="seconds"),
+                tool=tool,
+                client=client,
+            )
+    except Exception as exc:  # noqa: BLE001 — telemetry must never break a call
+        logger.debug("tool tick skipped: %s", exc)
+
+
 def build_server(
     cfg: Config | None = None,
     *,
@@ -1068,7 +1087,26 @@ def build_server(
         validate_bind_host(cfg.mcp.host)
 
     class _ProtectedFastMCP(FastMCP):
-        """FastMCP whose complete HTTP app shares the local bearer boundary."""
+        """FastMCP whose complete HTTP app shares the local bearer boundary.
+
+        Also the single interception point for local tool-call counting: every
+        registered tool dispatches through ``call_tool``, so one override
+        covers the whole surface without touching individual tools.
+        """
+
+        async def call_tool(self, name, arguments):  # type: ignore[no-untyped-def]
+            client = ""
+            try:
+                params = self.get_context().session.client_params
+                if params is not None and params.clientInfo is not None:
+                    client = str(params.clientInfo.name or "")[:64]
+            except Exception:  # noqa: BLE001 — attribution is best-effort
+                client = ""
+            # Local-only usage tick (see SECURITY_PRIVACY.md: no phone-home).
+            # Runs off-loop; _record_tool_tick never raises, so only
+            # cancellation can propagate — and then the call is dying anyway.
+            await asyncio.to_thread(_record_tool_tick, name, client)
+            return await super().call_tool(name, arguments)
 
         def streamable_http_app(self):  # type: ignore[no-untyped-def]
             app = super().streamable_http_app()

--- a/src/persome/session/tick.py
+++ b/src/persome/session/tick.py
@@ -30,6 +30,7 @@ from ..evomem import inversion as evo_inversion
 from ..logger import get
 from ..store import fts
 from ..store import parser_ticks as parser_ticks_store
+from ..store import tool_ticks as tool_ticks_store
 from ..writer import agent as writer_agent
 from ..writer import classifier as classifier_mod
 from ..writer import (
@@ -47,9 +48,12 @@ _WAL_CHECKPOINT_INTERVAL_SECONDS = 60
 
 
 def _prune_telemetry_tables() -> dict[str, int]:
-    """Bound the parser audit table from the daily safety-net tick."""
+    """Bound the telemetry audit tables from the daily safety-net tick."""
     with fts.cursor() as conn:
-        return {"parser_ticks": parser_ticks_store.prune(conn)}
+        return {
+            "parser_ticks": parser_ticks_store.prune(conn),
+            "tool_ticks": tool_ticks_store.prune(conn),
+        }
 
 
 def recover_stranded_sessions(*, now: datetime | None = None) -> list[session_store.SessionRow]:

--- a/src/persome/store/schema_dump.py
+++ b/src/persome/store/schema_dump.py
@@ -99,6 +99,7 @@ def _index_db_steps() -> list[tuple[str, Callable[[sqlite3.Connection], None]]]:
         parser_ticks,
         relation_edges,
         schema_faces,
+        tool_ticks,
     )
 
     return [
@@ -110,6 +111,7 @@ def _index_db_steps() -> list[tuple[str, Callable[[sqlite3.Connection], None]]]:
         ("store/owner_aliases.py", owner_aliases.ensure_schema),
         ("store/parser_ticks.py", parser_ticks.ensure_schema),
         ("store/schema_faces.py", schema_faces.ensure_schema),
+        ("store/tool_ticks.py", tool_ticks.ensure_schema),
         ("source_import.py", source_import.ensure_schema),
         ("evomem/store.py", evo_store.ensure_schema),
         ("evomem/integrity.py", evo_integrity.ensure_check_runs_schema),

--- a/src/persome/store/tool_ticks.py
+++ b/src/persome/store/tool_ticks.py
@@ -1,0 +1,121 @@
+"""MCP tool-call telemetry persistence and aggregation.
+
+Local-only usage counting: which MCP tools were called, when, and by which
+client. Rows never leave ``index.db`` — see ``SECURITY_PRIVACY.md`` ("no
+telemetry or update phone-home"); this table exists so the owner can see
+their own usage (heatmap / leverage metrics) and export bare daily counts
+by explicit choice (``persome stats export``). Arguments and results are
+deliberately NOT recorded.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+
+from ..logger import get
+
+logger = get("persome.store.tool_ticks")
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS tool_ticks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts TEXT NOT NULL,              -- ISO8601 call time (local, with offset)
+    tool TEXT NOT NULL,            -- MCP tool name (e.g. 'search')
+    client TEXT NOT NULL,          -- clientInfo.name best-effort ('' unknown)
+    created_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_tool_ticks_ts ON tool_ticks(ts DESC);
+"""
+
+
+def ensure_schema(conn: sqlite3.Connection) -> None:
+    from . import fts
+
+    if fts.is_client_process():
+        return
+    conn.executescript(SCHEMA)
+
+
+def record_tick(
+    conn: sqlite3.Connection,
+    *,
+    ts: str,
+    tool: str,
+    client: str = "",
+) -> int:
+    """Insert one tool-call telemetry row. Returns the row id.
+
+    Only the tool name and timestamp are stored — never arguments or
+    results. ``client`` is the MCP clientInfo name when the session
+    exposes one, else the empty string.
+    """
+    ensure_schema(conn)
+    cur = conn.execute(
+        """
+        INSERT INTO tool_ticks (ts, tool, client, created_at)
+        VALUES (?, ?, ?, ?)
+        """,
+        (
+            ts,
+            str(tool or ""),
+            str(client or ""),
+            datetime.now().isoformat(timespec="seconds"),
+        ),
+    )
+    conn.commit()
+    return int(cur.lastrowid or 0)
+
+
+def stats(conn: sqlite3.Connection, *, since: str = "", until: str = "￿") -> dict:
+    """Tool-call telemetry over ``[since, until)`` by ts.
+
+    Returns:
+        - ``total``     — number of calls in the window.
+        - ``by_tool``   — ``{<tool>: count}``.
+        - ``by_client`` — ``{<client>: count}`` (``""`` bucket = unknown).
+        - ``by_day``    — ``{YYYY-MM-DD: count}`` daily totals; this is the
+                           series retention math consumes (a day is "active"
+                           when its count is > 0).
+        - ``first_ts`` / ``last_ts`` — bounds of the recorded window
+                           (``None`` when empty).
+        - ``since`` / ``until`` — echoed bounds (``None`` when unbounded).
+    """
+    ensure_schema(conn)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT ts, tool, client FROM tool_ticks WHERE ts >= ? AND ts < ? ORDER BY ts",
+        (since, until),
+    ).fetchall()
+    total = len(rows)
+    by_tool: dict[str, int] = {}
+    by_client: dict[str, int] = {}
+    by_day: dict[str, int] = {}
+    for r in rows:
+        by_tool[str(r["tool"])] = by_tool.get(str(r["tool"]), 0) + 1
+        by_client[str(r["client"])] = by_client.get(str(r["client"]), 0) + 1
+        day = str(r["ts"])[:10]
+        by_day[day] = by_day.get(day, 0) + 1
+    return {
+        "total": total,
+        "by_tool": by_tool,
+        "by_client": by_client,
+        "by_day": by_day,
+        "first_ts": str(rows[0]["ts"]) if rows else None,
+        "last_ts": str(rows[-1]["ts"]) if rows else None,
+        "since": since or None,
+        "until": until if until != "￿" else None,
+    }
+
+
+def prune(conn: sqlite3.Connection, *, keep: int = 50000) -> int:
+    """Keep only the most recent ``keep`` rows (bounded telemetry). Returns the
+    number of rows deleted."""
+    ensure_schema(conn)
+    cur = conn.execute(
+        "DELETE FROM tool_ticks WHERE id NOT IN "
+        "(SELECT id FROM tool_ticks ORDER BY id DESC LIMIT ?)",
+        (keep,),
+    )
+    conn.commit()
+    return cur.rowcount

--- a/tests/test_cli_stats.py
+++ b/tests/test_cli_stats.py
@@ -1,0 +1,76 @@
+"""Tests for `persome stats` — local usage summary and consented export."""
+
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from persome import __version__, cli
+from persome.store import fts
+from persome.store import tool_ticks as tt
+
+
+def _seed(days_ago_counts: dict[int, int]) -> None:
+    """Insert ``count`` search ticks ``days_ago`` days before today."""
+    today = date.today()
+    with fts.cursor() as conn:
+        for days_ago, count in days_ago_counts.items():
+            day = (today - timedelta(days=days_ago)).isoformat()
+            for i in range(count):
+                tt.record_tick(conn, ts=f"{day}T10:{i:02d}:00+08:00", tool="search")
+
+
+def test_stats_show_summarizes_window(ac_root: Path) -> None:
+    _seed({0: 2, 1: 3, 40: 5})  # the 40-days-ago ticks fall outside --days 30
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["stats", "show", "--days", "30"])
+    assert result.exit_code == 0, result.output
+    assert "tool calls, last 30d: 5" in result.output
+    assert "active days: 2/30" in result.output
+    assert "search" in result.output
+
+
+def test_stats_export_payload_is_bare_daily_counts(ac_root: Path) -> None:
+    _seed({0: 2, 1: 3})
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["stats", "export", "--days", "7"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["persome_version"] == __version__
+    assert payload["window_days"] == 7
+    assert payload["days_active"] == 2
+    # Exactly one integer per day, zero-days explicit, newest day included.
+    assert len(payload["daily_calls"]) == 7
+    today = date.today().isoformat()
+    yesterday = (date.today() - timedelta(days=1)).isoformat()
+    assert payload["daily_calls"][today] == 2
+    assert payload["daily_calls"][yesterday] == 3
+    assert sum(payload["daily_calls"].values()) == 5
+    # Privacy contract: no tool names, no client names anywhere in the export.
+    assert "by_tool" not in payload
+    assert "by_client" not in payload
+    assert "search" not in result.output
+
+
+def test_stats_export_writes_file(ac_root: Path, tmp_path: Path) -> None:
+    _seed({0: 1})
+    out = tmp_path / "usage.json"
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["stats", "export", "--days", "3", "--out", str(out)])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["days_active"] == 1
+    assert len(payload["daily_calls"]) == 3
+
+
+def test_stats_export_empty_db(ac_root: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["stats", "export", "--days", "14"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["first_recorded"] is None
+    assert payload["days_active"] == 0
+    assert sum(payload["daily_calls"].values()) == 0

--- a/tests/test_session_tick.py
+++ b/tests/test_session_tick.py
@@ -115,7 +115,8 @@ def test_build_manager_wires_reducer_end_to_end(ac_root: Path, monkeypatch) -> N
 
 def test_prune_telemetry_calls_parser_store(ac_root: Path, monkeypatch) -> None:
     monkeypatch.setattr(session_tick.parser_ticks_store, "prune", lambda conn: 7)
-    assert session_tick._prune_telemetry_tables() == {"parser_ticks": 7}
+    monkeypatch.setattr(session_tick.tool_ticks_store, "prune", lambda conn: 3)
+    assert session_tick._prune_telemetry_tables() == {"parser_ticks": 7, "tool_ticks": 3}
 
 
 def test_model_dirty_generation_does_not_clear_newer_evidence(ac_root: Path) -> None:

--- a/tests/test_tool_ticks.py
+++ b/tests/test_tool_ticks.py
@@ -1,0 +1,105 @@
+"""Tests for MCP tool-call telemetry persistence."""
+
+from __future__ import annotations
+
+from persome.store import fts
+from persome.store import tool_ticks as tt
+
+
+def _tick(conn, *, ts, tool, client=""):  # noqa: ANN001
+    tt.record_tick(conn, ts=ts, tool=tool, client=client)
+
+
+def test_stats_counts_and_buckets(ac_root) -> None:  # noqa: ANN001
+    with fts.cursor() as conn:
+        _tick(conn, ts="2026-08-01T10:00:00+08:00", tool="search", client="claude-code")
+        _tick(conn, ts="2026-08-01T10:01:00+08:00", tool="search", client="claude-code")
+        _tick(conn, ts="2026-08-01T10:02:00+08:00", tool="current_context", client="codex")
+        _tick(conn, ts="2026-08-02T09:00:00+08:00", tool="search")
+        s = tt.stats(conn)
+    assert s["total"] == 4
+    assert s["by_tool"] == {"search": 3, "current_context": 1}
+    assert s["by_client"] == {"claude-code": 2, "codex": 1, "": 1}
+    assert s["by_day"] == {"2026-08-01": 3, "2026-08-02": 1}
+    assert s["first_ts"] == "2026-08-01T10:00:00+08:00"
+    assert s["last_ts"] == "2026-08-02T09:00:00+08:00"
+
+
+def test_stats_window_filter(ac_root) -> None:  # noqa: ANN001
+    with fts.cursor() as conn:
+        _tick(conn, ts="2026-08-01T10:00:00+08:00", tool="search")
+        _tick(conn, ts="2026-08-02T10:00:00+08:00", tool="chat")
+        s = tt.stats(conn, since="2026-08-02T00:00", until="2026-08-03T00:00")
+    assert s["total"] == 1
+    assert s["by_tool"] == {"chat": 1}
+    assert s["by_day"] == {"2026-08-02": 1}
+    assert s["since"] == "2026-08-02T00:00"
+    assert s["until"] == "2026-08-03T00:00"
+
+
+def test_stats_empty(ac_root) -> None:  # noqa: ANN001
+    with fts.cursor() as conn:
+        s = tt.stats(conn)
+    assert s["total"] == 0
+    assert s["by_tool"] == {}
+    assert s["by_client"] == {}
+    assert s["by_day"] == {}
+    assert s["first_ts"] is None
+    assert s["last_ts"] is None
+    assert s["since"] is None
+    assert s["until"] is None
+
+
+def test_record_tick_returns_rowid_and_roundtrips(ac_root) -> None:  # noqa: ANN001
+    with fts.cursor() as conn:
+        rid = tt.record_tick(
+            conn, ts="2026-08-01T10:00:00+08:00", tool="search", client="claude-code"
+        )
+        assert rid > 0
+        row = conn.execute(
+            "SELECT ts, tool, client FROM tool_ticks WHERE id = ?", (rid,)
+        ).fetchone()
+    assert row["ts"] == "2026-08-01T10:00:00+08:00"
+    assert row["tool"] == "search"
+    assert row["client"] == "claude-code"
+
+
+def test_prune_keeps_recent(ac_root) -> None:  # noqa: ANN001
+    with fts.cursor() as conn:
+        for i in range(10):
+            _tick(conn, ts=f"2026-08-01T10:{i:02d}:00+08:00", tool="search")
+        deleted = tt.prune(conn, keep=4)
+        s = tt.stats(conn)
+    assert deleted == 6
+    assert s["total"] == 4
+
+
+def test_server_call_tool_records_tick(ac_root) -> None:  # noqa: ANN001
+    """The FastMCP.call_tool override records exactly one local tick per call."""
+    import asyncio
+
+    from persome.mcp import server as mcp_server
+
+    server = mcp_server.build_server(auth_enabled=False, include_http_routes=False)
+    asyncio.run(server.call_tool("list_memories", {}))
+    with fts.cursor() as conn:
+        s = tt.stats(conn)
+    assert s["total"] == 1
+    assert s["by_tool"] == {"list_memories": 1}
+    # No request context in a direct call — attribution degrades to "".
+    assert s["by_client"] == {"": 1}
+
+
+def test_tick_failure_never_breaks_the_call(ac_root, monkeypatch) -> None:  # noqa: ANN001
+    """A telemetry write failure is swallowed; the tool call still succeeds."""
+    import asyncio
+
+    from persome.mcp import server as mcp_server
+
+    def _boom(*a, **k):  # noqa: ANN001, ANN002, ANN003
+        raise RuntimeError("disk on fire")
+
+    monkeypatch.setattr(tt, "record_tick", _boom)
+    server = mcp_server.build_server(auth_enabled=False, include_http_routes=False)
+    result = asyncio.run(server.call_tool("list_memories", {}))
+    assert result is not None


### PR DESCRIPTION
## Why

Persome's MCP surface currently has no way to answer the most basic question about itself: **is it actually being used?** GitHub tells us who cloned; nothing tells us (or an owner) whether the runtime is alive on day 14. This PR adds that capability **without touching the privacy promise** — everything stays in `index.db` on the owner's machine.

Two concrete needs drive it:

1. **Owner-facing**: the upcoming heatmap / leverage (HET) card needs per-tool, per-client call counts as its data source. This PR is that data source.
2. **Beta cohort retention**: testers can run `persome stats export` and *choose* to share a JSON containing nothing but daily call totals — enough to compute D14/D28 retention, and nothing else.

## What

- **`store/tool_ticks.py`** — new `tool_ticks` table (`ts`, `tool`, `client`), mirroring the `parser_ticks` pattern: client-process schema gate, bounded retention (50k rows), `stats()` with per-day aggregation.
- **`mcp/server.py`** — one override in `_ProtectedFastMCP.call_tool` covers every registered tool; no per-tool changes. Client attribution is best-effort from MCP `clientInfo` (so `claude-code` vs `codex` shows up distinctly). The tick write runs off-loop and **can never break the tool call it describes** — any failure degrades to a debug log.
- **`persome stats show [--days N]`** — local summary: total calls, active days, by-tool and by-client ranking.
- **`persome stats export [--days N] [--out FILE]`** — bare daily counts as JSON: version, window, first-recorded date, one integer per day. **No tool names, no client names, no content.** Zero-days are written explicitly so downstream retention math is unambiguous. Tests assert the exclusions.
- **`session/tick.py`** — `tool_ticks` joins the existing daily telemetry prune.
- **Schema registry + `docs/db-schema.sql`** regenerated (drift guard passes).
- **`SECURITY_PRIVACY.md`** — documents that local counting is not egress. The *"no telemetry or update phone-home"* promise is **unchanged**: there is no new network path, no endpoint, no upload. Export is a file the owner reads and shares by hand, or doesn't.

## What this is deliberately NOT

- Not phone-home telemetry — nothing transmits, opt-in or otherwise.
- Not content logging — arguments and results are never recorded, only tool name + timestamp.
- Not a new dependency — pure SQLite, same patterns the codebase already uses.

## Testing

- `tests/test_tool_ticks.py` — store roundtrip, window filter, prune, plus two dispatch-path tests: a real `server.call_tool()` records exactly one tick, and a poisoned `record_tick` (raises) still lets the tool call succeed.
- `tests/test_cli_stats.py` — show/export output, file writing, empty DB, and the privacy contract (no tool/client names in export).
- Full suite: **2235 passed, 13 skipped**. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)