### PR TITLE
perf(viewer): make the model's drag and pinch-zoom keep up with the hand

### DIFF
--- a/docs/model-contract.md
+++ b/docs/model-contract.md
@@ -146,8 +146,20 @@ local smoke tests.
 
 Zoom is relative to the fitted model: the visible minus, percentage, and plus controls cover 50%
 through 400%, the percentage resets to 100%, and the plus, minus, and zero keys provide the same
-actions. Wheel and trackpad pinch gestures zoom toward the pointer. `window.__persomeZoomState`
-exposes only aggregate distance and percentage values for local visual smoke tests.
+actions in 25% steps. Wheel and trackpad pinch gestures zoom continuously toward the pointer,
+gliding to their goal under the same damping that carries orbit and pan, so releasing a gesture
+coasts to a stop rather than stopping dead. Wheel deltas are normalized to pixels first, so a
+gesture means the same amount of zoom whether the browser reports pixels, lines, or pages, and one
+comfortable trackpad pinch is worth roughly a doubling on every display. A pinch is read from
+`ctrlKey` wheel events and, on browsers that report one instead, from gesture events; a touchscreen
+pinch and a middle-button drag keep the orbit controller's own dolly, which already tracks the
+fingers directly. `window.__persomeZoomState` exposes only aggregate distance and percentage values
+for local visual smoke tests.
+
+Dragging works anywhere over the model, including on a label and over the read-only legend and
+status panels, and a second finger cancels the click so a pinch never selects a node.
+`window.__persomeFrameStats` exposes rolling p50, p95, and worst frame costs in milliseconds over
+the last 240 frames, so a smoothness regression is measurable locally rather than only visible.
 
 ## Owner corrections
 

--- a/resources/model_assets/layout.mjs
+++ b/resources/model_assets/layout.mjs
@@ -527,8 +527,47 @@ function nextZoomPercent(
   );
 }
 
+// A wheel event's `deltaY` means three different things depending on
+// `deltaMode`, and browsers disagree on which they send: Chrome reports pixels
+// (a notch is ~100), Firefox reports lines (a notch is ~3), and page mode shows
+// up on some remote-desktop stacks. Reduce all three to CSS pixels so one
+// gesture means the same amount of zoom everywhere.
+const WHEEL_LINE_HEIGHT_PX = 16;
+const WHEEL_PIXEL_LIMIT_PX = 400;
+
+function wheelZoomPixels(event, viewportHeight = 800) {
+  const raw = Number(event?.deltaY);
+  if (!Number.isFinite(raw)) return 0;
+  const height = Number.isFinite(viewportHeight) && viewportHeight > 0 ? viewportHeight : 800;
+  const pixels = event.deltaMode === 1
+    ? raw * WHEEL_LINE_HEIGHT_PX
+    : event.deltaMode === 2
+      ? raw * height
+      : raw;
+  // Kinetic scrolling and page mode can deliver one enormous event. Cap a
+  // single event so no gesture can teleport the camera across the whole range.
+  return Math.max(-WHEEL_PIXEL_LIMIT_PX, Math.min(WHEEL_PIXEL_LIMIT_PX, pixels));
+}
+
+// Zoom is exponential in accumulated wheel pixels, so a gesture composed of
+// many small events lands in the same place as one large event of equal total.
+// A macOS trackpad pinch (ctrlKey wheel) accumulates roughly 300px over one
+// comfortable spread, which should be worth about a doubling; a mouse notch is
+// 100px and should be a much smaller, discrete-feeling step.
+const PINCH_GAIN_PER_PX = Math.LN2 / 300;
+const WHEEL_GAIN_PER_PX = Math.log(1.16) / 100;
+
+function wheelZoomFactor(event, viewportHeight = 800) {
+  const pixels = wheelZoomPixels(event, viewportHeight);
+  const gain = event?.ctrlKey ? PINCH_GAIN_PER_PX : WHEEL_GAIN_PER_PX;
+  // Wheel-up and pinch-out both report a negative delta and both mean "closer".
+  return Math.exp(-pixels * gain);
+}
+
 export const zoomMath = {
   clampPercent: clampZoomPercent,
   nextPercent: nextZoomPercent,
   percentForDistance: zoomPercentForDistance,
+  wheelFactor: wheelZoomFactor,
+  wheelPixels: wheelZoomPixels,
 };

--- a/resources/model_assets/viewer.css
+++ b/resources/model_assets/viewer.css
@@ -27,6 +27,14 @@ body {
   height: 100%;
   margin: 0;
   overflow: hidden;
+  /* The model is dragged, not scrolled: stop a two-finger swipe from rubber
+     banding the page or triggering the browser's back gesture mid-orbit. */
+  overscroll-behavior: none;
+  /* A drag across the canvas would otherwise paint a text selection across
+     whatever overlay copy it passes over. Selection comes back below on the
+     panels whose text is worth copying — a drawer's claim, and an error the
+     owner may want to paste into a bug report. */
+  user-select: none;
   background: var(--bg);
   color: var(--text);
   font: 14px/1.45 -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", sans-serif;
@@ -73,6 +81,21 @@ button {
   position: fixed;
   z-index: 1;
   inset: 0;
+}
+
+/* On the host, not only on the canvas: the label layer sits on top of the
+   canvas, and a touch that lands on a label must not start a browser pan. */
+#canvas {
+  touch-action: none;
+}
+
+/* Selection comes back where the words matter: the drawer's claim and
+   provenance, and any failure the owner might want to quote back to us. */
+.detail,
+.error,
+.edit-alert,
+.share-notice {
+  user-select: text;
 }
 
 #canvas canvas {
@@ -461,6 +484,9 @@ button {
   min-height: 54px;
   overflow: hidden;
   border-radius: 15px;
+  /* A read-only tally of the model's composition. Nothing to click, so it does
+     not get to absorb a drag. */
+  pointer-events: none;
 }
 
 .status-loading {
@@ -553,6 +579,8 @@ button {
   --build-glow: rgba(78, 240, 195, 0.72);
 }
 
+/* Inert, like .story: a legend that reads "how to read your model" has nothing
+   to click, so it must not be a place where dragging the model does nothing. */
 .legend {
   position: absolute;
   z-index: 8;
@@ -562,6 +590,7 @@ button {
   padding: 12px 14px 13px;
   border-radius: 15px;
   background: var(--surface-soft);
+  pointer-events: none;
 }
 
 .legend > p {
@@ -671,6 +700,9 @@ button {
   width: min(400px, calc(100vw - 48px));
   max-height: min(520px, calc(100vh - 190px));
   overflow: auto;
+  /* Keep a flick inside the drawer from chaining out to the page once it hits
+     the end of its content. */
+  overscroll-behavior: contain;
   padding: 22px 50px 20px 20px;
   border-radius: var(--radius);
   background:
@@ -1095,9 +1127,17 @@ button {
   pointer-events: auto;
   text-align: left;
   text-overflow: ellipsis;
-  transition: border-color 140ms ease, background 140ms ease, box-shadow 140ms ease, transform 140ms ease;
+  /* `transform` must never be transitioned here. CSS2DRenderer rewrites this
+     element's inline transform on every animation frame, so a transition on it
+     restarts every frame and the label becomes a 140ms-lagging follower of the
+     node it names — the single most visible way this view stops feeling
+     smooth while the camera moves. */
+  transition: border-color 140ms ease, background 140ms ease, box-shadow 140ms ease;
   white-space: nowrap;
-  backdrop-filter: blur(8px);
+  /* No backdrop-filter: up to twenty of these move over a canvas that repaints
+     every frame, so each one is a per-frame backdrop readback and blur, and at
+     78% background opacity almost none of it is visible anyway. */
+  will-change: transform;
 }
 
 .model-label::before {
@@ -1118,11 +1158,12 @@ button {
 .model-label[data-kind="root"] { --label-accent: var(--root); }
 .model-label[data-kind="context"] { --label-accent: var(--muted); }
 
+/* No `transform` lift here: the renderer owns this element's transform and
+   overwrites any rule with an inline one, so the lift never rendered. */
 .model-label:hover,
 .model-label:focus-visible {
   border-color: var(--label-accent);
   background: rgba(20, 17, 34, 0.96);
-  transform: translateY(-1px);
 }
 
 .model-label[aria-expanded="true"] {
@@ -1140,9 +1181,11 @@ button {
   color: var(--muted);
 }
 
+/* `display: none` rather than `visibility: hidden`: a culled label is one of
+   hundreds, and hidden is not the same as gone — laid-out labels still cost a
+   style and layout pass on every frame the camera moves. */
 .model-label.hidden {
-  visibility: hidden;
-  pointer-events: none;
+  display: none;
 }
 
 @media (min-width: 1181px) and (max-width: 1360px) {

--- a/resources/model_assets/viewer.js
+++ b/resources/model_assets/viewer.js
@@ -70,10 +70,15 @@ const scene = new THREE.Scene();
 scene.fog = new THREE.FogExp2(0x070610, 0.026);
 
 const camera = new THREE.PerspectiveCamera(50, 1, 0.1, 100);
+// No `preserveDrawingBuffer`: it makes the browser copy the whole framebuffer
+// every frame (tens of megabytes at 2x device pixel ratio) to serve readers
+// that may never come. Both readers here — samplePixels() and
+// createConstellationBlob() — read inside the same synchronous task as the
+// render that produced the pixels, which is exactly when the buffer is still
+// valid without it.
 const renderer = new THREE.WebGLRenderer({
   antialias: true,
   alpha: true,
-  preserveDrawingBuffer: true,
 });
 renderer.setClearColor(0x000000, 0);
 renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
@@ -94,10 +99,15 @@ canvasHost.appendChild(labelRenderer.domElement);
 const controls = new OrbitControls(camera, renderer.domElement);
 controls.enableDamping = true;
 controls.dampingFactor = 0.07;
-controls.zoomSpeed = 0.62;
+// OrbitControls keeps its dolly, which is what a touchscreen pinch and a
+// middle-button drag ride on, but it never sees the wheel: the viewer takes
+// that in the capture phase below. Its wheel path applies the whole delta in
+// one update and resets the accumulator, so wheel zoom landed in hard steps
+// while orbit and pan glided under damping, and it normalises by
+// `devicePixelRatio | 0`, which halves the gain on a Retina display — a full
+// trackpad pinch moved the camera 5% — and divides by zero once the ratio
+// drops below 1, where one notch teleports to the zoom limit.
 controls.zoomToCursor = true;
-controls.minDistance = 5;
-controls.maxDistance = 32;
 controls.target.set(0, 2.2, 0);
 
 scene.add(new THREE.HemisphereLight(0xdad6ff, 0x080710, 2.25));
@@ -121,6 +131,15 @@ let minTime = new Date();
 let maxTime = new Date();
 let playTimer = null;
 let pointerDown = null;
+// Which pointers are down, tracked apart from the click candidate. A gesture
+// stays live whatever it turns out to be — a second finger retires the click
+// candidate because a pinch must never select a node, and a right-drag is a
+// pan that carries no click candidate at all — and hover picking and the graph
+// poll must stay out of the way of all of them. Identities rather than a count:
+// a release can land on a label instead of the canvas, and a counter that
+// missed one would wedge closed for the rest of the session.
+const livePointers = new Set();
+let labelGesture = null;
 let hoverPointer = null;
 let hoverDirty = false;
 let selected = null;
@@ -143,6 +162,8 @@ let framedRadius = 0;
 let pulseGlows = [];
 let fitDistance = 12;
 let zoomGoalDistance = null;
+let zoomAnchor = null;
+let canvasBounds = null;
 let lastZoomPercent = null;
 let lastFrameTime = performance.now();
 let shareReady = false;
@@ -159,6 +180,15 @@ const kindLayers = {
 const raycaster = new THREE.Raycaster();
 const pointer = new THREE.Vector2();
 const zoomDirection = new THREE.Vector3();
+const zoomRaycaster = new THREE.Raycaster();
+const zoomPlane = new THREE.Plane();
+const zoomViewDirection = new THREE.Vector3();
+const zoomAnchorBefore = new THREE.Vector3();
+const zoomAnchorAfter = new THREE.Vector3();
+const zoomShift = new THREE.Vector3();
+const zoomAnchorNdc = new THREE.Vector2();
+const pickWorldPosition = new THREE.Vector3();
+const pickProjected = new THREE.Vector3();
 const MIN_NODE_HIT_RADIUS_PX = 12;
 const MIN_LINE_HIT_RADIUS_PX = 8;
 const ZOOM_MIN_PERCENT = 50;
@@ -321,9 +351,43 @@ function addLabel(text, position, layer, priority, kind, item, context = false) 
   label.position.copy(position);
   label.userData.priority = priority;
   registerSelectionTarget(kind, item.id, label);
-  element.addEventListener("pointerdown", (event) => event.stopPropagation());
+  element.addEventListener("pointerdown", (event) => {
+    if (event.pointerType === "mouse" && event.button !== 0) return;
+    // A label used to swallow the gesture outright, so the twenty of them on
+    // screen were twenty places where a drag did nothing at all. Hand the
+    // pointer to the canvas — OrbitControls captures it there and orbits — and
+    // record what was under it so a gesture that turns out to be a click still
+    // opens this label's node.
+    event.preventDefault();
+    // preventDefault also suppresses the focus the button would have taken, so
+    // give it back: a mouse user who selects a node should still be able to
+    // Tab onward from it.
+    element.focus({ preventScroll: true });
+    labelGesture = { kind, item };
+    renderer.domElement.dispatchEvent(new PointerEvent("pointerdown", {
+      pointerId: event.pointerId,
+      pointerType: event.pointerType,
+      isPrimary: event.isPrimary,
+      button: event.button,
+      buttons: event.buttons,
+      clientX: event.clientX,
+      clientY: event.clientY,
+      // Modifiers pick the gesture: shift or ctrl turns OrbitControls' left
+      // drag from an orbit into a pan, and a drag begun on a label has to mean
+      // the same thing as one begun on bare canvas.
+      ctrlKey: event.ctrlKey,
+      shiftKey: event.shiftKey,
+      altKey: event.altKey,
+      metaKey: event.metaKey,
+      bubbles: false,
+      cancelable: true,
+    }));
+  });
   element.addEventListener("click", (event) => {
     event.stopPropagation();
+    // Pointer-driven activation is resolved on the canvas above. Only keyboard
+    // activation, which reports no pointer detail, still arrives here.
+    if (event.detail !== 0) return;
     showDetails(kind, item);
   });
   register(label, layer);
@@ -686,6 +750,14 @@ function buildScene() {
   renderStatus();
   emptyEl.hidden = visiblePoints.length > 0;
   frameLayout(false);
+  // Fresh label elements and a possibly-resized status strip: both cached
+  // measurements have to be taken again.
+  invalidatePanelBoxes();
+  // A viewer that started against an empty store rendered nothing for its
+  // first frames and would otherwise have spent its whole probe budget on a
+  // blank scene, leaving the local smoke signal reading "nothing rendered"
+  // forever. A new scene deserves a fresh look.
+  renderProbeSweeps = 0;
   const renderedLines = renderedLineItems.length;
   window.__persomeViewerState = {
     schemaVersion: model.schema_version,
@@ -951,6 +1023,7 @@ function clearSelection() {
   evidenceTrail = [];
   detailEl.hidden = true;
   delete detailEl.dataset.kind;
+  invalidatePanelBoxes();
   syncSelectionState();
 }
 
@@ -1558,6 +1631,9 @@ function showDetails(kind, item) {
   selected = { kind, id: item.id };
   selectedItem = item;
   pauseAutoRotate();
+  // The drawer is one of the boxes labels are culled against, and it has just
+  // changed shape.
+  invalidatePanelBoxes();
   syncSelectionState();
   detailEl.dataset.kind = kind;
   detailKindEl.textContent = kind === "context" ? "entity" : kind;
@@ -1748,6 +1824,11 @@ function frameLayout(force) {
   controls.target.set(0, 0, 0);
   controls.minDistance = distance * 100 / ZOOM_MAX_PERCENT;
   controls.maxDistance = distance * 100 / ZOOM_MIN_PERCENT;
+  // Zooming at the cursor walks the orbit centre towards whatever is under it.
+  // Bound how far it may wander so a long pinch cannot strand the constellation
+  // off-screen with nothing left to orbit around.
+  controls.maxTargetRadius = radius * 1.5;
+  zoomAnchor = null;
   framedRadius = radius;
   controls.update();
   syncZoomUI();
@@ -1771,27 +1852,44 @@ function currentZoomPercent() {
   );
 }
 
+// Rebuilt in place rather than reallocated: syncZoomUI runs once per frame and
+// a fresh object literal per frame is pure garbage for the collector to chase
+// during exactly the gesture we are trying to keep smooth.
+window.__persomeZoomState = {
+  percent: 100,
+  distance: 0,
+  fitDistance: 0,
+  minPercent: ZOOM_MIN_PERCENT,
+  maxPercent: ZOOM_MAX_PERCENT,
+  animating: false,
+};
+
 function syncZoomUI() {
   const distance = camera.position.distanceTo(controls.target);
-  const percent = currentZoomPercent();
+  const percent = zoomMath.percentForDistance(
+    fitDistance,
+    distance,
+    ZOOM_MIN_PERCENT,
+    ZOOM_MAX_PERCENT,
+  );
+  // The DOM writes are the expensive half. They only mean anything when the
+  // rounded percent actually changes, which during a glide is a few frames out
+  // of every hundred.
   if (percent !== lastZoomPercent) {
     zoomResetButton.textContent = `${percent}%`;
     zoomResetButton.setAttribute(
       "aria-label",
       `Reset zoom to 100 percent (currently ${percent} percent)`,
     );
+    zoomOutButton.disabled = percent <= ZOOM_MIN_PERCENT;
+    zoomInButton.disabled = percent >= ZOOM_MAX_PERCENT;
     lastZoomPercent = percent;
   }
-  zoomOutButton.disabled = percent <= ZOOM_MIN_PERCENT;
-  zoomInButton.disabled = percent >= ZOOM_MAX_PERCENT;
-  window.__persomeZoomState = {
-    percent,
-    distance: Number(distance.toFixed(3)),
-    fitDistance: Number(fitDistance.toFixed(3)),
-    minPercent: ZOOM_MIN_PERCENT,
-    maxPercent: ZOOM_MAX_PERCENT,
-    animating: zoomGoalDistance !== null,
-  };
+  const state = window.__persomeZoomState;
+  state.percent = percent;
+  state.distance = Number(distance.toFixed(3));
+  state.fitDistance = Number(fitDistance.toFixed(3));
+  state.animating = zoomGoalDistance !== null;
 }
 
 function requestZoom(percent) {
@@ -1801,6 +1899,22 @@ function requestZoom(percent) {
     controls.minDistance,
     controls.maxDistance,
   );
+  zoomAnchor = null;
+}
+
+// Wheel and pinch drive the goal multiplicatively from wherever the glide is
+// already headed, so a stream of small events composes into one continuous
+// gesture instead of repeatedly restarting from the camera's current position.
+function requestZoomBy(factor, anchor) {
+  const base = zoomGoalDistance === null
+    ? camera.position.distanceTo(controls.target)
+    : zoomGoalDistance;
+  zoomGoalDistance = THREE.MathUtils.clamp(
+    base / factor,
+    controls.minDistance,
+    controls.maxDistance,
+  );
+  zoomAnchor = anchor || null;
 }
 
 function stepZoom(direction) {
@@ -1821,30 +1935,78 @@ function stepZoom(direction) {
   ));
 }
 
+// Where the ray through `ndc` meets the plane that carries the orbit target and
+// faces the camera. Zooming keeps this point pinned under the pointer.
+function anchorWorldPoint(ndc, out) {
+  camera.updateMatrixWorld();
+  zoomRaycaster.setFromCamera(ndc, camera);
+  camera.getWorldDirection(zoomViewDirection);
+  zoomPlane.setFromNormalAndCoplanarPoint(zoomViewDirection, controls.target);
+  return zoomRaycaster.ray.intersectPlane(zoomPlane, out);
+}
+
 function applyZoomAnimation(deltaSeconds) {
   if (zoomGoalDistance === null) return;
   const currentDistance = camera.position.distanceTo(controls.target);
   const nextDistance = REDUCED_MOTION
     ? zoomGoalDistance
     : THREE.MathUtils.damp(currentDistance, zoomGoalDistance, 12, deltaSeconds);
+  const settled = Math.abs(nextDistance - zoomGoalDistance) < 0.01;
+  const landedDistance = settled ? zoomGoalDistance : nextDistance;
+  const anchored = zoomAnchor !== null
+    && anchorWorldPoint(zoomAnchor, zoomAnchorBefore) !== null;
+
   zoomDirection.copy(camera.position).sub(controls.target);
   if (zoomDirection.lengthSq() < 1e-8) zoomDirection.set(0, 0, 1);
-  zoomDirection.setLength(nextDistance);
+  zoomDirection.setLength(landedDistance);
   camera.position.copy(controls.target).add(zoomDirection);
-  if (Math.abs(nextDistance - zoomGoalDistance) < 0.01) {
-    zoomDirection.setLength(zoomGoalDistance);
-    camera.position.copy(controls.target).add(zoomDirection);
+
+  if (anchored && anchorWorldPoint(zoomAnchor, zoomAnchorAfter) !== null) {
+    // Translating the camera and the orbit target by the same vector leaves the
+    // spherical radius, theta and phi untouched, so OrbitControls' damping
+    // carries on undisturbed while the anchored point stays under the pointer.
+    zoomShift.copy(zoomAnchorBefore).sub(zoomAnchorAfter);
+    camera.position.add(zoomShift);
+    controls.target.add(zoomShift);
+  }
+
+  if (settled) {
     zoomGoalDistance = null;
+    zoomAnchor = null;
   }
 }
 
-function cullLabels() {
-  const occupied = [...document.querySelectorAll(".story, .legend, .status, .timeline, .detail:not([hidden])")]
+// Reading an element's box forces the browser to flush pending layout. The
+// render loop writes a fresh inline transform onto every label each frame, so
+// layout is always dirty by the time culling runs — measuring here meant one
+// full-document reflow per frame, across hundreds of labels. Nothing being
+// measured actually changes that often: a label pill is sized by its own text
+// and a fixed max-width, and the overlay panels move only on resize or when the
+// drawer opens. Measure each once and cache.
+let occupiedPanels = null;
+
+function invalidatePanelBoxes() {
+  occupiedPanels = null;
+  canvasBounds = null;
+}
+
+function panelBoxes() {
+  if (occupiedPanels) return occupiedPanels;
+  occupiedPanels = [...document.querySelectorAll(".story, .legend, .status, .timeline, .detail:not([hidden])")]
     .map((element) => element.getBoundingClientRect())
     .filter((box) => box.width > 0 && box.height > 0)
     .map((box) => ({ x0: box.left - 6, x1: box.right + 6, y0: box.top - 6, y1: box.bottom + 6 }));
+  return occupiedPanels;
+}
+
+const cullProjected = new THREE.Vector3();
+const cullCandidates = [];
+
+function cullLabels() {
+  const occupied = panelBoxes().slice();
   const mobile = window.innerWidth < 760;
   const maxLabels = mobile ? 8 : 20;
+  const maxWidth = mobile ? 130 : 220;
   const safeArea = {
     left: mobile ? 8 : 6,
     right: window.innerWidth - (mobile ? 8 : 6),
@@ -1852,18 +2014,39 @@ function cullLabels() {
     bottom: window.innerHeight - (mobile ? 70 : 64),
   };
   let shown = 0;
-  const projected = new THREE.Vector3();
-  const candidates = labels.filter((label) => label.visible).map((label) => {
+  const projected = cullProjected;
+  cullCandidates.length = 0;
+  labels.forEach((label) => {
+    if (!label.visible) return;
     label.getWorldPosition(projected);
     projected.project(camera);
     const x = (projected.x * 0.5 + 0.5) * window.innerWidth;
     const y = (-projected.y * 0.5 + 0.5) * window.innerHeight;
-    const maxWidth = mobile ? 130 : 220;
-    const fallbackWidth = (label.element.textContent.length * 6.2) + 16;
-    const width = Math.min(maxWidth, Math.max(32, label.element.offsetWidth || fallbackWidth));
-    const height = Math.max(21, label.element.offsetHeight || 21);
-    return { label, x, y, width, height, priority: label.userData.priority || 0, depth: projected.z };
-  }).sort((a, b) => b.priority - a.priority);
+    // Measure only labels that are on screen and not yet known. Culling runs
+    // before labelRenderer.render(), so a freshly built label is not in the
+    // document on its first pass and measures zero — cache that and the size is
+    // wrong for as long as the label lives. A culled label is display:none and
+    // measures zero too, so asking it costs a reflow and answers nothing.
+    // Everything else settles after one read and is never measured again.
+    if (!label.userData.measuredWidth && !label.element.classList.contains("hidden")) {
+      const measured = label.element.offsetWidth;
+      if (measured) {
+        label.userData.measuredWidth = Math.max(32, measured);
+        label.userData.measuredHeight = Math.max(21, label.element.offsetHeight || 21);
+      }
+    }
+    const estimatedWidth = (label.element.textContent.length * 6.2) + 16;
+    cullCandidates.push({
+      label,
+      x,
+      y,
+      width: Math.min(maxWidth, label.userData.measuredWidth || Math.max(32, estimatedWidth)),
+      height: label.userData.measuredHeight || 21,
+      priority: label.userData.priority || 0,
+      depth: projected.z,
+    });
+  });
+  const candidates = cullCandidates.sort((a, b) => b.priority - a.priority);
 
   candidates.forEach((candidate) => {
     const { label, x, y, width, height, depth } = candidate;
@@ -1885,8 +2068,22 @@ function cullLabels() {
   window.__persomeLabelHealth = { total: labels.length, shown, max: maxLabels };
 }
 
+// Each gl.readPixels blocks until the GPU catches up, so this 77-point sweep is
+// 77 pipeline stalls. It only latched once it saw something lit, and a viewer
+// whose model is empty, still loading, or has every layer toggled off never
+// does — so the render loop paid the whole sweep on every frame, forever, in
+// exactly the states where the owner is most likely to be poking at the
+// controls. The sweep is unchanged; it is now bounded, and it reuses one
+// buffer instead of allocating 77 per frame. It must stay inside the render
+// task: without `preserveDrawingBuffer` the pixels are only valid there.
+const RENDER_PROBE_MAX_SWEEPS = 30;
+const renderProbePixel = new Uint8Array(4);
+let renderProbeSweeps = 0;
+
 function samplePixels() {
   if (window.__persomeModelRender?.lit > 0) return;
+  if (renderProbeSweeps >= RENDER_PROBE_MAX_SWEEPS) return;
+  renderProbeSweeps += 1;
   const gl = renderer.getContext();
   const width = gl.drawingBufferWidth;
   const height = gl.drawingBufferHeight;
@@ -1894,13 +2091,12 @@ function samplePixels() {
   let checked = 0;
   for (let y = 1; y < 8; y += 1) {
     for (let x = 1; x < 12; x += 1) {
-      const pixel = new Uint8Array(4);
-      gl.readPixels(Math.floor(width * x / 12), Math.floor(height * y / 8), 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixel);
+      gl.readPixels(Math.floor(width * x / 12), Math.floor(height * y / 8), 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, renderProbePixel);
       checked += 1;
-      if (pixel[0] + pixel[1] + pixel[2] > 96) lit += 1;
+      if (renderProbePixel[0] + renderProbePixel[1] + renderProbePixel[2] > 96) lit += 1;
     }
   }
-  window.__persomeModelRender = { width, height, checked, lit };
+  window.__persomeModelRender = { width, height, checked, lit, sweeps: renderProbeSweeps };
   canvasHost.dataset.litPixels = String(lit);
 }
 
@@ -1930,6 +2126,93 @@ zoomResetButton.addEventListener("click", () => requestZoom(100));
 zoomInButton.addEventListener("click", () => stepZoom(1));
 controls.addEventListener("start", () => {
   zoomGoalDistance = null;
+  zoomAnchor = null;
+});
+
+// Zoom input lives on the whole viewer, not just the canvas: the topbar, the
+// legend and the status strip cover a good part of the screen, and a wheel that
+// lands on one of them used to fall through to the browser instead of the
+// model. The drawer is a real scroll container, so it keeps its own wheel.
+function anchorFromClient(clientX, clientY) {
+  // Cached: a trackpad delivers wheel events faster than the display refreshes,
+  // and this rect only moves when the window does.
+  if (!canvasBounds) canvasBounds = renderer.domElement.getBoundingClientRect();
+  const bounds = canvasBounds;
+  if (!bounds.width || !bounds.height) return null;
+  zoomAnchorNdc.set(
+    ((clientX - bounds.left) / bounds.width) * 2 - 1,
+    -((clientY - bounds.top) / bounds.height) * 2 + 1,
+  );
+  return zoomAnchorNdc;
+}
+
+// Safari reports a trackpad pinch as its own gesture events and never as a
+// ctrlKey wheel, so a viewer that only listens for the wheel has no pinch at
+// all there. These listeners are registered unconditionally: engines that do
+// not implement the events simply never fire them, which is cheaper and more
+// honest than sniffing for a vendor hook whose name has moved around.
+let gestureScale = 0;
+let gestureSeenAt = 0;
+const gestureAnchor = new THREE.Vector2();
+const GESTURE_IDLE_MS = 400;
+
+// A gesture whose `gestureend` never arrives must not wedge the wheel off for
+// the rest of the session, so an idle gesture is treated as finished.
+function gestureInFlight() {
+  if (!gestureScale) return false;
+  if (performance.now() - gestureSeenAt < GESTURE_IDLE_MS) return true;
+  gestureScale = 0;
+  return false;
+}
+
+// Capture phase on the whole viewer, so this runs before OrbitControls' own
+// wheel listener on the canvas and stops the event reaching it. That leaves
+// OrbitControls' touch and middle-button dolly intact while the wheel — the
+// path with the bad normalisation and no damping — belongs to the viewer. It
+// also means a wheel over the topbar, legend or status strip zooms the model
+// instead of falling through to the browser.
+viewerEl.addEventListener("wheel", (event) => {
+  // The drawer and the line picker are real scroll containers; leave them be.
+  if (event.target.closest?.(".detail, .line-explorer")) return;
+  event.stopPropagation();
+  // If a gesture is in flight this wheel is the same fingers counted twice.
+  if (gestureInFlight()) return;
+  // Chrome and Firefox report a trackpad pinch as a wheel with ctrlKey set,
+  // which is also the browser's own page-zoom chord: without preventDefault the
+  // page would zoom instead of the model.
+  event.preventDefault();
+  pauseAutoRotate();
+  requestZoomBy(
+    zoomMath.wheelFactor(event, window.innerHeight),
+    anchorFromClient(event.clientX, event.clientY),
+  );
+}, { passive: false, capture: true });
+
+viewerEl.addEventListener("gesturestart", (event) => {
+  if (event.target.closest?.(".detail, .line-explorer")) return;
+  event.preventDefault();
+  gestureScale = 1;
+  gestureSeenAt = performance.now();
+  if (anchorFromClient(event.clientX, event.clientY)) gestureAnchor.copy(zoomAnchorNdc);
+  else gestureAnchor.set(0, 0);
+  pauseAutoRotate();
+});
+viewerEl.addEventListener("gesturechange", (event) => {
+  if (!gestureScale) return;
+  event.preventDefault();
+  gestureSeenAt = performance.now();
+  const scale = Number(event.scale);
+  if (!Number.isFinite(scale) || scale <= 0) return;
+  // `scale` is cumulative since gesturestart, so the step is the ratio since
+  // the last event — which composes into the same goal a wheel stream would.
+  zoomAnchorNdc.copy(gestureAnchor);
+  requestZoomBy(scale / gestureScale, zoomAnchorNdc);
+  gestureScale = scale;
+});
+viewerEl.addEventListener("gestureend", (event) => {
+  if (!gestureScale) return;
+  event.preventDefault();
+  gestureScale = 0;
 });
 document.getElementById("reset").addEventListener("click", resetCamera);
 document.getElementById("close-detail").addEventListener("click", clearSelection);
@@ -1969,8 +2252,11 @@ function pickAt(event) {
     x: event.clientX - bounds.left,
     y: event.clientY - bounds.top,
   };
+  // Projecting into a shared scratch vector rather than cloning per candidate:
+  // hover picking runs on the frame after every pointer move, over every
+  // visible node, so a clone per node is a steady drip of garbage.
   const projectWorldPoint = (worldPosition) => {
-    const projected = worldPosition.clone().project(camera);
+    const projected = pickProjected.copy(worldPosition).project(camera);
     if (projected.z < -1 || projected.z > 1) return null;
     return {
       x: (projected.x + 1) * 0.5 * bounds.width,
@@ -1978,10 +2264,10 @@ function pickAt(event) {
       depth: projected.z,
     };
   };
-  const worldPosition = new THREE.Vector3();
-  const nodeCandidates = pickables.filter((object) => object.visible).map((object) => {
-    object.getWorldPosition(worldPosition);
-    const projected = projectWorldPoint(worldPosition);
+  const visiblePickables = pickables.filter((object) => object.visible);
+  const nodeCandidates = visiblePickables.map((object) => {
+    object.getWorldPosition(pickWorldPosition);
+    const projected = projectWorldPoint(pickWorldPosition);
     return projected ? { ...projected, target: object } : null;
   }).filter(Boolean);
   const screenNode = pickScreenTarget(
@@ -1995,10 +2281,7 @@ function pickAt(event) {
   pointer.x = (localPointer.x / bounds.width) * 2 - 1;
   pointer.y = -(localPointer.y / bounds.height) * 2 + 1;
   raycaster.setFromCamera(pointer, camera);
-  const meshHit = raycaster.intersectObjects(
-    pickables.filter((object) => object.visible),
-    false,
-  )[0];
+  const meshHit = raycaster.intersectObjects(visiblePickables, false)[0];
   if (meshHit) return meshHit;
 
   const lineCandidates = screenLinePickables.filter((object) => object.visible).map((object) => {
@@ -2022,33 +2305,76 @@ function pickAt(event) {
   return screenLine ? { object: screenLine } : null;
 }
 
+// How far a pointer may travel and still count as a click rather than a drag.
+// Measured as a real distance, not the sum of the axes, so a diagonal nudge is
+// not penalised twice; a finger wobbles far more than a mouse does.
+function clickSlopFor(pointerType) {
+  if (pointerType === "touch") return 12;
+  if (pointerType === "pen") return 8;
+  return 5;
+}
+
 renderer.domElement.addEventListener("pointerdown", (event) => {
-  pointerDown = { x: event.clientX, y: event.clientY };
+  // Every button counts as a live gesture: the right button pans and the middle
+  // button dollies, and neither wants hover picking running underneath it. Only
+  // the primary button can become a click.
+  livePointers.add(event.pointerId);
+  const primary = event.pointerType !== "mouse" || event.button === 0;
+  // A second finger means a pinch. Whatever the first finger was doing, it was
+  // not choosing a node, so retire the click candidate rather than letting the
+  // gesture end in an accidental selection.
+  pointerDown = primary && livePointers.size === 1
+    ? { x: event.clientX, y: event.clientY, type: event.pointerType }
+    : null;
+  if (livePointers.size > 1 || !primary) labelGesture = null;
   hoverDirty = false;
+  hoverPointer = null;
   renderer.domElement.style.cursor = "grabbing";
 });
 renderer.domElement.addEventListener("pointermove", (event) => {
-  if (pointerDown) return;
+  if (livePointers.size) return;
   hoverPointer = { clientX: event.clientX, clientY: event.clientY };
   hoverDirty = true;
 });
 renderer.domElement.addEventListener("pointerleave", () => {
   hoverPointer = null;
   hoverDirty = false;
-  if (!pointerDown) renderer.domElement.style.cursor = "grab";
+  if (!livePointers.size) renderer.domElement.style.cursor = "grab";
 });
+
+// Releases are pruned on the window, not the canvas. A gesture that began on a
+// label is captured by the canvas, but a second, uncaptured pointer releases
+// wherever it happens to be — on the label, on an overlay — and a pointer left
+// behind in the set would stop hover picking and the graph poll for good.
+window.addEventListener("pointerup", (event) => livePointers.delete(event.pointerId), true);
+window.addEventListener("pointercancel", (event) => livePointers.delete(event.pointerId), true);
+
 renderer.domElement.addEventListener("pointercancel", () => {
   pointerDown = null;
+  labelGesture = null;
   hoverPointer = null;
   hoverDirty = false;
   renderer.domElement.style.cursor = "grab";
 });
 renderer.domElement.addEventListener("pointerup", (event) => {
-  if (!pointerDown) return;
-  const movement = Math.abs(event.clientX - pointerDown.x) + Math.abs(event.clientY - pointerDown.y);
+  if (event.pointerType === "mouse" && event.button !== 0) return;
+  const started = pointerDown;
+  const label = labelGesture;
   pointerDown = null;
-  if (movement > 5) {
+  labelGesture = null;
+  if (!started) return;
+  const dx = event.clientX - started.x;
+  const dy = event.clientY - started.y;
+  const slop = clickSlopFor(started.type);
+  if (dx * dx + dy * dy > slop * slop) {
     renderer.domElement.style.cursor = "grab";
+    return;
+  }
+  // A gesture that began on a label and stayed put is that label's click; the
+  // canvas captured the pointer, so the label never sees a click of its own.
+  if (label) {
+    renderer.domElement.style.cursor = "pointer";
+    showDetails(label.kind, label.item);
     return;
   }
   const hit = pickAt(event);
@@ -2100,6 +2426,7 @@ window.addEventListener("resize", () => {
   camera.updateProjectionMatrix();
   renderer.setSize(window.innerWidth, window.innerHeight);
   labelRenderer.setSize(window.innerWidth, window.innerHeight);
+  invalidatePanelBoxes();
   const portrait = window.innerWidth / window.innerHeight < 0.72;
   if (portrait !== portraitMode) resetCamera();
 });
@@ -2113,11 +2440,39 @@ window.addEventListener("unhandledrejection", (event) => {
   errorEl.hidden = false;
 });
 
+// A rolling window of how long each frame's own work took, so a smoothness
+// regression is a number somebody can read rather than a feeling. Written into
+// a pre-allocated ring: a probe that allocates every frame would measure itself.
+const FRAME_SAMPLE_COUNT = 240;
+const frameSamples = new Float32Array(FRAME_SAMPLE_COUNT);
+const frameSamplesSorted = new Float32Array(FRAME_SAMPLE_COUNT);
+let frameSampleIndex = 0;
+let frameSampleFilled = 0;
+window.__persomeFrameStats = { p50: 0, p95: 0, worst: 0, samples: 0 };
+
+function recordFrameCost(milliseconds) {
+  frameSamples[frameSampleIndex] = milliseconds;
+  frameSampleIndex = (frameSampleIndex + 1) % FRAME_SAMPLE_COUNT;
+  frameSampleFilled = Math.min(FRAME_SAMPLE_COUNT, frameSampleFilled + 1);
+  if (frameSampleIndex % 30 !== 0) return;
+  frameSamplesSorted.set(frameSamples);
+  const recent = frameSamplesSorted.subarray(0, frameSampleFilled);
+  recent.sort();
+  const stats = window.__persomeFrameStats;
+  stats.p50 = Number(recent[Math.floor(frameSampleFilled * 0.5)].toFixed(2));
+  stats.p95 = Number(recent[Math.floor(frameSampleFilled * 0.95)].toFixed(2));
+  stats.worst = Number(recent[frameSampleFilled - 1].toFixed(2));
+  stats.samples = frameSampleFilled;
+}
+
 function animate(frameTime = performance.now()) {
+  const frameStart = performance.now();
   const deltaSeconds = Math.min(Math.max((frameTime - lastFrameTime) / 1000, 0), 0.5);
   lastFrameTime = frameTime;
   applyZoomAnimation(deltaSeconds);
-  controls.update();
+  // Auto-rotate advances by wall time rather than by frame, so the model turns
+  // at one speed whether the display runs at 60Hz or 120Hz.
+  controls.update(deltaSeconds);
   syncZoomUI();
   const time = performance.now() * 0.001;
   if (!REDUCED_MOTION) {
@@ -2126,7 +2481,7 @@ function animate(frameTime = performance.now()) {
       glow.scale.setScalar(glow.userData.glowBase * pulse);
     });
   }
-  if (hoverDirty && hoverPointer && !pointerDown) {
+  if (hoverDirty && hoverPointer && !livePointers.size) {
     renderer.domElement.style.cursor = pickAt(hoverPointer) ? "pointer" : "grab";
     hoverDirty = false;
   }
@@ -2134,10 +2489,16 @@ function animate(frameTime = performance.now()) {
   renderer.render(scene, camera);
   labelRenderer.render(scene, camera);
   samplePixels();
+  recordFrameCost(performance.now() - frameStart);
   window.requestAnimationFrame(animate);
 }
 
 resetCamera();
 animate();
 await loadModel(true);
-window.setInterval(() => loadModel(false), 5000);
+window.setInterval(() => {
+  // Parsing a multi-megabyte snapshot and fingerprinting every Point takes long
+  // enough to drop frames. Never do it under the owner's finger.
+  if (livePointers.size) return;
+  loadModel(false);
+}, 5000);

--- a/tests/js/model_zoom.test.mjs
+++ b/tests/js/model_zoom.test.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { zoomMath } from "../../resources/model_assets/layout.mjs";
+
+function wheel(deltaY, { deltaMode = 0, ctrlKey = false } = {}) {
+  return { deltaY, deltaMode, ctrlKey };
+}
+
+// One comfortable macOS trackpad pinch-out spreads the fingers over roughly
+// 300px of accumulated ctrl+wheel delta, delivered as dozens of small events.
+function pinchGesture(totalPixels, events = 40) {
+  const step = -totalPixels / events;
+  let factor = 1;
+  for (let index = 0; index < events; index += 1) {
+    factor *= zoomMath.wheelFactor(wheel(step, { ctrlKey: true }), 657);
+  }
+  return factor;
+}
+
+test("a trackpad pinch is worth a meaningful part of the zoom range", () => {
+  const factor = pinchGesture(300);
+  // The regression this guards: normalising by devicePixelRatio made one whole
+  // pinch worth 1.05x, so crossing 50%-400% took about twenty-nine of them.
+  assert.ok(factor > 1.8, `one pinch should roughly double the zoom, got ${factor}`);
+  assert.ok(factor < 2.2, `one pinch must not overshoot a doubling, got ${factor}`);
+
+  const rangeRatio = 400 / 50;
+  const pinchesToCrossRange = Math.log(rangeRatio) / Math.log(factor);
+  assert.ok(
+    pinchesToCrossRange > 2 && pinchesToCrossRange < 5,
+    `crossing the whole range should take a handful of pinches, got ${pinchesToCrossRange}`,
+  );
+});
+
+test("a gesture composes the same whether it arrives in one event or many", () => {
+  const asOneEvent = zoomMath.wheelFactor(wheel(-300, { ctrlKey: true }), 657);
+  const asManyEvents = pinchGesture(300, 60);
+  assert.ok(
+    Math.abs(asOneEvent - asManyEvents) < 1e-9,
+    `${asOneEvent} vs ${asManyEvents} — an exponential curve must be path independent`,
+  );
+});
+
+test("wheel notches are a smaller step than a pinch of the same nominal delta", () => {
+  const notch = zoomMath.wheelFactor(wheel(-100), 657);
+  const pinch = zoomMath.wheelFactor(wheel(-100, { ctrlKey: true }), 657);
+  assert.ok(notch > 1.1 && notch < 1.25, `a wheel notch should be a visible step, got ${notch}`);
+  assert.ok(pinch > notch, "a pinch tracks the fingers, so it must out-gain a wheel notch");
+});
+
+test("line and page deltas are normalised to pixels", () => {
+  // Firefox reports deltaMode 1 with deltaY around 3 per notch. Reading that as
+  // pixels made its wheel and pinch do nothing at all.
+  assert.equal(zoomMath.wheelPixels(wheel(-3, { deltaMode: 1 }), 657), -48);
+  assert.equal(zoomMath.wheelPixels(wheel(2, { deltaMode: 2 }), 300), 400);
+  assert.equal(zoomMath.wheelPixels(wheel(-120), 657), -120);
+
+  const firefoxNotch = zoomMath.wheelFactor(wheel(-3, { deltaMode: 1 }), 657);
+  assert.ok(firefoxNotch > 1.05, `a line-mode notch must actually zoom, got ${firefoxNotch}`);
+});
+
+test("a single absurd event cannot teleport the camera", () => {
+  assert.equal(zoomMath.wheelPixels(wheel(-100000), 657), -400);
+  assert.equal(zoomMath.wheelPixels(wheel(100000, { deltaMode: 2 }), 4000), 400);
+  const factor = zoomMath.wheelFactor(wheel(-1e9, { ctrlKey: true }), 657);
+  assert.ok(Number.isFinite(factor) && factor < 3, `one event stays bounded, got ${factor}`);
+});
+
+test("zoom direction follows the platform convention", () => {
+  assert.ok(zoomMath.wheelFactor(wheel(-100), 657) > 1, "wheel up and pinch out zoom in");
+  assert.ok(zoomMath.wheelFactor(wheel(100), 657) < 1, "wheel down and pinch in zoom out");
+});
+
+test("opposite gestures of equal size return to where they started", () => {
+  const inFactor = zoomMath.wheelFactor(wheel(-140, { ctrlKey: true }), 657);
+  const outFactor = zoomMath.wheelFactor(wheel(140, { ctrlKey: true }), 657);
+  assert.ok(Math.abs(inFactor * outFactor - 1) < 1e-12, "the curve must be symmetric");
+});
+
+test("malformed wheel events are inert rather than destructive", () => {
+  // A divide-by-zero in the old normalisation turned one notch into a jump to
+  // the zoom limit, so degenerate input must resolve to "no zoom", never NaN.
+  assert.equal(zoomMath.wheelPixels(wheel(Number.NaN), 657), 0);
+  assert.equal(zoomMath.wheelPixels(wheel(undefined), 657), 0);
+  assert.equal(zoomMath.wheelFactor(wheel(Number.NaN), 657), 1);
+  assert.equal(zoomMath.wheelPixels(wheel(-100), 0), -100);
+  assert.ok(Number.isFinite(zoomMath.wheelFactor(wheel(-100), Number.NaN)));
+});
+
+test("a trackpad's sub-percent steps survive as a continuous factor", () => {
+  // The wheel path multiplies a continuous goal distance rather than a rounded
+  // percent: a trackpad delivers dozens of sub-percent events a second, and
+  // rounding each one would quantise the glide into visible stairs.
+  const tiny = zoomMath.wheelFactor(wheel(-1, { ctrlKey: true }), 657);
+  assert.ok(tiny > 1 && tiny < 1.01, `a 1px event must still register, got ${tiny}`);
+  assert.notEqual(tiny, 1);
+});
+
+test("the button and keyboard zoom steps are unchanged", () => {
+  // stepZoom still snaps to the 25% grid; only wheel and pinch went continuous.
+  assert.equal(zoomMath.nextPercent(100, 1, 25, 50, 400), 125);
+  assert.equal(zoomMath.nextPercent(141, -1, 25, 50, 400), 125);
+  assert.equal(zoomMath.nextPercent(400, 1, 25, 50, 400), 400);
+  assert.equal(zoomMath.nextPercent(50, -1, 25, 50, 400), 50);
+});

--- a/tests/test_model_layout_asset.py
+++ b/tests/test_model_layout_asset.py
@@ -19,6 +19,7 @@ def test_model_viewer_node_suite() -> None:
             "tests/js/model_evidence.test.mjs",
             "tests/js/model_layout.test.mjs",
             "tests/js/model_share.test.mjs",
+            "tests/js/model_zoom.test.mjs",
         ],
         cwd=root,
         capture_output=True,

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -474,6 +474,20 @@ class TestViewPage:
         assert b"--build-color: var(--root)" in css.body
         assert b"--build-color: var(--point)" in css.body
         assert b"controls.zoomToCursor = true" in viewer.body
+        # The wheel is the viewer's, not OrbitControls'. Its wheel path lands
+        # the whole delta in one step while orbit and pan glide under damping,
+        # and normalises by devicePixelRatio, which halves the gain on a Retina
+        # display and divides by zero below 1. The viewer takes the wheel in the
+        # capture phase and drives its own damped, cursor-anchored goal — and
+        # taking only the wheel leaves OrbitControls' touch pinch and
+        # middle-button dolly working.
+        assert b"{ passive: false, capture: true }" in viewer.body
+        assert b"zoomAnchor" in viewer.body
+        assert b"zoomMath.wheelFactor" in viewer.body
+        assert b"controls.enableZoom = false" not in viewer.body
+        # Safari reports a trackpad pinch only as a gesture event, so a viewer
+        # that listens for ctrlKey wheel alone has no pinch there at all.
+        assert b'addEventListener("gesturechange"' in viewer.body
         assert b"downloadShareImage" in viewer.body
         assert b"shareReady = Boolean" in viewer.body
         assert b"window.open" in viewer.body


### PR DESCRIPTION
The nebula view stopped feeling direct once a model grew past a few hundred Points. On a seeded 914-Point model the viewer spent **55 ms of CPU on every frame of a drag** — the constellation arrived at ~11 fps and trailed the pointer — and **a full trackpad pinch moved the camera 5%**, so crossing the 50%–400% range took about twenty-nine of them. Both had the same character: most of what each frame did was work nobody asked for.

## Frame cost

| | before | after |
|---|---|---|
| viewer frame cost p50 | 55 ms | **14 ms** |
| viewer frame cost p95 | 62 ms | **18 ms** |
| frame interval p50 | 87 ms (~11 fps) | **33 ms (~30 fps)** |

- Labels transitioned `transform` — the one property `CSS2DRenderer` rewrites inline every frame — so each of 824 labels restarted a 140 ms transition every frame and rendered as a lagging follower of the node it named. The only author-declared `transform` on that element could never apply anyway, because an inline style always wins.
- Culling measured every label's box and every overlay panel's rect every frame, forcing a full document reflow each time, to answer questions whose answers change on resize at most.
- The "did anything render" probe issued 77 blocking `readPixels` per frame and only stopped once it saw something lit — which never happens while the model is empty, still loading, or has its layers switched off.
- `preserveDrawingBuffer` made the browser copy the framebuffer every frame for two readers that both read inside the render's own task.
- Culled labels stayed in layout, twenty labels each carried a backdrop blur over a continuously repainting canvas, and the 5 s graph poll parsed and fingerprinted the whole snapshot under the owner's finger.

## Gestures

| gesture | before | after |
|---|---|---|
| one trackpad pinch | ×1.05 | **×2.00** |
| one mouse wheel notch | ×1.02 | **×1.16** |
| one Firefox line-mode notch | nothing | **×1.07** |
| Safari trackpad pinch | nothing | **×2.00** |
| drag started on a label | camera does not move | **camera moves** |
| zoom at the cursor | — | point under cursor holds to **0 px** (21 px if centre-anchored) |

`OrbitControls` applies a wheel's dolly in one step and resets it, while orbit and pan glide under damping — so zoom alone arrived in hard steps. It also normalises the wheel by `devicePixelRatio | 0`, which halves the gain on a Retina display and **divides by zero below 1**, where a single notch teleports to the zoom limit.

The viewer now takes the wheel in the capture phase and drives the damped goal distance it already ran for its zoom buttons, so a pinch coasts to a stop. It keeps the cursor anchored by translating camera and target by the same vector, which leaves the spherical state untouched and so does not fight the damping. Taking *only* the wheel leaves the touchscreen pinch and middle-button dolly on their existing path.

Also: wheel deltas are normalised to pixels so line-mode wheels do something; Safari gets a pinch at all (it reports one only as a gesture event); labels hand their gesture to the canvas instead of swallowing it; pointers are tracked by identity so a right-drag counts as the pan it is and a release landing off-canvas cannot stall the model poll; a second finger retires the click candidate so a pinch cannot select a node.

**The vendored `OrbitControls.js` and `three.module.js` stay byte-identical to upstream r160** — `git diff --stat` over `resources/model_assets/jsm/` is empty.

## Verification

- `pytest -m "not macos and not integration"` → 2288 passed
- `ruff check`, `ruff format --check`, secret / PII / language scans → clean
- `node --test tests/js/*.test.mjs` → 32 passed, including 10 new tests for the wheel-delta normalisation and the zoom curve
- Every number above was measured in-browser against a seeded 914-Point model (824 label nodes), A/B in the same surface at the same viewport, one port serving `main` and one serving this branch
- The constellation share export was checked against the `preserveDrawingBuffer` removal: same dimensions, same 611 distinct colours, same ~1.096 MB blob

`window.__persomeFrameStats` publishes rolling p50/p95/worst frame costs, so the next regression is a number somebody can read rather than only a feeling.

## Still worth a human's hands

Browser automation cannot produce a real trackpad gesture. The feel of the glide, the tracking of a live pinch, and Chrome-versus-Safari behaviour want a manual pass; the measurements here were taken in WebKit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
