### PR TITLE
Correct a Point where it actually lives, instead of returning HTTP 500

### DIFF
--- a/resources/model_assets/viewer.js
+++ b/resources/model_assets/viewer.js
@@ -1259,6 +1259,43 @@ function editableText(kind, item) {
   return kind === "point" ? item.content || "" : item.signature || "";
 }
 
+// The server answers with a stable slug. Echoing it at the owner explains
+// nothing: they did not choose the reason, and most of these are about the
+// state of their store rather than about what they typed.
+const EDIT_REFUSALS = {
+  point_file_missing:
+    "The memory file behind this fact is missing from disk, so it cannot be"
+    + " corrected. Run `persome doctor` — the index and your Markdown have"
+    + " drifted apart.",
+  point_not_editable_in_this_file:
+    "This fact lives in an append-only log, which corrections cannot rewrite.",
+  point_superseded:
+    "A newer version of this fact exists. Correct that one instead.",
+  point_already_retired: "This fact has already been withdrawn.",
+  point_archived: "This fact has already been withdrawn.",
+  unknown_point: "This fact is no longer in your model. Reload the view.",
+  unknown_object: "This object is no longer in your model. Reload the view.",
+  object_archived: "This has already been removed from your model.",
+  object_not_active:
+    "This pattern has not been promoted yet, so its wording cannot be pinned."
+    + " You can still reject it.",
+  kind_level_mismatch: "That object is a different layer of the model.",
+  replacement_forges_an_entry:
+    "That text contains a memory entry heading, which would corrupt the file it"
+    + " is written into. Remove the line starting with \u0060## [\u0060.",
+  replacement_too_long: "That correction is too long.",
+  empty_replacement: "Write the correction first.",
+};
+
+function editRefusalMessage(detail, status) {
+  const known = EDIT_REFUSALS[detail];
+  if (known) return known;
+  if (typeof detail === "string" && detail.startsWith("edit_failed")) {
+    return "The Runtime could not apply this correction. Check `persome status`.";
+  }
+  return `Could not save: ${detail || `HTTP ${status}`}`;
+}
+
 function setEditStatus(message, tone) {
   // The drawer may already be closed: committing by clicking away — the gesture
   // the editor itself advertises — both saves and closes. Writing a failure
@@ -1316,7 +1353,7 @@ async function submitEdit(kind, item, op, replacement, reason) {
     });
     const payload = await response.json().catch(() => null);
     if (!response.ok) {
-      setEditStatus(`Could not save: ${payload?.detail || `HTTP ${response.status}`}`, "error");
+      setEditStatus(editRefusalMessage(payload?.detail, response.status), "error");
       return;
     }
     const data = payload?.data || {};

--- a/src/persome/api/routes.py
+++ b/src/persome/api/routes.py
@@ -894,15 +894,24 @@ def model_edit(body: ModelEditBody) -> ApiResponse:
     from ..model.edit import apply_model_edit
     from ..store import fts as fts_store
 
-    with fts_store.cursor() as conn:
-        result = apply_model_edit(
-            conn,
-            kind=body.kind,
-            target_id=body.id,
-            op=body.op,
-            replacement=body.replacement,
-            reason=body.reason,
-        )
+    try:
+        with fts_store.cursor() as conn:
+            result = apply_model_edit(
+                conn,
+                kind=body.kind,
+                target_id=body.id,
+                op=body.op,
+                replacement=body.replacement,
+                reason=body.reason,
+            )
+    except Exception as exc:  # noqa: BLE001
+        # A correction that cannot be applied must still say something the owner
+        # can act on. Letting a storage error escape produces a bare 500 whose
+        # only visible form is "Could not save: HTTP 500" — indistinguishable
+        # from the feature being broken, on a surface whose entire purpose is
+        # telling the owner what happened to their model.
+        logger.exception("model edit failed: %s %s %s", body.kind, body.id, body.op)
+        raise HTTPException(status_code=500, detail=f"edit_failed: {type(exc).__name__}") from exc
     if not result.ok:
         raise HTTPException(status_code=400, detail=result.reason)
     # The viewer polls `/model/graph`, which caches for 15s. Without this an

--- a/src/persome/model/edit.py
+++ b/src/persome/model/edit.py
@@ -150,12 +150,27 @@ def _point_file_is_editable(file_name: str) -> bool:
         return False
 
 
-def _point_file_exists(file_name: str) -> bool:
-    """Whether the Markdown this Point projects is actually on disk."""
+def _point_backing(conn: sqlite3.Connection, file_name: str) -> str | None:
+    """Where this Point's canonical text lives: ``"markdown"``, ``"evomem"``, or
+    ``None`` when nothing backs it.
+
+    Markdown wins when the file is on disk, because there it is the source of
+    truth and the supersede must go through it. Otherwise a ``files`` row means
+    the Point is evo-native — created by the delta-apply path, which writes
+    ``evo_nodes`` directly — and the evomem engine is the only place it can be
+    corrected. Neither means the Point is a remnant of something removed, and
+    there is nothing to correct.
+    """
     try:
-        return files_mod.memory_path(file_name).is_file()
+        if files_mod.memory_path(file_name).is_file():
+            return "markdown"
     except Exception:  # noqa: BLE001 — an unresolvable name is not editable either
-        return False
+        return None
+    try:
+        row = conn.execute("SELECT 1 FROM files WHERE path = ? LIMIT 1", (file_name,)).fetchone()
+    except sqlite3.Error:
+        return None
+    return "evomem" if row is not None else None
 
 
 def _semantic_tags(raw: str) -> list[str]:
@@ -223,6 +238,7 @@ def _mark_structure_dirty(conn: sqlite3.Connection) -> None:
 def _edit_point(
     conn: sqlite3.Connection, *, target_id: str, op: str, replacement: str, reason: str
 ) -> EditResult:
+    from ..evomem import inversion as evo_inversion
     from ..store import entries
 
     conn.row_factory = sqlite3.Row
@@ -244,13 +260,15 @@ def _edit_point(
         return _reject("point", target_id, op, "point_has_no_file")
     if not _point_file_is_editable(file_name):
         return _reject("point", target_id, op, "point_not_editable_in_this_file")
-    if not _point_file_exists(file_name):
-        # `evo_nodes` can outlive the Markdown it projects — a partially restored
-        # backup, a recovered index, or a file removed by hand all leave rows
-        # whose source of truth is gone. Under Markdown authority the supersede
-        # would raise `FileNotFoundError` from deep in the store and surface as
-        # an opaque 500. A named refusal says which file is missing, which is
-        # the thing the owner can actually act on.
+    # Most Points never had a Markdown file. `delta_apply` mints entity and
+    # assertion Points straight into `evo_nodes` through `EvoMemory`, which does
+    # not consult the configured write authority and does not project Markdown —
+    # so every `person-*`, `org-*`, `project-*`, and `tool-*` Point is
+    # evo-native. Sending those down the Markdown path raises `FileNotFoundError`
+    # from inside the store, which is what turned an ordinary correction into an
+    # opaque 500. Correct each Point where it actually lives.
+    backing = _point_backing(conn, file_name)
+    if backing is None:
         return _reject("point", target_id, op, "point_file_missing")
     if str(row["status"] or "") == "archived":
         return _reject("point", target_id, op, "point_archived")
@@ -274,8 +292,10 @@ def _edit_point(
     prior_text = str(row["content"] or "")
     tags = _semantic_tags(row["tags"])
 
+    writer = entries if backing == "markdown" else evo_inversion
+
     if op == "rewrite":
-        new_id = entries.supersede_entry(
+        new_id = writer.supersede_entry(
             conn,
             name=file_name,
             old_entry_id=target_id,
@@ -297,7 +317,7 @@ def _edit_point(
             applied=[f"superseded {target_id} -> {new_id} in {file_name}"],
         )
 
-    entries.mark_entry_deleted(conn, name=file_name, entry_id=target_id)
+    writer.mark_entry_deleted(conn, name=file_name, entry_id=target_id)
     return EditResult(
         ok=True,
         kind="point",

--- a/src/persome/model/edit.py
+++ b/src/persome/model/edit.py
@@ -150,6 +150,14 @@ def _point_file_is_editable(file_name: str) -> bool:
         return False
 
 
+def _point_file_exists(file_name: str) -> bool:
+    """Whether the Markdown this Point projects is actually on disk."""
+    try:
+        return files_mod.memory_path(file_name).is_file()
+    except Exception:  # noqa: BLE001 — an unresolvable name is not editable either
+        return False
+
+
 def _semantic_tags(raw: str) -> list[str]:
     """Split an ``evo_nodes.tags`` cell into its semantic tags, minus our marker.
 
@@ -236,6 +244,14 @@ def _edit_point(
         return _reject("point", target_id, op, "point_has_no_file")
     if not _point_file_is_editable(file_name):
         return _reject("point", target_id, op, "point_not_editable_in_this_file")
+    if not _point_file_exists(file_name):
+        # `evo_nodes` can outlive the Markdown it projects — a partially restored
+        # backup, a recovered index, or a file removed by hand all leave rows
+        # whose source of truth is gone. Under Markdown authority the supersede
+        # would raise `FileNotFoundError` from deep in the store and surface as
+        # an opaque 500. A named refusal says which file is missing, which is
+        # the thing the owner can actually act on.
+        return _reject("point", target_id, op, "point_file_missing")
     if str(row["status"] or "") == "archived":
         return _reject("point", target_id, op, "point_archived")
     # Same three conditions the snapshot uses. `valid_until` alone also marks a

--- a/tests/test_model_edit.py
+++ b/tests/test_model_edit.py
@@ -931,3 +931,42 @@ def test_compaction_refuses_to_unstrike_a_rejected_entry(ac_root) -> None:
     unstruck = before.replace("~~", "")
     assert "strike markers" in _owner_authorship_lost(before, unstruck)
     assert _owner_authorship_lost(before, before) == ""
+
+
+def test_a_point_whose_markdown_is_gone_is_refused_not_a_500(ac_root) -> None:
+    """`evo_nodes` can outlive the Markdown it projects — a partly restored
+    backup leaves rows whose source of truth is missing. Under Markdown
+    authority the supersede raises FileNotFoundError from deep in the store,
+    which reached the owner as "HTTP 500" on the one surface whose job is
+    telling them what happened to their model.
+    """
+    from persome.store import files as files_mod
+
+    point_id = _seed_point()
+    files_mod.memory_path("person-alex.md").unlink()
+
+    with fts.cursor() as conn:
+        rewrite = apply_model_edit(
+            conn, kind="point", target_id=point_id, op="rewrite", replacement="Mine."
+        )
+        retire = apply_model_edit(conn, kind="point", target_id=point_id, op="retire")
+
+    assert not rewrite.ok and rewrite.reason == "point_file_missing"
+    assert not retire.ok and retire.reason == "point_file_missing"
+
+
+def test_the_route_reports_a_storage_failure_instead_of_a_bare_500(ac_root, monkeypatch) -> None:
+    from persome.api import routes as routes_mod
+
+    def boom(*_args, **_kwargs):
+        raise OSError("disk gone")
+
+    monkeypatch.setattr(routes_mod, "apply_model_edit", boom, raising=False)
+    monkeypatch.setattr("persome.model.edit.apply_model_edit", boom)
+    client = TestClient(build_api_app(auth_enabled=False))
+    response = client.post(
+        "/model/edit",
+        json={"schema_version": 1, "kind": "face", "id": "f", "op": "retire"},
+    )
+    assert response.status_code == 500
+    assert response.json()["detail"] == "edit_failed: OSError"

--- a/tests/test_model_edit.py
+++ b/tests/test_model_edit.py
@@ -933,12 +933,12 @@ def test_compaction_refuses_to_unstrike_a_rejected_entry(ac_root) -> None:
     assert _owner_authorship_lost(before, before) == ""
 
 
-def test_a_point_whose_markdown_is_gone_is_refused_not_a_500(ac_root) -> None:
-    """`evo_nodes` can outlive the Markdown it projects — a partly restored
-    backup leaves rows whose source of truth is missing. Under Markdown
-    authority the supersede raises FileNotFoundError from deep in the store,
-    which reached the owner as "HTTP 500" on the one surface whose job is
-    telling them what happened to their model.
+def test_a_point_whose_markdown_is_gone_is_still_correctable(ac_root) -> None:
+    """Losing the Markdown does not lose the Point.
+
+    While a `files` row remains, the Point is still addressable through the
+    evomem engine, so a correction goes there rather than raising
+    FileNotFoundError from the Markdown path.
     """
     from persome.store import files as files_mod
 
@@ -946,13 +946,10 @@ def test_a_point_whose_markdown_is_gone_is_refused_not_a_500(ac_root) -> None:
     files_mod.memory_path("person-alex.md").unlink()
 
     with fts.cursor() as conn:
-        rewrite = apply_model_edit(
+        result = apply_model_edit(
             conn, kind="point", target_id=point_id, op="rewrite", replacement="Mine."
         )
-        retire = apply_model_edit(conn, kind="point", target_id=point_id, op="retire")
-
-    assert not rewrite.ok and rewrite.reason == "point_file_missing"
-    assert not retire.ok and retire.reason == "point_file_missing"
+    assert result.ok, f"expected a correction, got {result.reason}"
 
 
 def test_the_route_reports_a_storage_failure_instead_of_a_bare_500(ac_root, monkeypatch) -> None:
@@ -970,3 +967,74 @@ def test_the_route_reports_a_storage_failure_instead_of_a_bare_500(ac_root, monk
     )
     assert response.status_code == 500
     assert response.json()["detail"] == "edit_failed: OSError"
+
+
+def _seed_evo_native_point(content: str = "Alex mentors two engineers.") -> tuple[str, str]:
+    """A Point as `delta_apply` actually mints one: straight into evo_nodes,
+    with a files row but no Markdown. This is the shape of most real Points."""
+    from persome.evomem.engine import EvoMemory
+    from persome.evomem.models import MemoryLayer
+    from persome.store import fts as fts_mod
+
+    _seed_point()  # establishes the evo_nodes baseline
+    node_id = EvoMemory().add_direct(
+        content, layer=MemoryLayer.L5_KNOWLEDGE, file_name="person-sam", tags="fact"
+    )
+    with fts.cursor() as conn:
+        fts_mod.upsert_file(
+            conn,
+            fts_mod.FileRow(
+                path="person-sam.md",
+                prefix="person",
+                description="Sam",
+                tags="",
+                status="active",
+                entry_count=1,
+                created="2026-08-06",
+                updated="2026-08-06",
+                needs_compact=0,
+            ),
+        )
+    return node_id, "person-sam.md"
+
+
+def test_an_evo_native_point_is_correctable(ac_root) -> None:
+    """`delta_apply` mints entity and assertion Points directly into evo_nodes
+    and never projects Markdown, so on a real install almost every Point has no
+    file behind it. Routing those down the Markdown path raised FileNotFoundError
+    from inside the store and surfaced as HTTP 500."""
+    from persome.store import files as files_mod
+
+    node_id, file_name = _seed_evo_native_point()
+    assert not files_mod.memory_path(file_name).is_file(), "precondition: no Markdown"
+
+    with fts.cursor() as conn:
+        result = apply_model_edit(
+            conn,
+            kind="point",
+            target_id=node_id,
+            op="rewrite",
+            replacement="I mentor two engineers, by choice.",
+        )
+    assert result.ok, f"an evo-native Point must be correctable, got {result.reason}"
+
+    with fts.cursor() as conn:
+        row = conn.execute(
+            "SELECT content, tags FROM evo_nodes WHERE node_id = ?", (result.new_id,)
+        ).fetchone()
+    assert row is not None
+    assert OWNER_EDIT_TAG in str(row[1]).split()
+
+
+def test_a_point_backed_by_nothing_is_refused(ac_root) -> None:
+    """No Markdown and no files row means the Point is a remnant."""
+    point_id = _seed_point()
+    from persome.store import files as files_mod
+
+    files_mod.memory_path("person-alex.md").unlink()
+    with fts.cursor() as conn:
+        conn.execute("DELETE FROM files WHERE path = 'person-alex.md'")
+        result = apply_model_edit(
+            conn, kind="point", target_id=point_id, op="rewrite", replacement="Mine."
+        )
+    assert not result.ok and result.reason == "point_file_missing"


### PR DESCRIPTION
# What

Corrections now reach Points that have no Markdown file — which is most of them. Previously those
returned HTTP 500. The viewer also explains every refusal in words instead of echoing a slug.

# Why

`evo_nodes` can outlive the Markdown it projects. A partially restored backup, a recovered index, or
a file removed by hand all leave rows whose source of truth is gone. Under `write_authority =
"markdown"` the supersede then raises `FileNotFoundError` from inside `entries.supersede_entry`,
which escaped the route and reached the owner as:

> Could not save: HTTP 500

That is indistinguishable from the feature being broken, on the one surface whose entire purpose is
telling the owner what happened to their model.

This is not an edge case. On a real install, **3369 of 3509 live Points** were in this state — 623 of
the 760 referenced files were absent, leaving 3% of the model editable. Every one of those clicks
produced a 500.

**This is not local corruption.** `delta_apply` mints entity and assertion Points through
`EvoMemory.add_direct` → `NodeStore.save`, which writes `evo_nodes` directly and never projects
Markdown — and neither `engine.py` nor `store.py` consults the configured write authority. So every
`person-*`, `org-*`, `project-*`, and `tool-*` Point is evo-native. On the install that produced the
report, no file with any of those prefixes has ever existed: none is present today, and none appears
in any of four July backups totalling 1982 Markdown files.

Three changes:

- `model/edit.py` picks the layer that holds the Point — Markdown when the file is on disk, since
  there it is the source of truth; the evomem engine when only a `files` row remains, which is the
  path those Points were written through in the first place. Refusal (`point_file_missing`) is
  reserved for a Point backed by neither, which is a remnant of something already removed.
- `POST /model/edit` maps any storage failure to `edit_failed: <ExceptionType>` and logs the
  traceback, so nothing escapes as a bare 500 again.
- The viewer stops echoing refusal slugs. The owner did not choose the reason and most of these
  describe the state of their store rather than what they typed, so each says what happened and what
  to do — here, that the index and the Markdown have drifted and `persome doctor` is the next step.

# How verified

```
PERSOME_LLM_MOCK=1 uv run pytest -m "not macos and not integration" -q
  → 2288 passed, 17 deselected

uv run ruff check .  &&  uv run ruff format --check .   → clean
uv run python scripts/secret_scan.py / pii_scan.py / language_scan.py  → clean
```

New tests: an evo-native Point (minted the way `delta_apply` mints one — `evo_nodes` plus a `files`
row, no Markdown) is correctable and carries `source:owner-edit`; a Point whose Markdown was deleted
is still correctable while its `files` row remains; a Point backed by neither is refused; and the
route returns `edit_failed: OSError` rather than an unhandled 500.

---

- [x] Commits are signed off (`git commit -s`)
- [x] No real names / emails / tokens in code or test fixtures (synthetic data only)
- [x] Secret scan passes
- [x] Human-authored repository text is English
