### PR TITLE
Fix stale memory correction propagation

### DIFF
--- a/MCP.md
+++ b/MCP.md
@@ -84,7 +84,7 @@ of returning partial results.
 | Tool | Purpose |
 |---|---|
 | `remember` | Append a user-requested, auditable memory. |
-| `correct_memory` | Supersede or revoke memory while preserving provenance. |
+| `correct_memory` | Supersede or revoke memory while preserving provenance; returns separate `applied` and `errors` lists and reports `ok` only after the planned writes and immediate model refresh succeed. |
 
 The server exposes no computer-use, meeting, notification, product dashboard,
 or task-lifecycle tools.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -61,7 +61,7 @@ Example stdio client configuration:
 | `entity_graph` | Read the entity/relation graph; retained as a compatibility model view. |
 | `verify_fact` | Check a claim's freshness and explain existing open contradiction ledger rows. |
 | `remember` | Append an explicit, auditable memory. |
-| `correct_memory` | Supersede or revoke memory through the correction workflow. |
+| `correct_memory` | Supersede or revoke memory through the correction workflow. The result separates successful `applied` operations from `errors`; `ok` is true only when the writes and immediate model refresh complete. |
 | `process_pending_model_work` | Process a bounded number of pending sessions with the connected client's model allowance through MCP Sampling. |
 | `get_pending_model_work` | Inspect the semantic session backlog without invoking a model. |
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -269,8 +269,12 @@ persome entity-retype --help
 ```
 
 Trusted agents can call MCP `remember` and `correct_memory`. Correction keeps
-the prior state and receipts so the change remains auditable. Use erasure, not
-correction, when history itself must be deleted.
+the prior state and receipts so the change remains auditable. Its result
+separates successful writes from errors and reports success only after the
+immediate schema/Root refresh completes. When a derived schema is the only
+remaining writable receipt, correction also supersedes its matching active
+Face or Volume so the retired belief cannot continue feeding Root synthesis.
+Use erasure, not correction, when history itself must be deleted.
 
 ## Export
 

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -1776,6 +1776,8 @@ def correct_cmd(
     typer.echo(f"correct: {res.kind}  ok={res.ok}")
     for a in res.applied:
         typer.echo(f"  - {a}")
+    for error in getattr(res, "errors", []):
+        typer.echo(f"  ! {error}", err=True)
     if res.reason:
         typer.echo(f"  reason: {res.reason}")
     if not res.ok and not dry_run and res.kind == "noop":

--- a/src/persome/mcp/server.py
+++ b/src/persome/mcp/server.py
@@ -1190,7 +1190,13 @@ def build_server(
             res = correct_mod.update_memory(cfg, conn, correction, source="agent")
         model_snapshot_cache.clear()
         return json.dumps(
-            {"kind": res.kind, "applied": res.applied, "reason": res.reason, "ok": res.ok},
+            {
+                "kind": res.kind,
+                "applied": res.applied,
+                "errors": getattr(res, "errors", []),
+                "reason": res.reason,
+                "ok": res.ok,
+            },
             ensure_ascii=False,
         )
 

--- a/src/persome/store/schema_faces.py
+++ b/src/persome/store/schema_faces.py
@@ -288,6 +288,73 @@ def maybe_promote(
     return False
 
 
+def supersede_signature(
+    conn: sqlite3.Connection,
+    *,
+    old_signature: str,
+    new_signature: str = "",
+) -> list[str]:
+    """Apply a supervised correction to active geometry carrying a schema signature.
+
+    ``schema-*.md`` and ``schema_faces`` are projections of the same modeled
+    object. When the correction workflow must update a schema directly (because
+    its source fact projection is unavailable), leaving the old Face or Volume
+    active would keep feeding the retired belief into recall and Root synthesis.
+    Close every exact normalized match and, when a corrected signature is
+    supplied, carry its evidence footprint into a fresh active successor.
+    """
+    ensure_schema(conn)
+    old_norm = _norm_sig(old_signature)
+    new_clean = (new_signature or "").strip()
+    if not old_norm or old_norm == _norm_sig(new_clean):
+        return []
+
+    conn.row_factory = sqlite3.Row
+    rows = [
+        row
+        for row in conn.execute(
+            "SELECT * FROM schema_faces WHERE status = ? AND valid_to IS NULL AND level IN (1, 2)",
+            (MemoryStatus.ACTIVE.value,),
+        )
+        if _norm_sig(str(row["signature"])) == old_norm
+    ]
+    changed: list[str] = []
+    for row in rows:
+        now = _now()
+        old_id = str(row["face_id"])
+        conn.execute(
+            "UPDATE schema_faces SET valid_to = ?, status = ? WHERE face_id = ?",
+            (now, MemoryStatus.SUPERSEDED.value, old_id),
+        )
+        changed.append(old_id)
+        if not new_clean:
+            continue
+        new_id = "face-" + hashlib.sha1((now + old_id + new_clean).encode()).hexdigest()[:12]
+        conn.execute(
+            "INSERT INTO schema_faces (face_id, level, parent_face, signature, members,"
+            " footprints, provenance, observations, confidence, status, valid_from,"
+            " valid_to, created_at, anchors)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)",
+            (
+                new_id,
+                int(row["level"]),
+                row["parent_face"],
+                new_clean,
+                row["members"],
+                row["footprints"],
+                row["provenance"],
+                int(row["observations"]) + 1,
+                float(row["confidence"]),
+                MemoryStatus.ACTIVE.value,
+                now,
+                now,
+                row["anchors"],
+            ),
+        )
+        changed.append(new_id)
+    return changed
+
+
 def resident_faces(conn: sqlite3.Connection, *, top_k: int = 5) -> list[sqlite3.Row]:
     """The §3.1 residency selection: ACTIVE (= promoted, both-provenance) faces,
     strongest first, capped — the O(1) tower-top block the system prompt holds.

--- a/src/persome/writer/correct.py
+++ b/src/persome/writer/correct.py
@@ -48,6 +48,7 @@ class UpdateResult:
     applied: list[str] = field(default_factory=list)  # human-readable of what changed
     reason: str = ""
     ok: bool = False
+    errors: list[str] = field(default_factory=list)
 
 
 def _content_of(resp: Any) -> str:
@@ -69,6 +70,23 @@ def _build_llm_call(cfg: Any) -> Callable[[list[dict]], Any]:
 _IDENTITY_PREFIXES = ("user-", "person-", "org-", "project-", "tool-", "topic-", "schema-")
 
 
+def _target_is_writable(name: str) -> bool:
+    """Return whether a correction target has an authoritative write surface.
+
+    Under Markdown authority, SQLite is only a derived mirror. A live-looking row
+    whose Markdown file has disappeared is stale and cannot be corrected through
+    the normal supersede choke point. Under evomem authority, the canonical node
+    store remains writable even when its Markdown projection is temporarily absent.
+    """
+    try:
+        from ..evomem import inversion
+        from ..store import files as files_mod
+
+        return inversion.routes_to_engine(name) or files_mod.memory_path(name).exists()
+    except (OSError, ValueError):
+        return False
+
+
 def _candidates(cfg: Any, conn: sqlite3.Connection, query: str, cap: int = 16) -> list[Any]:
     """Credit assignment (backprop): trace the wrong output back to the SOURCE fact entries.
 
@@ -80,7 +98,7 @@ def _candidates(cfg: Any, conn: sqlite3.Connection, query: str, cap: int = 16) -
     out: dict[str, Any] = {}
 
     def _add(eid: str, path: str, content: str) -> None:
-        if eid and eid not in out:
+        if eid and eid not in out and _target_is_writable(path):
             out[eid] = SimpleNamespace(id=eid, path=path, content=content)
 
     try:
@@ -91,8 +109,8 @@ def _candidates(cfg: Any, conn: sqlite3.Connection, query: str, cap: int = 16) -
                 "SELECT id, path, content FROM entries WHERE superseded = 0 AND content LIKE ?"
                 " ORDER BY (CASE WHEN "
                 + " OR ".join(f"path LIKE '{p}%'" for p in _IDENTITY_PREFIXES)
-                + " THEN 0 ELSE 1 END), timestamp DESC LIMIT 12",
-                (f"%{ent}%",),
+                + " THEN 0 ELSE 1 END), timestamp DESC LIMIT ?",
+                (f"%{ent}%", max(12, cap * 4)),
             ).fetchall()
             for r in rows:
                 _add(str(r[0]), str(r[1]), str(r[2]))
@@ -100,14 +118,97 @@ def _candidates(cfg: Any, conn: sqlite3.Connection, query: str, cap: int = 16) -
         logger.debug("entity credit-assignment failed", exc_info=True)
 
     try:  # lexical fallback (also covers corrections that name no roster entity)
-        for h in fts.search(conn, query=query, top_k=8):
+        for h in fts.search(conn, query=query, top_k=max(8, cap * 4)):
             _add(h.id, h.path, h.content)
     except Exception:  # noqa: BLE001
         pass
     return list(out.values())[:cap]
 
 
-def _log_update(signal: str, kind: str, applied: list[str], reason: str, source: str) -> None:
+def _normalize_supersedes(
+    conn: sqlite3.Connection, planned: list[dict]
+) -> tuple[list[dict], list[str]]:
+    """Bind LLM-planned targets to the authoritative live SQLite receipt.
+
+    The model is allowed to select only supplied ``file#entry_id`` candidates,
+    but the entry id is the stable handle. Resolve its path again at apply time
+    so a mistyped file cannot redirect a correction, and reject stale DB rows
+    whose Markdown authority has disappeared.
+    """
+    normalized: list[dict] = []
+    errors: list[str] = []
+    seen: set[str] = set()
+    for item in planned:
+        eid = str(item.get("entry_id", "")).strip()
+        if not eid or eid in seen:
+            continue
+        seen.add(eid)
+        row = conn.execute(
+            "SELECT path, superseded, content FROM entries WHERE id = ? LIMIT 1",
+            (eid,),
+        ).fetchone()
+        if row is None:
+            errors.append(f"supersede {eid}: receipt is missing from the index")
+            continue
+        name = str(row[0])
+        if bool(row[1]):
+            errors.append(f"supersede {name}#{eid}: receipt is already superseded")
+            continue
+        if not _target_is_writable(name):
+            errors.append(
+                f"supersede {name}#{eid}: authoritative memory file is missing; "
+                "rebuild the index before retrying"
+            )
+            continue
+        target = dict(item)
+        target["file"] = name
+        target["_previous_content"] = str(row[2] or "")
+        normalized.append(target)
+    return normalized, errors
+
+
+def _schema_signature(content: str) -> str:
+    """Extract the modeled proposition from a schema body or direct correction."""
+    lines = [line.strip() for line in (content or "").splitlines() if line.strip()]
+    for line in lines:
+        if line.startswith("central:"):
+            return line.split(":", 1)[1].strip()
+    for line in lines:
+        if not line.startswith(("summary:", "inferences:", "-", "<!--")):
+            return line
+    return ""
+
+
+def _update_direct_schema_geometry(
+    conn: sqlite3.Connection,
+    *,
+    name: str,
+    previous_content: str,
+    replacement: str,
+) -> list[str]:
+    """Keep schema geometry aligned when a derived schema is corrected directly."""
+    if not name.startswith("schema-"):
+        return []
+    from ..store import schema_faces
+
+    changed = schema_faces.supersede_signature(
+        conn,
+        old_signature=_schema_signature(previous_content),
+        new_signature=_schema_signature(replacement),
+    )
+    if not changed:
+        return []
+    return [f"updated derived model geometry for {name} ({len(changed)} nodes)"]
+
+
+def _log_update(
+    signal: str,
+    kind: str,
+    applied: list[str],
+    reason: str,
+    source: str,
+    errors: list[str] | None = None,
+) -> None:
     """Append to ``logs/memory-updates.jsonl`` — the RLHF reward signal (a user 'this is wrong'
     is the most valuable label). Fail-open."""
     try:
@@ -119,6 +220,7 @@ def _log_update(signal: str, kind: str, applied: list[str], reason: str, source:
             "signal": signal[:500],
             "kind": kind,
             "applied": applied,
+            "errors": list(errors or []),
             "reason": reason[:300],
             "source": source,  # user (supervised) | agent | observation
         }
@@ -188,30 +290,45 @@ def _apply_entity_op(
         return []
 
 
-def _reforward(cfg: Any, conn: sqlite3.Connection, files: set[str]) -> list[str]:
+def _reforward(cfg: Any, conn: sqlite3.Connection, files: set[str]) -> tuple[list[str], list[str]]:
     """Re-run the FORWARD pass on the affected path after a weight (fact) update — the closed
     loop: update the weight → re-run forward so the change propagates to the resident apex NOW,
     not on the next daily tick. For each file whose facts changed, re-derive its schema (targeted
     re-mine, reading the CORRECTED ``entries`` projection so it sees the supersede), then
-    re-synthesize the level-3 root apex (top of the forward pass). Fail-open."""
+    re-synthesize the level-3 root apex (top of the forward pass). A failed propagation is
+    returned to the caller instead of being reported as a successful real-time correction."""
     done: list[str] = []
+    errors: list[str] = []
     try:
         from ..writer import root_synthesis
         from ..writer import schema_miner_stage as sm
 
         # from_evomem=False: read the entries projection, which the choke-point supersede just
         # updated (superseded=1) — evo_nodes may not reflect a markdown-authority correction.
+        fact_files = {name for name in files if not name.startswith("schema-")}
         bundles = [
-            b for b in sm.collect_fact_bundles(conn, from_evomem=False) if b.source_path in files
+            b
+            for b in sm.collect_fact_bundles(conn, from_evomem=False)
+            if b.source_path in fact_files
         ]
         if bundles:
-            sm.mine_bundles_and_write(cfg, conn, bundles)
-            done.append(f"re-derived schema for {sorted(b.source_path for b in bundles)}")
+            run = sm.mine_bundles_and_write(cfg, conn, bundles)
+            written = {w.path for w in run.written}
+            expected = {sm.schema_name_for(b.source_path) for b in bundles}
+            missing = sorted(expected - written)
+            if missing:
+                errors.append(f"schema refresh produced no replacement for {missing}")
+            else:
+                done.append(f"re-derived schema for {sorted(b.source_path for b in bundles)}")
         rr = root_synthesis.run_root_synthesis(cfg, conn)  # re-synth the apex (top of forward)
-        done.append(f"re-synth root apex ({rr.reason})")
-    except Exception:  # noqa: BLE001 — the forward re-run never fails the update
+        if rr.reason in {"written", "disabled"}:
+            done.append(f"re-synth root apex ({rr.reason})")
+        else:
+            errors.append(f"root apex refresh did not produce a replacement ({rr.reason})")
+    except Exception as exc:  # noqa: BLE001 — source correction remains durable
         logger.exception("reforward failed")
-    return done
+        errors.append(f"forward refresh failed: {exc}")
+    return done, errors
 
 
 def update_memory(
@@ -248,40 +365,67 @@ def update_memory(
             },
         ]
         parsed = parse_json_object(_content_of(call(messages))) or {}
-        supersede = [s for s in (parsed.get("supersede") or []) if isinstance(s, dict)]
+        planned_supersede = [s for s in (parsed.get("supersede") or []) if isinstance(s, dict)]
         entity_op = parsed.get("entity_op") if isinstance(parsed.get("entity_op"), dict) else None
         reason = str(parsed.get("reason", signal))[:300]
 
-        if not supersede and not (entity_op and entity_op.get("op") in _ENTITY_OPS):
+        if not planned_supersede and not (entity_op and entity_op.get("op") in _ENTITY_OPS):
             return UpdateResult("noop", reason=reason, ok=False)
+        supersede, errors = _normalize_supersedes(conn, planned_supersede)
         if dry_run:
             return UpdateResult(
-                "update", applied=_plan(supersede, entity_op), reason=reason, ok=False
+                "error" if errors else "update",
+                applied=_plan(supersede, entity_op),
+                reason=reason,
+                ok=False,
+                errors=errors,
             )
 
         applied: list[str] = []
         kind = "update"
         touched_files: set[str] = set()
         if supersede:  # fact/point layer → reuse the shared update executor (delta_apply ⊖ leg)
-            r = delta_apply.apply_delta(conn, cfg, {"supersede": supersede})
             for s in supersede:
-                if s.get("entry_id"):
-                    applied.append(f"superseded {s.get('file')}#{s.get('entry_id')}")
-                    if s.get("file"):
-                        touched_files.add(str(s["file"]))
-            if r.errors:
-                applied.append(f"errors: {r.errors}")
+                delta_item = {k: v for k, v in s.items() if not k.startswith("_")}
+                r = delta_apply.apply_delta(conn, cfg, {"supersede": [delta_item]})
+                name = str(s["file"])
+                eid = str(s["entry_id"])
+                if r.supersedes_applied:
+                    applied.append(f"superseded {name}#{eid}")
+                    touched_files.add(name)
+                    try:
+                        applied += _update_direct_schema_geometry(
+                            conn,
+                            name=name,
+                            previous_content=str(s.get("_previous_content", "")),
+                            replacement=str(s.get("replacement", "")),
+                        )
+                    except Exception as exc:  # noqa: BLE001 — source correction remains durable
+                        logger.exception("direct schema geometry refresh failed")
+                        errors.append(f"derived geometry refresh failed for {name}: {exc}")
+                else:
+                    errors.extend(r.errors or [f"supersede {name}#{eid}: no change applied"])
         if entity_op and entity_op.get("op") in _ENTITY_OPS:  # entity layer → retype verbs
             applied += _apply_entity_op(entity_op, cfg, conn, signal=signal, source=source)
             kind = "entity_update" if not supersede else "update"
 
         # Closed loop: weight update (backward) → re-run the forward pass on the affected path so
         # the correction reaches the resident apex immediately (not on the next daily tick).
-        if reforward and touched_files and any("superseded" in a for a in applied):
-            applied += _reforward(cfg, conn, touched_files)
+        if reforward and touched_files:
+            forward_applied, forward_errors = _reforward(cfg, conn, touched_files)
+            applied += forward_applied
+            errors += forward_errors
 
-        _log_update(signal, kind, applied, reason, source)
-        return UpdateResult(kind, applied=applied, reason=reason, ok=bool(applied))
+        if errors:
+            kind = "error"
+        _log_update(signal, kind, applied, reason, source, errors)
+        return UpdateResult(
+            kind,
+            applied=applied,
+            reason=reason,
+            ok=bool(applied) and not errors,
+            errors=errors,
+        )
     except Exception:  # noqa: BLE001 — a bad update never crashes the caller
         logger.exception("update_memory failed")
         return UpdateResult("error", ok=False)

--- a/tests/test_schema_faces.py
+++ b/tests/test_schema_faces.py
@@ -192,6 +192,62 @@ class TestStabilityGateAndPromotion:
         assert faces.maybe_promote(conn, "face-nope") is False
 
 
+class TestSupervisedCorrection:
+    def test_supersede_signature_replaces_active_geometry_and_keeps_footprint(self, conn):
+        old_id = faces.record_face(
+            conn,
+            source="mined",
+            signature="Valse builds coding-agent management",
+            members=MEMBERS,
+            confidence=0.9,
+            level=2,
+        )
+        faces.record_face(
+            conn,
+            source="emergent",
+            signature="Valse builds coding-agent management",
+            members=MEMBERS,
+            confidence=0.9,
+            level=2,
+        )
+        assert faces.maybe_promote(conn, old_id)
+
+        changed = faces.supersede_signature(
+            conn,
+            old_signature="  valse builds coding-agent management ",
+            new_signature="Valse helps individuals restore continuous personal state",
+        )
+
+        assert changed[0] == old_id
+        new_id = changed[1]
+        old = _row(conn, old_id)
+        new = _row(conn, new_id)
+        assert old["status"] == "superseded" and old["valid_to"] is not None
+        assert new["status"] == "active" and new["valid_to"] is None
+        assert new["signature"] == "Valse helps individuals restore continuous personal state"
+        assert new["members"] == old["members"]
+        assert new["footprints"] == old["footprints"]
+        assert new["observations"] == old["observations"] + 1
+
+    def test_supersede_signature_can_retire_without_replacement(self, conn):
+        old_id = faces.record_face(
+            conn,
+            source="mined",
+            signature="obsolete claim",
+            members=MEMBERS,
+        )
+        conn.execute(
+            "UPDATE schema_faces SET status = 'active' WHERE face_id = ?",
+            (old_id,),
+        )
+
+        assert faces.supersede_signature(
+            conn,
+            old_signature="obsolete claim",
+        ) == [old_id]
+        assert _row(conn, old_id)["status"] == "superseded"
+
+
 class TestResidency:
     def _promoted(self, conn, sig, members, obs_extra=0):
         fid = faces.record_face(conn, source="mined", signature=sig, members=members)

--- a/tests/test_update_memory.py
+++ b/tests/test_update_memory.py
@@ -15,6 +15,7 @@ from types import SimpleNamespace
 
 from persome.store import entries as E
 from persome.store import fts
+from persome.store import schema_faces as F
 from persome.writer import correct as C
 
 
@@ -22,6 +23,7 @@ def _cfg():
     return SimpleNamespace(
         memory_delta=SimpleNamespace(apply_assertions=False),
         search=SimpleNamespace(default_top_k=5),
+        schema=SimpleNamespace(root_synthesis_enabled=False),
     )
 
 
@@ -257,3 +259,180 @@ def test_update_logged_as_feedback_signal(ac_root):
     assert log.stat().st_mode & 0o777 == 0o600
     row = json.loads(log.read_text(encoding="utf-8").splitlines()[-1])
     assert row["source"] == "user" and row["kind"] == "update"
+    assert row["errors"] == []
+
+
+def test_correction_rebinds_target_path_from_receipt(ac_root):
+    with fts.cursor() as conn:
+        face_id = F.record_face(
+            conn,
+            source="mined",
+            signature="Valse is coding-agent infrastructure",
+            members=["fact-a", "fact-b"],
+        )
+        F.record_face(
+            conn,
+            source="emergent",
+            signature="Valse is coding-agent infrastructure",
+            members=["fact-a", "fact-b"],
+        )
+        assert F.maybe_promote(conn, face_id)
+        eid = _seed_fact(
+            conn,
+            "central: Valse is coding-agent infrastructure",
+            name="schema-org-valse-ai.md",
+        )
+        res = C.update_memory(
+            _cfg(),
+            conn,
+            "Valse no longer builds coding-agent infrastructure",
+            reforward=False,
+            llm_call=_llm(
+                {
+                    "supersede": [
+                        {
+                            # A model-provided path must never override the stable receipt.
+                            "file": "org-valse-ai.md",
+                            "entry_id": eid,
+                            "reason": "positioning changed",
+                            "replacement": "Valse helps individuals restore continuous state",
+                        }
+                    ],
+                    "entity_op": None,
+                    "reason": "positioning changed",
+                }
+            ),
+        )
+
+    assert res.ok and res.errors == []
+    assert res.applied == [
+        f"superseded schema-org-valse-ai.md#{eid}",
+        "updated derived model geometry for schema-org-valse-ai.md (2 nodes)",
+    ]
+    assert "~~central: Valse is coding-agent infrastructure~~" in _md_body(
+        ac_root, "schema-org-valse-ai.md"
+    )
+    with fts.cursor() as conn:
+        old = conn.execute(
+            "SELECT status FROM schema_faces WHERE face_id = ?", (face_id,)
+        ).fetchone()
+        replacement = conn.execute(
+            "SELECT signature, status FROM schema_faces"
+            " WHERE signature = 'Valse helps individuals restore continuous state'"
+        ).fetchone()
+    assert old[0] == "superseded"
+    assert tuple(replacement) == (
+        "Valse helps individuals restore continuous state",
+        "active",
+    )
+
+
+def test_correction_does_not_claim_missing_markdown_target_was_applied(ac_root, monkeypatch):
+    with fts.cursor() as conn:
+        eid = _seed_fact(
+            conn,
+            "Valse is coding-agent infrastructure",
+            name="org-valse-ai.md",
+        )
+        (Path(ac_root) / "memory" / "org-valse-ai.md").unlink()
+
+        def unexpected_reforward(*_args, **_kwargs):
+            raise AssertionError("failed source writes must not regenerate derived memory")
+
+        monkeypatch.setattr(C, "_reforward", unexpected_reforward)
+        res = C.update_memory(
+            _cfg(),
+            conn,
+            "Valse no longer builds coding-agent infrastructure",
+            llm_call=_llm(
+                {
+                    "supersede": [
+                        {
+                            "file": "org-valse-ai.md",
+                            "entry_id": eid,
+                            "reason": "positioning changed",
+                        }
+                    ],
+                    "entity_op": None,
+                    "reason": "positioning changed",
+                }
+            ),
+        )
+        superseded = conn.execute("SELECT superseded FROM entries WHERE id = ?", (eid,)).fetchone()[
+            0
+        ]
+
+    assert res.kind == "error" and not res.ok
+    assert res.applied == []
+    assert any("authoritative memory file is missing" in error for error in res.errors)
+    assert superseded == 0
+
+
+def test_candidates_skip_stale_rows_without_authoritative_file(ac_root):
+    with fts.cursor() as conn:
+        stale_id = _seed_fact(
+            conn,
+            "Valse is coding-agent infrastructure",
+            name="org-valse-ai.md",
+        )
+        live_id = _seed_fact(
+            conn,
+            "Valse product positioning summary",
+            name="schema-org-valse-ai.md",
+        )
+        (Path(ac_root) / "memory" / "org-valse-ai.md").unlink()
+
+        hits = C._candidates(_cfg(), conn, "Valse product positioning")
+
+    ids = {hit.id for hit in hits}
+    assert stale_id not in ids
+    assert live_id in ids
+
+
+def test_forward_refresh_failure_is_not_reported_as_success(ac_root, monkeypatch):
+    with fts.cursor() as conn:
+        eid = _seed_fact(conn, "User lives in Beijing")
+        monkeypatch.setattr(
+            C,
+            "_reforward",
+            lambda *_args, **_kwargs: ([], ["schema refresh produced no replacement"]),
+        )
+        res = C.update_memory(
+            _cfg(),
+            conn,
+            "User lives in Shanghai",
+            llm_call=_llm(
+                {
+                    "supersede": [
+                        {
+                            "file": "user-profile.md",
+                            "entry_id": eid,
+                            "replacement": "User lives in Shanghai",
+                            "reason": "moved",
+                        }
+                    ],
+                    "entity_op": None,
+                    "reason": "moved",
+                }
+            ),
+        )
+
+    assert res.kind == "error" and not res.ok
+    assert res.applied == [f"superseded user-profile.md#{eid}"]
+    assert res.errors == ["schema refresh produced no replacement"]
+
+
+def test_skipped_root_refresh_is_reported_as_incomplete(ac_root, monkeypatch):
+    monkeypatch.setattr(
+        "persome.writer.root_synthesis.run_root_synthesis",
+        lambda *_args, **_kwargs: SimpleNamespace(reason="skip_hallucination"),
+    )
+    with fts.cursor() as conn:
+        applied, errors = C._reforward(
+            _cfg(),
+            conn,
+            {"schema-org-valse-ai.md"},
+        )
+
+    assert applied == []
+    assert errors == ["root apex refresh did not produce a replacement (skip_hallucination)"]


### PR DESCRIPTION
## Summary

- report only corrections that were actually persisted, with propagation failures returned separately as `errors`
- rebind correction targets through authoritative receipts and skip stale projection rows whose Markdown source no longer exists
- keep direct schema corrections synchronized with active Face/Volume geometry so Root synthesis cannot restore an obsolete belief
- document the stricter `ok`, `applied`, and `errors` semantics for CLI and MCP callers

## Root cause

`correct_memory` previously returned planned supersedes as if they had been applied even when `delta_apply` failed. The follow-up schema/Root refresh could also report success when no replacement was written. In addition, direct edits to a schema Markdown file did not retire the corresponding active geometry. Together, stale database projections and derived state could repopulate an outdated product direction after a correction appeared to succeed.

## Behavior after this change

- `ok` is true only when at least one change was applied and no propagation error remains
- CLI and MCP responses distinguish `applied` changes from `errors`
- schema and Root refreshes are verified instead of assumed successful
- direct schema corrections retire matching active geometry and create an updated successor when appropriate

## Validation

- `PERSOME_LLM_MOCK=1 uv run pytest -m 'not macos and not integration' -q` — 2227 passed, 17 deselected
- related correction, schema, Root, CLI, and MCP tests — 95 passed
- Ruff check and format check passed for all changed Python files
- `git diff --check` passed
