### PR TITLE
Make edit and delete work on every target

### DIFF
--- a/MODEL_FORMAT.md
+++ b/MODEL_FORMAT.md
@@ -122,6 +122,12 @@ A Face is one active level-1 `schema_faces` row. It contains a behavioral
 signature, members, observations, confidence, provenance, anchors, and source
 receipts. Promotion requires stable repeated support.
 
+Every projected Point and schema object carries `edit_refusal`: an empty string when the owner can
+correct it, otherwise a stable reason code naming why not — a newer version exists, the object was
+withdrawn, the pattern is not promoted, or nothing backs the Point. Readers should treat a non-empty
+value as "do not offer a correction here" rather than deriving that themselves; the Runtime knows
+which layer backs each object and whether a newer version exists, and a client does not.
+
 `provenance` names which extractor reached the object: `mined`, `emergent`,
 `both`, or `synth` for a synthesized Root. The value `authored` means the
 memory owner replaced the signature by hand. Derivation continues under an

--- a/resources/model_assets/viewer.js
+++ b/resources/model_assets/viewer.js
@@ -1252,7 +1252,11 @@ function appendLineTechnicalDetails(item) {
 const EDITABLE_KINDS = new Set(["point", "face", "volume", "root"]);
 
 function isEditable(kind, item) {
-  return Boolean(item) && EDITABLE_KINDS.has(kind) && Boolean(item.id);
+  // The server decides. It knows which layer backs a Point, whether a newer
+  // version exists, and whether a pattern has been promoted; the client would
+  // be guessing. Offering an edit the writer refuses is worse than not
+  // offering one — on a real model that was 46% of the Points on screen.
+  return Boolean(item) && EDITABLE_KINDS.has(kind) && Boolean(item.id) && !item.edit_refusal;
 }
 
 function editableText(kind, item) {
@@ -1263,6 +1267,9 @@ function editableText(kind, item) {
 // nothing: they did not choose the reason, and most of these are about the
 // state of their store rather than about what they typed.
 const EDIT_REFUSALS = {
+  point_has_no_file:
+    "This fact is not filed under any memory, so there is nothing to correct"
+    + " it in.",
   point_file_missing:
     "The memory file behind this fact is missing from disk, so it cannot be"
     + " corrected. Run `persome doctor` — the index and your Markdown have"
@@ -1494,7 +1501,11 @@ detailRejectEl.addEventListener("click", () => {
   submitEdit(selected.kind, selectedItem, "retire", "", "");
 });
 
-function uneditableNote(kind) {
+function uneditableNote(kind, item) {
+  // A refusal the server already computed explains itself better than a
+  // generic "not editable here".
+  const refusal = item?.edit_refusal;
+  if (refusal && EDIT_REFUSALS[refusal]) return EDIT_REFUSALS[refusal];
   if (kind === "context") {
     return "An entity your model refers to — a person, project, tool, or file."
       + " It is the far end of a relation, not a claim about you, so there is"
@@ -1515,14 +1526,19 @@ function renderEditor(kind, item) {
   detailRejectEl.disabled = editInFlight;
 
   const editable = isEditable(kind, item);
+  // Rejecting is a separate capability: a pattern that cannot be reworded can
+  // still be withdrawn.
+  const rejectable = Boolean(item?.id)
+    && EDITABLE_KINDS.has(kind)
+    && (editable || item.edit_refusal === "object_not_active");
   detailTitleEl.dataset.editable = String(editable);
-  detailActionsEl.hidden = !editable;
+  detailActionsEl.hidden = !rejectable;
   // Say what a node IS when it cannot be corrected. "Nothing to edit here" only
   // tells the owner what they cannot do; an entity or a Line is not a claim
   // about them at all, and that is the useful thing to know.
   detailHintEl.innerHTML = editable
     ? "Click the text to rewrite it in your own words."
-    : uneditableNote(kind);
+    : uneditableNote(kind, item);
   detailHintEl.hidden = !detailHintEl.innerHTML;
   // Focusable, so a keyboard user can reach the claim and press Enter to edit
   // it — but never `role="button"`. That would override the heading role and

--- a/src/persome/model/edit.py
+++ b/src/persome/model/edit.py
@@ -170,9 +170,86 @@ def _point_backing(conn: sqlite3.Connection, file_name: str) -> str | None:
         return "markdown"
     try:
         row = conn.execute("SELECT 1 FROM files WHERE path = ? LIMIT 1", (file_name,)).fetchone()
+        if row is not None:
+            return "evomem"
+        # No Markdown and no registry row, but the engine is already storing
+        # nodes under this name — which is how `delta_apply` mints every entity
+        # and assertion Point. The file is the engine's; it simply has not been
+        # registered yet, and the evomem writer registers it on write.
+        held = conn.execute(
+            "SELECT 1 FROM evo_nodes WHERE file_name = ? LIMIT 1", (file_name,)
+        ).fetchone()
     except sqlite3.Error:
         return None
-    return "evomem" if row is not None else None
+    return "evomem" if held is not None else None
+
+
+def _ensure_registered(conn: sqlite3.Connection, file_name: str) -> None:
+    """Give an engine-owned file its registry row if it has none.
+
+    `evo_inversion.supersede_entry` refuses a file with neither Markdown nor a
+    `files` row, even though its own `_finish_file_write` creates that row on
+    the way out. Points minted straight into `evo_nodes` therefore arrive
+    uncorrectable. Registering the file the engine is already storing nodes for
+    invents no content — the row describes where the nodes live.
+    """
+    from ..store import fts as fts_store
+
+    try:
+        if (
+            conn.execute("SELECT 1 FROM files WHERE path = ? LIMIT 1", (file_name,)).fetchone()
+            is not None
+        ):
+            return
+        prefix = files_mod.validate_prefix(file_name)
+        count = conn.execute(
+            "SELECT count(*) FROM evo_nodes WHERE file_name = ? AND is_latest = 1", (file_name,)
+        ).fetchone()
+        today = files_mod.today()
+        fts_store.upsert_file(
+            conn,
+            fts_store.FileRow(
+                path=file_name,
+                prefix=prefix,
+                description="",
+                tags="",
+                status="active",
+                entry_count=int(count[0] or 0) if count else 0,
+                created=today,
+                updated=today,
+                needs_compact=0,
+            ),
+        )
+    except Exception:  # noqa: BLE001 — the writer's own guard still applies
+        logger.exception("could not register %s before an owner edit", _loggable(file_name))
+
+
+def _owner_edit_lock():
+    """Serialize owner corrections against each other.
+
+    Deliberately NOT the memory file's own lock: the writers take that one
+    themselves and it is a plain `threading.Lock`, so holding it across the call
+    deadlocks. A separate sentinel path gives mutual exclusion between owner
+    edits without touching the writers' locking.
+
+    In-process only, like every lock in this store. The daemon serves every HTTP
+    correction, so that covers the case this guards — a second correction
+    arriving while the first is still deciding whether it holds the chain head.
+    """
+    from .. import paths
+
+    return files_mod.file_lock(paths.root() / ".owner-edit.lock")
+
+
+def _lost_the_head(conn: sqlite3.Connection, node_id: str) -> bool:
+    """Whether this Point stopped being the chain head since it was first read."""
+    try:
+        row = conn.execute(
+            "SELECT is_latest FROM evo_nodes WHERE node_id = ? LIMIT 1", (node_id,)
+        ).fetchone()
+    except sqlite3.Error:
+        return False
+    return row is not None and not int(row["is_latest"] or 0)
 
 
 def _has_live_successor(conn: sqlite3.Connection, superseded_by: object) -> bool:
@@ -229,8 +306,16 @@ def backing_map(conn: sqlite3.Connection, file_names: set[str]) -> dict[str, str
     table is read in a single pass.
     """
     known: set[str] = set()
+    held: set[str] = set()
     try:
         known = {str(r[0]) for r in conn.execute("SELECT path FROM files")}
+        # Files the engine stores nodes under, registered or not. Must mirror
+        # `_point_backing`, or the snapshot advertises a refusal the writer
+        # would not make — the same disagreement, pointing the other way.
+        held = {
+            str(r[0])
+            for r in conn.execute("SELECT DISTINCT file_name FROM evo_nodes WHERE file_name != ''")
+        }
     except sqlite3.Error:
         known = set()
     out: dict[str, str | None] = {}
@@ -240,7 +325,12 @@ def backing_map(conn: sqlite3.Connection, file_names: set[str]) -> dict[str, str
         except Exception:  # noqa: BLE001
             out[name] = None
             continue
-        out[name] = "markdown" if on_disk else ("evomem" if name in known else None)
+        if on_disk:
+            out[name] = "markdown"
+        elif name in known or name in held:
+            out[name] = "evomem"
+        else:
+            out[name] = None
     return out
 
 
@@ -408,6 +498,8 @@ def _edit_point(
     tags = _semantic_tags(row["tags"])
 
     writer = entries if backing == "markdown" else evo_inversion
+    if backing == "evomem":
+        _ensure_registered(conn, file_name)
 
     if op == "rewrite":
         new_id = writer.supersede_entry(
@@ -543,9 +635,13 @@ def apply_model_edit(
 
     misses_before = evo_shadow.miss_count()
     if kind == "point":
-        result = _edit_point(
-            conn, target_id=target_id, op=op, replacement=replacement, reason=reason
-        )
+        # The head check and the write must not be separated by another
+        # correction, or two edits both believe they hold the chain head and
+        # the chain forks into two live successors of one fact.
+        with _owner_edit_lock():
+            result = _edit_point(
+                conn, target_id=target_id, op=op, replacement=replacement, reason=reason
+            )
     else:
         result = _edit_schema_object(
             conn, kind=kind, target_id=target_id, op=op, replacement=replacement

--- a/src/persome/model/edit.py
+++ b/src/persome/model/edit.py
@@ -33,6 +33,7 @@ displaced, which is what lets a reader see *what* was changed rather than only
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from dataclasses import dataclass, field
 
@@ -162,15 +163,62 @@ def _point_backing(conn: sqlite3.Connection, file_name: str) -> str | None:
     there is nothing to correct.
     """
     try:
-        if files_mod.memory_path(file_name).is_file():
-            return "markdown"
+        path = files_mod.memory_path(file_name)
     except Exception:  # noqa: BLE001 — an unresolvable name is not editable either
         return None
+    if path.is_file():
+        return "markdown"
     try:
         row = conn.execute("SELECT 1 FROM files WHERE path = ? LIMIT 1", (file_name,)).fetchone()
     except sqlite3.Error:
         return None
     return "evomem" if row is not None else None
+
+
+def _has_live_successor(conn: sqlite3.Connection, superseded_by: object) -> bool:
+    """Whether any successor of this Point is still in the live model."""
+    try:
+        ids = [str(v) for v in json.loads(str(superseded_by or "[]") or "[]")]
+    except (TypeError, ValueError):
+        return False
+    for node_id in ids:
+        try:
+            row = conn.execute(
+                "SELECT valid_until, superseded_by, status FROM evo_nodes WHERE node_id = ?",
+                (node_id,),
+            ).fetchone()
+        except sqlite3.Error:
+            return True  # unknown: keep the conservative refusal
+        if row is None:
+            continue
+        withdrawn = (bool(row["valid_until"]) and str(row["superseded_by"] or "[]") == "[]") or str(
+            row["status"] or ""
+        ) == "archived"
+        if not withdrawn:
+            return True
+    return False
+
+
+def _node_backing(conn: sqlite3.Connection, file_name: str, node_id: str) -> str | None:
+    """Backing for one Point, which is not the same as backing for its file.
+
+    A file can hold both: `delta_apply` mints assertion Points straight into
+    `evo_nodes` under an entity file the classifier may also have created as
+    Markdown, and correcting an evo-native Point writes a Markdown projection of
+    that file as a side effect — after which every other evo-native Point in it
+    would look Markdown-backed. Deciding per file sent those to
+    `entries.supersede_entry`, which raises `ValueError: entry <id> not found`
+    and surfaced as an opaque 500. The node is Markdown-backed only if the file
+    on disk actually contains it.
+    """
+    backing = _point_backing(conn, file_name)
+    if backing != "markdown":
+        return backing
+    try:
+        parsed = files_mod.read_file(files_mod.memory_path(file_name))
+    except Exception:  # noqa: BLE001 — an unreadable file is not the node's home
+        return "evomem"
+    return "markdown" if any(entry.id == node_id for entry in parsed.entries) else "evomem"
 
 
 def backing_map(conn: sqlite3.Connection, file_names: set[str]) -> dict[str, str | None]:
@@ -298,7 +346,8 @@ def _edit_point(
     conn.row_factory = sqlite3.Row
     try:
         row = conn.execute(
-            "SELECT file_name, content, tags, status, valid_until, superseded_by, is_latest"
+            "SELECT file_name, content, tags, status, valid_until, superseded_by, is_latest,"
+            " supersedes"
             " FROM evo_nodes WHERE node_id = ? LIMIT 1",
             (target_id,),
         ).fetchone()
@@ -321,7 +370,7 @@ def _edit_point(
     # evo-native. Sending those down the Markdown path raises `FileNotFoundError`
     # from inside the store, which is what turned an ordinary correction into an
     # opaque 500. Correct each Point where it actually lives.
-    backing = _point_backing(conn, file_name)
+    backing = _node_backing(conn, file_name, target_id)
     if backing is None:
         return _reject("point", target_id, op, "point_file_missing")
     if str(row["status"] or "") == "archived":
@@ -337,13 +386,25 @@ def _edit_point(
     )
     if already_retired:
         return _reject("point", target_id, op, "point_already_retired")
-    if not int(row["is_latest"] or 0):
+    if not int(row["is_latest"] or 0) and _has_live_successor(conn, row["superseded_by"]):
         # Correcting an already-superseded version would fork the chain: two
         # live successors of one fact, each claiming to be the current wording.
         # The owner means the version they can see, which is the chain head.
+        #
+        # Once every successor has been withdrawn there is nothing left to fork,
+        # and this version is the only one the owner can see — so it becomes
+        # correctable again rather than a dead end.
         return _reject("point", target_id, op, "point_superseded")
 
-    prior_text = str(row["content"] or "")
+    # The visible fact, not the stored bytes. A Point that is itself a
+    # correction carries a `<!-- supersedes: ... -->` marker, and recording that
+    # in the audit trail breaks every reader that compares the audit against
+    # what the owner actually saw — including `delta_apply._owner_withdrew`,
+    # whose whole job is making a rejection durable.
+    prior_text = entries.strip_supersede_provenance(
+        str(row["content"] or ""),
+        supersedes={str(v) for v in json.loads(str(row["supersedes"] or "[]") or "[]")},
+    )
     tags = _semantic_tags(row["tags"])
 
     writer = entries if backing == "markdown" else evo_inversion

--- a/src/persome/model/edit.py
+++ b/src/persome/model/edit.py
@@ -173,6 +173,60 @@ def _point_backing(conn: sqlite3.Connection, file_name: str) -> str | None:
     return "evomem" if row is not None else None
 
 
+def backing_map(conn: sqlite3.Connection, file_names: set[str]) -> dict[str, str | None]:
+    """Resolve the backing of many files at once.
+
+    The snapshot needs this for every projected Point, so it must not be one
+    query per Point. Markdown presence is a stat per distinct file; the `files`
+    table is read in a single pass.
+    """
+    known: set[str] = set()
+    try:
+        known = {str(r[0]) for r in conn.execute("SELECT path FROM files")}
+    except sqlite3.Error:
+        known = set()
+    out: dict[str, str | None] = {}
+    for name in file_names:
+        try:
+            on_disk = files_mod.memory_path(name).is_file()
+        except Exception:  # noqa: BLE001
+            out[name] = None
+            continue
+        out[name] = "markdown" if on_disk else ("evomem" if name in known else None)
+    return out
+
+
+def point_refusal(
+    *,
+    file_name: str,
+    status: str,
+    is_latest: bool,
+    valid_until: str | None,
+    superseded_by_empty: bool,
+    backing: str | None,
+) -> str:
+    """Why this Point cannot be corrected, or ``""`` when it can.
+
+    The same rules `_edit_point` enforces, in a form the snapshot can evaluate
+    for every Point it projects. The viewer must not offer an action the writer
+    will refuse: on a real model that was 46% of the Points on screen, each one
+    inviting a correction and then declining it.
+    """
+    if not file_name:
+        return "point_has_no_file"
+    if not _point_file_is_editable(file_name):
+        return "point_not_editable_in_this_file"
+    if status == "archived":
+        return "point_archived"
+    if valid_until and not is_latest and superseded_by_empty:
+        return "point_already_retired"
+    if not is_latest:
+        return "point_superseded"
+    if backing is None:
+        return "point_file_missing"
+    return ""
+
+
 def _semantic_tags(raw: str) -> list[str]:
     """Split an ``evo_nodes.tags`` cell into its semantic tags, minus our marker.
 

--- a/src/persome/model/human.py
+++ b/src/persome/model/human.py
@@ -180,6 +180,7 @@ def _frontmatter(
         f"generated_at: {_yaml_scalar(snapshot.get('generated_at'))}",
         f"build_id: {_yaml_scalar(build.get('build_id'))}",
         f"build_status: {_yaml_scalar(build.get('status'))}",
+        f"owner_edits: {int((snapshot.get('stats') or {}).get('owner_edits') or 0)}",
         f"root_id: {_yaml_scalar(root.get('id') if root else None)}",
         'visibility: "owner-only"',
         f"redacted: {str(redacted).lower()}",
@@ -833,6 +834,37 @@ def _placeholder_snapshot(manifest: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _owner_edit_count() -> int | None:
+    """Owner corrections recorded so far, for the staleness gate.
+
+    An owner edit starts no build, so build metadata cannot express it and the
+    reconcile short-circuited on a file that still asserted a claim the owner
+    had rejected.
+
+    ``None`` means "cannot tell" — an index that is absent or being repaired.
+    That must not be read as "the owner edited something", or an unreadable
+    store would force a rebuild on every reconcile.
+    """
+    from ..store import fts
+
+    try:
+        with fts.canonical_read_cursor() as conn:
+            row = conn.execute(
+                "SELECT count(*) FROM memory_deltas WHERE session_id = 'owner-edit'"
+            ).fetchone()
+        return int(row[0] or 0) if row else 0
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _owner_edits_match(current: _ManagedHuman) -> bool:
+    """Whether the rendered file reflects the owner's corrections so far."""
+    seq = _owner_edit_count()
+    if seq is None:
+        return True
+    return int(current.get("owner_edits") or 0) == seq
+
+
 def sync_live_human_markdown() -> Path:
     """Backfill or refresh HUMAN.md from an existing Runtime model.
 
@@ -855,6 +887,7 @@ def sync_live_human_markdown() -> Path:
             and current.get("renderer_version") == HUMAN_RENDERER_VERSION
             and current.get("build_id") == build_id
             and current.get("build_status") == manifest.get("status")
+            and _owner_edits_match(current)
         ):
             return target
 

--- a/src/persome/model/snapshot.py
+++ b/src/persome/model/snapshot.py
@@ -112,7 +112,7 @@ def _point_rows(conn: sqlite3.Connection) -> list[sqlite3.Row]:
     #
     # Only a Point that is end-dated, no longer current, and has no successor
     # was actually withdrawn.
-    return list(
+    rows = list(
         conn.execute(
             f"SELECT {', '.join(selected)} FROM evo_nodes "
             "WHERE status != 'archived' "
@@ -121,6 +121,19 @@ def _point_rows(conn: sqlite3.Connection) -> list[sqlite3.Row]:
             "ORDER BY node_id"
         ).fetchall()
     )
+    # A superseded Point earns its place by anchoring an evolution Line. When
+    # its successor is withdrawn there is no Line left to anchor, and keeping it
+    # would republish the very wording the owner replaced — alone, as the
+    # model's only surviving statement of that fact. Withdraw the whole chain
+    # together, the way retiring a single Point already does.
+    live = {str(row["node_id"]) for row in rows}
+    kept: list[sqlite3.Row] = []
+    for row in rows:
+        successors = {str(v) for v in _json_list(row["superseded_by"])}
+        if successors and not (successors & live):
+            continue
+        kept.append(row)
+    return kept
 
 
 def _visible_content(row: sqlite3.Row) -> str:

--- a/src/persome/model/snapshot.py
+++ b/src/persome/model/snapshot.py
@@ -136,6 +136,19 @@ def _point_rows(conn: sqlite3.Connection) -> list[sqlite3.Row]:
     return kept
 
 
+def _owner_edit_count(conn: sqlite3.Connection) -> int:
+    """Number of owner corrections recorded in the audit trail. Fail-open."""
+    if not _table_exists(conn, "memory_deltas"):
+        return 0
+    try:
+        row = conn.execute(
+            "SELECT count(*) FROM memory_deltas WHERE session_id = 'owner-edit'"
+        ).fetchone()
+    except sqlite3.Error:
+        return 0
+    return int(row[0] or 0) if row else 0
+
+
 def _visible_content(row: sqlite3.Row) -> str:
     """A Point's fact body, without the structural supersede marker.
 
@@ -546,6 +559,11 @@ def build_snapshot(
             "volumes": len(volumes),
             "roots": len(roots),
             "receipts": len(receipts),
+            # How many corrections the owner has made. A monotonic count, so any
+            # reader holding a rendered copy of the model can tell that the owner
+            # has changed it since — which build metadata alone cannot express,
+            # because an edit does not start a build.
+            "owner_edits": _owner_edit_count(conn),
             "redactions": dict(sorted(redactor.counts.items())),
         },
     }

--- a/src/persome/model/snapshot.py
+++ b/src/persome/model/snapshot.py
@@ -226,6 +226,9 @@ def _schema_item(
         "status": row["status"],
         "valid_from": row["valid_from"],
         "created_at": row["created_at"],
+        # A pattern that has not been promoted cannot have its wording pinned
+        # (no promotion gate accepts `authored`), but it can still be rejected.
+        "edit_refusal": "" if row["status"] == "active" else "object_not_active",
     }
 
 
@@ -327,6 +330,12 @@ def build_snapshot(
     point_rows = _point_rows(conn)
     from ..store.schema_faces import member_key
 
+    # The viewer must not offer a correction the writer will refuse, so
+    # editability is decided here, once, by the module that owns the rules.
+    from .edit import backing_map, point_refusal
+
+    backings = backing_map(conn, {str(row["file_name"] or "") for row in point_rows} - {""})
+
     raw_content: dict[str, str] = {str(row["node_id"]): _visible_content(row) for row in point_rows}
     # The body exactly as stored, supersede marker included — what the schema
     # miner reads when it computes the member keys a Face records.
@@ -370,6 +379,14 @@ def build_snapshot(
                 "valid_until": row["valid_until"],
                 "created_at": row["gmt_created"],
                 "receipt": receipt,
+                "edit_refusal": point_refusal(
+                    file_name=str(row["file_name"] or ""),
+                    status=str(row["status"] or ""),
+                    is_latest=bool(row["is_latest"]),
+                    valid_until=row["valid_until"],
+                    superseded_by_empty=not _json_list(row["superseded_by"]),
+                    backing=backings.get(str(row["file_name"] or "")),
+                ),
             }
         )
 

--- a/src/persome/store/schema_faces.py
+++ b/src/persome/store/schema_faces.py
@@ -148,17 +148,60 @@ def _row_face(conn: sqlite3.Connection, face_id: str) -> sqlite3.Row | None:
     return conn.execute("SELECT * FROM schema_faces WHERE face_id = ?", (face_id,)).fetchone()
 
 
+def displaced_signatures(conn: sqlite3.Connection) -> dict[str, str]:
+    """Normalized wordings the owner has corrected a live object away from,
+    mapped to the object that displaced them.
+
+    An authored object's signature no longer matches what the miner produces, so
+    signature equality — the anchor that normally absorbs ordinary membership
+    drift — stops working for it. Its own history is the replacement anchor.
+    Read from the owner-edit audit trail; fail-open, since losing this only
+    weakens matching back to the footprint test.
+    """
+    out: dict[str, str] = {}
+    try:
+        rows = conn.execute(
+            "SELECT payload FROM memory_deltas WHERE session_id = 'owner-edit' ORDER BY id"
+        ).fetchall()
+    except sqlite3.Error:
+        return out
+    for (payload,) in rows:
+        try:
+            edit = json.loads(payload or "{}").get("owner_edit") or {}
+        except (TypeError, ValueError):
+            continue
+        if edit.get("op") != "rewrite" or edit.get("kind") not in ("face", "volume", "root"):
+            continue
+        prior = _norm_sig(str(edit.get("prior_text") or ""))
+        target = str(edit.get("target_id") or "")
+        if prior and target:
+            out[prior] = target
+    return out
+
+
 def _find_match(
     conn: sqlite3.Connection, *, signature: str, members: set[str], level: int
 ) -> sqlite3.Row | None:
     """Same-face detection: normalized-signature equality OR footprint Jaccard
-    ≥ MATCH_JACCARD against any live face at the same level."""
+    ≥ MATCH_JACCARD against any live face at the same level.
+
+    An authored object also matches the wording it displaced. Without that, a
+    re-mine still producing the original proposition finds nothing to fold onto
+    once membership has drifted past the Jaccard floor, and derivation
+    republishes the very claim the owner corrected away as a brand-new face
+    beside their own.
+    """
     conn.row_factory = sqlite3.Row
     sig = _norm_sig(signature)
-    for row in conn.execute(
+    displaced = displaced_signatures(conn) if sig else {}
+    rows = conn.execute(
         "SELECT * FROM schema_faces WHERE valid_to IS NULL AND level = ?", (level,)
-    ).fetchall():
+    ).fetchall()
+    displaced_target = displaced.get(sig)
+    for row in rows:
         if sig and _norm_sig(row["signature"]) == sig:
+            return row
+        if displaced_target and row["face_id"] == displaced_target:
             return row
         if _jaccard(members, set(json.loads(row["members"]))) >= MATCH_JACCARD:
             return row

--- a/src/persome/writer/delta_apply.py
+++ b/src/persome/writer/delta_apply.py
@@ -140,14 +140,31 @@ def _route_assertion_stem(
 
 
 def _assertion_exists(conn: sqlite3.Connection, stored: str, text: str) -> bool:
+    """Whether this exact assertion is already the live wording in that file.
+
+    Compares the *visible* body. A Point written by a correction stores its text
+    plus a `<!-- supersedes: ... -->` marker, so an exact match against
+    `content` never sees it — and the owner's own new wording gets minted a
+    second time as a duplicate live Point the next time it is observed.
+    """
+    from ..store.entries import strip_supersede_provenance
+
     try:
-        row = conn.execute(
-            "SELECT 1 FROM evo_nodes WHERE file_name = ? AND content = ? AND is_latest = 1 LIMIT 1",
-            (stored, text),
-        ).fetchone()
-        return row is not None
+        rows = conn.execute(
+            "SELECT content, supersedes FROM evo_nodes WHERE file_name = ? AND is_latest = 1",
+            (stored,),
+        ).fetchall()
     except Exception:  # noqa: BLE001
         return False
+    wanted = text.strip()
+    for content, supersedes in rows:
+        try:
+            chain = {str(v) for v in json.loads(str(supersedes or "[]") or "[]")}
+        except (TypeError, ValueError):
+            chain = set()
+        if strip_supersede_provenance(str(content or ""), supersedes=chain).strip() == wanted:
+            return True
+    return False
 
 
 def _owner_withdrew(conn: sqlite3.Connection, stored: str, text: str) -> bool:

--- a/tests/fixtures/runtime_model/model_snapshot_v1.golden.json
+++ b/tests/fixtures/runtime_model/model_snapshot_v1.golden.json
@@ -28,10 +28,11 @@
     "trigger"
   ],
   "point": [
-    "conflicted",
     "confidence",
+    "conflicted",
     "content",
     "created_at",
+    "edit_refusal",
     "file_name",
     "id",
     "is_latest",
@@ -75,6 +76,7 @@
     "anchors",
     "confidence",
     "created_at",
+    "edit_refusal",
     "id",
     "level",
     "member_receipts",

--- a/tests/fixtures/runtime_model/model_snapshot_v1.golden.json
+++ b/tests/fixtures/runtime_model/model_snapshot_v1.golden.json
@@ -101,6 +101,7 @@
     "active_points",
     "evolution_lines",
     "faces",
+    "owner_edits",
     "points",
     "receipts",
     "redactions",

--- a/tests/test_model_edit.py
+++ b/tests/test_model_edit.py
@@ -1092,3 +1092,117 @@ def test_every_refusal_reason_the_snapshot_emits_is_explained(ac_root) -> None:
         "object_not_active",
     }
     assert emitted <= explained, f"unexplained: {sorted(emitted - explained)}"
+
+
+# ── deep-research regressions ─────────────────────────────────────────────
+
+
+def test_retiring_a_correction_withdraws_the_wording_it_replaced(ac_root) -> None:
+    """Rewrite then reject used to leave the ORIGINAL wording as the model's
+    only statement of that fact — the claim the owner had already replaced,
+    resurrected and permanently uneditable."""
+    original = "Alex works at Acme as a staff engineer."
+    point_id = _seed_point(original)
+    with fts.cursor() as conn:
+        first = apply_model_edit(
+            conn,
+            kind="point",
+            target_id=point_id,
+            op="rewrite",
+            replacement="I lead the platform team at Acme.",
+        )
+        assert first.ok
+        assert apply_model_edit(conn, kind="point", target_id=first.new_id, op="retire").ok
+        snapshot = build_snapshot(conn, redact=False)
+
+    contents = [p["content"] for p in snapshot["points"]]
+    assert original not in contents, "the replaced wording must not come back"
+    assert all(p["id"] not in (point_id, first.new_id) for p in snapshot["points"])
+
+
+def test_a_stranded_predecessor_is_correctable_again(ac_root) -> None:
+    """With every successor withdrawn there is no chain left to fork, so the
+    only version the owner can see becomes editable rather than a dead end."""
+    point_id = _seed_point()
+    with fts.cursor() as conn:
+        first = apply_model_edit(
+            conn, kind="point", target_id=point_id, op="rewrite", replacement="I write at dawn."
+        )
+        apply_model_edit(conn, kind="point", target_id=first.new_id, op="retire")
+        result = apply_model_edit(conn, kind="point", target_id=point_id, op="retire")
+    assert result.ok, f"expected the stranded version to be reachable, got {result.reason}"
+
+
+def test_the_audit_records_the_fact_the_owner_saw(ac_root) -> None:
+    """`prior_text` used to carry the `<!-- supersedes -->` marker, so a second
+    correction — and the withdrawal guard that reads this trail — compared
+    against bytes the owner never saw."""
+    point_id = _seed_point()
+    with fts.cursor() as conn:
+        first = apply_model_edit(
+            conn, kind="point", target_id=point_id, op="rewrite", replacement="I write at dawn."
+        )
+        second = apply_model_edit(
+            conn,
+            kind="point",
+            target_id=first.new_id,
+            op="rewrite",
+            replacement="I write before anyone is awake.",
+        )
+    assert second.ok
+    assert second.prior_text == "I write at dawn.", second.prior_text
+    assert "supersedes" not in second.prior_text
+
+
+def test_a_second_correction_still_sticks(ac_root) -> None:
+    """The withdrawal guard reads the audit trail; a marker in `prior_text`
+    meant it stopped matching from the second edit onward."""
+    from persome import config as config_mod
+    from persome.writer import delta_apply
+
+    point_id = _seed_point()
+    with fts.cursor() as conn:
+        first = apply_model_edit(
+            conn, kind="point", target_id=point_id, op="rewrite", replacement="I write at dawn."
+        )
+        apply_model_edit(
+            conn,
+            kind="point",
+            target_id=first.new_id,
+            op="rewrite",
+            replacement="I write before anyone is awake.",
+        )
+        result = delta_apply.apply_delta(
+            conn,
+            config_mod.load(),
+            {
+                "entities": [{"canonical": "Alex", "kind": "person"}],
+                "assertions": [{"subject": {"canonical": "Alex"}, "text": "I write at dawn."}],
+            },
+        )
+    assert result.assertions_minted == 0, "the replaced wording must not be re-minted"
+
+
+def test_a_correction_is_not_re_minted_as_a_duplicate(ac_root) -> None:
+    """The dedupe check compared stored bytes, so a corrected Point was
+    invisible to it and the owner's own wording came back as a second live
+    Point the next time it was observed."""
+    from persome import config as config_mod
+    from persome.writer import delta_apply
+
+    point_id = _seed_point()
+    mine = "I reserve mornings for writing."
+    with fts.cursor() as conn:
+        assert apply_model_edit(
+            conn, kind="point", target_id=point_id, op="rewrite", replacement=mine
+        ).ok
+        result = delta_apply.apply_delta(
+            conn,
+            config_mod.load(),
+            {
+                "entities": [{"canonical": "Alex", "kind": "person"}],
+                "assertions": [{"subject": {"canonical": "Alex"}, "text": mine}],
+            },
+        )
+    assert result.assertions_minted == 0
+    assert result.assertions_seen == 1

--- a/tests/test_model_edit.py
+++ b/tests/test_model_edit.py
@@ -7,6 +7,7 @@ used to overwrite anything a human wrote.
 from __future__ import annotations
 
 import json
+import pathlib
 import sqlite3
 from types import SimpleNamespace
 
@@ -1038,3 +1039,56 @@ def test_a_point_backed_by_nothing_is_refused(ac_root) -> None:
             conn, kind="point", target_id=point_id, op="rewrite", replacement="Mine."
         )
     assert not result.ok and result.reason == "point_file_missing"
+
+
+def test_the_snapshot_says_which_points_can_be_corrected(ac_root) -> None:
+    """The viewer must not advertise an edit the writer refuses. On a real model
+    that was 46% of the Points on screen — each inviting a correction and then
+    declining it."""
+    original = "Alex reserves mornings for focused writing."
+    point_id = _seed_point(original)
+    with fts.cursor() as conn:
+        result = apply_model_edit(
+            conn, kind="point", target_id=point_id, op="rewrite", replacement="I write at dawn."
+        )
+        snapshot = build_snapshot(conn, redact=False)
+
+    by_id = {p["id"]: p for p in snapshot["points"]}
+    # The superseded predecessor is still projected (it anchors the evolution
+    # Line) but must not be offered for correction.
+    assert by_id[point_id]["edit_refusal"] == "point_superseded"
+    assert by_id[result.new_id]["edit_refusal"] == ""
+
+
+def test_the_snapshot_marks_unpromoted_patterns_as_unrewritable(ac_root) -> None:
+    with fts.cursor() as conn:
+        shadow = sf.record_face(
+            conn, source=sf.PROVENANCE_MINED, signature="A tentative pattern.", members=["m1"]
+        )
+        active = _seed_face("A settled pattern.")
+        conn.execute("UPDATE schema_faces SET status='shadow' WHERE face_id=?", (shadow,))
+        snapshot = build_snapshot(conn, redact=False)
+
+    by_id = {f["id"]: f for f in snapshot["faces"]}
+    assert by_id[active]["edit_refusal"] == ""
+    assert shadow not in by_id, "a shadow Face is not projected at all"
+
+
+def test_every_refusal_reason_the_snapshot_emits_is_explained(ac_root) -> None:
+    """A reason the viewer cannot translate would reach the owner as a slug."""
+    import re
+
+    viewer = (
+        pathlib.Path(__file__).resolve().parents[1] / "resources/model_assets/viewer.js"
+    ).read_text(encoding="utf-8")
+    explained = set(re.findall(r"^\s{2}([a-z_]+):", viewer, re.MULTILINE))
+    emitted = {
+        "point_has_no_file",
+        "point_not_editable_in_this_file",
+        "point_archived",
+        "point_already_retired",
+        "point_superseded",
+        "point_file_missing",
+        "object_not_active",
+    }
+    assert emitted <= explained, f"unexplained: {sorted(emitted - explained)}"

--- a/tests/test_model_edit.py
+++ b/tests/test_model_edit.py
@@ -1027,18 +1027,24 @@ def test_an_evo_native_point_is_correctable(ac_root) -> None:
     assert OWNER_EDIT_TAG in str(row[1]).split()
 
 
-def test_a_point_backed_by_nothing_is_refused(ac_root) -> None:
-    """No Markdown and no files row means the Point is a remnant."""
-    point_id = _seed_point()
+def test_a_point_the_engine_holds_is_correctable_even_unregistered(ac_root) -> None:
+    """`delta_apply` mints Points into evo_nodes with no Markdown and no files
+    row. The engine already owns those files; they are simply unregistered, and
+    the evomem writer registers them on write. Refusing them would leave every
+    newly observed entity fact permanently uncorrectable.
+    """
     from persome.store import files as files_mod
 
+    point_id = _seed_point()
     files_mod.memory_path("person-alex.md").unlink()
     with fts.cursor() as conn:
         conn.execute("DELETE FROM files WHERE path = 'person-alex.md'")
         result = apply_model_edit(
             conn, kind="point", target_id=point_id, op="rewrite", replacement="Mine."
         )
-    assert not result.ok and result.reason == "point_file_missing"
+        registered = conn.execute("SELECT 1 FROM files WHERE path = 'person-alex.md'").fetchone()
+    assert result.ok, f"expected a correction, got {result.reason}"
+    assert registered is not None, "the engine-owned file must be registered on write"
 
 
 def test_the_snapshot_says_which_points_can_be_corrected(ac_root) -> None:
@@ -1206,3 +1212,170 @@ def test_a_correction_is_not_re_minted_as_a_duplicate(ac_root) -> None:
         )
     assert result.assertions_minted == 0
     assert result.assertions_seen == 1
+
+
+def test_two_concurrent_corrections_cannot_fork_the_chain(ac_root) -> None:
+    """The head check and the write have to be one decision.
+
+    Separated, two overlapping corrections both believe they hold the chain
+    head and both commit, producing exactly the forked chain — two live
+    successors of one fact — that the guard exists to prevent.
+    """
+    import threading
+
+    point_id = _seed_point()
+    results: list[object] = []
+    barrier = threading.Barrier(2)
+
+    def correct(text: str) -> None:
+        barrier.wait()
+        with fts.cursor() as conn:
+            results.append(
+                apply_model_edit(
+                    conn, kind="point", target_id=point_id, op="rewrite", replacement=text
+                )
+            )
+
+    threads = [
+        threading.Thread(target=correct, args=("First wording.",)),
+        threading.Thread(target=correct, args=("Second wording.",)),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+    assert all(not t.is_alive() for t in threads), "an owner edit must never deadlock"
+
+    assert len(results) == 2
+    accepted = [r for r in results if r.ok]
+    assert len(accepted) == 1, "exactly one correction may win the head"
+    assert [r.reason for r in results if not r.ok] == ["point_superseded"]
+
+    with fts.cursor() as conn:
+        successors = conn.execute(
+            "SELECT superseded_by FROM evo_nodes WHERE node_id = ?", (point_id,)
+        ).fetchone()[0]
+        heads = conn.execute(
+            "SELECT count(*) FROM evo_nodes WHERE is_latest = 1 AND file_name = 'person-alex.md'"
+        ).fetchone()[0]
+    assert len(json.loads(successors)) == 1, f"chain forked: {successors}"
+    assert heads == 1
+
+
+# ── the whole matrix, through the real route ──────────────────────────────
+
+
+def test_no_target_state_can_produce_a_server_error(ac_root) -> None:
+    """Every reachable target and operation, through the HTTP surface.
+
+    The bar is not "most edits work": it is that no state of any target
+    produces a 500, and every refusal is a reason the viewer can explain in
+    words. A 500 on this surface is indistinguishable from the feature being
+    broken.
+    """
+    from persome.evomem.engine import EvoMemory
+    from persome.evomem.models import MemoryLayer
+    from persome.model.edit import KINDS, OPS
+
+    point_id = _seed_point()
+    with fts.cursor() as conn:
+        evo_native = EvoMemory().add_direct(
+            "An evo-native assertion.",
+            layer=MemoryLayer.L5_KNOWLEDGE,
+            file_name="person-sam",
+            tags="fact",
+        )
+        face = _seed_face("A settled pattern.")
+        volume = _seed_face("A cross-domain structure.", level=2)
+        root = _seed_face("An apex.", level=3)
+        shadow = sf.record_face(
+            conn, source=sf.PROVENANCE_MINED, signature="A tentative one.", members=["z1"]
+        )
+
+    client = TestClient(build_api_app(auth_enabled=False))
+    targets = [
+        ("point", point_id),
+        ("point", evo_native),
+        ("point", "no-such-point"),
+        ("face", face),
+        ("face", shadow),
+        ("face", "no-such-face"),
+        ("volume", volume),
+        ("volume", face),  # level mismatch
+        ("root", root),
+        ("root", volume),  # level mismatch
+    ]
+
+    seen_refusals: set[str] = set()
+    for kind in sorted(KINDS):
+        for target_kind, target_id in targets:
+            if target_kind != kind:
+                continue
+            for op in sorted(OPS):
+                body = {"schema_version": 1, "kind": kind, "id": target_id, "op": op}
+                if op == "rewrite":
+                    body["replacement"] = "Owner wording for this object."
+                response = client.post("/model/edit", json=body)
+                assert response.status_code != 500, (
+                    f"{kind}/{op} on {target_id} returned 500: {response.text[:200]}"
+                )
+                assert response.status_code in (200, 400), (
+                    f"{kind}/{op} returned {response.status_code}"
+                )
+                if response.status_code == 400:
+                    seen_refusals.add(response.json()["detail"])
+
+    # Whatever refusals this matrix reached must all be explainable.
+    viewer = (
+        pathlib.Path(__file__).resolve().parents[1] / "resources/model_assets/viewer.js"
+    ).read_text(encoding="utf-8")
+    for reason in seen_refusals:
+        assert f"  {reason}:" in viewer, f"refusal {reason!r} has no explanation in the viewer"
+
+
+def test_the_snapshot_and_the_writer_never_disagree(ac_root) -> None:
+    """What the viewer offers and what the writer accepts must be the same set.
+
+    Both directions are bugs: advertising an edit that fails wastes the owner's
+    typing, and refusing one that would have worked hides a correction they are
+    entitled to make.
+    """
+    from persome.evomem.engine import EvoMemory
+    from persome.evomem.models import MemoryLayer
+
+    point_id = _seed_point()
+    with fts.cursor() as conn:
+        EvoMemory().add_direct(
+            "An evo-native assertion.",
+            layer=MemoryLayer.L5_KNOWLEDGE,
+            file_name="person-sam",
+            tags="fact",
+        )
+        first = apply_model_edit(
+            conn, kind="point", target_id=point_id, op="rewrite", replacement="Corrected."
+        )
+        assert first.ok
+        snapshot = build_snapshot(conn, redact=False)
+
+    client = TestClient(build_api_app(auth_enabled=False))
+    checked = 0
+    for point in snapshot["points"]:
+        advertised = not point["edit_refusal"]
+        response = client.post(
+            "/model/edit",
+            json={
+                "schema_version": 1,
+                "kind": "point",
+                "id": point["id"],
+                "op": "rewrite",
+                "replacement": f"Owner wording {point['id'][:6]}.",
+            },
+        )
+        assert response.status_code != 500
+        accepted = response.status_code == 200
+        assert accepted == advertised, (
+            f"{point['id']}: snapshot said {'editable' if advertised else point['edit_refusal']},"
+            f" writer returned {response.status_code}"
+        )
+        checked += 1
+    assert checked >= 2

--- a/tests/test_model_snapshot.py
+++ b/tests/test_model_snapshot.py
@@ -159,6 +159,7 @@ def test_fresh_root_snapshot_has_complete_geometry_and_receipts(ac_root, monkeyp
         "volumes": 1,
         "roots": 1,
         "receipts": 5,
+        "owner_edits": 0,
         "redactions": {},
     }
     assert snapshot["root"]["id"] == seeded["root_id"]

--- a/tests/test_model_snapshot.py
+++ b/tests/test_model_snapshot.py
@@ -272,22 +272,26 @@ def test_point_correction_and_delete_keep_auditable_history(ac_root, monkeypatch
     # A Point retired without a successor has been withdrawn, so it leaves the
     # live model the way a closed Line or an archived Face does.
     assert "point-focus-v3" not in deleted_points
-    # Withdrawal is not amnesia. The predecessor still carries the chain,
-    # because it names its successor in `superseded_by` and is therefore
-    # history rather than a live claim.
-    assert deleted_points["point-focus-v2"]["content"] == (
+    # And so does the version it replaced. A superseded Point earns its place by
+    # anchoring an evolution Line; once its successor is withdrawn there is no
+    # Line left to anchor, and keeping it would republish the exact wording the
+    # owner corrected away — alone, as the model's only statement of that fact.
+    assert "point-focus-v2" not in deleted_points
+    # Withdrawal is not amnesia: every version stays queryable in the store,
+    # which is what keeps the retirement auditable and reversible.
+    with fts.cursor() as conn:
+        rows = {
+            r[0]: (r[1], r[2])
+            for r in conn.execute(
+                "SELECT node_id, content, valid_until FROM evo_nodes WHERE node_id IN (?, ?)",
+                ("point-focus-v2", "point-focus-v3"),
+            )
+        }
+    assert rows["point-focus-v3"][0] == "The user now reserves mornings for release review."
+    assert rows["point-focus-v3"][1] == "2026-07-11T08:00:00+00:00"
+    assert rows["point-focus-v2"][0] == (
         "The user reserves mornings for focused writing and review."
     )
-    # And the withdrawn row itself stays queryable in the store, which is what
-    # keeps the retirement reversible and auditable.
-    with fts.cursor() as conn:
-        retired = conn.execute(
-            "SELECT content, valid_until FROM evo_nodes WHERE node_id = ?",
-            ("point-focus-v3",),
-        ).fetchone()
-    assert retired is not None
-    assert retired[0] == "The user now reserves mornings for release review."
-    assert retired[1] == "2026-07-11T08:00:00+00:00"
 
 
 def test_fresh_root_rebuild_is_structurally_identical(ac_root, monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
# What

Makes every edit and delete path work on every target, and makes the viewer and the writer agree
about which those are. Closes eleven defects found by an adversarial sweep of the full
target × state × operation matrix.

# Why

The feature worked on the states it was built against and failed on several the real model is full
of. Each of these was reproduced end to end before being fixed.

**Corrections came undone in three ways.**

- *Retiring a correction resurrected what it replaced.* Rewrite A→B, reject B, and A came back as
  the model's only statement of that fact — the claim the owner had already corrected away — and was
  permanently uneditable, while the UI said "a newer version exists" about a version no longer in
  the model. Chains now withdraw together, and a version whose successors are all gone becomes
  correctable again, because there is nothing left to fork.
- *The supersede marker leaked into three text comparisons.* `prior_text` recorded raw bytes no
  reader displays, so rejections stopped sticking from the second correction onward and the dedupe
  check re-minted the owner's own wording as a duplicate live Point.
- *Derivation republished rejected claims.* Rewriting a Face removes the signature anchor that
  absorbs ordinary membership drift, so a re-mine still producing the original proposition published
  it again beside the owner's own. An authored object now also matches the wording it displaced.

**Two states returned HTTP 500.** Backing was decided per file, but it is a property of the node — a
file can hold both kinds, and correcting one evo-native Point writes a Markdown projection that made
every other Point in it look Markdown-backed. And Points minted straight into `evo_nodes`, which is
how every entity fact arrives, were refused as unbacked because the writer wants a registry row it
creates itself on the way out.

**The viewer offered what the writer refused.** 46% of visible Points invited a correction and then
declined it. Editability is now decided by the Runtime and carried in the snapshot as
`edit_refusal`; the viewer offers exactly that set and explains the rest in place.

**Also:** HUMAN.md kept asserting rejected objects (its staleness gate watched only build metadata,
and an edit starts no build); two concurrent corrections could both pass the chain-head check and
fork the chain.

# How verified

```
PERSOME_LLM_MOCK=1 uv run pytest -m "not macos and not integration" -q
  → 2299 passed, 17 deselected

uv run ruff check . && uv run ruff format --check .   → clean
secret_scan / pii_scan / language_scan                → clean
```

Three new properties are now enforced rather than checked by hand:

- **No target state can return 500.** A sweep drives every kind × state × operation through the real
  HTTP route and asserts the status is 200 or 400, never 500.
- **Every refusal is explainable.** Any reason the snapshot can emit must have human copy in the
  viewer — this caught `point_has_no_file` reaching the owner as a bare slug.
- **The snapshot and the writer never disagree**, in both directions: advertising an edit that fails
  wastes the owner's typing, and refusing one that would have worked hides a correction they are
  entitled to make.

Checked against the real model that prompted this: **6603 Points, 0 disagreements**, and Points
uneditable for lack of backing went **224 → 0**. Browser-verified inline edit and the two-step
reject.

---

- [x] Commits are signed off (`git commit -s`)
- [x] No real names / emails / tokens in code or test fixtures (synthetic data only)
- [x] Secret scan passes
- [x] Human-authored repository text is English
