### PR TITLE
Polish the local model galaxy experience

### DIFF
--- a/docs/model-contract.md
+++ b/docs/model-contract.md
@@ -151,13 +151,15 @@ Both share actions take their written summaries and aggregate counts from the ca
 `/model/share-card` projection rather than the owner-only graph. The adjacent `Card` action remains
 a separate renderer that downloads the portrait `my-human-card.png` without opening X. Neighborhood
 dimming and layer toggles are suspended only while the WebGL constellation is rendered for sharing.
-The constellation share always renders the latest complete time slice, matching the current narrative
-and aggregate counts returned by `/model/share-card`, even when the owner is inspecting history. It
-uses a fitted 16:9 overview at the artifact's own 1200-by-675 dimensions rather than cropping the
-owner's focused, zoomed, or portrait viewport. Renderer resolution, camera position and target,
-timeline cutoff, hidden-layer choices, any in-flight camera/zoom animation, selection, and focus
-return target are restored immediately after the pixels are copied, so the owner's inspection state
-is unchanged.
+The constellation share always renders the latest complete time slice from the same cached snapshot
+generation as the current narrative and aggregate counts returned by `/model/share-card`, even when
+the owner is inspecting history. The client rejects a version mismatch instead of combining two
+generations. The export uses a fitted 16:9 overview at the artifact's own 1200-by-675 dimensions
+rather than cropping the owner's focused, zoomed, or portrait viewport. Renderer resolution, camera
+position and target,
+timeline cutoff, hidden-layer choices, auto-rotation, any in-flight camera/zoom animation, selection,
+the inspected snapshot, and focus return target are restored immediately after the pixels are copied,
+so the owner's inspection state is unchanged.
 
 Visible node labels and their Point, Face, Volume, Root, or context meshes open the same provenance
 detail panel. Overview summarizes the evidence footprint, Evidence presents human-readable source
@@ -180,7 +182,8 @@ while retaining the same Overview, Evidence, History, and correction controls. C
 and Line hit radii expand beyond the 12- and 8-pixel desktop minimums, and primary mobile controls
 provide at least a 44-pixel target. The full legend yields to a compact, collapsed Guide disclosure
 above the timeline; its summary keeps `inferred placement · not evidence` visible without covering
-the primary controls, and expanding it explains where to find sourced support.
+the primary controls, uses normal-text contrast for that safety boundary, and expanding it explains
+where to find sourced support.
 
 Zoom is relative to the fitted model: the visible minus, percentage, and plus controls cover 50%
 through 400%, the percentage resets to 100%, and the plus, minus, and zero keys provide the same

--- a/docs/model-contract.md
+++ b/docs/model-contract.md
@@ -146,8 +146,14 @@ artifact; the owner attaches the downloaded image and confirms the post in X.
 Both share actions take their written summaries and aggregate counts from the canonically scrubbed
 `/model/share-card` projection rather than the owner-only graph. The adjacent `Card` action remains
 a separate renderer that downloads the portrait `my-human-card.png` without opening X. Neighborhood
-dimming is suspended only while the WebGL constellation is rendered for sharing, then restored, so
-the exported image remains the complete constellation and the owner's inspection state is unchanged.
+dimming and layer toggles are suspended only while the WebGL constellation is rendered for sharing.
+The constellation share always renders the latest complete time slice, matching the current narrative
+and aggregate counts returned by `/model/share-card`, even when the owner is inspecting history. It
+uses a fitted 16:9 overview at the artifact's own 1200-by-675 dimensions rather than cropping the
+owner's focused, zoomed, or portrait viewport. Renderer resolution, camera position and target,
+timeline cutoff, hidden-layer choices, any in-flight camera/zoom animation, selection, and focus
+return target are restored immediately after the pixels are copied, so the owner's inspection state
+is unchanged.
 
 Visible node labels and their Point, Face, Volume, Root, or context meshes open the same provenance
 detail panel. Overview summarizes the evidence footprint, Evidence presents human-readable source
@@ -168,7 +174,9 @@ Layer controls expose current snapshot counts, and the explanatory legend is col
 changing layer visibility. On narrow screens the detail panel becomes a safe-area-aware bottom sheet
 while retaining the same Overview, Evidence, History, and correction controls. Coarse-pointer node
 and Line hit radii expand beyond the 12- and 8-pixel desktop minimums, and primary mobile controls
-provide at least a 44-pixel target.
+provide at least a 44-pixel target. The full legend yields to a compact, collapsed Guide disclosure
+above the timeline; its summary keeps `inferred placement · not evidence` visible without covering
+the primary controls, and expanding it explains where to find sourced support.
 
 Zoom is relative to the fitted model: the visible minus, percentage, and plus controls cover 50%
 through 400%, the percentage resets to 100%, and the plus, minus, and zero keys provide the same

--- a/docs/model-contract.md
+++ b/docs/model-contract.md
@@ -119,7 +119,11 @@ exposes aggregate layout health for local visual smoke tests without exposing no
 Search is a local view over the objects visible at the current model-history cutoff. It ranks
 human-readable text from the already-loaded snapshot; it does not call another service, persist
 queries, or expand the canonical model. Choosing a result opens the same detail surface as selecting
-its rendered object. The search surface states this scope narrowly: search queries stay on the Mac;
+its rendered object. Point heads that are active at the selected cutoff rank ahead of shadow and
+historical Points. Those
+non-active Points remain discoverable by specific content or state searches and are labeled as
+shadow or historical results, preserving the snapshot's audit and time-travel boundary. The search
+surface states this scope narrowly: search queries stay on the Mac;
 the separate, explicit share actions retain their own review-before-posting boundary.
 
 Selection also creates a first-order "model neighborhood" from explicit Lines and the deterministic

--- a/docs/model-contract.md
+++ b/docs/model-contract.md
@@ -116,6 +116,22 @@ The layout is append-stable for normal chronological growth: existing nodes keep
 coordinates while later evidence expands the surrounding cloud. `window.__persomeLayoutState`
 exposes aggregate layout health for local visual smoke tests without exposing node content or IDs.
 
+Search is a local view over the objects visible at the current model-history cutoff. It ranks
+human-readable text from the already-loaded snapshot; it does not call another service, persist
+queries, or expand the canonical model. Choosing a result opens the same detail surface as selecting
+its rendered object. The search surface states this scope narrowly: search queries stay on the Mac;
+the separate, explicit share actions retain their own review-before-posting boundary.
+
+Selection also creates a first-order "model neighborhood" from explicit Lines and the deterministic
+Root, Volume, Face, and Point hierarchy already used for layout. The selected object and its direct
+semantic and hierarchy neighbors remain prominent while unrelated geometry is visually muted.
+Hierarchy membership may be inferred from receipts for layout, so this focus is navigation, not
+evidence; only explicit Lines and the Evidence surface establish provenance. Focusing does not mutate
+snapshot objects, coordinates, or persisted model state. Search reveal may enable the selected
+object's layer when it was hidden; ordinary focus leaves layer visibility unchanged. The detail
+surface labels the state as a navigation view, offers `Show all`, and temporarily adds a bounded set
+of labels for otherwise-unlabeled first-order neighbors.
+
 The viewer presents that hierarchy as a personal constellation: a Root-centered luminous core,
 Volume and Face orbit structures, Point clouds, and restrained ambient depth cues. Its editorial
 frame uses the live Root signature as the model's plain-language identity statement so each view is
@@ -129,7 +145,9 @@ Point labels, receipts, source names, timestamps, and viewer credentials are exc
 artifact; the owner attaches the downloaded image and confirms the post in X.
 Both share actions take their written summaries and aggregate counts from the canonically scrubbed
 `/model/share-card` projection rather than the owner-only graph. The adjacent `Card` action remains
-a separate renderer that downloads the portrait `my-human-card.png` without opening X.
+a separate renderer that downloads the portrait `my-human-card.png` without opening X. Neighborhood
+dimming is suspended only while the WebGL constellation is rendered for sharing, then restored, so
+the exported image remains the complete constellation and the owner's inspection state is unchanged.
 
 Visible node labels and their Point, Face, Volume, Root, or context meshes open the same provenance
 detail panel. Overview summarizes the evidence footprint, Evidence presents human-readable source
@@ -140,9 +158,17 @@ screen-space hit target so distant geometry stays selectable. Evolution and rela
 their own human-readable endpoint, exact predicate, and evidence detail through an 8-pixel
 screen-space hit target; node hits always win where geometry overlaps. Keyboard focus reveals a
 line picker with the same detail action. Raw line and endpoint IDs remain inside collapsed technical
-details. Derived hierarchy connectors remain visual-only.
+details. Explicit Lines and their count/toggle remain separate from derived hierarchy guides. The
+guides follow endpoint-layer visibility and are named in the legend as inferred placement, not
+evidence; they remain visual-only.
 `window.__persomeInteractionState` exposes aggregate interaction counts and hit-target bounds for
 local smoke tests.
+
+Layer controls expose current snapshot counts, and the explanatory legend is collapsible without
+changing layer visibility. On narrow screens the detail panel becomes a safe-area-aware bottom sheet
+while retaining the same Overview, Evidence, History, and correction controls. Coarse-pointer node
+and Line hit radii expand beyond the 12- and 8-pixel desktop minimums, and primary mobile controls
+provide at least a 44-pixel target.
 
 Zoom is relative to the fitted model: the visible minus, percentage, and plus controls cover 50%
 through 400%, the percentage resets to 100%, and the plus, minus, and zero keys provide the same
@@ -156,8 +182,13 @@ pinch and a middle-button drag keep the orbit controller's own dolly, which alre
 fingers directly. `window.__persomeZoomState` exposes only aggregate distance and percentage values
 for local visual smoke tests.
 
-Dragging works anywhere over the model, including on a label and over the read-only legend and
-status panels, and a second finger cancels the click so a pinch never selects a node.
+Choosing a search result, or pressing `F` for the current selection, smoothly flies the camera to
+that object without changing the deterministic layout. With reduced motion requested, the same move
+is immediate. `Frame` restores the fitted overview independently of the selection and active layers.
+
+Dragging works across the model canvas, including on a label, while search, the collapsible legend,
+and the detail surfaces retain their own pointer and scroll behavior. A second finger cancels the
+click so a pinch never selects a node.
 `window.__persomeFrameStats` exposes rolling p50, p95, and worst frame costs in milliseconds over
 the last 240 frames, so a smoothness regression is measurable locally rather than only visible.
 

--- a/docs/model-contract.md
+++ b/docs/model-contract.md
@@ -146,8 +146,20 @@ local smoke tests.
 
 Zoom is relative to the fitted model: the visible minus, percentage, and plus controls cover 50%
 through 400%, the percentage resets to 100%, and the plus, minus, and zero keys provide the same
-actions. Wheel and trackpad pinch gestures zoom toward the pointer. `window.__persomeZoomState`
-exposes only aggregate distance and percentage values for local visual smoke tests.
+actions in 25% steps. Wheel and trackpad pinch gestures zoom continuously toward the pointer,
+gliding to their goal under the same damping that carries orbit and pan, so releasing a gesture
+coasts to a stop rather than stopping dead. Wheel deltas are normalized to pixels first, so a
+gesture means the same amount of zoom whether the browser reports pixels, lines, or pages, and one
+comfortable trackpad pinch is worth roughly a doubling on every display. A pinch is read from
+`ctrlKey` wheel events and, on browsers that report one instead, from gesture events; a touchscreen
+pinch and a middle-button drag keep the orbit controller's own dolly, which already tracks the
+fingers directly. `window.__persomeZoomState` exposes only aggregate distance and percentage values
+for local visual smoke tests.
+
+Dragging works anywhere over the model, including on a label and over the read-only legend and
+status panels, and a second finger cancels the click so a pinch never selects a node.
+`window.__persomeFrameStats` exposes rolling p50, p95, and worst frame costs in milliseconds over
+the last 240 frames, so a smoothness regression is measurable locally rather than only visible.
 
 ## Owner corrections
 

--- a/openapi.json
+++ b/openapi.json
@@ -331,7 +331,7 @@
           "model"
         ],
         "summary": "Model Share Card",
-        "description": "Return the minimal, canonically scrubbed public share projection.",
+        "description": "Return a scrubbed projection version-matched to the owner graph cache.",
         "operationId": "model_share_card_model_share_card_get",
         "responses": {
           "200": {

--- a/resources/model_assets/evidence.mjs
+++ b/resources/model_assets/evidence.mjs
@@ -116,33 +116,51 @@ export function evidenceBreadcrumb(data) {
   return compactText(data?.label || data?.summary, humanizePath(data?.path) || data?.kind || "Evidence", 72);
 }
 
-function modelNodeLabel(id, model) {
-  if (id === "self") return "You";
-  const candidates = [
+function modelNodeCandidates(model) {
+  return [
     ["point", model?.points || [], "Observed point"],
     ["face", model?.faces || [], "Model pattern"],
     ["volume", model?.volumes || [], "Model structure"],
     ["root", model?.root ? [model.root] : [], "Personal model"],
   ];
-  for (const [, nodes, fallback] of candidates) {
+}
+
+function modelNodeDisplayLabel(node, fallback) {
+  return compactText(
+    node?.content || node?.signature || node?.label || node?.title,
+    fallback,
+    88,
+  );
+}
+
+export function modelNodeLabelIndex(model) {
+  const labels = new Map([["self", "You"]]);
+  modelNodeCandidates(model).forEach(([, nodes, fallback]) => {
+    nodes.forEach((node) => {
+      if (node?.id && !labels.has(node.id)) {
+        labels.set(node.id, modelNodeDisplayLabel(node, fallback));
+      }
+    });
+  });
+  return labels;
+}
+
+function modelNodeLabel(id, model, labels = null) {
+  if (id === "self") return "You";
+  if (labels) return labels.get(id) || "Context node";
+  for (const [, nodes, fallback] of modelNodeCandidates(model)) {
     const node = nodes.find((item) => item.id === id);
-    if (node) {
-      return compactText(
-        node.content || node.signature || node.label || node.title,
-        fallback,
-        88,
-      );
-    }
+    if (node) return modelNodeDisplayLabel(node, fallback);
   }
   return "Context node";
 }
 
-export function linePresentation(line, model) {
+export function linePresentation(line, model, nodeLabels = null) {
   const fallbackPredicate = line?.kind === "evolution" ? "supersedes" : "relation";
   const predicate = compactText(line?.predicate, fallbackPredicate, 72);
   const label = String(line?.label || "").replace(/\s+/g, " ").trim().slice(0, 88);
-  const source = modelNodeLabel(line?.source, model);
-  const target = modelNodeLabel(line?.target, model);
+  const source = modelNodeLabel(line?.source, model, nodeLabels);
+  const target = modelNodeLabel(line?.target, model, nodeLabels);
   const title = label || predicate;
   return {
     title,
@@ -152,6 +170,13 @@ export function linePresentation(line, model) {
     target,
     option: `${title}: ${source} → ${target}`,
   };
+}
+
+export function indexLinePresentations(lines, model, nodeLabels) {
+  return new Map(lines.map((line) => [
+    line.id,
+    linePresentation(line, model, nodeLabels),
+  ]));
 }
 
 export const evidenceText = { compactText, humanizePath, parseReceipt };

--- a/resources/model_assets/explore.mjs
+++ b/resources/model_assets/explore.mjs
@@ -1,0 +1,147 @@
+const KIND_PRIORITY = {
+  root: 0,
+  volume: 1,
+  face: 2,
+  point: 3,
+  line: 4,
+  context: 5,
+};
+
+function normalize(value) {
+  return String(value || "")
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLocaleLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function subsequenceScore(text, query) {
+  let cursor = -1;
+  let gap = 0;
+  for (const character of query) {
+    const next = text.indexOf(character, cursor + 1);
+    if (next < 0) return 0;
+    if (cursor >= 0) gap += next - cursor - 1;
+    cursor = next;
+  }
+  return Math.max(4, 18 - Math.min(gap, 14));
+}
+
+function scoreEntry(entry, query) {
+  const title = normalize(entry.title);
+  const searchable = normalize([
+    entry.title,
+    entry.subtitle,
+    ...(entry.aliases || []),
+  ].filter(Boolean).join(" "));
+  const terms = normalize(query).split(" ").filter(Boolean);
+  if (!terms.length) return Number(entry.weight || 0);
+
+  let score = 0;
+  for (const term of terms) {
+    if (title === term) score += 180;
+    else if (title.startsWith(term)) score += 110;
+    else if (title.split(/[^\p{L}\p{N}]+/u).some((word) => word.startsWith(term))) score += 78;
+    else if (title.includes(term)) score += 58;
+    else if (searchable.includes(term)) score += 34;
+    else {
+      const fuzzy = subsequenceScore(title, term);
+      if (!fuzzy) return null;
+      score += fuzzy;
+    }
+  }
+  return score + Number(entry.weight || 0);
+}
+
+export function rankSearchEntries(entries, query, limit = 9) {
+  const boundedLimit = Math.max(1, Math.min(50, Number(limit) || 9));
+  return entries
+    .map((entry) => ({ entry, score: scoreEntry(entry, query) }))
+    .filter(({ score }) => score !== null)
+    .sort((left, right) => (
+      right.score - left.score
+      || (KIND_PRIORITY[left.entry.kind] ?? 99) - (KIND_PRIORITY[right.entry.kind] ?? 99)
+      || String(left.entry.title || "").localeCompare(String(right.entry.title || ""))
+      || String(left.entry.key || "").localeCompare(String(right.entry.key || ""))
+    ))
+    .slice(0, boundedLimit)
+    .map(({ entry }) => entry);
+}
+
+function selectionKey(kind, id) {
+  return `${kind}:${id}`;
+}
+
+function mapValues(map, key) {
+  const value = map?.get?.(key);
+  return Array.isArray(value) ? value : [];
+}
+
+export function focusKeysForSelection(model, layout, selection) {
+  const focus = new Set();
+  if (!selection?.kind || !selection?.id) return focus;
+
+  const points = new Set((model?.points || []).map((item) => item.id));
+  const faces = new Set((model?.faces || []).map((item) => item.id));
+  const volumes = new Set((model?.volumes || []).map((item) => item.id));
+  const rootId = model?.root?.id;
+  const kindForId = (id) => {
+    if (points.has(id)) return "point";
+    if (faces.has(id)) return "face";
+    if (volumes.has(id)) return "volume";
+    if (rootId === id) return "root";
+    return "context";
+  };
+  const add = (kind, id) => {
+    if (id) focus.add(selectionKey(kind, id));
+  };
+  const addEndpoint = (id) => add(kindForId(id), id);
+  const addLine = (line) => {
+    if (!line) return;
+    add("line", line.id);
+    addEndpoint(line.source);
+    addEndpoint(line.target);
+  };
+  const addFace = (faceId, includePoints = true) => {
+    if (!faceId) return;
+    add("face", faceId);
+    if (includePoints) mapValues(layout?.facePointIds, faceId).forEach((id) => add("point", id));
+  };
+  const addVolume = (volumeId, includeFaces = true) => {
+    if (!volumeId) return;
+    add("volume", volumeId);
+    if (includeFaces) mapValues(layout?.volumeFaceIds, volumeId).forEach((id) => addFace(id, false));
+  };
+
+  add(selection.kind, selection.id);
+  if (selection.kind === "line") {
+    addLine((model?.lines || []).find((line) => line.id === selection.id));
+    return focus;
+  }
+
+  if (selection.kind === "point" || selection.kind === "context") {
+    (model?.lines || [])
+      .filter((line) => line.source === selection.id || line.target === selection.id)
+      .forEach(addLine);
+  }
+
+  if (selection.kind === "point") {
+    const cluster = layout?.pointClusterById?.get?.(selection.id);
+    if (String(cluster || "").startsWith("face:")) addFace(String(cluster).slice(5));
+  } else if (selection.kind === "face") {
+    addFace(selection.id);
+    layout?.volumeFaceIds?.forEach?.((faceIds, volumeId) => {
+      if (faceIds.includes(selection.id)) addVolume(volumeId, false);
+    });
+  } else if (selection.kind === "volume") {
+    addVolume(selection.id);
+    if ((layout?.rootVolumeIds || []).includes(selection.id) && rootId) add("root", rootId);
+  } else if (selection.kind === "root") {
+    (layout?.rootVolumeIds || []).forEach((id) => addVolume(id, false));
+  }
+
+  return focus;
+}
+
+export const exploreText = { normalize };

--- a/resources/model_assets/explore.mjs
+++ b/resources/model_assets/explore.mjs
@@ -7,6 +7,72 @@ const KIND_PRIORITY = {
   context: 5,
 };
 
+const MODEL_GESTURE_PASSTHROUGH_SELECTOR = ".detail, .line-explorer, .search-panel";
+
+export function handleSearchShortcut(event, editing, openSearch) {
+  const shortcut = (event?.metaKey || event?.ctrlKey)
+    && String(event?.key || "").toLowerCase() === "k";
+  if (!shortcut) return false;
+  // Search moves focus into its dialog. While the owner is rewriting a claim,
+  // that blur is also the save gesture, so consume the chord without opening
+  // search rather than committing text that was still being drafted.
+  event.preventDefault?.();
+  if (!editing) openSearch?.();
+  return true;
+}
+
+export function shouldHandleModelGesture(target) {
+  // These surfaces own real scrolling or native selection. The legend does not:
+  // wheel and pinch over it still belong to the model behind the explanation.
+  return !target?.closest?.(MODEL_GESTURE_PASSTHROUGH_SELECTOR);
+}
+
+export function pointerUpOutcome(event, overTarget = false) {
+  const selectionEligible = event?.pointerType !== "mouse" || event?.button === 0;
+  return {
+    selectionEligible,
+    cursor: selectionEligible && overTarget ? "pointer" : "grab",
+  };
+}
+
+export function reconcileSceneSelection(
+  selection,
+  items,
+  layerVisible,
+  kindLayers,
+  replacement = null,
+) {
+  if (!selection?.kind || !selection?.id) {
+    return { selection: null, invalidated: false, replaced: false };
+  }
+
+  let next = selection;
+  let replaced = false;
+  if (
+    replacement?.kind === selection.kind
+    && replacement?.fromId === selection.id
+    && replacement?.toId
+    && items?.has?.(selectionKey(selection.kind, replacement.toId))
+  ) {
+    next = { kind: selection.kind, id: replacement.toId };
+    replaced = replacement.toId !== selection.id;
+  }
+
+  const key = selectionKey(next.kind, next.id);
+  const layer = kindLayers?.[next.kind];
+  if (!items?.has?.(key) || (layer && !layerVisible?.[layer])) {
+    return { selection: null, invalidated: true, replaced: false };
+  }
+  return { selection: next, invalidated: false, replaced };
+}
+
+export function recoverInvalidSceneSelection(reconciliation, clearSelection, resetCamera) {
+  if (!reconciliation?.invalidated) return false;
+  clearSelection?.();
+  resetCamera?.();
+  return true;
+}
+
 function normalize(value) {
   return String(value || "")
     .normalize("NFKD")

--- a/resources/model_assets/explore.mjs
+++ b/resources/model_assets/explore.mjs
@@ -6,6 +6,9 @@ const KIND_PRIORITY = {
   line: 4,
   context: 5,
 };
+const HISTORICAL_POINT_PENALTY = -72;
+const INACTIVE_POINT_PENALTY = -56;
+const EXACT_STATE_QUERY_BOOST = 120;
 
 const MODEL_GESTURE_PASSTHROUGH_SELECTOR = ".detail, .line-explorer, .search-panel";
 
@@ -98,21 +101,114 @@ function subsequenceScore(text, query) {
   return Math.max(4, 18 - Math.min(gap, 14));
 }
 
-function scoreEntry(entry, query) {
-  const title = normalize(entry.title);
-  const searchable = normalize([
-    entry.title,
-    entry.subtitle,
-    ...(entry.aliases || []),
-  ].filter(Boolean).join(" "));
-  const terms = normalize(query).split(" ").filter(Boolean);
-  if (!terms.length) return Number(entry.weight || 0);
+function searchWeight(entry) {
+  const weight = Number(entry.weight || 0);
+  return Number.isFinite(weight) ? weight : 0;
+}
 
-  let score = 0;
+export function prepareSearchEntries(entries) {
+  // This work belongs to scene rebuilds, not the per-keystroke ranking path.
+  return entries.map((entry) => {
+    const title = String(entry.title || "Untitled").replace(/\s+/g, " ").trim();
+    const subtitle = String(entry.subtitle || "").replace(/\s+/g, " ").trim();
+    const aliases = Array.isArray(entry.aliases) ? entry.aliases.filter(Boolean) : [];
+    const stateAliases = Array.isArray(entry.stateAliases)
+      ? entry.stateAliases.filter(Boolean)
+      : [];
+    const normalizedTitle = normalize(title);
+    return {
+      ...entry,
+      title,
+      subtitle,
+      aliases,
+      stateAliases,
+      normalizedTitle,
+      normalizedSearchable: normalize([title, subtitle, ...aliases].join(" ")),
+      normalizedStateAliases: stateAliases.map(normalize).filter(Boolean),
+      normalizedTitleWords: normalizedTitle.split(/[^\p{L}\p{N}]+/u).filter(Boolean),
+    };
+  });
+}
+
+function timestamp(value, fallback = Number.NaN) {
+  if (value === null || value === undefined || value === "") return fallback;
+  const parsed = value instanceof Date ? value.getTime() : new Date(value).getTime();
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export function pointSearchMetadata(point, cutoff = new Date()) {
+  const status = String(point?.status || "").trim().toLocaleLowerCase();
+  const cutoffTime = timestamp(cutoff, Date.now());
+  const validFrom = timestamp(point?.valid_from);
+  const validUntil = timestamp(point?.valid_until);
+  const started = !Number.isFinite(validFrom) || validFrom <= cutoffTime;
+  const ended = Number.isFinite(validUntil) && validUntil <= cutoffTime;
+  const insideValidity = started && !ended;
+  // Superseding a Point rewrites its present-day lifecycle fields to
+  // is_latest=false/status=shadow. Before its valid_until, however, that
+  // predecessor is the head at the selected historical cutoff.
+  const historicalHead = !point?.is_latest && Number.isFinite(validUntil) && insideValidity;
+  const isCurrent = insideValidity && (
+    (Boolean(point?.is_latest) && status === "active") || historicalHead
+  );
+  if (isCurrent) {
+    return {
+      state: "current",
+      subtitle: "Modeled observation · current",
+      aliases: ["current", "active"],
+      weightAdjustment: 0,
+    };
+  }
+
+  if (!point?.is_latest || ended) {
+    const historyStates = [...new Set([
+      ended ? "ended" : "",
+      status && status !== "active" ? status : "",
+    ].filter(Boolean))];
+    const statusSuffix = historyStates.length ? ` · ${historyStates.join(" · ")}` : "";
+    return {
+      state: "history",
+      subtitle: `Modeled observation · historical${statusSuffix}`,
+      aliases: ["history", "historical", "not current", ...historyStates],
+      // Exact content remains findable, but a retired revision cannot outrank
+      // the current version of the same claim.
+      weightAdjustment: HISTORICAL_POINT_PENALTY,
+    };
+  }
+
+  const inactiveState = status || "inactive";
+  return {
+    state: inactiveState,
+    subtitle: `Modeled observation · ${inactiveState} · not active`,
+    aliases: [inactiveState, "inactive", "not active"],
+    weightAdjustment: INACTIVE_POINT_PENALTY,
+  };
+}
+
+function scoreEntry(entry, terms, normalizedQuery) {
+  const title = typeof entry.normalizedTitle === "string"
+    ? entry.normalizedTitle
+    : normalize(entry.title);
+  const searchable = typeof entry.normalizedSearchable === "string"
+    ? entry.normalizedSearchable
+    : normalize([
+      entry.title,
+      entry.subtitle,
+      ...(entry.aliases || []),
+    ].filter(Boolean).join(" "));
+  const titleWords = Array.isArray(entry.normalizedTitleWords)
+    ? entry.normalizedTitleWords
+    : title.split(/[^\p{L}\p{N}]+/u).filter(Boolean);
+  const stateAliases = Array.isArray(entry.normalizedStateAliases)
+    ? entry.normalizedStateAliases
+    : (entry.stateAliases || []).map(normalize).filter(Boolean);
+  if (!terms.length) return searchWeight(entry);
+
+  let score = stateAliases.includes(normalizedQuery) ? EXACT_STATE_QUERY_BOOST : 0;
   for (const term of terms) {
     if (title === term) score += 180;
     else if (title.startsWith(term)) score += 110;
-    else if (title.split(/[^\p{L}\p{N}]+/u).some((word) => word.startsWith(term))) score += 78;
+    else if (titleWords.some((word) => word.startsWith(term))) score += 78;
     else if (title.includes(term)) score += 58;
     else if (searchable.includes(term)) score += 34;
     else {
@@ -121,22 +217,45 @@ function scoreEntry(entry, query) {
       score += fuzzy;
     }
   }
-  return score + Number(entry.weight || 0);
+  return score + searchWeight(entry);
+}
+
+function compareRankedEntries(left, right) {
+  return (
+    right.score - left.score
+    || (KIND_PRIORITY[left.entry.kind] ?? 99) - (KIND_PRIORITY[right.entry.kind] ?? 99)
+    || String(left.entry.title || "").localeCompare(String(right.entry.title || ""))
+    || String(left.entry.key || "").localeCompare(String(right.entry.key || ""))
+  );
+}
+
+function insertBounded(ranked, candidate, limit) {
+  if (
+    ranked.length === limit
+    && compareRankedEntries(candidate, ranked[ranked.length - 1]) >= 0
+  ) return;
+
+  let low = 0;
+  let high = ranked.length;
+  while (low < high) {
+    const middle = (low + high) >> 1;
+    if (compareRankedEntries(candidate, ranked[middle]) < 0) high = middle;
+    else low = middle + 1;
+  }
+  ranked.splice(low, 0, candidate);
+  if (ranked.length > limit) ranked.pop();
 }
 
 export function rankSearchEntries(entries, query, limit = 9) {
   const boundedLimit = Math.max(1, Math.min(50, Number(limit) || 9));
-  return entries
-    .map((entry) => ({ entry, score: scoreEntry(entry, query) }))
-    .filter(({ score }) => score !== null)
-    .sort((left, right) => (
-      right.score - left.score
-      || (KIND_PRIORITY[left.entry.kind] ?? 99) - (KIND_PRIORITY[right.entry.kind] ?? 99)
-      || String(left.entry.title || "").localeCompare(String(right.entry.title || ""))
-      || String(left.entry.key || "").localeCompare(String(right.entry.key || ""))
-    ))
-    .slice(0, boundedLimit)
-    .map(({ entry }) => entry);
+  const normalizedQuery = normalize(query);
+  const terms = normalizedQuery.split(" ").filter(Boolean);
+  const ranked = [];
+  entries.forEach((entry) => {
+    const score = scoreEntry(entry, terms, normalizedQuery);
+    if (score !== null) insertBounded(ranked, { entry, score }, boundedLimit);
+  });
+  return ranked.map(({ entry }) => entry);
 }
 
 function selectionKey(kind, id) {

--- a/resources/model_assets/explore.mjs
+++ b/resources/model_assets/explore.mjs
@@ -21,10 +21,14 @@ export function handleSearchShortcut(event, editing, openSearch) {
   return true;
 }
 
-export function shouldHandleModelGesture(target) {
-  // These surfaces own real scrolling or native selection. The legend does not:
-  // wheel and pinch over it still belong to the model behind the explanation.
-  return !target?.closest?.(MODEL_GESTURE_PASSTHROUGH_SELECTOR);
+export function shouldHandleModelGesture(event) {
+  // A pinch is model navigation even when it starts over a scroll container;
+  // otherwise the browser zooms the entire page. Ordinary wheel input still
+  // belongs to panels with real scrolling. The legend is not one of them.
+  const pinch = Boolean(event?.ctrlKey)
+    || String(event?.type || "").startsWith("gesture");
+  if (pinch) return true;
+  return !event?.target?.closest?.(MODEL_GESTURE_PASSTHROUGH_SELECTOR);
 }
 
 export function pointerUpOutcome(event, overTarget = false) {

--- a/resources/model_assets/layout.mjs
+++ b/resources/model_assets/layout.mjs
@@ -438,6 +438,28 @@ export function computeClusterLayout(model) {
 
 export const layoutMath = { distance, magnitude, stableHash };
 
+export function fittedOverviewPose(layoutRadius, viewportWidth, viewportHeight) {
+  const width = Number.isFinite(Number(viewportWidth)) && Number(viewportWidth) > 0
+    ? Number(viewportWidth)
+    : 1;
+  const height = Number.isFinite(Number(viewportHeight)) && Number(viewportHeight) > 0
+    ? Number(viewportHeight)
+    : 1;
+  const rawRadius = Number(layoutRadius);
+  const radius = Math.max(4.8, Number.isFinite(rawRadius) && rawRadius > 0 ? rawRadius : 6);
+  const portrait = width / height < 0.72;
+  const direction = normalize([portrait ? 0.58 : 0.72, portrait ? 1.25 : 1.05, 1]);
+  const distance = Math.max(portrait ? 15 : 12, radius * (portrait ? 3.0 : 2.55));
+  return {
+    aspect: width / height,
+    portrait,
+    radius,
+    distance,
+    position: scale(direction, distance),
+    target: [0, 0, 0],
+  };
+}
+
 function pointSegmentDistanceSquared(pointer, start, end) {
   const dx = end.x - start.x;
   const dy = end.y - start.y;

--- a/resources/model_assets/layout.mjs
+++ b/resources/model_assets/layout.mjs
@@ -527,8 +527,47 @@ function nextZoomPercent(
   );
 }
 
+// A wheel event's `deltaY` means three different things depending on
+// `deltaMode`, and browsers disagree on which they send: Chrome reports pixels
+// (a notch is ~100), Firefox reports lines (a notch is ~3), and page mode shows
+// up on some remote-desktop stacks. Reduce all three to CSS pixels so one
+// gesture means the same amount of zoom everywhere.
+const WHEEL_LINE_HEIGHT_PX = 16;
+const WHEEL_PIXEL_LIMIT_PX = 400;
+
+function wheelZoomPixels(event, viewportHeight = 800) {
+  const raw = Number(event?.deltaY);
+  if (!Number.isFinite(raw)) return 0;
+  const height = Number.isFinite(viewportHeight) && viewportHeight > 0 ? viewportHeight : 800;
+  const pixels = event.deltaMode === 1
+    ? raw * WHEEL_LINE_HEIGHT_PX
+    : event.deltaMode === 2
+      ? raw * height
+      : raw;
+  // Kinetic scrolling and page mode can deliver one enormous event. Cap a
+  // single event so no gesture can teleport the camera across the whole range.
+  return Math.max(-WHEEL_PIXEL_LIMIT_PX, Math.min(WHEEL_PIXEL_LIMIT_PX, pixels));
+}
+
+// Zoom is exponential in accumulated wheel pixels, so a gesture composed of
+// many small events lands in the same place as one large event of equal total.
+// A macOS trackpad pinch (ctrlKey wheel) accumulates roughly 300px over one
+// comfortable spread, which should be worth about a doubling; a mouse notch is
+// 100px and should be a much smaller, discrete-feeling step.
+const PINCH_GAIN_PER_PX = Math.LN2 / 300;
+const WHEEL_GAIN_PER_PX = Math.log(1.16) / 100;
+
+function wheelZoomFactor(event, viewportHeight = 800) {
+  const pixels = wheelZoomPixels(event, viewportHeight);
+  const gain = event?.ctrlKey ? PINCH_GAIN_PER_PX : WHEEL_GAIN_PER_PX;
+  // Wheel-up and pinch-out both report a negative delta and both mean "closer".
+  return Math.exp(-pixels * gain);
+}
+
 export const zoomMath = {
   clampPercent: clampZoomPercent,
   nextPercent: nextZoomPercent,
   percentForDistance: zoomPercentForDistance,
+  wheelFactor: wheelZoomFactor,
+  wheelPixels: wheelZoomPixels,
 };

--- a/resources/model_assets/viewer.css
+++ b/resources/model_assets/viewer.css
@@ -232,6 +232,7 @@ button {
 .view-actions,
 .status,
 .legend,
+.mobile-guide,
 .detail,
 .timeline,
 .empty,
@@ -754,6 +755,63 @@ button {
   opacity: 0.8;
 }
 .swatch.root { color: var(--root); background: var(--root); transform: rotate(45deg); border-radius: 2px; }
+
+.mobile-guide {
+  display: none;
+}
+
+.mobile-guide > summary {
+  display: grid;
+  grid-template-columns: 10px auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 7px;
+  min-height: 26px;
+  color: var(--dim);
+  cursor: pointer;
+  list-style: none;
+}
+
+.mobile-guide > summary::-webkit-details-marker {
+  display: none;
+}
+
+.mobile-guide > summary::after {
+  grid-column: 4;
+  color: #898397;
+  content: "+";
+}
+
+.mobile-guide[open] > summary::after {
+  content: "−";
+}
+
+.mobile-guide > summary b {
+  color: #d8d4e1;
+  font-size: 10px;
+  font-weight: 650;
+}
+
+.mobile-guide > summary span:last-of-type {
+  overflow: hidden;
+  font-size: 9px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mobile-guide > summary:focus-visible {
+  border-radius: 5px;
+  outline: 2px solid var(--volume);
+  outline-offset: 5px;
+}
+
+.mobile-guide > p {
+  margin: 9px 0 0;
+  padding-top: 8px;
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+  color: #858092;
+  font-size: 9px;
+  line-height: 1.5;
+}
 
 .search-panel {
   position: fixed;
@@ -1681,6 +1739,19 @@ button {
   .brand-lockup span,
   .legend {
     display: none;
+  }
+
+  .mobile-guide {
+    position: absolute;
+    z-index: 8;
+    bottom: 76px;
+    left: 10px;
+    display: block;
+    width: min(290px, calc(100vw - 20px));
+    padding: 9px 11px;
+    border-radius: 12px;
+    background: rgba(13, 12, 24, 0.82);
+    pointer-events: auto;
   }
 
   .brand-tools {

--- a/resources/model_assets/viewer.css
+++ b/resources/model_assets/viewer.css
@@ -27,6 +27,14 @@ body {
   height: 100%;
   margin: 0;
   overflow: hidden;
+  /* The model is dragged, not scrolled: stop a two-finger swipe from rubber
+     banding the page or triggering the browser's back gesture mid-orbit. */
+  overscroll-behavior: none;
+  /* A drag across the canvas would otherwise paint a text selection across
+     whatever overlay copy it passes over. Selection comes back below on the
+     panels whose text is worth copying — a drawer's claim, and an error the
+     owner may want to paste into a bug report. */
+  user-select: none;
   background: var(--bg);
   color: var(--text);
   font: 14px/1.45 -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", sans-serif;
@@ -73,6 +81,21 @@ button {
   position: fixed;
   z-index: 1;
   inset: 0;
+}
+
+/* On the host, not only on the canvas: the label layer sits on top of the
+   canvas, and a touch that lands on a label must not start a browser pan. */
+#canvas {
+  touch-action: none;
+}
+
+/* Selection comes back where the words matter: the drawer's claim and
+   provenance, and any failure the owner might want to quote back to us. */
+.detail,
+.error,
+.edit-alert,
+.share-notice {
+  user-select: text;
 }
 
 #canvas canvas {
@@ -461,6 +484,9 @@ button {
   min-height: 54px;
   overflow: hidden;
   border-radius: 15px;
+  /* A read-only tally of the model's composition. Nothing to click, so it does
+     not get to absorb a drag. */
+  pointer-events: none;
 }
 
 .status-loading {
@@ -553,6 +579,8 @@ button {
   --build-glow: rgba(78, 240, 195, 0.72);
 }
 
+/* Inert, like .story: a legend that reads "how to read your model" has nothing
+   to click, so it must not be a place where dragging the model does nothing. */
 .legend {
   position: absolute;
   z-index: 8;
@@ -562,6 +590,7 @@ button {
   padding: 12px 14px 13px;
   border-radius: 15px;
   background: var(--surface-soft);
+  pointer-events: none;
 }
 
 .legend > p {
@@ -671,6 +700,9 @@ button {
   width: min(400px, calc(100vw - 48px));
   max-height: min(520px, calc(100vh - 190px));
   overflow: auto;
+  /* Keep a flick inside the drawer from chaining out to the page once it hits
+     the end of its content. */
+  overscroll-behavior: contain;
   padding: 22px 50px 20px 20px;
   border-radius: var(--radius);
   background:
@@ -1095,9 +1127,17 @@ button {
   pointer-events: auto;
   text-align: left;
   text-overflow: ellipsis;
-  transition: border-color 140ms ease, background 140ms ease, box-shadow 140ms ease, transform 140ms ease;
+  /* `transform` must never be transitioned here. CSS2DRenderer rewrites this
+     element's inline transform on every animation frame, so a transition on it
+     restarts every frame and the label becomes a 140ms-lagging follower of the
+     node it names — the single most visible way this view stops feeling
+     smooth while the camera moves. */
+  transition: border-color 140ms ease, background 140ms ease, box-shadow 140ms ease;
   white-space: nowrap;
-  backdrop-filter: blur(8px);
+  /* No backdrop-filter: up to twenty of these move over a canvas that repaints
+     every frame, so each one is a per-frame backdrop readback and blur, and at
+     78% background opacity almost none of it is visible anyway. */
+  will-change: transform;
 }
 
 .model-label::before {
@@ -1118,11 +1158,12 @@ button {
 .model-label[data-kind="root"] { --label-accent: var(--root); }
 .model-label[data-kind="context"] { --label-accent: var(--muted); }
 
+/* No `transform` lift here: the renderer owns this element's transform and
+   overwrites any rule with an inline one, so the lift never rendered. */
 .model-label:hover,
 .model-label:focus-visible {
   border-color: var(--label-accent);
   background: rgba(20, 17, 34, 0.96);
-  transform: translateY(-1px);
 }
 
 .model-label[aria-expanded="true"] {
@@ -1140,9 +1181,11 @@ button {
   color: var(--muted);
 }
 
+/* `display: none` rather than `visibility: hidden`: a culled label is one of
+   hundreds, and hidden is not the same as gone — laid-out labels still cost a
+   style and layout pass on every frame the camera moves. */
 .model-label.hidden {
-  visibility: hidden;
-  pointer-events: none;
+  display: none;
 }
 
 @media (min-width: 1181px) and (max-width: 1360px) {

--- a/resources/model_assets/viewer.css
+++ b/resources/model_assets/viewer.css
@@ -121,6 +121,13 @@ button {
   pointer-events: auto;
 }
 
+.brand-tools {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-width: 0;
+}
+
 .brand {
   display: flex;
   align-items: center;
@@ -169,6 +176,56 @@ button {
   font-weight: 700;
   letter-spacing: 0.18em;
   text-transform: uppercase;
+}
+
+.search-trigger {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  min-height: 36px;
+  padding: 0 8px 0 10px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 999px;
+  background: rgba(13, 12, 24, 0.6);
+  color: var(--muted);
+  cursor: pointer;
+  transition: border-color 160ms ease, background 160ms ease, color 160ms ease;
+}
+
+.search-trigger > span {
+  color: #d7d2e2;
+  font-size: 17px;
+  line-height: 1;
+}
+
+.search-trigger b {
+  overflow: hidden;
+  font-size: 10px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.search-trigger kbd,
+.search-dialog kbd {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.045);
+  color: var(--dim);
+  font: 8px/1.5 ui-monospace, "SFMono-Regular", Menlo, monospace;
+}
+
+.search-trigger kbd {
+  padding: 2px 5px;
+}
+
+.search-trigger:hover,
+.search-trigger:focus-visible {
+  border-color: rgba(119, 152, 255, 0.42);
+  outline: none;
+  background: rgba(119, 152, 255, 0.1);
+  color: var(--text);
 }
 
 .layers,
@@ -227,6 +284,18 @@ button {
   border-radius: 50%;
   background: currentColor;
   box-shadow: 0 0 8px currentColor;
+}
+
+.layers button small {
+  min-width: 19px;
+  padding: 1px 5px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.055);
+  color: currentColor;
+  font-size: 7px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.45;
+  opacity: 0.76;
 }
 
 .layers button[data-layer="points"] { color: var(--point); }
@@ -579,8 +648,6 @@ button {
   --build-glow: rgba(78, 240, 195, 0.72);
 }
 
-/* Inert, like .story: a legend that reads "how to read your model" has nothing
-   to click, so it must not be a place where dragging the model does nothing. */
 .legend {
   position: absolute;
   z-index: 8;
@@ -590,19 +657,54 @@ button {
   padding: 12px 14px 13px;
   border-radius: 15px;
   background: var(--surface-soft);
-  pointer-events: none;
+  pointer-events: auto;
 }
 
-.legend > p {
-  margin: 0 0 7px;
+.legend > summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
   color: var(--dim);
+  cursor: pointer;
   font-size: 8px;
   font-weight: 750;
   letter-spacing: 0.13em;
+  list-style: none;
   text-transform: uppercase;
 }
 
-.legend > div {
+.legend > summary::-webkit-details-marker {
+  display: none;
+}
+
+.legend > summary::after {
+  color: #898397;
+  content: "−";
+  font-size: 12px;
+  font-weight: 400;
+  letter-spacing: 0;
+}
+
+.legend:not([open]) > summary::after {
+  content: "+";
+}
+
+.legend > summary small {
+  margin-left: auto;
+  color: #706a80;
+  font-size: 7px;
+  font-weight: 650;
+  letter-spacing: 0.08em;
+}
+
+.legend-body {
+  display: grid;
+  gap: 0;
+  margin-top: 7px;
+}
+
+.legend-body > div {
   display: grid;
   grid-template-columns: 10px 47px 1fr;
   align-items: center;
@@ -612,10 +714,16 @@ button {
   font-size: 9px;
 }
 
-.legend b {
+.legend-body b {
   color: #d8d4e1;
   font-size: 9px;
   font-weight: 650;
+}
+
+.legend > summary:focus-visible {
+  border-radius: 5px;
+  outline: 2px solid var(--volume);
+  outline-offset: 5px;
 }
 
 .swatch {
@@ -627,6 +735,13 @@ button {
 
 .swatch.point { color: var(--point); background: var(--point); }
 .swatch.line { color: var(--line); height: 1px; border-radius: 0; background: var(--line); }
+.swatch.guide {
+  color: var(--muted);
+  height: 1px;
+  border-top: 1px dashed var(--muted);
+  border-radius: 0;
+  box-shadow: none;
+}
 .swatch.face { color: var(--face); border-radius: 1px; background: var(--face); transform: rotate(45deg); }
 .swatch.volume { color: var(--volume); border: 1px solid var(--volume); background: transparent; }
 /* Entities render as small grey cubes, so the swatch is a square rather than a
@@ -639,6 +754,222 @@ button {
   opacity: 0.8;
 }
 .swatch.root { color: var(--root); background: var(--root); transform: rotate(45deg); border-radius: 2px; }
+
+.search-panel {
+  position: fixed;
+  z-index: 32;
+  inset: 0;
+  display: grid;
+  align-items: start;
+  justify-items: center;
+  padding: clamp(76px, 10vh, 118px) 20px 24px;
+  background: rgba(3, 2, 8, 0.7);
+  backdrop-filter: blur(12px) saturate(115%);
+  -webkit-backdrop-filter: blur(12px) saturate(115%);
+}
+
+.search-panel[hidden] {
+  display: none;
+}
+
+.search-dialog {
+  width: min(680px, calc(100vw - 40px));
+  max-height: min(720px, calc(100dvh - 112px));
+  overflow: hidden auto;
+  padding: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 22px;
+  background:
+    radial-gradient(circle at 78% 0%, rgba(119, 152, 255, 0.12), transparent 35%),
+    rgba(10, 9, 19, 0.97);
+  box-shadow: 0 36px 120px rgba(0, 0, 0, 0.58), inset 0 1px 0 rgba(255, 255, 255, 0.055);
+  color: var(--text);
+  overscroll-behavior: contain;
+  user-select: text;
+}
+
+.search-dialog > header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.search-kicker {
+  margin: 0 0 5px;
+  color: var(--volume);
+  font-size: 8px;
+  font-weight: 750;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.search-dialog h2 {
+  margin: 0;
+  font-size: 19px;
+  font-weight: 650;
+  letter-spacing: -0.025em;
+}
+
+.search-field {
+  display: grid;
+  grid-template-columns: 24px 1fr auto;
+  align-items: center;
+  gap: 7px;
+  margin-top: 16px;
+  padding: 5px 7px 5px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.045);
+}
+
+.search-field:focus-within {
+  border-color: rgba(119, 152, 255, 0.62);
+  box-shadow: 0 0 0 3px rgba(119, 152, 255, 0.09), 0 0 28px rgba(119, 152, 255, 0.08);
+}
+
+.search-field > span {
+  color: #c4bfd0;
+  font-size: 19px;
+}
+
+.search-field input {
+  width: 100%;
+  min-height: 40px;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--text);
+  font-size: 14px;
+  user-select: text;
+}
+
+.search-field input::placeholder {
+  color: #726d7f;
+}
+
+.search-field kbd {
+  padding: 3px 6px;
+}
+
+.search-summary,
+.search-empty {
+  margin: 12px 2px 8px;
+  color: var(--dim);
+  font-size: 9px;
+}
+
+.search-results {
+  display: grid;
+  gap: 5px;
+}
+
+.search-result {
+  --result-accent: var(--muted);
+  display: grid;
+  grid-template-columns: 8px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 11px;
+  width: 100%;
+  min-height: 58px;
+  padding: 9px 11px;
+  border: 1px solid transparent;
+  border-radius: 13px;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  text-align: left;
+}
+
+.search-result[data-kind="point"] { --result-accent: var(--point); }
+.search-result[data-kind="line"] { --result-accent: var(--line); }
+.search-result[data-kind="face"] { --result-accent: var(--face); }
+.search-result[data-kind="volume"] { --result-accent: var(--volume); }
+.search-result[data-kind="root"] { --result-accent: var(--root); }
+
+.search-result > i {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--result-accent);
+  box-shadow: 0 0 9px var(--result-accent);
+}
+
+.search-result > span {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.search-result b,
+.search-result small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.search-result b {
+  font-size: 11px;
+  font-weight: 620;
+}
+
+.search-result small,
+.search-result > em {
+  color: var(--dim);
+  font-size: 8px;
+  font-style: normal;
+}
+
+.search-result > em {
+  padding: 3px 6px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  text-transform: capitalize;
+}
+
+.search-result:hover,
+.search-result:focus-visible,
+.search-result[aria-selected="true"] {
+  border-color: color-mix(in srgb, var(--result-accent) 42%, transparent);
+  outline: none;
+  background: color-mix(in srgb, var(--result-accent) 9%, transparent);
+}
+
+.search-dialog > footer {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-top: 12px;
+  padding: 10px 2px 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+  color: #6e6979;
+  font-size: 8px;
+}
+
+.search-dialog > footer span:last-child {
+  margin-left: auto;
+  color: #696475;
+}
+
+.search-dialog > footer kbd {
+  display: inline-grid;
+  min-width: 18px;
+  margin-right: 3px;
+  padding: 1px 4px;
+  place-items: center;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
 
 .line-explorer {
   position: absolute;
@@ -747,6 +1078,54 @@ button {
 
 .detail-kind {
   color: var(--detail-accent, var(--root));
+}
+
+.focus-note {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 0 0 14px;
+  padding: 8px 9px 8px 11px;
+  border: 1px solid color-mix(in srgb, var(--detail-accent, var(--root)) 22%, transparent);
+  border-radius: 11px;
+  background: color-mix(in srgb, var(--detail-accent, var(--root)) 6%, transparent);
+}
+
+.focus-note > span {
+  display: grid;
+  gap: 2px;
+}
+
+.focus-note b {
+  color: #dcd7e7;
+  font-size: 9px;
+  font-weight: 650;
+}
+
+.focus-note small {
+  color: var(--dim);
+  font-size: 8px;
+}
+
+.focus-note button {
+  flex: none;
+  min-height: 30px;
+  padding: 0 10px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.045);
+  color: #c9c3d3;
+  cursor: pointer;
+  font-size: 8px;
+}
+
+.focus-note button:hover,
+.focus-note button:focus-visible {
+  border-color: color-mix(in srgb, var(--detail-accent, var(--root)) 48%, transparent);
+  outline: none;
+  background: color-mix(in srgb, var(--detail-accent, var(--root)) 10%, transparent);
+  color: var(--text);
 }
 
 /* The claim's box lives on `.detail-claim` alone, so the heading and the
@@ -1188,7 +1567,40 @@ button {
   display: none;
 }
 
+.model-label.focus-muted {
+  opacity: 0.08;
+  pointer-events: none;
+}
+
+.model-label.focus-neighbor:not([aria-expanded="true"]) {
+  border-color: color-mix(in srgb, var(--label-accent) 38%, transparent);
+  background: rgba(12, 10, 22, 0.9);
+}
+
+@media (min-width: 1361px) and (max-width: 1640px) {
+  .action-button b {
+    display: none;
+  }
+
+  .action-button {
+    width: 36px;
+    justify-content: center;
+    padding: 0;
+  }
+}
+
 @media (min-width: 1181px) and (max-width: 1360px) {
+  .search-trigger b,
+  .search-trigger kbd {
+    display: none;
+  }
+
+  .search-trigger {
+    width: 36px;
+    justify-content: center;
+    padding: 0;
+  }
+
   .share-button {
     width: 40px;
     padding: 0;
@@ -1219,6 +1631,8 @@ button {
   }
 
   .privacy-badge,
+  .search-trigger b,
+  .search-trigger kbd,
   .action-button b,
   .gesture-hint {
     display: none;
@@ -1228,6 +1642,13 @@ button {
     width: 34px;
     padding: 0;
     justify-content: center;
+  }
+
+  .search-trigger {
+    width: 36px;
+    flex: none;
+    justify-content: center;
+    padding: 0;
   }
 
   .story {
@@ -1262,6 +1683,21 @@ button {
     display: none;
   }
 
+  .brand-tools {
+    gap: 8px;
+  }
+
+  .search-trigger {
+    width: 44px;
+    min-height: 44px;
+  }
+
+  #close-search {
+    width: 44px;
+    min-width: 44px;
+    min-height: 44px;
+  }
+
   .layers {
     grid-column: 1 / -1;
     grid-row: 2;
@@ -1274,13 +1710,30 @@ button {
   .layers button {
     justify-content: center;
     min-width: 0;
+    min-height: 44px;
     padding: 5px 3px;
     font-size: 9px;
+  }
+
+  .layers button small {
+    display: none;
   }
 
   .view-actions {
     grid-column: 2;
     grid-row: 1;
+  }
+
+  .view-actions .share-button,
+  .view-actions .action-button {
+    width: 44px;
+    min-height: 44px;
+  }
+
+  #human-card,
+  #rotate,
+  .zoom-controls {
+    display: none;
   }
 
   .share-button {
@@ -1299,7 +1752,7 @@ button {
   }
 
   .story {
-    top: 112px;
+    top: 120px;
     left: 14px;
     width: 220px;
   }
@@ -1328,7 +1781,7 @@ button {
   }
 
   .status {
-    top: 116px;
+    top: 124px;
     right: 10px;
     bottom: auto;
     left: auto;
@@ -1358,20 +1811,36 @@ button {
   }
 
   .detail {
-    right: 10px;
-    bottom: 76px;
-    left: 10px;
+    right: 0;
+    bottom: 0;
+    left: 0;
     width: auto;
-    max-height: 46vh;
+    max-height: min(66dvh, 620px);
+    padding-bottom: calc(24px + env(safe-area-inset-bottom));
+    border-radius: 22px 22px 0 0;
+  }
+
+  .detail .close {
+    width: 44px;
+    min-height: 44px;
+  }
+
+  .focus-note button {
+    min-height: 44px;
   }
 
   .timeline {
     right: 10px;
     bottom: 10px;
     left: 10px;
-    grid-template-columns: 34px minmax(0, 1fr) 48px;
+    grid-template-columns: 44px minmax(0, 1fr) 48px;
     width: auto;
     transform: none;
+  }
+
+  .timeline .icon-button {
+    width: 44px;
+    min-height: 44px;
   }
 
   .timeline-copy {
@@ -1383,6 +1852,39 @@ button {
     max-width: 128px;
     padding: 5px 8px;
     font-size: 8px;
+  }
+}
+
+@media (max-width: 640px) {
+  .stat[data-kind="faces"] {
+    display: none;
+  }
+
+  .search-panel {
+    align-items: end;
+    padding: 0;
+  }
+
+  .search-dialog {
+    width: 100%;
+    max-height: min(78dvh, 720px);
+    padding: 17px 14px calc(15px + env(safe-area-inset-bottom));
+    border-right: 0;
+    border-bottom: 0;
+    border-left: 0;
+    border-radius: 22px 22px 0 0;
+  }
+
+  .search-dialog h2 {
+    font-size: 17px;
+  }
+
+  .search-result {
+    min-height: 62px;
+  }
+
+  .search-dialog > footer span:last-child {
+    display: none;
   }
 }
 

--- a/resources/model_assets/viewer.css
+++ b/resources/model_assets/viewer.css
@@ -765,7 +765,7 @@ button {
   grid-template-columns: 10px auto minmax(0, 1fr) auto;
   align-items: center;
   gap: 7px;
-  min-height: 26px;
+  min-height: 44px;
   color: var(--dim);
   cursor: pointer;
   list-style: none;
@@ -793,7 +793,9 @@ button {
 
 .mobile-guide > summary span:last-of-type {
   overflow: hidden;
-  font-size: 9px;
+  color: #aaa4b6;
+  font-size: 10px;
+  font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
 }

--- a/resources/model_assets/viewer.js
+++ b/resources/model_assets/viewer.js
@@ -77,6 +77,7 @@ const sliderLabel = document.getElementById("as-of-label");
 const zoomOutButton = document.getElementById("zoom-out");
 const zoomResetButton = document.getElementById("zoom-reset");
 const zoomInButton = document.getElementById("zoom-in");
+const rotateButton = document.getElementById("rotate");
 const cardButton = document.getElementById("human-card");
 const shareButton = document.getElementById("share-x");
 const shareNoticeEl = document.getElementById("share-notice");
@@ -1204,7 +1205,7 @@ function selectSearchMatch(entry) {
 function pauseAutoRotate() {
   if (!controls.autoRotate) return;
   controls.autoRotate = false;
-  document.getElementById("rotate").setAttribute("aria-pressed", "false");
+  rotateButton.setAttribute("aria-pressed", "false");
 }
 
 function showShareNotice(title, message, failed = false) {
@@ -1239,8 +1240,10 @@ async function loadShareProjection() {
     });
     if (!response.ok) throw new Error(`Share endpoint returned HTTP ${response.status}`);
     const payload = await response.json();
+    const generatedAt = String(payload.generated_at || "");
     if (
-      !payload.model
+      !generatedAt
+      || !payload.model
       || !Array.isArray(payload.model.faces)
       || !Array.isArray(payload.model.volumes)
       || !payload.model.stats
@@ -1248,10 +1251,30 @@ async function loadShareProjection() {
     ) {
       throw new Error("Share endpoint returned an invalid projection");
     }
-    return payload.model;
+    return { generatedAt, model: payload.model };
   } finally {
     window.clearTimeout(timeout);
   }
+}
+
+async function loadConstellationBundle() {
+  // `/share-card` exposes only scrubbed summaries, while `/graph` supplies the
+  // private geometry already available to this owner-local viewer. Match their
+  // server generation before drawing so text/counts can never describe a newer
+  // model than the constellation. A cache expiry can land between the two GETs,
+  // so carry the newer graph into bounded retries rather than guessing.
+  let graphPayload = modelGeneratedAt ? { generated_at: modelGeneratedAt, model } : null;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const share = await loadShareProjection();
+    if (graphPayload?.generated_at === share.generatedAt) {
+      return { shareModel: share.model, graphModel: graphPayload.model };
+    }
+    graphPayload = await fetchModelGraph();
+    if (graphPayload.generated_at === share.generatedAt) {
+      return { shareModel: share.model, graphModel: graphPayload.model };
+    }
+  }
+  throw new Error("The model changed while preparing the share image. Try again.");
 }
 
 function createHumanCardBlob(shareModel) {
@@ -1269,7 +1292,7 @@ function createHumanCardBlob(shareModel) {
   });
 }
 
-function createConstellationBlob(shareModel) {
+function createConstellationBlob(shareModel, shareGraphModel = model) {
   const canvas = document.createElement("canvas");
   canvas.width = CONSTELLATION_CARD_WIDTH;
   canvas.height = CONSTELLATION_CARD_HEIGHT;
@@ -1308,18 +1331,31 @@ function createConstellationBlob(shareModel) {
     minDistance: controls.minDistance,
     maxDistance: controls.maxDistance,
     maxTargetRadius: controls.maxTargetRadius,
+    autoRotate: controls.autoRotate,
+    model,
+    minTime: new Date(minTime),
+    maxTime: new Date(maxTime),
   };
 
   try {
+    pauseAutoRotate();
     cameraFlight = null;
     zoomGoalDistance = null;
     zoomAnchor = null;
     focusVisualsSuspended = true;
 
+    const exportingDifferentModel = shareGraphModel !== model;
+    if (exportingDifferentModel) {
+      model = shareGraphModel;
+      slider.value = "100";
+      updateTimelineBounds();
+      buildScene({ frame: false, preserveSelection: true });
+    }
+
     // The share projection is current, so its picture must be current too.
     // Rebuild at Now before fitting the export; otherwise time travel would pair
     // a historical constellation with current narrative and aggregate counts.
-    if (slider.value !== "100") {
+    if (!exportingDifferentModel && slider.value !== "100") {
       slider.value = "100";
       updateCutoff();
       buildScene({ frame: false, preserveSelection: true });
@@ -1353,6 +1389,10 @@ function createConstellationBlob(shareModel) {
     renderer.setPixelRatio(viewState.pixelRatio);
     renderer.setSize(viewState.rendererSize.x, viewState.rendererSize.y, false);
 
+    const exportedDifferentModel = model !== viewState.model;
+    model = viewState.model;
+    minTime = viewState.minTime;
+    maxTime = viewState.maxTime;
     slider.value = viewState.sliderValue;
     sliderLabel.textContent = viewState.sliderLabel;
     cutoff = viewState.cutoff;
@@ -1361,7 +1401,7 @@ function createConstellationBlob(shareModel) {
     });
     // A historical export temporarily built the latest scene. Rebuild the
     // owner's exact slice before restoring the camera and focus over it.
-    if (viewState.sliderValue !== "100") {
+    if (exportedDifferentModel || viewState.sliderValue !== "100") {
       buildScene({ frame: false, preserveSelection: true });
     }
 
@@ -1380,6 +1420,8 @@ function createConstellationBlob(shareModel) {
     cameraFlight = viewState.cameraFlight;
     zoomGoalDistance = viewState.zoomGoalDistance;
     zoomAnchor = viewState.zoomAnchor;
+    controls.autoRotate = viewState.autoRotate;
+    rotateButton.setAttribute("aria-pressed", String(viewState.autoRotate));
     selected = viewState.selected;
     selectedItem = selected
       ? items.get(selectionKey(selected.kind, selected.id)) || viewState.selectedItem
@@ -1429,10 +1471,9 @@ function paintConstellationHandoff(popup) {
 
 async function exportHumanCard() {
   setShareBusy(true);
-  pauseAutoRotate();
   try {
-    const shareModel = await loadShareProjection();
-    const blob = await createHumanCardBlob(shareModel);
+    const share = await loadShareProjection();
+    const blob = await createHumanCardBlob(share.model);
     downloadShareImage(blob, HUMAN_CARD_FILE_NAME);
     showShareNotice(
       "HUMAN.md Card downloaded",
@@ -1449,10 +1490,9 @@ async function shareConstellationToX() {
   const popup = window.open("about:blank", "_blank");
   paintConstellationHandoff(popup);
   setShareBusy(true);
-  pauseAutoRotate();
   try {
-    const shareModel = await loadShareProjection();
-    const blob = await createConstellationBlob(shareModel);
+    const { shareModel, graphModel } = await loadConstellationBundle();
+    const blob = await createConstellationBlob(shareModel, graphModel);
     downloadShareImage(blob, CONSTELLATION_FILE_NAME);
     showShareNotice(
       "Constellation downloaded",
@@ -2344,7 +2384,7 @@ function updateHealthBanner(health) {
   banner.hidden = false;
 }
 
-async function loadModelOnce(force, selectionReplacement = null) {
+async function fetchModelGraph() {
   const controller = new AbortController();
   const timeout = window.setTimeout(() => controller.abort(), MODEL_GRAPH_TIMEOUT_MS);
   try {
@@ -2354,9 +2394,22 @@ async function loadModelOnce(force, selectionReplacement = null) {
     });
     if (!response.ok) throw new Error(`Model endpoint returned HTTP ${response.status}`);
     const payload = await response.json();
-    if (!payload.model || !Array.isArray(payload.model.points)) {
+    if (
+      !String(payload.generated_at || "")
+      || !payload.model
+      || !Array.isArray(payload.model.points)
+    ) {
       throw new Error("Model endpoint returned an invalid snapshot");
     }
+    return payload;
+  } finally {
+    window.clearTimeout(timeout);
+  }
+}
+
+async function loadModelOnce(force, selectionReplacement = null) {
+  try {
+    const payload = await fetchModelGraph();
     errorEl.hidden = true;
     const nextFingerprint = fingerprint(payload.model);
     if (!force && nextFingerprint === modelFingerprint) return true;
@@ -2378,8 +2431,6 @@ async function loadModelOnce(force, selectionReplacement = null) {
     // Reported rather than swallowed: a caller that just wrote to the model
     // needs to know it is still looking at pre-write state.
     return false;
-  } finally {
-    window.clearTimeout(timeout);
   }
 }
 
@@ -2844,7 +2895,7 @@ lineSelectEl.addEventListener("change", () => {
 });
 
 
-document.getElementById("rotate").addEventListener("click", (event) => {
+rotateButton.addEventListener("click", (event) => {
   controls.autoRotate = !controls.autoRotate;
   controls.autoRotateSpeed = 0.7;
   event.currentTarget.setAttribute("aria-pressed", String(controls.autoRotate));

--- a/resources/model_assets/viewer.js
+++ b/resources/model_assets/viewer.js
@@ -70,10 +70,15 @@ const scene = new THREE.Scene();
 scene.fog = new THREE.FogExp2(0x070610, 0.026);
 
 const camera = new THREE.PerspectiveCamera(50, 1, 0.1, 100);
+// No `preserveDrawingBuffer`: it makes the browser copy the whole framebuffer
+// every frame (tens of megabytes at 2x device pixel ratio) to serve readers
+// that may never come. Both readers here — samplePixels() and
+// createConstellationBlob() — read inside the same synchronous task as the
+// render that produced the pixels, which is exactly when the buffer is still
+// valid without it.
 const renderer = new THREE.WebGLRenderer({
   antialias: true,
   alpha: true,
-  preserveDrawingBuffer: true,
 });
 renderer.setClearColor(0x000000, 0);
 renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
@@ -94,10 +99,15 @@ canvasHost.appendChild(labelRenderer.domElement);
 const controls = new OrbitControls(camera, renderer.domElement);
 controls.enableDamping = true;
 controls.dampingFactor = 0.07;
-controls.zoomSpeed = 0.62;
+// OrbitControls keeps its dolly, which is what a touchscreen pinch and a
+// middle-button drag ride on, but it never sees the wheel: the viewer takes
+// that in the capture phase below. Its wheel path applies the whole delta in
+// one update and resets the accumulator, so wheel zoom landed in hard steps
+// while orbit and pan glided under damping, and it normalises by
+// `devicePixelRatio | 0`, which halves the gain on a Retina display — a full
+// trackpad pinch moved the camera 5% — and divides by zero once the ratio
+// drops below 1, where one notch teleports to the zoom limit.
 controls.zoomToCursor = true;
-controls.minDistance = 5;
-controls.maxDistance = 32;
 controls.target.set(0, 2.2, 0);
 
 scene.add(new THREE.HemisphereLight(0xdad6ff, 0x080710, 2.25));
@@ -121,6 +131,15 @@ let minTime = new Date();
 let maxTime = new Date();
 let playTimer = null;
 let pointerDown = null;
+// Which pointers are down, tracked apart from the click candidate. A gesture
+// stays live whatever it turns out to be — a second finger retires the click
+// candidate because a pinch must never select a node, and a right-drag is a
+// pan that carries no click candidate at all — and hover picking and the graph
+// poll must stay out of the way of all of them. Identities rather than a count:
+// a release can land on a label instead of the canvas, and a counter that
+// missed one would wedge closed for the rest of the session.
+const livePointers = new Set();
+let labelGesture = null;
 let hoverPointer = null;
 let hoverDirty = false;
 let selected = null;
@@ -143,6 +162,8 @@ let framedRadius = 0;
 let pulseGlows = [];
 let fitDistance = 12;
 let zoomGoalDistance = null;
+let zoomAnchor = null;
+let canvasBounds = null;
 let lastZoomPercent = null;
 let lastFrameTime = performance.now();
 let shareReady = false;
@@ -159,6 +180,15 @@ const kindLayers = {
 const raycaster = new THREE.Raycaster();
 const pointer = new THREE.Vector2();
 const zoomDirection = new THREE.Vector3();
+const zoomRaycaster = new THREE.Raycaster();
+const zoomPlane = new THREE.Plane();
+const zoomViewDirection = new THREE.Vector3();
+const zoomAnchorBefore = new THREE.Vector3();
+const zoomAnchorAfter = new THREE.Vector3();
+const zoomShift = new THREE.Vector3();
+const zoomAnchorNdc = new THREE.Vector2();
+const pickWorldPosition = new THREE.Vector3();
+const pickProjected = new THREE.Vector3();
 const MIN_NODE_HIT_RADIUS_PX = 12;
 const MIN_LINE_HIT_RADIUS_PX = 8;
 const ZOOM_MIN_PERCENT = 50;
@@ -321,9 +351,43 @@ function addLabel(text, position, layer, priority, kind, item, context = false) 
   label.position.copy(position);
   label.userData.priority = priority;
   registerSelectionTarget(kind, item.id, label);
-  element.addEventListener("pointerdown", (event) => event.stopPropagation());
+  element.addEventListener("pointerdown", (event) => {
+    if (event.pointerType === "mouse" && event.button !== 0) return;
+    // A label used to swallow the gesture outright, so the twenty of them on
+    // screen were twenty places where a drag did nothing at all. Hand the
+    // pointer to the canvas — OrbitControls captures it there and orbits — and
+    // record what was under it so a gesture that turns out to be a click still
+    // opens this label's node.
+    event.preventDefault();
+    // preventDefault also suppresses the focus the button would have taken, so
+    // give it back: a mouse user who selects a node should still be able to
+    // Tab onward from it.
+    element.focus({ preventScroll: true });
+    labelGesture = { kind, item };
+    renderer.domElement.dispatchEvent(new PointerEvent("pointerdown", {
+      pointerId: event.pointerId,
+      pointerType: event.pointerType,
+      isPrimary: event.isPrimary,
+      button: event.button,
+      buttons: event.buttons,
+      clientX: event.clientX,
+      clientY: event.clientY,
+      // Modifiers pick the gesture: shift or ctrl turns OrbitControls' left
+      // drag from an orbit into a pan, and a drag begun on a label has to mean
+      // the same thing as one begun on bare canvas.
+      ctrlKey: event.ctrlKey,
+      shiftKey: event.shiftKey,
+      altKey: event.altKey,
+      metaKey: event.metaKey,
+      bubbles: false,
+      cancelable: true,
+    }));
+  });
   element.addEventListener("click", (event) => {
     event.stopPropagation();
+    // Pointer-driven activation is resolved on the canvas above. Only keyboard
+    // activation, which reports no pointer detail, still arrives here.
+    if (event.detail !== 0) return;
     showDetails(kind, item);
   });
   register(label, layer);
@@ -686,6 +750,14 @@ function buildScene() {
   renderStatus();
   emptyEl.hidden = visiblePoints.length > 0;
   frameLayout(false);
+  // Fresh label elements and a possibly-resized status strip: both cached
+  // measurements have to be taken again.
+  invalidatePanelBoxes();
+  // A viewer that started against an empty store rendered nothing for its
+  // first frames and would otherwise have spent its whole probe budget on a
+  // blank scene, leaving the local smoke signal reading "nothing rendered"
+  // forever. A new scene deserves a fresh look.
+  renderProbeSweeps = 0;
   const renderedLines = renderedLineItems.length;
   window.__persomeViewerState = {
     schemaVersion: model.schema_version,
@@ -951,6 +1023,7 @@ function clearSelection() {
   evidenceTrail = [];
   detailEl.hidden = true;
   delete detailEl.dataset.kind;
+  invalidatePanelBoxes();
   syncSelectionState();
 }
 
@@ -1558,6 +1631,9 @@ function showDetails(kind, item) {
   selected = { kind, id: item.id };
   selectedItem = item;
   pauseAutoRotate();
+  // The drawer is one of the boxes labels are culled against, and it has just
+  // changed shape.
+  invalidatePanelBoxes();
   syncSelectionState();
   detailEl.dataset.kind = kind;
   detailKindEl.textContent = kind === "context" ? "entity" : kind;
@@ -1748,6 +1824,11 @@ function frameLayout(force) {
   controls.target.set(0, 0, 0);
   controls.minDistance = distance * 100 / ZOOM_MAX_PERCENT;
   controls.maxDistance = distance * 100 / ZOOM_MIN_PERCENT;
+  // Zooming at the cursor walks the orbit centre towards whatever is under it.
+  // Bound how far it may wander so a long pinch cannot strand the constellation
+  // off-screen with nothing left to orbit around.
+  controls.maxTargetRadius = radius * 1.5;
+  zoomAnchor = null;
   framedRadius = radius;
   controls.update();
   syncZoomUI();
@@ -1771,27 +1852,44 @@ function currentZoomPercent() {
   );
 }
 
+// Rebuilt in place rather than reallocated: syncZoomUI runs once per frame and
+// a fresh object literal per frame is pure garbage for the collector to chase
+// during exactly the gesture we are trying to keep smooth.
+window.__persomeZoomState = {
+  percent: 100,
+  distance: 0,
+  fitDistance: 0,
+  minPercent: ZOOM_MIN_PERCENT,
+  maxPercent: ZOOM_MAX_PERCENT,
+  animating: false,
+};
+
 function syncZoomUI() {
   const distance = camera.position.distanceTo(controls.target);
-  const percent = currentZoomPercent();
+  const percent = zoomMath.percentForDistance(
+    fitDistance,
+    distance,
+    ZOOM_MIN_PERCENT,
+    ZOOM_MAX_PERCENT,
+  );
+  // The DOM writes are the expensive half. They only mean anything when the
+  // rounded percent actually changes, which during a glide is a few frames out
+  // of every hundred.
   if (percent !== lastZoomPercent) {
     zoomResetButton.textContent = `${percent}%`;
     zoomResetButton.setAttribute(
       "aria-label",
       `Reset zoom to 100 percent (currently ${percent} percent)`,
     );
+    zoomOutButton.disabled = percent <= ZOOM_MIN_PERCENT;
+    zoomInButton.disabled = percent >= ZOOM_MAX_PERCENT;
     lastZoomPercent = percent;
   }
-  zoomOutButton.disabled = percent <= ZOOM_MIN_PERCENT;
-  zoomInButton.disabled = percent >= ZOOM_MAX_PERCENT;
-  window.__persomeZoomState = {
-    percent,
-    distance: Number(distance.toFixed(3)),
-    fitDistance: Number(fitDistance.toFixed(3)),
-    minPercent: ZOOM_MIN_PERCENT,
-    maxPercent: ZOOM_MAX_PERCENT,
-    animating: zoomGoalDistance !== null,
-  };
+  const state = window.__persomeZoomState;
+  state.percent = percent;
+  state.distance = Number(distance.toFixed(3));
+  state.fitDistance = Number(fitDistance.toFixed(3));
+  state.animating = zoomGoalDistance !== null;
 }
 
 function requestZoom(percent) {
@@ -1801,6 +1899,22 @@ function requestZoom(percent) {
     controls.minDistance,
     controls.maxDistance,
   );
+  zoomAnchor = null;
+}
+
+// Wheel and pinch drive the goal multiplicatively from wherever the glide is
+// already headed, so a stream of small events composes into one continuous
+// gesture instead of repeatedly restarting from the camera's current position.
+function requestZoomBy(factor, anchor) {
+  const base = zoomGoalDistance === null
+    ? camera.position.distanceTo(controls.target)
+    : zoomGoalDistance;
+  zoomGoalDistance = THREE.MathUtils.clamp(
+    base / factor,
+    controls.minDistance,
+    controls.maxDistance,
+  );
+  zoomAnchor = anchor || null;
 }
 
 function stepZoom(direction) {
@@ -1821,30 +1935,78 @@ function stepZoom(direction) {
   ));
 }
 
+// Where the ray through `ndc` meets the plane that carries the orbit target and
+// faces the camera. Zooming keeps this point pinned under the pointer.
+function anchorWorldPoint(ndc, out) {
+  camera.updateMatrixWorld();
+  zoomRaycaster.setFromCamera(ndc, camera);
+  camera.getWorldDirection(zoomViewDirection);
+  zoomPlane.setFromNormalAndCoplanarPoint(zoomViewDirection, controls.target);
+  return zoomRaycaster.ray.intersectPlane(zoomPlane, out);
+}
+
 function applyZoomAnimation(deltaSeconds) {
   if (zoomGoalDistance === null) return;
   const currentDistance = camera.position.distanceTo(controls.target);
   const nextDistance = REDUCED_MOTION
     ? zoomGoalDistance
     : THREE.MathUtils.damp(currentDistance, zoomGoalDistance, 12, deltaSeconds);
+  const settled = Math.abs(nextDistance - zoomGoalDistance) < 0.01;
+  const landedDistance = settled ? zoomGoalDistance : nextDistance;
+  const anchored = zoomAnchor !== null
+    && anchorWorldPoint(zoomAnchor, zoomAnchorBefore) !== null;
+
   zoomDirection.copy(camera.position).sub(controls.target);
   if (zoomDirection.lengthSq() < 1e-8) zoomDirection.set(0, 0, 1);
-  zoomDirection.setLength(nextDistance);
+  zoomDirection.setLength(landedDistance);
   camera.position.copy(controls.target).add(zoomDirection);
-  if (Math.abs(nextDistance - zoomGoalDistance) < 0.01) {
-    zoomDirection.setLength(zoomGoalDistance);
-    camera.position.copy(controls.target).add(zoomDirection);
+
+  if (anchored && anchorWorldPoint(zoomAnchor, zoomAnchorAfter) !== null) {
+    // Translating the camera and the orbit target by the same vector leaves the
+    // spherical radius, theta and phi untouched, so OrbitControls' damping
+    // carries on undisturbed while the anchored point stays under the pointer.
+    zoomShift.copy(zoomAnchorBefore).sub(zoomAnchorAfter);
+    camera.position.add(zoomShift);
+    controls.target.add(zoomShift);
+  }
+
+  if (settled) {
     zoomGoalDistance = null;
+    zoomAnchor = null;
   }
 }
 
-function cullLabels() {
-  const occupied = [...document.querySelectorAll(".story, .legend, .status, .timeline, .detail:not([hidden])")]
+// Reading an element's box forces the browser to flush pending layout. The
+// render loop writes a fresh inline transform onto every label each frame, so
+// layout is always dirty by the time culling runs — measuring here meant one
+// full-document reflow per frame, across hundreds of labels. Nothing being
+// measured actually changes that often: a label pill is sized by its own text
+// and a fixed max-width, and the overlay panels move only on resize or when the
+// drawer opens. Measure each once and cache.
+let occupiedPanels = null;
+
+function invalidatePanelBoxes() {
+  occupiedPanels = null;
+  canvasBounds = null;
+}
+
+function panelBoxes() {
+  if (occupiedPanels) return occupiedPanels;
+  occupiedPanels = [...document.querySelectorAll(".story, .legend, .status, .timeline, .detail:not([hidden])")]
     .map((element) => element.getBoundingClientRect())
     .filter((box) => box.width > 0 && box.height > 0)
     .map((box) => ({ x0: box.left - 6, x1: box.right + 6, y0: box.top - 6, y1: box.bottom + 6 }));
+  return occupiedPanels;
+}
+
+const cullProjected = new THREE.Vector3();
+const cullCandidates = [];
+
+function cullLabels() {
+  const occupied = panelBoxes().slice();
   const mobile = window.innerWidth < 760;
   const maxLabels = mobile ? 8 : 20;
+  const maxWidth = mobile ? 130 : 220;
   const safeArea = {
     left: mobile ? 8 : 6,
     right: window.innerWidth - (mobile ? 8 : 6),
@@ -1852,18 +2014,39 @@ function cullLabels() {
     bottom: window.innerHeight - (mobile ? 70 : 64),
   };
   let shown = 0;
-  const projected = new THREE.Vector3();
-  const candidates = labels.filter((label) => label.visible).map((label) => {
+  const projected = cullProjected;
+  cullCandidates.length = 0;
+  labels.forEach((label) => {
+    if (!label.visible) return;
     label.getWorldPosition(projected);
     projected.project(camera);
     const x = (projected.x * 0.5 + 0.5) * window.innerWidth;
     const y = (-projected.y * 0.5 + 0.5) * window.innerHeight;
-    const maxWidth = mobile ? 130 : 220;
-    const fallbackWidth = (label.element.textContent.length * 6.2) + 16;
-    const width = Math.min(maxWidth, Math.max(32, label.element.offsetWidth || fallbackWidth));
-    const height = Math.max(21, label.element.offsetHeight || 21);
-    return { label, x, y, width, height, priority: label.userData.priority || 0, depth: projected.z };
-  }).sort((a, b) => b.priority - a.priority);
+    // Measure only labels that are on screen and not yet known. Culling runs
+    // before labelRenderer.render(), so a freshly built label is not in the
+    // document on its first pass and measures zero — cache that and the size is
+    // wrong for as long as the label lives. A culled label is display:none and
+    // measures zero too, so asking it costs a reflow and answers nothing.
+    // Everything else settles after one read and is never measured again.
+    if (!label.userData.measuredWidth && !label.element.classList.contains("hidden")) {
+      const measured = label.element.offsetWidth;
+      if (measured) {
+        label.userData.measuredWidth = Math.max(32, measured);
+        label.userData.measuredHeight = Math.max(21, label.element.offsetHeight || 21);
+      }
+    }
+    const estimatedWidth = (label.element.textContent.length * 6.2) + 16;
+    cullCandidates.push({
+      label,
+      x,
+      y,
+      width: Math.min(maxWidth, label.userData.measuredWidth || Math.max(32, estimatedWidth)),
+      height: label.userData.measuredHeight || 21,
+      priority: label.userData.priority || 0,
+      depth: projected.z,
+    });
+  });
+  const candidates = cullCandidates.sort((a, b) => b.priority - a.priority);
 
   candidates.forEach((candidate) => {
     const { label, x, y, width, height, depth } = candidate;
@@ -1885,8 +2068,22 @@ function cullLabels() {
   window.__persomeLabelHealth = { total: labels.length, shown, max: maxLabels };
 }
 
+// Each gl.readPixels blocks until the GPU catches up, so this 77-point sweep is
+// 77 pipeline stalls. It only latched once it saw something lit, and a viewer
+// whose model is empty, still loading, or has every layer toggled off never
+// does — so the render loop paid the whole sweep on every frame, forever, in
+// exactly the states where the owner is most likely to be poking at the
+// controls. The sweep is unchanged; it is now bounded, and it reuses one
+// buffer instead of allocating 77 per frame. It must stay inside the render
+// task: without `preserveDrawingBuffer` the pixels are only valid there.
+const RENDER_PROBE_MAX_SWEEPS = 30;
+const renderProbePixel = new Uint8Array(4);
+let renderProbeSweeps = 0;
+
 function samplePixels() {
   if (window.__persomeModelRender?.lit > 0) return;
+  if (renderProbeSweeps >= RENDER_PROBE_MAX_SWEEPS) return;
+  renderProbeSweeps += 1;
   const gl = renderer.getContext();
   const width = gl.drawingBufferWidth;
   const height = gl.drawingBufferHeight;
@@ -1894,13 +2091,12 @@ function samplePixels() {
   let checked = 0;
   for (let y = 1; y < 8; y += 1) {
     for (let x = 1; x < 12; x += 1) {
-      const pixel = new Uint8Array(4);
-      gl.readPixels(Math.floor(width * x / 12), Math.floor(height * y / 8), 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixel);
+      gl.readPixels(Math.floor(width * x / 12), Math.floor(height * y / 8), 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, renderProbePixel);
       checked += 1;
-      if (pixel[0] + pixel[1] + pixel[2] > 96) lit += 1;
+      if (renderProbePixel[0] + renderProbePixel[1] + renderProbePixel[2] > 96) lit += 1;
     }
   }
-  window.__persomeModelRender = { width, height, checked, lit };
+  window.__persomeModelRender = { width, height, checked, lit, sweeps: renderProbeSweeps };
   canvasHost.dataset.litPixels = String(lit);
 }
 
@@ -1930,6 +2126,93 @@ zoomResetButton.addEventListener("click", () => requestZoom(100));
 zoomInButton.addEventListener("click", () => stepZoom(1));
 controls.addEventListener("start", () => {
   zoomGoalDistance = null;
+  zoomAnchor = null;
+});
+
+// Zoom input lives on the whole viewer, not just the canvas: the topbar, the
+// legend and the status strip cover a good part of the screen, and a wheel that
+// lands on one of them used to fall through to the browser instead of the
+// model. The drawer is a real scroll container, so it keeps its own wheel.
+function anchorFromClient(clientX, clientY) {
+  // Cached: a trackpad delivers wheel events faster than the display refreshes,
+  // and this rect only moves when the window does.
+  if (!canvasBounds) canvasBounds = renderer.domElement.getBoundingClientRect();
+  const bounds = canvasBounds;
+  if (!bounds.width || !bounds.height) return null;
+  zoomAnchorNdc.set(
+    ((clientX - bounds.left) / bounds.width) * 2 - 1,
+    -((clientY - bounds.top) / bounds.height) * 2 + 1,
+  );
+  return zoomAnchorNdc;
+}
+
+// Safari reports a trackpad pinch as its own gesture events and never as a
+// ctrlKey wheel, so a viewer that only listens for the wheel has no pinch at
+// all there. These listeners are registered unconditionally: engines that do
+// not implement the events simply never fire them, which is cheaper and more
+// honest than sniffing for a vendor hook whose name has moved around.
+let gestureScale = 0;
+let gestureSeenAt = 0;
+const gestureAnchor = new THREE.Vector2();
+const GESTURE_IDLE_MS = 400;
+
+// A gesture whose `gestureend` never arrives must not wedge the wheel off for
+// the rest of the session, so an idle gesture is treated as finished.
+function gestureInFlight() {
+  if (!gestureScale) return false;
+  if (performance.now() - gestureSeenAt < GESTURE_IDLE_MS) return true;
+  gestureScale = 0;
+  return false;
+}
+
+// Capture phase on the whole viewer, so this runs before OrbitControls' own
+// wheel listener on the canvas and stops the event reaching it. That leaves
+// OrbitControls' touch and middle-button dolly intact while the wheel — the
+// path with the bad normalisation and no damping — belongs to the viewer. It
+// also means a wheel over the topbar, legend or status strip zooms the model
+// instead of falling through to the browser.
+viewerEl.addEventListener("wheel", (event) => {
+  // The drawer and the line picker are real scroll containers; leave them be.
+  if (event.target.closest?.(".detail, .line-explorer")) return;
+  event.stopPropagation();
+  // If a gesture is in flight this wheel is the same fingers counted twice.
+  if (gestureInFlight()) return;
+  // Chrome and Firefox report a trackpad pinch as a wheel with ctrlKey set,
+  // which is also the browser's own page-zoom chord: without preventDefault the
+  // page would zoom instead of the model.
+  event.preventDefault();
+  pauseAutoRotate();
+  requestZoomBy(
+    zoomMath.wheelFactor(event, window.innerHeight),
+    anchorFromClient(event.clientX, event.clientY),
+  );
+}, { passive: false, capture: true });
+
+viewerEl.addEventListener("gesturestart", (event) => {
+  if (event.target.closest?.(".detail, .line-explorer")) return;
+  event.preventDefault();
+  gestureScale = 1;
+  gestureSeenAt = performance.now();
+  if (anchorFromClient(event.clientX, event.clientY)) gestureAnchor.copy(zoomAnchorNdc);
+  else gestureAnchor.set(0, 0);
+  pauseAutoRotate();
+});
+viewerEl.addEventListener("gesturechange", (event) => {
+  if (!gestureScale) return;
+  event.preventDefault();
+  gestureSeenAt = performance.now();
+  const scale = Number(event.scale);
+  if (!Number.isFinite(scale) || scale <= 0) return;
+  // `scale` is cumulative since gesturestart, so the step is the ratio since
+  // the last event — which composes into the same goal a wheel stream would.
+  zoomAnchorNdc.copy(gestureAnchor);
+  requestZoomBy(scale / gestureScale, zoomAnchorNdc);
+  gestureScale = scale;
+});
+viewerEl.addEventListener("gestureend", (event) => {
+  if (!gestureScale) return;
+  event.preventDefault();
+  gestureScale = 0;
 });
 document.getElementById("reset").addEventListener("click", resetCamera);
 document.getElementById("close-detail").addEventListener("click", clearSelection);
@@ -1969,8 +2252,11 @@ function pickAt(event) {
     x: event.clientX - bounds.left,
     y: event.clientY - bounds.top,
   };
+  // Projecting into a shared scratch vector rather than cloning per candidate:
+  // hover picking runs on the frame after every pointer move, over every
+  // visible node, so a clone per node is a steady drip of garbage.
   const projectWorldPoint = (worldPosition) => {
-    const projected = worldPosition.clone().project(camera);
+    const projected = pickProjected.copy(worldPosition).project(camera);
     if (projected.z < -1 || projected.z > 1) return null;
     return {
       x: (projected.x + 1) * 0.5 * bounds.width,
@@ -1978,10 +2264,10 @@ function pickAt(event) {
       depth: projected.z,
     };
   };
-  const worldPosition = new THREE.Vector3();
-  const nodeCandidates = pickables.filter((object) => object.visible).map((object) => {
-    object.getWorldPosition(worldPosition);
-    const projected = projectWorldPoint(worldPosition);
+  const visiblePickables = pickables.filter((object) => object.visible);
+  const nodeCandidates = visiblePickables.map((object) => {
+    object.getWorldPosition(pickWorldPosition);
+    const projected = projectWorldPoint(pickWorldPosition);
     return projected ? { ...projected, target: object } : null;
   }).filter(Boolean);
   const screenNode = pickScreenTarget(
@@ -1995,10 +2281,7 @@ function pickAt(event) {
   pointer.x = (localPointer.x / bounds.width) * 2 - 1;
   pointer.y = -(localPointer.y / bounds.height) * 2 + 1;
   raycaster.setFromCamera(pointer, camera);
-  const meshHit = raycaster.intersectObjects(
-    pickables.filter((object) => object.visible),
-    false,
-  )[0];
+  const meshHit = raycaster.intersectObjects(visiblePickables, false)[0];
   if (meshHit) return meshHit;
 
   const lineCandidates = screenLinePickables.filter((object) => object.visible).map((object) => {
@@ -2022,33 +2305,76 @@ function pickAt(event) {
   return screenLine ? { object: screenLine } : null;
 }
 
+// How far a pointer may travel and still count as a click rather than a drag.
+// Measured as a real distance, not the sum of the axes, so a diagonal nudge is
+// not penalised twice; a finger wobbles far more than a mouse does.
+function clickSlopFor(pointerType) {
+  if (pointerType === "touch") return 12;
+  if (pointerType === "pen") return 8;
+  return 5;
+}
+
 renderer.domElement.addEventListener("pointerdown", (event) => {
-  pointerDown = { x: event.clientX, y: event.clientY };
+  // Every button counts as a live gesture: the right button pans and the middle
+  // button dollies, and neither wants hover picking running underneath it. Only
+  // the primary button can become a click.
+  livePointers.add(event.pointerId);
+  const primary = event.pointerType !== "mouse" || event.button === 0;
+  // A second finger means a pinch. Whatever the first finger was doing, it was
+  // not choosing a node, so retire the click candidate rather than letting the
+  // gesture end in an accidental selection.
+  pointerDown = primary && livePointers.size === 1
+    ? { x: event.clientX, y: event.clientY, type: event.pointerType }
+    : null;
+  if (livePointers.size > 1 || !primary) labelGesture = null;
   hoverDirty = false;
+  hoverPointer = null;
   renderer.domElement.style.cursor = "grabbing";
 });
 renderer.domElement.addEventListener("pointermove", (event) => {
-  if (pointerDown) return;
+  if (livePointers.size) return;
   hoverPointer = { clientX: event.clientX, clientY: event.clientY };
   hoverDirty = true;
 });
 renderer.domElement.addEventListener("pointerleave", () => {
   hoverPointer = null;
   hoverDirty = false;
-  if (!pointerDown) renderer.domElement.style.cursor = "grab";
+  if (!livePointers.size) renderer.domElement.style.cursor = "grab";
 });
+
+// Releases are pruned on the window, not the canvas. A gesture that began on a
+// label is captured by the canvas, but a second, uncaptured pointer releases
+// wherever it happens to be — on the label, on an overlay — and a pointer left
+// behind in the set would stop hover picking and the graph poll for good.
+window.addEventListener("pointerup", (event) => livePointers.delete(event.pointerId), true);
+window.addEventListener("pointercancel", (event) => livePointers.delete(event.pointerId), true);
+
 renderer.domElement.addEventListener("pointercancel", () => {
   pointerDown = null;
+  labelGesture = null;
   hoverPointer = null;
   hoverDirty = false;
   renderer.domElement.style.cursor = "grab";
 });
 renderer.domElement.addEventListener("pointerup", (event) => {
-  if (!pointerDown) return;
-  const movement = Math.abs(event.clientX - pointerDown.x) + Math.abs(event.clientY - pointerDown.y);
+  if (event.pointerType === "mouse" && event.button !== 0) return;
+  const started = pointerDown;
+  const label = labelGesture;
   pointerDown = null;
-  if (movement > 5) {
+  labelGesture = null;
+  if (!started) return;
+  const dx = event.clientX - started.x;
+  const dy = event.clientY - started.y;
+  const slop = clickSlopFor(started.type);
+  if (dx * dx + dy * dy > slop * slop) {
     renderer.domElement.style.cursor = "grab";
+    return;
+  }
+  // A gesture that began on a label and stayed put is that label's click; the
+  // canvas captured the pointer, so the label never sees a click of its own.
+  if (label) {
+    renderer.domElement.style.cursor = "pointer";
+    showDetails(label.kind, label.item);
     return;
   }
   const hit = pickAt(event);
@@ -2100,6 +2426,7 @@ window.addEventListener("resize", () => {
   camera.updateProjectionMatrix();
   renderer.setSize(window.innerWidth, window.innerHeight);
   labelRenderer.setSize(window.innerWidth, window.innerHeight);
+  invalidatePanelBoxes();
   const portrait = window.innerWidth / window.innerHeight < 0.72;
   if (portrait !== portraitMode) resetCamera();
 });
@@ -2113,11 +2440,39 @@ window.addEventListener("unhandledrejection", (event) => {
   errorEl.hidden = false;
 });
 
+// A rolling window of how long each frame's own work took, so a smoothness
+// regression is a number somebody can read rather than a feeling. Written into
+// a pre-allocated ring: a probe that allocates every frame would measure itself.
+const FRAME_SAMPLE_COUNT = 240;
+const frameSamples = new Float32Array(FRAME_SAMPLE_COUNT);
+const frameSamplesSorted = new Float32Array(FRAME_SAMPLE_COUNT);
+let frameSampleIndex = 0;
+let frameSampleFilled = 0;
+window.__persomeFrameStats = { p50: 0, p95: 0, worst: 0, samples: 0 };
+
+function recordFrameCost(milliseconds) {
+  frameSamples[frameSampleIndex] = milliseconds;
+  frameSampleIndex = (frameSampleIndex + 1) % FRAME_SAMPLE_COUNT;
+  frameSampleFilled = Math.min(FRAME_SAMPLE_COUNT, frameSampleFilled + 1);
+  if (frameSampleIndex % 30 !== 0) return;
+  frameSamplesSorted.set(frameSamples);
+  const recent = frameSamplesSorted.subarray(0, frameSampleFilled);
+  recent.sort();
+  const stats = window.__persomeFrameStats;
+  stats.p50 = Number(recent[Math.floor(frameSampleFilled * 0.5)].toFixed(2));
+  stats.p95 = Number(recent[Math.floor(frameSampleFilled * 0.95)].toFixed(2));
+  stats.worst = Number(recent[frameSampleFilled - 1].toFixed(2));
+  stats.samples = frameSampleFilled;
+}
+
 function animate(frameTime = performance.now()) {
+  const frameStart = performance.now();
   const deltaSeconds = Math.min(Math.max((frameTime - lastFrameTime) / 1000, 0), 0.5);
   lastFrameTime = frameTime;
   applyZoomAnimation(deltaSeconds);
-  controls.update();
+  // Auto-rotate advances by wall time rather than by frame, so the model turns
+  // at one speed whether the display runs at 60Hz or 120Hz.
+  controls.update(deltaSeconds);
   syncZoomUI();
   const time = performance.now() * 0.001;
   if (!REDUCED_MOTION) {
@@ -2126,7 +2481,7 @@ function animate(frameTime = performance.now()) {
       glow.scale.setScalar(glow.userData.glowBase * pulse);
     });
   }
-  if (hoverDirty && hoverPointer && !pointerDown) {
+  if (hoverDirty && hoverPointer && !livePointers.size) {
     renderer.domElement.style.cursor = pickAt(hoverPointer) ? "pointer" : "grab";
     hoverDirty = false;
   }
@@ -2134,10 +2489,16 @@ function animate(frameTime = performance.now()) {
   renderer.render(scene, camera);
   labelRenderer.render(scene, camera);
   samplePixels();
+  recordFrameCost(performance.now() - frameStart);
   window.requestAnimationFrame(animate);
 }
 
 resetCamera();
 animate();
 await loadModel(true);
-window.setInterval(() => loadModel(false), 5000);
+window.setInterval(() => {
+  // Parsing a multi-megabyte snapshot and fingerprinting every Point takes long
+  // enough to drop frames. Never do it under the owner's finger.
+  if (livePointers.size) return;
+  loadModel(false);
+}, 5000);

--- a/resources/model_assets/viewer.js
+++ b/resources/model_assets/viewer.js
@@ -10,7 +10,9 @@ import {
 import {
   focusKeysForSelection,
   handleSearchShortcut,
+  pointSearchMetadata,
   pointerUpOutcome,
+  prepareSearchEntries,
   rankSearchEntries,
   reconcileSceneSelection,
   recoverInvalidSceneSelection,
@@ -19,7 +21,8 @@ import {
 import {
   evidenceBreadcrumb,
   evidenceOverview,
-  linePresentation,
+  indexLinePresentations,
+  modelNodeLabelIndex,
   nodeEvidenceCards,
   nodeHistoryCards,
   relationLabel,
@@ -184,6 +187,8 @@ let lineNavigatorItems = [];
 let selectionTargets = new Map();
 let positions = new Map();
 let items = new Map();
+let sceneNodeLabels = new Map();
+let linePresentations = new Map();
 let layerObjects = freshLayerObjects();
 let currentLayout = null;
 let layoutRadius = 6;
@@ -550,7 +555,7 @@ function renderLineExplorer(lines) {
   lines.forEach((line, index) => {
     const option = document.createElement("option");
     option.value = String(index + 1);
-    option.textContent = linePresentation(line, model).option;
+    option.textContent = linePresentations.get(line.id)?.option || "Relationship";
     lineSelectEl.appendChild(option);
   });
   lineExplorerEl.hidden = lines.length === 0;
@@ -582,6 +587,8 @@ function disposeGraph() {
   selectionTargets = new Map();
   positions = new Map();
   items = new Map();
+  sceneNodeLabels = new Map();
+  linePresentations = new Map();
   layerObjects = freshLayerObjects();
   pulseGlows = [];
   focusLabels = [];
@@ -927,6 +934,8 @@ function buildScene({
   const renderedLineItems = visibleLines.filter(
     (line) => positions.has(line.source) && positions.has(line.target),
   );
+  sceneNodeLabels = modelNodeLabelIndex(sceneModel);
+  linePresentations = indexLinePresentations(renderedLineItems, sceneModel, sceneNodeLabels);
   renderLineExplorer(renderedLineItems);
   visibleFaces.forEach((face) => addFace(face, labeledFaces.has(face.id)));
   visibleVolumes.forEach((volume) => addVolume(volume, labeledVolumes.has(volume.id)));
@@ -1039,18 +1048,15 @@ function updateLayerCounts(counts) {
   });
 }
 
-function searchTitle(kind, item) {
-  if (kind === "line") return linePresentation(item, sceneModel).title;
+function searchTitle(kind, item, lineDetail = null) {
+  if (kind === "line") return lineDetail?.title || item.label || item.predicate || item.kind || item.id;
   return item.content || item.signature || item.label || item.predicate || item.kind || item.id;
 }
 
-function searchSubtitle(kind, item) {
-  if (kind === "point") {
-    return item.status === "active" ? "Modeled observation · active" : "Modeled observation";
-  }
+function searchSubtitle(kind, item, lineDetail = null, pointDetail = null) {
+  if (kind === "point") return pointDetail?.subtitle || "Modeled observation · not active";
   if (kind === "line") {
-    const presentation = linePresentation(item, sceneModel);
-    return `${presentation.source} → ${presentation.target}`;
+    return lineDetail ? `${lineDetail.source} → ${lineDetail.target}` : "Relationship";
   }
   if (kind === "face") return "Stable pattern";
   if (kind === "volume") return "Cross-pattern structure";
@@ -1058,33 +1064,41 @@ function searchSubtitle(kind, item) {
   return "Context referenced by a relation";
 }
 
-function searchWeight(kind, item) {
+function searchWeight(kind, item, pointDetail = null) {
   const observations = Math.min(8, Number(item.observations || 0));
   if (kind === "root") return 24;
   if (kind === "volume") return 18 + observations;
   if (kind === "face") return 12 + observations;
-  if (kind === "point") return 6 + Math.min(4, Number(item.confidence || 0) * 4);
+  if (kind === "point") {
+    return 6
+      + Math.min(4, Number(item.confidence || 0) * 4)
+      + Number(pointDetail?.weightAdjustment || 0);
+  }
   if (kind === "line") return 3;
   return 1;
 }
 
 function rebuildSearchEntries() {
-  searchEntries = [...items.entries()].map(([key, item]) => {
+  const entries = [...items.entries()].map(([key, item]) => {
     const separator = key.indexOf(":");
     const kind = separator > 0 ? key.slice(0, separator) : "context";
-    const lineDetail = kind === "line" ? linePresentation(item, sceneModel) : null;
+    const lineDetail = kind === "line" ? linePresentations.get(item.id) : null;
+    const pointDetail = kind === "point" ? pointSearchMetadata(item, cutoff) : null;
     return {
       key,
       kind,
       id: item.id,
-      title: String(searchTitle(kind, item) || "Untitled").replace(/\s+/g, " ").trim(),
-      subtitle: searchSubtitle(kind, item),
+      title: searchTitle(kind, item, lineDetail),
+      subtitle: searchSubtitle(kind, item, lineDetail, pointDetail),
       aliases: lineDetail
         ? [lineDetail.predicate, lineDetail.label, lineDetail.source, lineDetail.target, item.kind]
-        : [item.kind, item.status],
-      weight: searchWeight(kind, item),
+        : [...new Set([item.kind, item.status, ...(pointDetail?.aliases || [])].filter(Boolean))],
+      stateAliases: pointDetail?.aliases || [],
+      weight: searchWeight(kind, item, pointDetail),
+      searchState: pointDetail?.state || "",
     };
   });
+  searchEntries = prepareSearchEntries(entries);
   if (!searchPanelEl.hidden) renderSearchResults();
 }
 
@@ -1118,6 +1132,7 @@ function renderSearchResults() {
     button.tabIndex = -1;
     button.className = "search-result";
     button.dataset.kind = entry.kind;
+    if (entry.searchState) button.dataset.searchState = entry.searchState;
     button.setAttribute("role", "option");
     button.setAttribute("aria-selected", String(index === searchActiveIndex));
 
@@ -2202,7 +2217,7 @@ function showDetails(kind, item, returnFocus = null) {
       ? candidate
       : openSearchButton;
   }
-  const lineDetail = kind === "line" ? linePresentation(item, model) : null;
+  const lineDetail = kind === "line" ? linePresentations.get(item.id) : null;
   selected = { kind, id: item.id };
   selectedItem = item;
   pauseAutoRotate();
@@ -2281,7 +2296,7 @@ function updateCutoff() {
 function fingerprint(nextModel) {
   return JSON.stringify({
     points: nextModel.points.map((item) => [
-      item.id, item.status, item.is_latest, item.content, item.valid_from,
+      item.id, item.status, item.is_latest, item.content, item.valid_from, item.valid_until,
     ]),
     lines: nextModel.lines.map((item) => [item.id, item.predicate, item.valid_from]),
     faces: nextModel.faces.map((item) => [

--- a/resources/model_assets/viewer.js
+++ b/resources/model_assets/viewer.js
@@ -2,7 +2,15 @@ import * as THREE from "three";
 import { OrbitControls } from "three/addons/controls/OrbitControls.js";
 import { CSS2DObject, CSS2DRenderer } from "three/addons/renderers/CSS2DRenderer.js";
 import { computeClusterLayout, pickScreenTarget, zoomMath } from "./layout.mjs";
-import { focusKeysForSelection, rankSearchEntries } from "./explore.mjs";
+import {
+  focusKeysForSelection,
+  handleSearchShortcut,
+  pointerUpOutcome,
+  rankSearchEntries,
+  reconcileSceneSelection,
+  recoverInvalidSceneSelection,
+  shouldHandleModelGesture,
+} from "./explore.mjs";
 import {
   evidenceBreadcrumb,
   evidenceOverview,
@@ -865,7 +873,7 @@ function addGround() {
   addOrbitRing(radius * 0.72, COLORS.root, 0.055, [Math.PI / 2.8, 0.42, 0.18], ringLayer);
 }
 
-function buildScene() {
+function buildScene(selectionReplacement = null) {
   disposeGraph();
   const visiblePoints = model.points.filter(visibleAt).sort((a, b) => a.id.localeCompare(b.id));
   const visibleFaces = model.faces.filter(visibleAt);
@@ -924,7 +932,7 @@ function buildScene() {
   };
   updateLayerCounts(currentCounts);
   rebuildSearchEntries();
-  applyLayerVisibility();
+  applyLayerVisibility(selectionReplacement);
   renderStatus(currentCounts);
   emptyEl.hidden = visiblePoints.length > 0;
   frameLayout(false);
@@ -1439,7 +1447,7 @@ function showAllModel() {
   resetCamera();
 }
 
-function applyLayerVisibility() {
+function applyLayerVisibility(selectionReplacement = null) {
   Object.entries(layerObjects).forEach(([layer, objects]) => {
     objects.forEach((object) => {
       const visible = layer === "hierarchy"
@@ -1457,13 +1465,24 @@ function applyLayerVisibility() {
   document.querySelectorAll("[data-layer]").forEach((button) => {
     button.setAttribute("aria-pressed", String(layerVisible[button.dataset.layer]));
   });
-  if (selected) {
-    const key = selectionKey(selected.kind, selected.id);
-    const layer = kindLayers[selected.kind];
-    if (!items.has(key) || (layer && !layerVisible[layer])) {
-      clearSelection();
-      return;
-    }
+  const reconciliation = reconcileSceneSelection(
+    selected,
+    items,
+    layerVisible,
+    kindLayers,
+    selectionReplacement,
+  );
+  if (reconciliation.invalidated) {
+    // The selected object may have been the camera's orbit target after search
+    // focus. Once a cutoff or layer removes it, the drawer's Show all action is
+    // gone too, so restore the fitted overview here rather than leaving an
+    // apparently empty viewport aimed at a node that no longer exists.
+    recoverInvalidSceneSelection(reconciliation, clearSelection, resetCamera);
+    return;
+  }
+  if (reconciliation.replaced) {
+    selected = reconciliation.selection;
+    selectedItem = items.get(selectionKey(selected.kind, selected.id)) || null;
   }
   syncSelectionState();
 }
@@ -1865,14 +1884,22 @@ async function submitEdit(kind, item, op, replacement, reason) {
       slider.value = "100";
       updateCutoff();
     }
-    const refreshed = await loadModel(true);
-    // The awaits above can span seconds. If the owner selected something else
-    // meanwhile, that selection is theirs.
-    if (!selected || selected.kind !== kind || selected.id !== item.id) return;
+    const refreshed = await loadModel(true, {
+      kind,
+      fromId: item.id,
+      toId: nextId,
+    });
     if (refreshed === false) {
-      setEditStatus("Saved, but the view could not refresh. Reload to see it.", "warn");
+      // The awaits above can span seconds. Do not write a warning into a detail
+      // drawer the owner opened for something else while this request ran.
+      if (selected?.kind === kind && selected.id === item.id) {
+        setEditStatus("Saved, but the view could not refresh. Reload to see it.", "warn");
+      }
       return;
     }
+    // A Point rewrite moves selection to its successor during scene rebuild.
+    // If the owner selected something else meanwhile, that selection is theirs.
+    if (!selected || selected.kind !== kind || selected.id !== nextId) return;
     if (op === "retire") {
       clearSelection();
       return;
@@ -2182,7 +2209,7 @@ function updateHealthBanner(health) {
   banner.hidden = false;
 }
 
-async function loadModelOnce(force) {
+async function loadModelOnce(force, selectionReplacement = null) {
   const controller = new AbortController();
   const timeout = window.setTimeout(() => controller.abort(), MODEL_GRAPH_TIMEOUT_MS);
   try {
@@ -2207,7 +2234,7 @@ async function loadModelOnce(force) {
     );
     setShareBusy(false);
     updateTimelineBounds();
-    buildScene();
+    buildScene(selectionReplacement);
     return true;
   } catch (error) {
     shareReady = false;
@@ -2221,14 +2248,14 @@ async function loadModelOnce(force) {
   }
 }
 
-function loadModel(force = false) {
+function loadModel(force = false, selectionReplacement = null) {
   // A forced load must actually observe the server again. Returning an
   // in-flight promise silently dropped `force`, so a poll issued microseconds
   // before a correction was saved would satisfy the reload that follows the
   // save — and the drawer would re-render from the pre-edit snapshot while
   // reporting success. A forced load now queues behind whatever is running.
   if (modelLoadPromise && !force) return modelLoadPromise;
-  const run = () => loadModelOnce(force);
+  const run = () => loadModelOnce(force, selectionReplacement);
   const started = modelLoadPromise ? modelLoadPromise.then(run, run) : run();
   const chained = started.finally(() => {
     // Only the newest load clears the slot; an older one finishing later must
@@ -2741,8 +2768,8 @@ function gestureInFlight() {
 // also means a wheel over the topbar, legend or status strip zooms the model
 // instead of falling through to the browser.
 viewerEl.addEventListener("wheel", (event) => {
-  // The drawer and the line picker are real scroll containers; leave them be.
-  if (event.target.closest?.(".detail, .line-explorer, .search-panel, .legend")) return;
+  // The drawer, line picker, and search panel own real scrolling; leave them be.
+  if (!shouldHandleModelGesture(event.target)) return;
   event.stopPropagation();
   // If a gesture is in flight this wheel is the same fingers counted twice.
   if (gestureInFlight()) return;
@@ -2758,7 +2785,7 @@ viewerEl.addEventListener("wheel", (event) => {
 }, { passive: false, capture: true });
 
 viewerEl.addEventListener("gesturestart", (event) => {
-  if (event.target.closest?.(".detail, .line-explorer, .search-panel, .legend")) return;
+  if (!shouldHandleModelGesture(event.target)) return;
   event.preventDefault();
   gestureScale = 1;
   gestureSeenAt = performance.now();
@@ -2930,12 +2957,19 @@ renderer.domElement.addEventListener("pointercancel", () => {
   renderer.domElement.style.cursor = "grab";
 });
 renderer.domElement.addEventListener("pointerup", (event) => {
-  if (event.pointerType === "mouse" && event.button !== 0) return;
+  const release = pointerUpOutcome(event);
+  if (!release.selectionEligible) {
+    renderer.domElement.style.cursor = release.cursor;
+    return;
+  }
   const started = pointerDown;
   const label = labelGesture;
   pointerDown = null;
   labelGesture = null;
-  if (!started) return;
+  if (!started) {
+    renderer.domElement.style.cursor = release.cursor;
+    return;
+  }
   const dx = event.clientX - started.x;
   const dy = event.clientY - started.y;
   const slop = clickSlopFor(started.type);
@@ -2946,12 +2980,12 @@ renderer.domElement.addEventListener("pointerup", (event) => {
   // A gesture that began on a label and stayed put is that label's click; the
   // canvas captured the pointer, so the label never sees a click of its own.
   if (label) {
-    renderer.domElement.style.cursor = "pointer";
+    renderer.domElement.style.cursor = pointerUpOutcome(event, true).cursor;
     showDetails(label.kind, label.item);
     return;
   }
   const hit = pickAt(event);
-  renderer.domElement.style.cursor = hit ? "pointer" : "grab";
+  renderer.domElement.style.cursor = pointerUpOutcome(event, Boolean(hit)).cursor;
   if (!hit?.object.userData.ref) {
     clearSelection();
     return;
@@ -2969,11 +3003,7 @@ window.addEventListener("keydown", (event) => {
     || target instanceof HTMLSelectElement
     || Boolean(target?.isContentEditable)
   );
-  if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
-    event.preventDefault();
-    openSearch();
-    return;
-  }
+  if (handleSearchShortcut(event, Boolean(editingItem), openSearch)) return;
   if (event.key === "Escape" && !searchPanelEl.hidden) {
     event.preventDefault();
     closeSearch();

--- a/resources/model_assets/viewer.js
+++ b/resources/model_assets/viewer.js
@@ -2,6 +2,7 @@ import * as THREE from "three";
 import { OrbitControls } from "three/addons/controls/OrbitControls.js";
 import { CSS2DObject, CSS2DRenderer } from "three/addons/renderers/CSS2DRenderer.js";
 import { computeClusterLayout, pickScreenTarget, zoomMath } from "./layout.mjs";
+import { focusKeysForSelection, rankSearchEntries } from "./explore.mjs";
 import {
   evidenceBreadcrumb,
   evidenceOverview,
@@ -65,6 +66,18 @@ const shareButton = document.getElementById("share-x");
 const shareNoticeEl = document.getElementById("share-notice");
 const lineExplorerEl = document.getElementById("line-explorer");
 const lineSelectEl = document.getElementById("line-select");
+const searchPanelEl = document.getElementById("model-search-panel");
+const searchInputEl = document.getElementById("model-search");
+const searchResultsEl = document.getElementById("search-results");
+const searchSummaryEl = document.getElementById("search-summary");
+const searchEmptyEl = document.getElementById("search-empty");
+const openSearchButton = document.getElementById("open-search");
+const closeSearchButton = document.getElementById("close-search");
+const clearFocusButton = document.getElementById("clear-focus");
+const layerCountEls = Object.fromEntries(
+  ["points", "lines", "faces", "volumes", "root"]
+    .map((kind) => [kind, document.getElementById(`layer-count-${kind}`)]),
+);
 
 const scene = new THREE.Scene();
 scene.fog = new THREE.FogExp2(0x070610, 0.026);
@@ -124,6 +137,7 @@ scene.add(violetLight);
 let graph = new THREE.Group();
 scene.add(graph);
 let model = { points: [], lines: [], faces: [], volumes: [], root: null, stats: {} };
+let sceneModel = { points: [], lines: [], faces: [], volumes: [], root: null };
 let modelFingerprint = "";
 let modelGeneratedAt = "";
 let cutoff = new Date();
@@ -144,6 +158,7 @@ let hoverPointer = null;
 let hoverDirty = false;
 let selected = null;
 let selectedItem = null;
+let selectionReturnFocus = null;
 let detailMode = "node";
 let evidenceTrail = [];
 let evidenceRequest = 0;
@@ -160,6 +175,8 @@ let currentLayout = null;
 let layoutRadius = 6;
 let framedRadius = 0;
 let pulseGlows = [];
+let focusLabels = [];
+let focusLabelsKey = "";
 let fitDistance = 12;
 let zoomGoalDistance = null;
 let zoomAnchor = null;
@@ -168,6 +185,11 @@ let lastZoomPercent = null;
 let lastFrameTime = performance.now();
 let shareReady = false;
 let modelLoadPromise = null;
+let searchEntries = [];
+let searchMatches = [];
+let searchActiveIndex = 0;
+let cameraFlight = null;
+let focusVisualsSuspended = false;
 const layerVisible = { points: true, lines: true, faces: true, volumes: true, root: true };
 const kindLayers = {
   point: "points",
@@ -191,6 +213,8 @@ const pickWorldPosition = new THREE.Vector3();
 const pickProjected = new THREE.Vector3();
 const MIN_NODE_HIT_RADIUS_PX = 12;
 const MIN_LINE_HIT_RADIUS_PX = 8;
+const TOUCH_NODE_HIT_RADIUS_PX = 22;
+const TOUCH_LINE_HIT_RADIUS_PX = 14;
 const ZOOM_MIN_PERCENT = 50;
 const ZOOM_MAX_PERCENT = 400;
 const ZOOM_STEP_PERCENT = 25;
@@ -200,7 +224,7 @@ const SHARE_CARD_TIMEOUT_MS = 15_000;
 const REDUCED_MOTION = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
 function freshLayerObjects() {
-  return { points: [], lines: [], faces: [], volumes: [], root: [] };
+  return { points: [], lines: [], hierarchy: [], faces: [], volumes: [], root: [] };
 }
 
 function hash(text) {
@@ -262,7 +286,7 @@ function glowTexture(color) {
   return texture;
 }
 
-function addGlow(position, color, size, opacity, layer, pulse = 0.06) {
+function addGlow(position, color, size, opacity, layer, pulse = 0.06, focusRefs = []) {
   const sprite = new THREE.Sprite(
     new THREE.SpriteMaterial({
       map: glowTexture(color),
@@ -279,7 +303,7 @@ function addGlow(position, color, size, opacity, layer, pulse = 0.06) {
   sprite.userData.glowBase = size;
   sprite.userData.glowPhase = hash(`${position.x}:${position.y}:${position.z}`) * Math.PI * 2;
   sprite.userData.glowPulse = pulse;
-  register(sprite, layer);
+  register(sprite, layer, focusRefs);
   pulseGlows.push(sprite);
   return sprite;
 }
@@ -310,8 +334,9 @@ function visibleAt(item) {
   return !time || time <= cutoff;
 }
 
-function register(object, layer) {
+function register(object, layer, focusRefs = []) {
   object.userData.layer = layer;
+  object.userData.focusRefs = focusRefs;
   layerObjects[layer].push(object);
   graph.add(object);
   return object;
@@ -395,14 +420,98 @@ function addLabel(text, position, layer, priority, kind, item, context = false) 
   return label;
 }
 
-function addLine(start, end, color, opacity, dashed, layer = "lines") {
+function clearFocusLabels() {
+  focusLabels.forEach((label) => {
+    graph.remove(label);
+    label.element.remove();
+    labels = labels.filter((candidate) => candidate !== label);
+    const layer = label.userData.layer;
+    if (layerObjects[layer]) {
+      layerObjects[layer] = layerObjects[layer].filter((candidate) => candidate !== label);
+    }
+    const ref = label.userData.ref;
+    if (ref) {
+      const key = selectionKey(ref.kind, ref.id);
+      const remaining = (selectionTargets.get(key) || [])
+        .filter((candidate) => candidate !== label);
+      if (remaining.length) selectionTargets.set(key, remaining);
+      else selectionTargets.delete(key);
+    }
+  });
+  focusLabels = [];
+}
+
+function updateFocusLabels(focusKeys, activeKey) {
+  const nextKey = activeKey
+    ? `${activeKey}|${[...focusKeys].sort().join("|")}`
+    : "";
+  if (nextKey === focusLabelsKey) return;
+  clearFocusLabels();
+  focusLabelsKey = nextKey;
+  if (!activeKey) return;
+
+  const kindPriority = { root: 0, volume: 1, face: 2, point: 3, context: 4 };
+  const candidates = [...focusKeys]
+    .map((key) => {
+      const separator = key.indexOf(":");
+      return {
+        key,
+        kind: separator > 0 ? key.slice(0, separator) : "context",
+        id: separator > 0 ? key.slice(separator + 1) : key,
+      };
+    })
+    .filter(({ kind }) => kind !== "line")
+    .sort((left, right) => (
+      Number(right.key === activeKey) - Number(left.key === activeKey)
+      || (kindPriority[left.kind] ?? 9) - (kindPriority[right.kind] ?? 9)
+      || left.key.localeCompare(right.key)
+    ));
+
+  let labeled = candidates.filter(({ key }) => (
+    (selectionTargets.get(key) || []).some((target) => target.element)
+  )).length;
+  for (const candidate of candidates) {
+    const alreadyLabeled = (selectionTargets.get(candidate.key) || [])
+      .some((target) => target.element);
+    if (alreadyLabeled) continue;
+    // The active object is the one label that must never lose a budget race.
+    // A high-degree node can already have nine labelled neighbors before this
+    // loop begins; allow one generated active label in that case, then stop.
+    if (labeled >= 9 && candidate.key !== activeKey) break;
+    const item = items.get(candidate.key);
+    const position = selectionPosition(candidate.kind, candidate.id);
+    const layer = kindLayers[candidate.kind];
+    if (!item || !position || !layer) continue;
+    const verticalOffset = {
+      root: 0.66,
+      volume: 0.55,
+      face: 0.4,
+      point: 0.25,
+      context: 0.24,
+    }[candidate.kind] || 0.25;
+    const label = addLabel(
+      searchTitle(candidate.kind, item),
+      position.add(new THREE.Vector3(0, verticalOffset, 0)),
+      layer,
+      850 - labeled,
+      candidate.kind,
+      item,
+      candidate.kind === "context",
+    );
+    label.userData.focusGenerated = true;
+    focusLabels.push(label);
+    labeled += 1;
+  }
+}
+
+function addLine(start, end, color, opacity, dashed, layer = "lines", focusRefs = []) {
   const geometry = new THREE.BufferGeometry().setFromPoints([start, end]);
   const material = dashed
     ? new THREE.LineDashedMaterial({ color, transparent: true, opacity, dashSize: 0.12, gapSize: 0.09 })
     : new THREE.LineBasicMaterial({ color, transparent: true, opacity });
   const line = new THREE.Line(geometry, material);
   if (dashed) line.computeLineDistances();
-  register(line, layer);
+  register(line, layer, focusRefs);
   return line;
 }
 
@@ -461,6 +570,8 @@ function disposeGraph() {
   items = new Map();
   layerObjects = freshLayerObjects();
   pulseGlows = [];
+  focusLabels = [];
+  focusLabelsKey = "";
 }
 
 function addPoint(point, position, baseRadius, showLabel, promoted) {
@@ -479,7 +590,15 @@ function addPoint(point, position, baseRadius, showLabel, promoted) {
   const mesh = registerPickable(new THREE.Mesh(geometry, material), "points", "point", point);
   mesh.position.copy(position);
   if (active && promoted && hash(`${point.id}:glow`) < 0.08) {
-    addGlow(position, COLORS.points, radius * 5.4, 0.2, "points", 0.08);
+    addGlow(
+      position,
+      COLORS.points,
+      radius * 5.4,
+      0.2,
+      "points",
+      0.08,
+      [selectionKey("point", point.id)],
+    );
   }
   if (showLabel) {
     addLabel(
@@ -520,7 +639,7 @@ function addContextNode(id) {
   }
 }
 
-function addClusterHalo(memberPositions, center) {
+function addClusterHalo(memberPositions, center, focusRefs = []) {
   if (memberPositions.length < 2) return;
   const radius = Math.min(1.9, Math.max(0.55, ...memberPositions.map((member) => member.distanceTo(center))) + 0.18);
   const mesh = register(
@@ -534,7 +653,8 @@ function addClusterHalo(memberPositions, center) {
         depthWrite: false,
       })
     ),
-    "faces"
+    "faces",
+    focusRefs,
   );
   mesh.position.copy(center);
   mesh.scale.setScalar(radius);
@@ -544,10 +664,11 @@ function addClusterHalo(memberPositions, center) {
 function addFace(face, showLabel) {
   const position = positions.get(face.id);
   if (!position) return;
+  const faceKey = selectionKey("face", face.id);
   const memberIds = currentLayout?.facePointIds.get(face.id) || [];
   const memberPositions = memberIds.map((id) => positions.get(id)).filter(Boolean);
-  addClusterHalo(memberPositions, position);
-  addGlow(position, COLORS.faces, 1.55, 0.22, "faces", 0.07);
+  addClusterHalo(memberPositions, position, [faceKey]);
+  addGlow(position, COLORS.faces, 1.55, 0.22, "faces", 0.07, [faceKey]);
   const node = registerPickable(
     new THREE.Mesh(
       new THREE.OctahedronGeometry(0.28, 0),
@@ -573,13 +694,27 @@ function addFace(face, showLabel) {
       face
     );
   }
-  memberPositions.forEach((member) => addLine(member, position, COLORS.hierarchy, 0.1, true));
+  memberIds.forEach((id) => {
+    const member = positions.get(id);
+    if (member) {
+      addLine(
+        member,
+        position,
+        COLORS.hierarchy,
+        0.1,
+        true,
+        "hierarchy",
+        [faceKey, selectionKey("point", id)],
+      );
+    }
+  });
 }
 
 function addVolume(volume, showLabel) {
   const position = positions.get(volume.id);
   if (!position) return;
-  addGlow(position, COLORS.volumes, 2.35, 0.25, "volumes", 0.06);
+  const volumeKey = selectionKey("volume", volume.id);
+  addGlow(position, COLORS.volumes, 2.35, 0.25, "volumes", 0.06, [volumeKey]);
   const mesh = registerPickable(
     new THREE.Mesh(
       new THREE.IcosahedronGeometry(0.48, 1),
@@ -602,7 +737,8 @@ function addVolume(volume, showLabel) {
       new THREE.IcosahedronGeometry(0.17, 1),
       new THREE.MeshBasicMaterial({ color: COLORS.volumes, transparent: true, opacity: 0.68 })
     ),
-    "volumes"
+    "volumes",
+    [volumeKey],
   );
   core.position.copy(position);
   if (showLabel) {
@@ -616,14 +752,27 @@ function addVolume(volume, showLabel) {
     );
   }
   const memberIds = currentLayout?.volumeFaceIds.get(volume.id) || [];
-  memberIds.map((id) => positions.get(id)).filter(Boolean)
-    .forEach((member) => addLine(member, position, COLORS.volumes, 0.22, false));
+  memberIds.forEach((id) => {
+    const member = positions.get(id);
+    if (member) {
+      addLine(
+        member,
+        position,
+        COLORS.volumes,
+        0.22,
+        false,
+        "hierarchy",
+        [volumeKey, selectionKey("face", id)],
+      );
+    }
+  });
 }
 
 function addRoot(root) {
   const position = positions.get(root.id);
   if (!position) return;
-  addGlow(position, COLORS.root, 4.2, 0.42, "root", 0.075);
+  const rootKey = selectionKey("root", root.id);
+  addGlow(position, COLORS.root, 4.2, 0.42, "root", 0.075, [rootKey]);
   const mesh = registerPickable(
     new THREE.Mesh(
       new THREE.DodecahedronGeometry(0.62, 0),
@@ -651,8 +800,20 @@ function addRoot(root) {
     root
   );
   const parentIds = currentLayout?.rootVolumeIds || [];
-  parentIds.map((id) => positions.get(id)).filter(Boolean)
-    .forEach((member) => addLine(member, position, COLORS.root, 0.32, false));
+  parentIds.forEach((id) => {
+    const member = positions.get(id);
+    if (member) {
+      addLine(
+        member,
+        position,
+        COLORS.root,
+        0.32,
+        false,
+        "hierarchy",
+        [rootKey, selectionKey("volume", id)],
+      );
+    }
+  });
 }
 
 function addModelLine(line) {
@@ -711,6 +872,13 @@ function buildScene() {
   const visibleVolumes = model.volumes.filter(visibleAt);
   const visibleRoot = model.root && visibleAt(model.root) ? model.root : null;
   const visibleLines = model.lines.filter(visibleAt);
+  sceneModel = {
+    points: visiblePoints,
+    lines: visibleLines,
+    faces: visibleFaces,
+    volumes: visibleVolumes,
+    root: visibleRoot,
+  };
   currentLayout = computeClusterLayout({
     points: visiblePoints,
     lines: visibleLines,
@@ -746,8 +914,18 @@ function buildScene() {
   visibleVolumes.forEach((volume) => addVolume(volume, labeledVolumes.has(volume.id)));
   if (visibleRoot) addRoot(visibleRoot);
 
+  const renderedLines = renderedLineItems.length;
+  const currentCounts = {
+    points: visiblePoints.length,
+    lines: renderedLines,
+    faces: visibleFaces.length,
+    volumes: visibleVolumes.length,
+    root: visibleRoot ? 1 : 0,
+  };
+  updateLayerCounts(currentCounts);
+  rebuildSearchEntries();
   applyLayerVisibility();
-  renderStatus();
+  renderStatus(currentCounts);
   emptyEl.hidden = visiblePoints.length > 0;
   frameLayout(false);
   // Fresh label elements and a possibly-resized status strip: both cached
@@ -758,7 +936,6 @@ function buildScene() {
   // blank scene, leaving the local smoke signal reading "nothing rendered"
   // forever. A new scene deserves a fresh look.
   renderProbeSweeps = 0;
-  const renderedLines = renderedLineItems.length;
   window.__persomeViewerState = {
     schemaVersion: model.schema_version,
     generatedAt: modelGeneratedAt || null,
@@ -786,15 +963,14 @@ function buildScene() {
   viewerEl.dataset.layoutVersion = currentLayout.diagnostics.version;
 }
 
-function renderStatus() {
-  const stats = model.stats || {};
+function renderStatus(counts) {
   statusEl.replaceChildren();
   const parts = [
-    ["points", "Points", stats.points || 0],
-    ["lines", "Lines", (stats.evolution_lines || 0) + (stats.relation_lines || 0)],
-    ["faces", "Faces", stats.faces || 0],
-    ["volumes", "Volumes", stats.volumes || 0],
-    ["root", "Root", stats.roots || 0],
+    ["points", "Points", counts.points],
+    ["lines", "Lines", counts.lines],
+    ["faces", "Faces", counts.faces],
+    ["volumes", "Volumes", counts.volumes],
+    ["root", "Root", counts.root],
   ];
   parts.forEach(([kind, label, value]) => {
     const stat = document.createElement("span");
@@ -830,6 +1006,166 @@ function renderStatus() {
   }
   modelIdentityEl.textContent = model.root?.signature
     || "A living map of what you notice, repeat, and become.";
+}
+
+function updateLayerCounts(counts) {
+  Object.entries(layerCountEls).forEach(([kind, countEl]) => {
+    if (!countEl) return;
+    const count = Number(counts[kind] || 0);
+    countEl.textContent = String(count);
+    const button = countEl.closest("button");
+    if (button) {
+      const label = kind === "root" ? "Root" : `${kind[0].toUpperCase()}${kind.slice(1)}`;
+      button.setAttribute("aria-label", `${label}: ${count}. Toggle visibility`);
+    }
+  });
+}
+
+function searchTitle(kind, item) {
+  if (kind === "line") return linePresentation(item, sceneModel).title;
+  return item.content || item.signature || item.label || item.predicate || item.kind || item.id;
+}
+
+function searchSubtitle(kind, item) {
+  if (kind === "point") {
+    return item.status === "active" ? "Modeled observation · active" : "Modeled observation";
+  }
+  if (kind === "line") {
+    const presentation = linePresentation(item, sceneModel);
+    return `${presentation.source} → ${presentation.target}`;
+  }
+  if (kind === "face") return "Stable pattern";
+  if (kind === "volume") return "Cross-pattern structure";
+  if (kind === "root") return "Current personal model";
+  return "Context referenced by a relation";
+}
+
+function searchWeight(kind, item) {
+  const observations = Math.min(8, Number(item.observations || 0));
+  if (kind === "root") return 24;
+  if (kind === "volume") return 18 + observations;
+  if (kind === "face") return 12 + observations;
+  if (kind === "point") return 6 + Math.min(4, Number(item.confidence || 0) * 4);
+  if (kind === "line") return 3;
+  return 1;
+}
+
+function rebuildSearchEntries() {
+  searchEntries = [...items.entries()].map(([key, item]) => {
+    const separator = key.indexOf(":");
+    const kind = separator > 0 ? key.slice(0, separator) : "context";
+    const lineDetail = kind === "line" ? linePresentation(item, sceneModel) : null;
+    return {
+      key,
+      kind,
+      id: item.id,
+      title: String(searchTitle(kind, item) || "Untitled").replace(/\s+/g, " ").trim(),
+      subtitle: searchSubtitle(kind, item),
+      aliases: lineDetail
+        ? [lineDetail.predicate, lineDetail.label, lineDetail.source, lineDetail.target, item.kind]
+        : [item.kind, item.status],
+      weight: searchWeight(kind, item),
+    };
+  });
+  if (!searchPanelEl.hidden) renderSearchResults();
+}
+
+function setSearchActiveIndex(nextIndex) {
+  if (!searchMatches.length) {
+    searchActiveIndex = 0;
+    searchInputEl.removeAttribute("aria-activedescendant");
+    return;
+  }
+  searchActiveIndex = (nextIndex + searchMatches.length) % searchMatches.length;
+  const buttons = [...searchResultsEl.querySelectorAll(".search-result")];
+  buttons.forEach((button, index) => {
+    button.setAttribute("aria-selected", String(index === searchActiveIndex));
+  });
+  const active = buttons[searchActiveIndex];
+  if (active) {
+    searchInputEl.setAttribute("aria-activedescendant", active.id);
+    active.scrollIntoView({ block: "nearest" });
+  }
+}
+
+function renderSearchResults() {
+  const query = searchInputEl.value.trim();
+  searchMatches = rankSearchEntries(searchEntries, query, 9);
+  searchActiveIndex = Math.min(searchActiveIndex, Math.max(0, searchMatches.length - 1));
+  searchResultsEl.replaceChildren();
+  searchMatches.forEach((entry, index) => {
+    const button = document.createElement("button");
+    button.id = `model-search-result-${index}`;
+    button.type = "button";
+    button.tabIndex = -1;
+    button.className = "search-result";
+    button.dataset.kind = entry.kind;
+    button.setAttribute("role", "option");
+    button.setAttribute("aria-selected", String(index === searchActiveIndex));
+
+    const marker = document.createElement("i");
+    marker.setAttribute("aria-hidden", "true");
+    const copy = document.createElement("span");
+    const title = document.createElement("b");
+    title.textContent = entry.title;
+    const subtitle = document.createElement("small");
+    subtitle.textContent = entry.subtitle;
+    copy.append(title, subtitle);
+    const kind = document.createElement("em");
+    kind.textContent = entry.kind === "context" ? "entity" : entry.kind;
+    button.append(marker, copy, kind);
+    button.addEventListener("pointerenter", () => setSearchActiveIndex(index));
+    button.addEventListener("click", () => selectSearchMatch(entry));
+    searchResultsEl.appendChild(button);
+  });
+  searchEmptyEl.hidden = searchMatches.length > 0;
+  searchSummaryEl.textContent = query
+    ? (searchMatches.length
+      ? `Top ${searchMatches.length} matches in this model view.`
+      : "No matching object in this model view.")
+    : `Showing ${searchMatches.length} anchors from this model view.`;
+  setSearchActiveIndex(searchActiveIndex);
+}
+
+function openSearch() {
+  pauseAutoRotate();
+  searchPanelEl.hidden = false;
+  searchInputEl.setAttribute("aria-expanded", "true");
+  searchActiveIndex = 0;
+  renderSearchResults();
+  invalidatePanelBoxes();
+  window.requestAnimationFrame(() => {
+    searchInputEl.focus({ preventScroll: true });
+    searchInputEl.select();
+  });
+}
+
+function closeSearch(restoreFocus = true) {
+  if (searchPanelEl.hidden) return;
+  searchPanelEl.hidden = true;
+  searchInputEl.setAttribute("aria-expanded", "false");
+  searchInputEl.removeAttribute("aria-activedescendant");
+  invalidatePanelBoxes();
+  if (restoreFocus) openSearchButton.focus({ preventScroll: true });
+}
+
+function selectSearchMatch(entry) {
+  const item = items.get(entry.key);
+  if (!item) {
+    rebuildSearchEntries();
+    renderSearchResults();
+    return;
+  }
+  const layer = kindLayers[entry.kind];
+  if (layer && !layerVisible[layer]) {
+    layerVisible[layer] = true;
+    applyLayerVisibility();
+    if (window.__persomeViewerState) window.__persomeViewerState.layers = { ...layerVisible };
+  }
+  closeSearch(false);
+  showDetails(entry.kind, item, openSearchButton);
+  flyToSelection(entry.kind, entry.id);
+  document.getElementById("close-detail").focus({ preventScroll: true });
 }
 
 function pauseAutoRotate() {
@@ -901,13 +1237,23 @@ function createHumanCardBlob(shareModel) {
 }
 
 function createConstellationBlob(shareModel) {
-  renderer.render(scene, camera);
   const canvas = document.createElement("canvas");
   canvas.width = CONSTELLATION_CARD_WIDTH;
   canvas.height = CONSTELLATION_CARD_HEIGHT;
   const context = canvas.getContext("2d");
   if (!context) return Promise.reject(new Error("Canvas export is unavailable"));
-  drawConstellationCard(context, renderer.domElement, shareModel);
+  // Focus is a reading aid, not part of the model. Export the complete current
+  // time slice even when the owner has a neighborhood selected.
+  focusVisualsSuspended = true;
+  syncSelectionState();
+  try {
+    renderer.render(scene, camera);
+    drawConstellationCard(context, renderer.domElement, shareModel);
+  } finally {
+    focusVisualsSuspended = false;
+    syncSelectionState();
+    renderer.render(scene, camera);
+  }
   return new Promise((resolve, reject) => {
     canvas.toBlob((blob) => {
       if (blob) resolve(blob);
@@ -987,8 +1333,59 @@ async function shareConstellationToX() {
   }
 }
 
+function objectFocusKeys(object) {
+  const keys = new Set(object.userData.focusRefs || []);
+  const ref = object.userData.ref;
+  if (ref?.kind && ref?.id) keys.add(selectionKey(ref.kind, ref.id));
+  return keys;
+}
+
+function applyMaterialFocus(object, focusing, relevant) {
+  const materials = Array.isArray(object.material) ? object.material : [object.material];
+  materials.filter(Boolean).forEach((material) => {
+    material.userData.persomeFocusBase ||= {
+      opacity: Number(material.opacity),
+      transparent: Boolean(material.transparent),
+      depthWrite: Boolean(material.depthWrite),
+      emissiveIntensity: Number.isFinite(material.emissiveIntensity)
+        ? Number(material.emissiveIntensity)
+        : null,
+    };
+    const base = material.userData.persomeFocusBase;
+    const muted = focusing && !relevant;
+    const nextTransparent = muted ? true : base.transparent;
+    if (material.transparent !== nextTransparent) material.needsUpdate = true;
+    material.transparent = nextTransparent;
+    const mutedFactor = object.isSprite ? 0.025 : (object.isLine ? 0.025 : 0.045);
+    material.opacity = muted ? base.opacity * mutedFactor : base.opacity;
+    material.depthWrite = muted ? false : base.depthWrite;
+    if (base.emissiveIntensity !== null) {
+      material.emissiveIntensity = muted ? base.emissiveIntensity * 0.045 : base.emissiveIntensity;
+    }
+  });
+}
+
 function syncSelectionState() {
-  const activeKey = selected ? selectionKey(selected.kind, selected.id) : null;
+  const selectionVisible = selected && !focusVisualsSuspended;
+  const activeKey = selectionVisible ? selectionKey(selected.kind, selected.id) : null;
+  const focusKeys = selectionVisible
+    ? focusKeysForSelection(sceneModel, currentLayout, selected)
+    : new Set();
+  const focusing = focusKeys.size > 0;
+  if (!focusVisualsSuspended) updateFocusLabels(focusKeys, activeKey);
+
+  Object.values(layerObjects).flat().forEach((object) => {
+    const keys = objectFocusKeys(object);
+    const relevant = [...keys].some((key) => focusKeys.has(key));
+    if (object.element) {
+      const active = keys.has(activeKey);
+      object.element.classList.toggle("focus-muted", focusing && !relevant);
+      object.element.classList.toggle("focus-neighbor", focusing && relevant && !active);
+    } else if (object.material) {
+      applyMaterialFocus(object, focusing, relevant);
+    }
+  });
+
   selectionTargets.forEach((targets, key) => {
     const active = key === activeKey;
     targets.forEach((target) => {
@@ -996,10 +1393,11 @@ function syncSelectionState() {
         target.element.setAttribute("aria-expanded", String(active));
       } else if (target.isLine && target.material) {
         const baseOpacity = Number(target.userData.baseOpacity || 0);
-        target.material.opacity = active ? Math.min(1, baseOpacity * 2 + 0.24) : baseOpacity;
+        if (active) target.material.opacity = Math.min(1, baseOpacity * 2 + 0.24);
         target.renderOrder = active ? 5 : 0;
       } else if (target.isMesh) {
-        target.scale.setScalar(active ? 1.45 : 1);
+        target.userData.selectionBaseScale ||= target.scale.clone();
+        target.scale.copy(target.userData.selectionBaseScale).multiplyScalar(active ? 1.45 : 1);
       }
     });
   });
@@ -1009,29 +1407,51 @@ function syncSelectionState() {
     screenLinePickables: screenLinePickables.length,
     minimumNodeHitRadiusPx: MIN_NODE_HIT_RADIUS_PX,
     minimumLineHitRadiusPx: MIN_LINE_HIT_RADIUS_PX,
+    touchNodeHitRadiusPx: TOUCH_NODE_HIT_RADIUS_PX,
+    touchLineHitRadiusPx: TOUCH_LINE_HIT_RADIUS_PX,
     nodePickables: pickables.length,
     interactiveLabels: labels.filter((label) => Boolean(label.userData.ref)).length,
     selected: selected ? { ...selected } : null,
+    focused: Boolean(selectionVisible),
+    neighborhoodObjects: focusKeys.size,
   };
 }
 
-function clearSelection() {
+function clearSelection(restoreFocus = false) {
+  const returnFocus = restoreFocus ? selectionReturnFocus : null;
   evidenceRequest += 1;
   selected = null;
   selectedItem = null;
+  selectionReturnFocus = null;
   detailMode = "node";
   evidenceTrail = [];
   detailEl.hidden = true;
   delete detailEl.dataset.kind;
   invalidatePanelBoxes();
   syncSelectionState();
+  if (returnFocus?.isConnected) {
+    window.requestAnimationFrame(() => returnFocus.focus({ preventScroll: true }));
+  }
+}
+
+function showAllModel() {
+  clearSelection(true);
+  resetCamera();
 }
 
 function applyLayerVisibility() {
   Object.entries(layerObjects).forEach(([layer, objects]) => {
     objects.forEach((object) => {
-      object.visible = layerVisible[layer];
-      if (object.element) object.element.hidden = !layerVisible[layer];
+      const visible = layer === "hierarchy"
+        ? [...objectFocusKeys(object)].every((key) => {
+          const separator = key.indexOf(":");
+          const kind = separator > 0 ? key.slice(0, separator) : "context";
+          const endpointLayer = kindLayers[kind];
+          return !endpointLayer || layerVisible[endpointLayer];
+        })
+        : layerVisible[layer];
+      object.visible = visible;
+      if (object.element) object.element.hidden = !visible;
     });
   });
   document.querySelectorAll("[data-layer]").forEach((button) => {
@@ -1626,7 +2046,15 @@ function renderEditor(kind, item) {
   }
 }
 
-function showDetails(kind, item) {
+function showDetails(kind, item, returnFocus = null) {
+  if (detailEl.hidden) {
+    const candidate = returnFocus || document.activeElement;
+    selectionReturnFocus = candidate instanceof HTMLElement
+      && candidate !== document.body
+      && !detailEl.contains(candidate)
+      ? candidate
+      : openSearchButton;
+  }
   const lineDetail = kind === "line" ? linePresentation(item, model) : null;
   selected = { kind, id: item.id };
   selectedItem = item;
@@ -1819,6 +2247,7 @@ function frameLayout(force) {
   const direction = new THREE.Vector3(portrait ? 0.58 : 0.72, portrait ? 1.25 : 1.05, 1).normalize();
   const distance = Math.max(portrait ? 15 : 12, radius * (portrait ? 3.0 : 2.55));
   fitDistance = distance;
+  cameraFlight = null;
   zoomGoalDistance = null;
   camera.position.copy(direction.multiplyScalar(distance));
   controls.target.set(0, 0, 0);
@@ -1836,6 +2265,73 @@ function frameLayout(force) {
 
 function resetCamera() {
   frameLayout(true);
+}
+
+function selectionPosition(kind, id) {
+  if (kind === "line") {
+    const line = sceneModel.lines.find((item) => item.id === id);
+    const start = line ? positions.get(line.source) : null;
+    const end = line ? positions.get(line.target) : null;
+    if (start && end) return start.clone().lerp(end, 0.5);
+  }
+  return positions.get(id)?.clone() || null;
+}
+
+function cameraFocusDistance(kind) {
+  const factor = {
+    root: 0.7,
+    volume: 0.56,
+    face: 0.42,
+    line: 0.36,
+    point: 0.3,
+    context: 0.3,
+  }[kind] || 0.42;
+  const cap = kind === "root" ? 18 : (kind === "volume" ? 14 : 10);
+  return THREE.MathUtils.clamp(
+    Math.min(cap, fitDistance * factor),
+    controls.minDistance,
+    controls.maxDistance,
+  );
+}
+
+function flyToSelection(kind, id) {
+  const target = selectionPosition(kind, id);
+  if (!target) return;
+  pauseAutoRotate();
+  zoomGoalDistance = null;
+  zoomAnchor = null;
+
+  const direction = camera.position.clone().sub(controls.target);
+  if (direction.lengthSq() < 1e-8) direction.set(0.72, 0.9, 1);
+  direction.normalize().applyAxisAngle(new THREE.Vector3(0, 1, 0), 0.16);
+  direction.y += 0.06;
+  direction.normalize().multiplyScalar(cameraFocusDistance(kind));
+  const destination = target.clone().add(direction);
+  const travel = controls.target.distanceTo(target) + camera.position.distanceTo(destination) * 0.24;
+  const duration = REDUCED_MOTION ? 0 : THREE.MathUtils.clamp(0.56 + travel * 0.025, 0.56, 1.15);
+  cameraFlight = {
+    elapsed: 0,
+    duration,
+    fromPosition: camera.position.clone(),
+    toPosition: destination,
+    fromTarget: controls.target.clone(),
+    toTarget: target,
+  };
+  if (!duration) applyCameraFlight(0);
+}
+
+function applyCameraFlight(deltaSeconds) {
+  if (!cameraFlight) return;
+  const flight = cameraFlight;
+  flight.elapsed += deltaSeconds;
+  const progress = flight.duration ? Math.min(1, flight.elapsed / flight.duration) : 1;
+  const eased = progress < 0.5
+    ? 4 * progress * progress * progress
+    : 1 - Math.pow(-2 * progress + 2, 3) / 2;
+  camera.position.lerpVectors(flight.fromPosition, flight.toPosition, eased);
+  controls.target.lerpVectors(flight.fromTarget, flight.toTarget, eased);
+  controls.update();
+  if (progress >= 1) cameraFlight = null;
 }
 
 function clampZoomPercent(value) {
@@ -1889,10 +2385,11 @@ function syncZoomUI() {
   state.percent = percent;
   state.distance = Number(distance.toFixed(3));
   state.fitDistance = Number(fitDistance.toFixed(3));
-  state.animating = zoomGoalDistance !== null;
+  state.animating = zoomGoalDistance !== null || cameraFlight !== null;
 }
 
 function requestZoom(percent) {
+  cameraFlight = null;
   const clamped = clampZoomPercent(percent);
   zoomGoalDistance = THREE.MathUtils.clamp(
     fitDistance * 100 / clamped,
@@ -1906,6 +2403,7 @@ function requestZoom(percent) {
 // already headed, so a stream of small events composes into one continuous
 // gesture instead of repeatedly restarting from the camera's current position.
 function requestZoomBy(factor, anchor) {
+  cameraFlight = null;
   const base = zoomGoalDistance === null
     ? camera.position.distanceTo(controls.target)
     : zoomGoalDistance;
@@ -1990,9 +2488,23 @@ function invalidatePanelBoxes() {
   canvasBounds = null;
 }
 
+const panelResizeObserver = "ResizeObserver" in window
+  ? new ResizeObserver(invalidatePanelBoxes)
+  : null;
+if (panelResizeObserver) {
+  document.querySelectorAll(
+    ".story, .legend, .status, .timeline, .detail, .search-dialog",
+  ).forEach((element) => panelResizeObserver.observe(element));
+}
+document.querySelector(".legend")?.addEventListener("toggle", invalidatePanelBoxes);
+detailEvidenceFoldEl.addEventListener("toggle", invalidatePanelBoxes);
+detailHistoryFoldEl.addEventListener("toggle", invalidatePanelBoxes);
+
 function panelBoxes() {
   if (occupiedPanels) return occupiedPanels;
-  occupiedPanels = [...document.querySelectorAll(".story, .legend, .status, .timeline, .detail:not([hidden])")]
+  occupiedPanels = [...document.querySelectorAll(
+    ".story, .legend, .status, .timeline, .detail:not([hidden]), .search-dialog",
+  )]
     .map((element) => element.getBoundingClientRect())
     .filter((box) => box.width > 0 && box.height > 0)
     .map((box) => ({ x0: box.left - 6, x1: box.right + 6, y0: box.top - 6, y1: box.bottom + 6 }));
@@ -2005,7 +2517,7 @@ const cullCandidates = [];
 function cullLabels() {
   const occupied = panelBoxes().slice();
   const mobile = window.innerWidth < 760;
-  const maxLabels = mobile ? 8 : 20;
+  const maxLabels = mobile ? (selected ? 9 : 8) : 20;
   const maxWidth = mobile ? 130 : 220;
   const safeArea = {
     left: mobile ? 8 : 6,
@@ -2018,6 +2530,12 @@ function cullLabels() {
   cullCandidates.length = 0;
   labels.forEach((label) => {
     if (!label.visible) return;
+    if (label.element.classList.contains("focus-muted")) {
+      label.element.classList.add("hidden");
+      label.element.setAttribute("aria-hidden", "true");
+      label.element.tabIndex = -1;
+      return;
+    }
     label.getWorldPosition(projected);
     projected.project(camera);
     const x = (projected.x * 0.5 + 0.5) * window.innerWidth;
@@ -2042,7 +2560,9 @@ function cullLabels() {
       y,
       width: Math.min(maxWidth, label.userData.measuredWidth || Math.max(32, estimatedWidth)),
       height: label.userData.measuredHeight || 21,
-      priority: label.userData.priority || 0,
+      priority: (label.userData.priority || 0)
+        + (label.element.getAttribute("aria-expanded") === "true" ? 1000 : 0)
+        + (label.element.classList.contains("focus-neighbor") ? 500 : 0),
       depth: projected.z,
     });
   });
@@ -2109,6 +2629,54 @@ document.querySelectorAll("[data-layer]").forEach((button) => {
   });
 });
 
+openSearchButton.addEventListener("click", openSearch);
+closeSearchButton.addEventListener("click", () => closeSearch());
+searchInputEl.addEventListener("input", () => {
+  searchActiveIndex = 0;
+  renderSearchResults();
+});
+searchPanelEl.addEventListener("click", (event) => {
+  if (event.target === searchPanelEl) closeSearch();
+});
+searchPanelEl.addEventListener("keydown", (event) => {
+  if (event.key === "Escape") {
+    event.preventDefault();
+    event.stopPropagation();
+    closeSearch();
+    return;
+  }
+  if (event.key === "ArrowDown") {
+    event.preventDefault();
+    setSearchActiveIndex(searchActiveIndex + 1);
+    return;
+  }
+  if (event.key === "ArrowUp") {
+    event.preventDefault();
+    setSearchActiveIndex(searchActiveIndex - 1);
+    return;
+  }
+  if (event.key === "Enter" && event.target === searchInputEl && searchMatches[searchActiveIndex]) {
+    event.preventDefault();
+    selectSearchMatch(searchMatches[searchActiveIndex]);
+    return;
+  }
+  if (event.key !== "Tab") return;
+  const focusable = [...searchPanelEl.querySelectorAll("button, input")]
+    .filter((element) => (
+      !element.disabled && element.tabIndex >= 0 && element.getClientRects().length > 0
+    ));
+  if (!focusable.length) return;
+  const first = focusable[0];
+  const last = focusable.at(-1);
+  if (event.shiftKey && document.activeElement === first) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && document.activeElement === last) {
+    event.preventDefault();
+    first.focus();
+  }
+});
+
 lineSelectEl.addEventListener("change", () => {
   const index = Number(lineSelectEl.value) - 1;
   const item = lineNavigatorItems[index];
@@ -2125,6 +2693,7 @@ zoomOutButton.addEventListener("click", () => stepZoom(-1));
 zoomResetButton.addEventListener("click", () => requestZoom(100));
 zoomInButton.addEventListener("click", () => stepZoom(1));
 controls.addEventListener("start", () => {
+  cameraFlight = null;
   zoomGoalDistance = null;
   zoomAnchor = null;
 });
@@ -2173,7 +2742,7 @@ function gestureInFlight() {
 // instead of falling through to the browser.
 viewerEl.addEventListener("wheel", (event) => {
   // The drawer and the line picker are real scroll containers; leave them be.
-  if (event.target.closest?.(".detail, .line-explorer")) return;
+  if (event.target.closest?.(".detail, .line-explorer, .search-panel, .legend")) return;
   event.stopPropagation();
   // If a gesture is in flight this wheel is the same fingers counted twice.
   if (gestureInFlight()) return;
@@ -2189,7 +2758,7 @@ viewerEl.addEventListener("wheel", (event) => {
 }, { passive: false, capture: true });
 
 viewerEl.addEventListener("gesturestart", (event) => {
-  if (event.target.closest?.(".detail, .line-explorer")) return;
+  if (event.target.closest?.(".detail, .line-explorer, .search-panel, .legend")) return;
   event.preventDefault();
   gestureScale = 1;
   gestureSeenAt = performance.now();
@@ -2215,7 +2784,8 @@ viewerEl.addEventListener("gestureend", (event) => {
   gestureScale = 0;
 });
 document.getElementById("reset").addEventListener("click", resetCamera);
-document.getElementById("close-detail").addEventListener("click", clearSelection);
+document.getElementById("close-detail").addEventListener("click", () => clearSelection(true));
+clearFocusButton.addEventListener("click", showAllModel);
 cardButton.addEventListener("click", exportHumanCard);
 shareButton.addEventListener("click", shareConstellationToX);
 
@@ -2252,6 +2822,9 @@ function pickAt(event) {
     x: event.clientX - bounds.left,
     y: event.clientY - bounds.top,
   };
+  const coarsePointer = event.pointerType === "touch" || window.innerWidth < 760;
+  const nodeHitRadius = coarsePointer ? TOUCH_NODE_HIT_RADIUS_PX : MIN_NODE_HIT_RADIUS_PX;
+  const lineHitRadius = coarsePointer ? TOUCH_LINE_HIT_RADIUS_PX : MIN_LINE_HIT_RADIUS_PX;
   // Projecting into a shared scratch vector rather than cloning per candidate:
   // hover picking runs on the frame after every pointer move, over every
   // visible node, so a clone per node is a steady drip of garbage.
@@ -2274,7 +2847,7 @@ function pickAt(event) {
     localPointer,
     nodeCandidates,
     [],
-    { nodeRadius: MIN_NODE_HIT_RADIUS_PX },
+    { nodeRadius: nodeHitRadius },
   );
   if (screenNode) return { object: screenNode };
 
@@ -2300,7 +2873,7 @@ function pickAt(event) {
     localPointer,
     [],
     lineCandidates,
-    { lineRadius: MIN_LINE_HIT_RADIUS_PX },
+    { lineRadius: lineHitRadius },
   );
   return screenLine ? { object: screenLine } : null;
 }
@@ -2396,6 +2969,16 @@ window.addEventListener("keydown", (event) => {
     || target instanceof HTMLSelectElement
     || Boolean(target?.isContentEditable)
   );
+  if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+    event.preventDefault();
+    openSearch();
+    return;
+  }
+  if (event.key === "Escape" && !searchPanelEl.hidden) {
+    event.preventDefault();
+    closeSearch();
+    return;
+  }
   if (event.key === "Escape" && selected) {
     // The claim editor handles its own Escape (discard, keep the drawer open)
     // and stops propagation, so anything reaching here is either not editing or
@@ -2405,11 +2988,17 @@ window.addEventListener("keydown", (event) => {
       target.blur();
       return;
     }
-    clearSelection();
+    clearSelection(true);
     return;
   }
   if (typing || event.metaKey || event.ctrlKey || event.altKey) return;
-  if (event.key === "+" || event.key === "=") {
+  if (event.key === "/") {
+    event.preventDefault();
+    openSearch();
+  } else if (event.key.toLowerCase() === "f" && selected) {
+    event.preventDefault();
+    flyToSelection(selected.kind, selected.id);
+  } else if (event.key === "+" || event.key === "=") {
     event.preventDefault();
     stepZoom(1);
   } else if (event.key === "-" || event.key === "_") {
@@ -2469,6 +3058,7 @@ function animate(frameTime = performance.now()) {
   const frameStart = performance.now();
   const deltaSeconds = Math.min(Math.max((frameTime - lastFrameTime) / 1000, 0), 0.5);
   lastFrameTime = frameTime;
+  applyCameraFlight(deltaSeconds);
   applyZoomAnimation(deltaSeconds);
   // Auto-rotate advances by wall time rather than by frame, so the model turns
   // at one speed whether the display runs at 60Hz or 120Hz.

--- a/resources/model_assets/viewer.js
+++ b/resources/model_assets/viewer.js
@@ -1,7 +1,12 @@
 import * as THREE from "three";
 import { OrbitControls } from "three/addons/controls/OrbitControls.js";
 import { CSS2DObject, CSS2DRenderer } from "three/addons/renderers/CSS2DRenderer.js";
-import { computeClusterLayout, pickScreenTarget, zoomMath } from "./layout.mjs";
+import {
+  computeClusterLayout,
+  fittedOverviewPose,
+  pickScreenTarget,
+  zoomMath,
+} from "./layout.mjs";
 import {
   focusKeysForSelection,
   handleSearchShortcut,
@@ -82,6 +87,7 @@ const searchEmptyEl = document.getElementById("search-empty");
 const openSearchButton = document.getElementById("open-search");
 const closeSearchButton = document.getElementById("close-search");
 const clearFocusButton = document.getElementById("clear-focus");
+const mobileGuideEl = document.getElementById("mobile-guide");
 const layerCountEls = Object.fromEntries(
   ["points", "lines", "faces", "volumes", "root"]
     .map((kind) => [kind, document.getElementById(`layer-count-${kind}`)]),
@@ -873,7 +879,11 @@ function addGround() {
   addOrbitRing(radius * 0.72, COLORS.root, 0.055, [Math.PI / 2.8, 0.42, 0.18], ringLayer);
 }
 
-function buildScene(selectionReplacement = null) {
+function buildScene({
+  frame = true,
+  preserveSelection = false,
+  selectionReplacement = null,
+} = {}) {
   disposeGraph();
   const visiblePoints = model.points.filter(visibleAt).sort((a, b) => a.id.localeCompare(b.id));
   const visibleFaces = model.faces.filter(visibleAt);
@@ -932,10 +942,10 @@ function buildScene(selectionReplacement = null) {
   };
   updateLayerCounts(currentCounts);
   rebuildSearchEntries();
-  applyLayerVisibility(selectionReplacement);
+  applyLayerVisibility({ preserveSelection, selectionReplacement });
   renderStatus(currentCounts);
   emptyEl.hidden = visiblePoints.length > 0;
-  frameLayout(false);
+  if (frame) frameLayout(false);
   // Fresh label elements and a possibly-resized status strip: both cached
   // measurements have to be taken again.
   invalidatePanelBoxes();
@@ -1250,16 +1260,124 @@ function createConstellationBlob(shareModel) {
   canvas.height = CONSTELLATION_CARD_HEIGHT;
   const context = canvas.getContext("2d");
   if (!context) return Promise.reject(new Error("Canvas export is unavailable"));
-  // Focus is a reading aid, not part of the model. Export the complete current
-  // time slice even when the owner has a neighborhood selected.
-  focusVisualsSuspended = true;
-  syncSelectionState();
+
+  // Sharing is a projection, not a screenshot of the owner's current camera.
+  // Preserve every interactive state that the temporary 16:9 overview touches
+  // so a focused/flying/zooming viewer resumes exactly where it was.
+  const rendererSize = renderer.getSize(new THREE.Vector2());
+  const returnFocusKey = [...selectionTargets.entries()].find(([, targets]) => (
+    targets.some((target) => target.element === selectionReturnFocus)
+  ))?.[0] || null;
+  const viewState = {
+    rendererSize,
+    pixelRatio: renderer.getPixelRatio(),
+    cameraAspect: camera.aspect,
+    cameraPosition: camera.position.clone(),
+    cameraQuaternion: camera.quaternion.clone(),
+    controlsTarget: controls.target.clone(),
+    cameraFlight,
+    zoomGoalDistance,
+    zoomAnchor,
+    selected: selected ? { ...selected } : null,
+    selectedItem,
+    selectionReturnFocus,
+    returnFocusKey,
+    focusVisualsSuspended,
+    layers: { ...layerVisible },
+    sliderValue: slider.value,
+    sliderLabel: sliderLabel.textContent,
+    cutoff: new Date(cutoff),
+    fitDistance,
+    framedRadius,
+    portraitMode,
+    minDistance: controls.minDistance,
+    maxDistance: controls.maxDistance,
+    maxTargetRadius: controls.maxTargetRadius,
+  };
+
   try {
+    cameraFlight = null;
+    zoomGoalDistance = null;
+    zoomAnchor = null;
+    focusVisualsSuspended = true;
+
+    // The share projection is current, so its picture must be current too.
+    // Rebuild at Now before fitting the export; otherwise time travel would pair
+    // a historical constellation with current narrative and aggregate counts.
+    if (slider.value !== "100") {
+      slider.value = "100";
+      updateCutoff();
+      buildScene({ frame: false, preserveSelection: true });
+    }
+
+    // Layer toggles are inspection state. The public artifact always shows the
+    // complete current time slice so its picture agrees with its full counts.
+    Object.keys(layerVisible).forEach((layer) => { layerVisible[layer] = true; });
+    applyLayerVisibility({ preserveSelection: true });
+
+    const overview = fittedOverviewPose(
+      layoutRadius,
+      CONSTELLATION_CARD_WIDTH,
+      CONSTELLATION_CARD_HEIGHT,
+    );
+
+    // Render at the artifact's own aspect ratio. Drawing a portrait viewport
+    // into the landscape card with drawCover() crops most of the constellation,
+    // even if that viewport's camera was otherwise fitted.
+    renderer.setPixelRatio(1);
+    renderer.setSize(CONSTELLATION_CARD_WIDTH, CONSTELLATION_CARD_HEIGHT, false);
+    camera.aspect = overview.aspect;
+    camera.position.set(...overview.position);
+    controls.target.set(...overview.target);
+    camera.lookAt(controls.target);
+    camera.updateProjectionMatrix();
+    camera.updateMatrixWorld(true);
     renderer.render(scene, camera);
     drawConstellationCard(context, renderer.domElement, shareModel);
   } finally {
-    focusVisualsSuspended = false;
-    syncSelectionState();
+    renderer.setPixelRatio(viewState.pixelRatio);
+    renderer.setSize(viewState.rendererSize.x, viewState.rendererSize.y, false);
+
+    slider.value = viewState.sliderValue;
+    sliderLabel.textContent = viewState.sliderLabel;
+    cutoff = viewState.cutoff;
+    Object.entries(viewState.layers).forEach(([layer, visible]) => {
+      layerVisible[layer] = visible;
+    });
+    // A historical export temporarily built the latest scene. Rebuild the
+    // owner's exact slice before restoring the camera and focus over it.
+    if (viewState.sliderValue !== "100") {
+      buildScene({ frame: false, preserveSelection: true });
+    }
+
+    camera.aspect = viewState.cameraAspect;
+    camera.position.copy(viewState.cameraPosition);
+    camera.quaternion.copy(viewState.cameraQuaternion);
+    controls.target.copy(viewState.controlsTarget);
+    camera.updateProjectionMatrix();
+    camera.updateMatrixWorld(true);
+    fitDistance = viewState.fitDistance;
+    framedRadius = viewState.framedRadius;
+    portraitMode = viewState.portraitMode;
+    controls.minDistance = viewState.minDistance;
+    controls.maxDistance = viewState.maxDistance;
+    controls.maxTargetRadius = viewState.maxTargetRadius;
+    cameraFlight = viewState.cameraFlight;
+    zoomGoalDistance = viewState.zoomGoalDistance;
+    zoomAnchor = viewState.zoomAnchor;
+    selected = viewState.selected;
+    selectedItem = selected
+      ? items.get(selectionKey(selected.kind, selected.id)) || viewState.selectedItem
+      : null;
+    focusVisualsSuspended = viewState.focusVisualsSuspended;
+    applyLayerVisibility();
+    // Restoring focus can generate labels that did not exist while focus was
+    // suspended, so resolve the return element only after selection sync.
+    selectionReturnFocus = selected && viewState.returnFocusKey
+      ? (selectionTargets.get(viewState.returnFocusKey) || [])
+        .find((target) => target.element)?.element || viewState.selectionReturnFocus
+      : viewState.selectionReturnFocus;
+    syncZoomUI();
     renderer.render(scene, camera);
   }
   return new Promise((resolve, reject) => {
@@ -1447,7 +1565,7 @@ function showAllModel() {
   resetCamera();
 }
 
-function applyLayerVisibility(selectionReplacement = null) {
+function applyLayerVisibility({ preserveSelection = false, selectionReplacement = null } = {}) {
   Object.entries(layerObjects).forEach(([layer, objects]) => {
     objects.forEach((object) => {
       const visible = layer === "hierarchy"
@@ -1465,24 +1583,26 @@ function applyLayerVisibility(selectionReplacement = null) {
   document.querySelectorAll("[data-layer]").forEach((button) => {
     button.setAttribute("aria-pressed", String(layerVisible[button.dataset.layer]));
   });
-  const reconciliation = reconcileSceneSelection(
-    selected,
-    items,
-    layerVisible,
-    kindLayers,
-    selectionReplacement,
-  );
-  if (reconciliation.invalidated) {
-    // The selected object may have been the camera's orbit target after search
-    // focus. Once a cutoff or layer removes it, the drawer's Show all action is
-    // gone too, so restore the fitted overview here rather than leaving an
-    // apparently empty viewport aimed at a node that no longer exists.
-    recoverInvalidSceneSelection(reconciliation, clearSelection, resetCamera);
-    return;
-  }
-  if (reconciliation.replaced) {
-    selected = reconciliation.selection;
-    selectedItem = items.get(selectionKey(selected.kind, selected.id)) || null;
+  if (!preserveSelection) {
+    const reconciliation = reconcileSceneSelection(
+      selected,
+      items,
+      layerVisible,
+      kindLayers,
+      selectionReplacement,
+    );
+    if (reconciliation.invalidated) {
+      // The selected object may have been the camera's orbit target after search
+      // focus. Once a cutoff or layer removes it, the drawer's Show all action is
+      // gone too, so restore the fitted overview here rather than leaving an
+      // apparently empty viewport aimed at a node that no longer exists.
+      recoverInvalidSceneSelection(reconciliation, clearSelection, resetCamera);
+      return;
+    }
+    if (reconciliation.replaced) {
+      selected = reconciliation.selection;
+      selectedItem = items.get(selectionKey(selected.kind, selected.id)) || null;
+    }
   }
   syncSelectionState();
 }
@@ -2234,7 +2354,7 @@ async function loadModelOnce(force, selectionReplacement = null) {
     );
     setShareBusy(false);
     updateTimelineBounds();
-    buildScene(selectionReplacement);
+    buildScene({ selectionReplacement });
     return true;
   } catch (error) {
     shareReady = false;
@@ -2267,25 +2387,22 @@ function loadModel(force = false, selectionReplacement = null) {
 }
 
 function frameLayout(force) {
-  const portrait = window.innerWidth / window.innerHeight < 0.72;
-  portraitMode = portrait;
-  const radius = Math.max(4.8, layoutRadius);
-  if (!force && framedRadius > 0 && radius <= framedRadius * 1.16) return;
-  const direction = new THREE.Vector3(portrait ? 0.58 : 0.72, portrait ? 1.25 : 1.05, 1).normalize();
-  const distance = Math.max(portrait ? 15 : 12, radius * (portrait ? 3.0 : 2.55));
-  fitDistance = distance;
+  const overview = fittedOverviewPose(layoutRadius, window.innerWidth, window.innerHeight);
+  portraitMode = overview.portrait;
+  if (!force && framedRadius > 0 && overview.radius <= framedRadius * 1.16) return;
+  fitDistance = overview.distance;
   cameraFlight = null;
   zoomGoalDistance = null;
-  camera.position.copy(direction.multiplyScalar(distance));
-  controls.target.set(0, 0, 0);
-  controls.minDistance = distance * 100 / ZOOM_MAX_PERCENT;
-  controls.maxDistance = distance * 100 / ZOOM_MIN_PERCENT;
+  camera.position.set(...overview.position);
+  controls.target.set(...overview.target);
+  controls.minDistance = overview.distance * 100 / ZOOM_MAX_PERCENT;
+  controls.maxDistance = overview.distance * 100 / ZOOM_MIN_PERCENT;
   // Zooming at the cursor walks the orbit centre towards whatever is under it.
   // Bound how far it may wander so a long pinch cannot strand the constellation
   // off-screen with nothing left to orbit around.
-  controls.maxTargetRadius = radius * 1.5;
+  controls.maxTargetRadius = overview.radius * 1.5;
   zoomAnchor = null;
-  framedRadius = radius;
+  framedRadius = overview.radius;
   controls.update();
   syncZoomUI();
 }
@@ -2520,17 +2637,18 @@ const panelResizeObserver = "ResizeObserver" in window
   : null;
 if (panelResizeObserver) {
   document.querySelectorAll(
-    ".story, .legend, .status, .timeline, .detail, .search-dialog",
+    ".story, .legend, .mobile-guide, .status, .timeline, .detail, .search-dialog",
   ).forEach((element) => panelResizeObserver.observe(element));
 }
 document.querySelector(".legend")?.addEventListener("toggle", invalidatePanelBoxes);
+mobileGuideEl?.addEventListener("toggle", invalidatePanelBoxes);
 detailEvidenceFoldEl.addEventListener("toggle", invalidatePanelBoxes);
 detailHistoryFoldEl.addEventListener("toggle", invalidatePanelBoxes);
 
 function panelBoxes() {
   if (occupiedPanels) return occupiedPanels;
   occupiedPanels = [...document.querySelectorAll(
-    ".story, .legend, .status, .timeline, .detail:not([hidden]), .search-dialog",
+    ".story, .legend, .mobile-guide, .status, .timeline, .detail:not([hidden]), .search-dialog",
   )]
     .map((element) => element.getBoundingClientRect())
     .filter((box) => box.width > 0 && box.height > 0)

--- a/resources/model_assets/viewer.js
+++ b/resources/model_assets/viewer.js
@@ -2768,15 +2768,19 @@ function gestureInFlight() {
 // also means a wheel over the topbar, legend or status strip zooms the model
 // instead of falling through to the browser.
 viewerEl.addEventListener("wheel", (event) => {
-  // The drawer, line picker, and search panel own real scrolling; leave them be.
-  if (!shouldHandleModelGesture(event.target)) return;
+  // The drawer, line picker, and search panel own ordinary scrolling. A
+  // ctrlKey wheel is a Chrome/Firefox trackpad pinch, though, and must remain
+  // model navigation even when the gesture starts over one of those panels.
+  if (!shouldHandleModelGesture(event)) return;
   event.stopPropagation();
+  // Prevent browser page zoom even when Safari also reports this pinch through
+  // GestureEvents and the duplicate wheel is discarded below.
+  event.preventDefault();
   // If a gesture is in flight this wheel is the same fingers counted twice.
   if (gestureInFlight()) return;
   // Chrome and Firefox report a trackpad pinch as a wheel with ctrlKey set,
   // which is also the browser's own page-zoom chord: without preventDefault the
   // page would zoom instead of the model.
-  event.preventDefault();
   pauseAutoRotate();
   requestZoomBy(
     zoomMath.wheelFactor(event, window.innerHeight),
@@ -2785,14 +2789,16 @@ viewerEl.addEventListener("wheel", (event) => {
 }, { passive: false, capture: true });
 
 viewerEl.addEventListener("gesturestart", (event) => {
-  if (!shouldHandleModelGesture(event.target)) return;
+  // Safari GestureEvents always describe a pinch, never ordinary scrolling,
+  // so panels do not opt out as they do for a plain wheel.
+  if (!shouldHandleModelGesture(event)) return;
   event.preventDefault();
   gestureScale = 1;
   gestureSeenAt = performance.now();
   if (anchorFromClient(event.clientX, event.clientY)) gestureAnchor.copy(zoomAnchorNdc);
   else gestureAnchor.set(0, 0);
   pauseAutoRotate();
-});
+}, { passive: false, capture: true });
 viewerEl.addEventListener("gesturechange", (event) => {
   if (!gestureScale) return;
   event.preventDefault();
@@ -2804,12 +2810,12 @@ viewerEl.addEventListener("gesturechange", (event) => {
   zoomAnchorNdc.copy(gestureAnchor);
   requestZoomBy(scale / gestureScale, zoomAnchorNdc);
   gestureScale = scale;
-});
+}, { passive: false, capture: true });
 viewerEl.addEventListener("gestureend", (event) => {
   if (!gestureScale) return;
   event.preventDefault();
   gestureScale = 0;
-});
+}, { passive: false, capture: true });
 document.getElementById("reset").addEventListener("click", resetCamera);
 document.getElementById("close-detail").addEventListener("click", () => clearSelection(true));
 clearFocusButton.addEventListener("click", showAllModel);

--- a/src/persome/api/model_view.py
+++ b/src/persome/api/model_view.py
@@ -95,6 +95,11 @@ _MEMORY_VIEW_TEMPLATE = """<!doctype html>
       </div>
     </details>
 
+    <details id="mobile-guide" class="mobile-guide" aria-label="Hierarchy guide explanation">
+      <summary><span class="swatch guide" aria-hidden="true"></span><b>Guide</b><span>inferred placement · not evidence</span></summary>
+      <p>These connectors help arrange the hierarchy. Open Evidence on a model object for sourced support.</p>
+    </details>
+
     <section id="model-search-panel" class="search-panel" role="dialog" aria-modal="true" aria-labelledby="search-title" hidden>
       <div class="search-dialog">
         <header>

--- a/src/persome/api/model_view.py
+++ b/src/persome/api/model_view.py
@@ -34,19 +34,24 @@ _MEMORY_VIEW_TEMPLATE = """<!doctype html>
     <div id="canvas"></div>
 
     <header class="topbar">
-      <div class="brand">
-        <span class="brand-mark" aria-hidden="true"><i></i><i></i><i></i></span>
-        <span class="brand-lockup">
-          <strong>Persome</strong>
-          <span>Personal Model</span>
-        </span>
+      <div class="brand-tools">
+        <div class="brand">
+          <span class="brand-mark" aria-hidden="true"><i></i><i></i><i></i></span>
+          <span class="brand-lockup">
+            <strong>Persome</strong>
+            <span>Personal Model</span>
+          </span>
+        </div>
+        <button id="open-search" class="search-trigger" type="button" aria-haspopup="dialog" aria-controls="model-search-panel" title="Find in your model (⌘K)">
+          <span aria-hidden="true">⌕</span><b>Find in your model</b><kbd>⌘K</kbd>
+        </button>
       </div>
       <div class="layers" role="group" aria-label="Visible model layers">
-        <button type="button" data-layer="points" aria-pressed="true" title="Toggle Points"><i></i>Points</button>
-        <button type="button" data-layer="lines" aria-pressed="true" title="Toggle Lines"><i></i>Lines</button>
-        <button type="button" data-layer="faces" aria-pressed="true" title="Toggle Faces"><i></i>Faces</button>
-        <button type="button" data-layer="volumes" aria-pressed="true" title="Toggle Volumes"><i></i>Volumes</button>
-        <button type="button" data-layer="root" aria-pressed="true" title="Toggle Root"><i></i>Root</button>
+        <button type="button" data-layer="points" aria-pressed="true" title="Toggle Points"><i></i><span>Points</span><small id="layer-count-points" aria-hidden="true">0</small></button>
+        <button type="button" data-layer="lines" aria-pressed="true" title="Toggle Lines"><i></i><span>Lines</span><small id="layer-count-lines" aria-hidden="true">0</small></button>
+        <button type="button" data-layer="faces" aria-pressed="true" title="Toggle Faces"><i></i><span>Faces</span><small id="layer-count-faces" aria-hidden="true">0</small></button>
+        <button type="button" data-layer="volumes" aria-pressed="true" title="Toggle Volumes"><i></i><span>Volumes</span><small id="layer-count-volumes" aria-hidden="true">0</small></button>
+        <button type="button" data-layer="root" aria-pressed="true" title="Toggle Root"><i></i><span>Root</span><small id="layer-count-root" aria-hidden="true">0</small></button>
       </div>
       <div class="view-actions">
         <span class="privacy-badge"><i aria-hidden="true"></i>Local only</span>
@@ -77,19 +82,49 @@ _MEMORY_VIEW_TEMPLATE = """<!doctype html>
       <span class="status-loading">Loading your model…</span>
     </section>
 
-    <aside class="legend" aria-label="Model layer legend">
-      <p>How to read your model</p>
-      <div><span class="swatch point"></span><b>Point</b><span>observed fact</span></div>
-      <div><span class="swatch line"></span><b>Line</b><span>evolution or relation</span></div>
-      <div><span class="swatch context"></span><b>Entity</b><span>the other end of a relation</span></div>
-      <div><span class="swatch face"></span><b>Face</b><span>stable pattern</span></div>
-      <div><span class="swatch volume"></span><b>Volume</b><span>cross-pattern structure</span></div>
-      <div><span class="swatch root"></span><b>Root</b><span>current personal model</span></div>
-    </aside>
+    <details class="legend" aria-label="Model layer legend" open>
+      <summary><span>How to read your model</span><small>7 cues</small></summary>
+      <div class="legend-body">
+        <div><span class="swatch point"></span><b>Point</b><span>sourced observation</span></div>
+        <div><span class="swatch line"></span><b>Line</b><span>stored evolution or relation</span></div>
+        <div><span class="swatch guide"></span><b>Guide</b><span>inferred placement · not evidence</span></div>
+        <div><span class="swatch context"></span><b>Entity</b><span>the other end of a relation</span></div>
+        <div><span class="swatch face"></span><b>Face</b><span>stable pattern</span></div>
+        <div><span class="swatch volume"></span><b>Volume</b><span>cross-pattern structure</span></div>
+        <div><span class="swatch root"></span><b>Root</b><span>current personal model</span></div>
+      </div>
+    </details>
+
+    <section id="model-search-panel" class="search-panel" role="dialog" aria-modal="true" aria-labelledby="search-title" hidden>
+      <div class="search-dialog">
+        <header>
+          <div>
+            <p class="search-kicker">Local model explorer</p>
+            <h2 id="search-title">Find a thought, pattern, or relation</h2>
+          </div>
+          <button id="close-search" class="icon-button" type="button" aria-label="Close model search" title="Close (Esc)">×</button>
+        </header>
+        <label class="visually-hidden" for="model-search">Search your personal model</label>
+        <div class="search-field">
+          <span aria-hidden="true">⌕</span>
+          <input id="model-search" type="search" role="combobox" autocomplete="off" spellcheck="false" placeholder="Search the local snapshot…" aria-autocomplete="list" aria-expanded="false" aria-controls="search-results" aria-describedby="search-summary">
+          <kbd>ESC</kbd>
+        </div>
+        <p id="search-summary" class="search-summary" aria-live="polite">Showing the clearest parts of your model.</p>
+        <div id="search-results" class="search-results" role="listbox" aria-label="Model search results"></div>
+        <p id="search-empty" class="search-empty" hidden>No matching model object. Try a shorter phrase.</p>
+        <footer><span><kbd>↑</kbd><kbd>↓</kbd> move</span><span><kbd>↵</kbd> focus</span><span>Search queries stay on this Mac</span></footer>
+      </div>
+    </section>
 
     <aside id="detail" class="detail" aria-labelledby="detail-title" hidden>
       <button id="close-detail" class="icon-button close" type="button" aria-label="Close" title="Close (Esc)">×</button>
       <p class="detail-eyebrow"><span id="detail-kind" class="detail-kind"></span><span id="detail-provenance">Evidence-backed</span></p>
+
+      <div class="focus-note" role="note">
+        <span><b>Focused neighborhood</b><small>Navigation view · not evidence</small></span>
+        <button id="clear-focus" type="button">Show all</button>
+      </div>
 
       <h1 id="detail-title" class="detail-claim" aria-describedby="detail-hint"></h1>
       <textarea id="detail-claim-input" class="detail-claim detail-claim-input" rows="1" maxlength="4000" aria-label="Edit this claim in your own words" hidden></textarea>
@@ -138,7 +173,7 @@ _MEMORY_VIEW_TEMPLATE = """<!doctype html>
       <output id="as-of-label" for="as-of">Now</output>
     </footer>
 
-    <p class="gesture-hint"><span aria-hidden="true">↗</span> Drag to orbit · Scroll or pinch to zoom · Select a thought</p>
+    <p class="gesture-hint"><span aria-hidden="true">↗</span> Drag to orbit · Pinch to zoom · Select to focus · ⌘K to find</p>
   </main>
   <script type="module" src="assets/viewer.js"></script>
 </body>

--- a/src/persome/api/routes.py
+++ b/src/persome/api/routes.py
@@ -750,6 +750,7 @@ def model_view(request: Request) -> HTMLResponse:
 
 _MODEL_ASSETS = {
     "evidence.mjs",
+    "explore.mjs",
     "onboarding.css",
     "onboarding.js",
     "three.module.js",

--- a/src/persome/api/routes.py
+++ b/src/persome/api/routes.py
@@ -29,6 +29,7 @@ from ..model import (
     build_live_snapshot,
     normalize_activity_identity,
 )
+from ..privacy.scrub import scan
 from ..security.auth import (
     BROWSER_BOOTSTRAP_PATH,
     BROWSER_BOOTSTRAP_TTL_SECONDS,
@@ -825,17 +826,19 @@ def model_graph() -> dict[str, Any]:
 
 
 def _share_card_projection(snapshot: dict[str, Any]) -> dict[str, Any]:
-    """Keep only scrubbed summaries and counts needed by public share artifacts.
+    """Keep and scrub only summaries and counts needed by public share artifacts.
 
     The owner viewer intentionally receives an unredacted graph. Sharing must
     cross a separate server-side boundary so raw receipts, identifiers, paths,
-    and source content never reach the export code by accident.
+    and source content never reach the export code by accident. This function
+    therefore scrubs each retained signature even when its input is the cached
+    owner graph rather than an already-redacted export snapshot.
     """
 
     def summary(item: object) -> dict[str, Any] | None:
         if not isinstance(item, dict):
             return None
-        signature = str(item.get("signature") or "").strip()
+        signature = scan(str(item.get("signature") or "")).redacted.strip()
         if not signature:
             return None
         return {
@@ -872,12 +875,12 @@ def _share_card_projection(snapshot: dict[str, Any]) -> dict[str, Any]:
 
 @router.get("/model/share-card", tags=["model"])
 def model_share_card() -> dict[str, Any]:
-    """Return the minimal, canonically scrubbed public share projection."""
-    from ..store import fts as fts_store
-
-    with fts_store.cursor() as conn:
-        snapshot = build_live_snapshot(conn, redact=True)
-    return {"model": _share_card_projection(snapshot)}
+    """Return a scrubbed projection version-matched to the owner graph cache."""
+    graph = model_graph()
+    return {
+        "generated_at": graph["generated_at"],
+        "model": _share_card_projection(graph["model"]),
+    }
 
 
 @router.post("/model/edit", response_model=ApiResponse, include_in_schema=False, tags=["model"])

--- a/tests/js/model_evidence.test.mjs
+++ b/tests/js/model_evidence.test.mjs
@@ -4,7 +4,9 @@ import test from "node:test";
 import {
   evidenceBreadcrumb,
   evidenceOverview,
+  indexLinePresentations,
   linePresentation,
+  modelNodeLabelIndex,
   nodeEvidenceCards,
   nodeHistoryCards,
   relationLabel,
@@ -77,4 +79,57 @@ test("presents line endpoints without exposing raw node IDs or replacing the pre
   assert.equal(relation.target, "Context node");
   assert.ok(!JSON.stringify(relation).includes("point-current"));
   assert.ok(!JSON.stringify(relation).includes("private-context-id"));
+});
+
+test("indexes node labels once and presents each Line once without rescanning model nodes", () => {
+  const points = Array.from({ length: 5_000 }, (_, index) => ({
+    id: `point-${index}`,
+    content: `Point ${index}`,
+  }));
+  const largeModel = { points };
+  const nodeLabels = modelNodeLabelIndex(largeModel);
+  points.find = () => {
+    throw new Error("pre-indexed Line presentation must not scan the Point array");
+  };
+
+  const reads = new Map();
+  const countedLine = (values) => new Proxy(values, {
+    get(target, property, receiver) {
+      if (["id", "kind", "label", "predicate", "source", "target"].includes(property)) {
+        reads.set(property, (reads.get(property) || 0) + 1);
+      }
+      return Reflect.get(target, property, receiver);
+    },
+  });
+  const lines = [
+    countedLine({
+      id: "line-a",
+      kind: "relation",
+      label: "supports",
+      predicate: "supports",
+      source: "point-1",
+      target: "point-4999",
+    }),
+    countedLine({
+      id: "line-b",
+      kind: "evolution",
+      label: "",
+      predicate: "supersedes",
+      source: "point-2",
+      target: "point-3",
+    }),
+  ];
+
+  const presentations = indexLinePresentations(lines, largeModel, nodeLabels);
+
+  assert.equal(presentations.get("line-a").option, "supports: Point 1 → Point 4999");
+  assert.equal(presentations.get("line-b").source, "Point 2");
+  assert.deepEqual(Object.fromEntries(reads), {
+    id: 2,
+    kind: 2,
+    predicate: 2,
+    label: 2,
+    source: 2,
+    target: 2,
+  });
 });

--- a/tests/js/model_explore.test.mjs
+++ b/tests/js/model_explore.test.mjs
@@ -3,8 +3,121 @@ import test from "node:test";
 
 import {
   focusKeysForSelection,
+  handleSearchShortcut,
+  pointerUpOutcome,
   rankSearchEntries,
+  reconcileSceneSelection,
+  recoverInvalidSceneSelection,
+  shouldHandleModelGesture,
 } from "../../resources/model_assets/explore.mjs";
+
+test("keeps an in-progress claim focused when the search chord is pressed", () => {
+  let prevented = false;
+  let opened = false;
+  const event = {
+    key: "k",
+    metaKey: true,
+    ctrlKey: false,
+    preventDefault() { prevented = true; },
+  };
+
+  assert.equal(handleSearchShortcut(event, true, () => { opened = true; }), true);
+  assert.equal(prevented, true);
+  assert.equal(opened, false);
+
+  prevented = false;
+  event.metaKey = false;
+  event.ctrlKey = true;
+  assert.equal(handleSearchShortcut(event, true, () => { opened = true; }), true);
+  assert.equal(prevented, true);
+  assert.equal(opened, false);
+
+  prevented = false;
+  assert.equal(handleSearchShortcut(event, false, () => { opened = true; }), true);
+  assert.equal(prevented, true);
+  assert.equal(opened, true);
+});
+
+test("zooms through the legend while preserving real scrolling surfaces", () => {
+  const targetIn = (className) => ({
+    closest(selector) {
+      return selector.split(", ").includes(className) ? { className } : null;
+    },
+  });
+
+  assert.equal(shouldHandleModelGesture(targetIn(".legend")), true);
+  assert.equal(shouldHandleModelGesture(targetIn(".detail")), false);
+  assert.equal(shouldHandleModelGesture(targetIn(".line-explorer")), false);
+  assert.equal(shouldHandleModelGesture(targetIn(".search-panel")), false);
+});
+
+test("restores the grab cursor after non-primary mouse gestures", () => {
+  assert.deepEqual(
+    pointerUpOutcome({ pointerType: "mouse", button: 1 }, true),
+    { selectionEligible: false, cursor: "grab" },
+  );
+  assert.deepEqual(
+    pointerUpOutcome({ pointerType: "mouse", button: 2 }, true),
+    { selectionEligible: false, cursor: "grab" },
+  );
+  assert.deepEqual(
+    pointerUpOutcome({ pointerType: "mouse", button: 0 }, true),
+    { selectionEligible: true, cursor: "pointer" },
+  );
+});
+
+test("invalidates hidden selections but carries a correction to its successor", () => {
+  const kindLayers = { point: "points", face: "faces" };
+  const visible = { points: true, faces: true };
+  const items = new Map([
+    ["point:point-new", { id: "point-new" }],
+    ["face:face-a", { id: "face-a" }],
+  ]);
+
+  assert.deepEqual(
+    reconcileSceneSelection(
+      { kind: "point", id: "point-old" },
+      items,
+      visible,
+      kindLayers,
+      { kind: "point", fromId: "point-old", toId: "point-new" },
+    ),
+    {
+      selection: { kind: "point", id: "point-new" },
+      invalidated: false,
+      replaced: true,
+    },
+  );
+  assert.deepEqual(
+    reconcileSceneSelection(
+      { kind: "point", id: "point-old" },
+      items,
+      visible,
+      kindLayers,
+    ),
+    { selection: null, invalidated: true, replaced: false },
+  );
+  assert.deepEqual(
+    reconcileSceneSelection(
+      { kind: "face", id: "face-a" },
+      items,
+      { ...visible, faces: false },
+      kindLayers,
+    ),
+    { selection: null, invalidated: true, replaced: false },
+  );
+
+  const recovery = [];
+  assert.equal(
+    recoverInvalidSceneSelection(
+      { invalidated: true },
+      () => recovery.push("clear"),
+      () => recovery.push("frame"),
+    ),
+    true,
+  );
+  assert.deepEqual(recovery, ["clear", "frame"]);
+});
 
 test("ranks exact and title-prefix matches ahead of metadata and fuzzy matches", () => {
   const entries = [

--- a/tests/js/model_explore.test.mjs
+++ b/tests/js/model_explore.test.mjs
@@ -4,7 +4,9 @@ import test from "node:test";
 import {
   focusKeysForSelection,
   handleSearchShortcut,
+  pointSearchMetadata,
   pointerUpOutcome,
+  prepareSearchEntries,
   rankSearchEntries,
   reconcileSceneSelection,
   recoverInvalidSceneSelection,
@@ -155,6 +157,153 @@ test("uses explicit entry weights with deterministic kind tie-breaking for empty
     rankSearchEntries(entries, "").map((entry) => entry.key),
     ["point:1", "root:1", "face:1"],
   );
+});
+
+test("labels inactive Points explicitly and keeps history discoverable below current claims", () => {
+  const points = [
+    { id: "current", content: "Protect focused attention", is_latest: true, status: "active" },
+    { id: "shadow", content: "Protect focused attention", is_latest: true, status: "shadow" },
+    { id: "history", content: "Protect focused attention", is_latest: false, status: "superseded" },
+  ];
+  const entries = prepareSearchEntries(points.map((point) => {
+    const metadata = pointSearchMetadata(point);
+    return {
+      key: `point:${point.id}`,
+      kind: "point",
+      title: point.content,
+      subtitle: metadata.subtitle,
+      aliases: metadata.aliases,
+      stateAliases: metadata.aliases,
+      weight: 6 + metadata.weightAdjustment,
+      searchState: metadata.state,
+    };
+  }));
+
+  assert.deepEqual(
+    entries.map(({ searchState, subtitle }) => ({ searchState, subtitle })),
+    [
+      { searchState: "current", subtitle: "Modeled observation · current" },
+      { searchState: "shadow", subtitle: "Modeled observation · shadow · not active" },
+      { searchState: "history", subtitle: "Modeled observation · historical · superseded" },
+    ],
+  );
+  assert.deepEqual(
+    rankSearchEntries(entries, "protect focused").map((entry) => entry.key),
+    ["point:current", "point:shadow", "point:history"],
+  );
+  const noisyFaces = prepareSearchEntries(Array.from({ length: 12 }, (_, index) => ({
+    key: `face:${index}`,
+    kind: "face",
+    title: `Sensible habits allow deliberate outcomes weekly ${index}`,
+    subtitle: "Stable pattern",
+    weight: 20,
+  })));
+  assert.equal(rankSearchEntries([...entries, ...noisyFaces], "historical")[0].key, "point:history");
+  assert.equal(rankSearchEntries([...entries, ...noisyFaces], "shadow")[0].key, "point:shadow");
+
+  const endedPoint = {
+    id: "ended",
+    is_latest: true,
+    status: "active",
+    valid_until: "2026-03-01T00:00:00Z",
+  };
+  assert.equal(
+    pointSearchMetadata(endedPoint, new Date("2026-02-28T23:59:59Z")).state,
+    "current",
+  );
+  assert.deepEqual(
+    pointSearchMetadata(endedPoint, new Date("2026-03-01T00:00:00Z")),
+    {
+      state: "history",
+      subtitle: "Modeled observation · historical · ended",
+      aliases: ["history", "historical", "not current", "ended"],
+      weightAdjustment: -72,
+    },
+  );
+
+  const predecessor = {
+    id: "predecessor",
+    is_latest: false,
+    status: "shadow",
+    valid_from: "2026-01-01T00:00:00Z",
+    valid_until: "2026-03-01T00:00:00Z",
+  };
+  assert.deepEqual(
+    pointSearchMetadata(predecessor, new Date("2026-02-01T00:00:00Z")),
+    {
+      state: "current",
+      subtitle: "Modeled observation · current",
+      aliases: ["current", "active"],
+      weightAdjustment: 0,
+    },
+  );
+  assert.deepEqual(
+    pointSearchMetadata(predecessor, new Date("2026-03-01T00:00:00Z")),
+    {
+      state: "history",
+      subtitle: "Modeled observation · historical · ended · shadow",
+      aliases: ["history", "historical", "not current", "ended", "shadow"],
+      weightAdjustment: -72,
+    },
+  );
+});
+
+test("bounded top-k ranking matches a full-sort reference across ties and input order", () => {
+  const kindPriority = { root: 0, volume: 1, face: 2, point: 3, line: 4, context: 5 };
+  const entries = prepareSearchEntries(Array.from({ length: 240 }, (_, index) => ({
+    key: `${["line", "point", "face", "volume"][index % 4]}:${String(index).padStart(3, "0")}`,
+    kind: ["line", "point", "face", "volume"][index % 4],
+    title: `Shared anchor ${String(239 - index).padStart(3, "0")}`,
+    subtitle: "Common match",
+    weight: index % 11,
+  })).reverse());
+  const expected = [...entries].sort((left, right) => (
+    right.weight - left.weight
+    || kindPriority[left.kind] - kindPriority[right.kind]
+    || left.title.localeCompare(right.title)
+    || left.key.localeCompare(right.key)
+  )).slice(0, 9).map((entry) => entry.key);
+
+  assert.deepEqual(
+    rankSearchEntries(entries, "shared", 9).map((entry) => entry.key),
+    expected,
+  );
+});
+
+test("large prepared indexes normalize only the query and avoid a full-result sort", () => {
+  const entries = prepareSearchEntries(Array.from({ length: 20_000 }, (_, index) => ({
+    key: `point:${index}`,
+    kind: "point",
+    title: index % 997 === 0 ? `Needle anchor ${index}` : `Memory object ${index}`,
+    subtitle: "Modeled observation · current",
+    aliases: ["active"],
+    weight: index % 17,
+  })));
+  const originalNormalize = String.prototype.normalize;
+  const originalSort = Array.prototype.sort;
+  let normalizeCalls = 0;
+  let largestSortedArray = 0;
+  let matches;
+
+  try {
+    String.prototype.normalize = function countedNormalize(...args) {
+      normalizeCalls += 1;
+      return originalNormalize.apply(this, args);
+    };
+    Array.prototype.sort = function countedSort(...args) {
+      largestSortedArray = Math.max(largestSortedArray, this.length);
+      return originalSort.apply(this, args);
+    };
+    matches = rankSearchEntries(entries, "needle", 9);
+  } finally {
+    String.prototype.normalize = originalNormalize;
+    Array.prototype.sort = originalSort;
+  }
+
+  assert.equal(normalizeCalls, 1);
+  assert.equal(largestSortedArray, 0);
+  assert.equal(matches.length, 9);
+  assert.ok(matches.every((entry) => entry.normalizedTitle.includes("needle")));
 });
 
 function modelFixture() {

--- a/tests/js/model_explore.test.mjs
+++ b/tests/js/model_explore.test.mjs
@@ -38,17 +38,27 @@ test("keeps an in-progress claim focused when the search chord is pressed", () =
   assert.equal(opened, true);
 });
 
-test("zooms through the legend while preserving real scrolling surfaces", () => {
+test("preserves ordinary panel scrolling but captures pinch everywhere", () => {
   const targetIn = (className) => ({
     closest(selector) {
       return selector.split(", ").includes(className) ? { className } : null;
     },
   });
+  const eventIn = (className, properties = {}) => ({
+    type: "wheel",
+    target: targetIn(className),
+    ...properties,
+  });
 
-  assert.equal(shouldHandleModelGesture(targetIn(".legend")), true);
-  assert.equal(shouldHandleModelGesture(targetIn(".detail")), false);
-  assert.equal(shouldHandleModelGesture(targetIn(".line-explorer")), false);
-  assert.equal(shouldHandleModelGesture(targetIn(".search-panel")), false);
+  assert.equal(shouldHandleModelGesture(eventIn(".legend")), true);
+  assert.equal(shouldHandleModelGesture(eventIn(".detail")), false);
+  assert.equal(shouldHandleModelGesture(eventIn(".line-explorer")), false);
+  assert.equal(shouldHandleModelGesture(eventIn(".search-panel")), false);
+
+  assert.equal(shouldHandleModelGesture(eventIn(".detail", { ctrlKey: true })), true);
+  assert.equal(shouldHandleModelGesture(eventIn(".line-explorer", { ctrlKey: true })), true);
+  assert.equal(shouldHandleModelGesture(eventIn(".search-panel", { ctrlKey: true })), true);
+  assert.equal(shouldHandleModelGesture(eventIn(".detail", { type: "gesturestart" })), true);
 });
 
 test("restores the grab cursor after non-primary mouse gestures", () => {

--- a/tests/js/model_explore.test.mjs
+++ b/tests/js/model_explore.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  focusKeysForSelection,
+  rankSearchEntries,
+} from "../../resources/model_assets/explore.mjs";
+
+test("ranks exact and title-prefix matches ahead of metadata and fuzzy matches", () => {
+  const entries = [
+    { key: "point:1", kind: "point", title: "Build an evidence trail", subtitle: "Point" },
+    { key: "face:1", kind: "face", title: "Evidence-led product work", subtitle: "Stable pattern" },
+    { key: "volume:1", kind: "volume", title: "Product craft", subtitle: "Evidence systems" },
+    { key: "root:1", kind: "root", title: "Evidence", subtitle: "Current personal model" },
+  ];
+
+  assert.deepEqual(
+    rankSearchEntries(entries, "evidence").map((entry) => entry.key),
+    ["root:1", "face:1", "point:1", "volume:1"],
+  );
+  assert.equal(rankSearchEntries(entries, "evdnc")[0].key, "root:1");
+});
+
+test("uses explicit entry weights with deterministic kind tie-breaking for empty search", () => {
+  const entries = [
+    { key: "point:1", kind: "point", title: "Point", weight: 999 },
+    { key: "face:1", kind: "face", title: "Face", weight: 10 },
+    { key: "root:1", kind: "root", title: "Root", weight: 10 },
+  ];
+
+  assert.deepEqual(
+    rankSearchEntries(entries, "").map((entry) => entry.key),
+    ["point:1", "root:1", "face:1"],
+  );
+});
+
+function modelFixture() {
+  return {
+    points: [{ id: "point-a" }, { id: "point-b" }, { id: "point-c" }],
+    lines: [
+      { id: "line-ab", source: "point-a", target: "point-b" },
+      { id: "line-context", source: "point-a", target: "project-x" },
+    ],
+    faces: [{ id: "face-work" }, { id: "face-life" }],
+    volumes: [{ id: "volume-craft" }],
+    root: { id: "root-self" },
+  };
+}
+
+function layoutFixture() {
+  return {
+    pointClusterById: new Map([
+      ["point-a", "face:face-work"],
+      ["point-b", "face:face-work"],
+      ["point-c", "face:face-life"],
+    ]),
+    facePointIds: new Map([
+      ["face-work", ["point-a", "point-b"]],
+      ["face-life", ["point-c"]],
+    ]),
+    volumeFaceIds: new Map([["volume-craft", ["face-work"]]]),
+    rootVolumeIds: ["volume-craft"],
+  };
+}
+
+test("focuses a Point's semantic cluster and directly connected relations", () => {
+  const focus = focusKeysForSelection(
+    modelFixture(),
+    layoutFixture(),
+    { kind: "point", id: "point-a" },
+  );
+
+  assert.deepEqual(focus, new Set([
+    "point:point-a",
+    "line:line-ab",
+    "point:point-b",
+    "line:line-context",
+    "context:project-x",
+    "face:face-work",
+  ]));
+  assert.equal(focus.has("point:point-c"), false);
+});
+
+test("focuses only the adjacent hierarchy shell for high-level selections", () => {
+  const model = modelFixture();
+  const layout = layoutFixture();
+
+  assert.deepEqual(
+    focusKeysForSelection(model, layout, { kind: "face", id: "face-work" }),
+    new Set(["face:face-work", "point:point-a", "point:point-b", "volume:volume-craft"]),
+  );
+  assert.deepEqual(
+    focusKeysForSelection(model, layout, { kind: "root", id: "root-self" }),
+    new Set(["root:root-self", "volume:volume-craft"]),
+  );
+});

--- a/tests/js/model_zoom.test.mjs
+++ b/tests/js/model_zoom.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { zoomMath } from "../../resources/model_assets/layout.mjs";
+import {
+  fittedOverviewPose,
+  zoomMath,
+} from "../../resources/model_assets/layout.mjs";
 
 function wheel(deltaY, { deltaMode = 0, ctrlKey = false } = {}) {
   return { deltaY, deltaMode, ctrlKey };
@@ -103,4 +106,32 @@ test("the button and keyboard zoom steps are unchanged", () => {
   assert.equal(zoomMath.nextPercent(141, -1, 25, 50, 400), 125);
   assert.equal(zoomMath.nextPercent(400, 1, 25, 50, 400), 400);
   assert.equal(zoomMath.nextPercent(50, -1, 25, 50, 400), 50);
+});
+
+test("the share overview is fitted to the artifact rather than the current viewport", () => {
+  const currentPortraitView = fittedOverviewPose(8, 390, 844);
+  const shareView = fittedOverviewPose(8, 1200, 675);
+
+  assert.equal(currentPortraitView.portrait, true);
+  assert.equal(shareView.portrait, false);
+  assert.equal(shareView.aspect, 1200 / 675);
+  assert.deepEqual(shareView.target, [0, 0, 0]);
+  assert.ok(
+    Math.abs(Math.hypot(...shareView.position) - shareView.distance) < 1e-12,
+    "the fitted camera position must stay exactly one fitted distance from the model centre",
+  );
+  assert.notDeepEqual(
+    shareView.position,
+    currentPortraitView.position,
+    "a portrait/focused viewport must not determine the landscape share framing",
+  );
+});
+
+test("the fitted overview uses safe deterministic defaults for malformed viewport input", () => {
+  const view = fittedOverviewPose(Number.NaN, 0, Number.NaN);
+  assert.equal(view.aspect, 1);
+  assert.equal(view.portrait, false);
+  assert.equal(view.radius, 6);
+  assert.ok(Number.isFinite(view.distance));
+  assert.ok(view.position.every(Number.isFinite));
 });

--- a/tests/js/model_zoom.test.mjs
+++ b/tests/js/model_zoom.test.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { zoomMath } from "../../resources/model_assets/layout.mjs";
+
+function wheel(deltaY, { deltaMode = 0, ctrlKey = false } = {}) {
+  return { deltaY, deltaMode, ctrlKey };
+}
+
+// One comfortable macOS trackpad pinch-out spreads the fingers over roughly
+// 300px of accumulated ctrl+wheel delta, delivered as dozens of small events.
+function pinchGesture(totalPixels, events = 40) {
+  const step = -totalPixels / events;
+  let factor = 1;
+  for (let index = 0; index < events; index += 1) {
+    factor *= zoomMath.wheelFactor(wheel(step, { ctrlKey: true }), 657);
+  }
+  return factor;
+}
+
+test("a trackpad pinch is worth a meaningful part of the zoom range", () => {
+  const factor = pinchGesture(300);
+  // The regression this guards: normalising by devicePixelRatio made one whole
+  // pinch worth 1.05x, so crossing 50%-400% took about twenty-nine of them.
+  assert.ok(factor > 1.8, `one pinch should roughly double the zoom, got ${factor}`);
+  assert.ok(factor < 2.2, `one pinch must not overshoot a doubling, got ${factor}`);
+
+  const rangeRatio = 400 / 50;
+  const pinchesToCrossRange = Math.log(rangeRatio) / Math.log(factor);
+  assert.ok(
+    pinchesToCrossRange > 2 && pinchesToCrossRange < 5,
+    `crossing the whole range should take a handful of pinches, got ${pinchesToCrossRange}`,
+  );
+});
+
+test("a gesture composes the same whether it arrives in one event or many", () => {
+  const asOneEvent = zoomMath.wheelFactor(wheel(-300, { ctrlKey: true }), 657);
+  const asManyEvents = pinchGesture(300, 60);
+  assert.ok(
+    Math.abs(asOneEvent - asManyEvents) < 1e-9,
+    `${asOneEvent} vs ${asManyEvents} — an exponential curve must be path independent`,
+  );
+});
+
+test("wheel notches are a smaller step than a pinch of the same nominal delta", () => {
+  const notch = zoomMath.wheelFactor(wheel(-100), 657);
+  const pinch = zoomMath.wheelFactor(wheel(-100, { ctrlKey: true }), 657);
+  assert.ok(notch > 1.1 && notch < 1.25, `a wheel notch should be a visible step, got ${notch}`);
+  assert.ok(pinch > notch, "a pinch tracks the fingers, so it must out-gain a wheel notch");
+});
+
+test("line and page deltas are normalised to pixels", () => {
+  // Firefox reports deltaMode 1 with deltaY around 3 per notch. Reading that as
+  // pixels made its wheel and pinch do nothing at all.
+  assert.equal(zoomMath.wheelPixels(wheel(-3, { deltaMode: 1 }), 657), -48);
+  assert.equal(zoomMath.wheelPixels(wheel(2, { deltaMode: 2 }), 300), 400);
+  assert.equal(zoomMath.wheelPixels(wheel(-120), 657), -120);
+
+  const firefoxNotch = zoomMath.wheelFactor(wheel(-3, { deltaMode: 1 }), 657);
+  assert.ok(firefoxNotch > 1.05, `a line-mode notch must actually zoom, got ${firefoxNotch}`);
+});
+
+test("a single absurd event cannot teleport the camera", () => {
+  assert.equal(zoomMath.wheelPixels(wheel(-100000), 657), -400);
+  assert.equal(zoomMath.wheelPixels(wheel(100000, { deltaMode: 2 }), 4000), 400);
+  const factor = zoomMath.wheelFactor(wheel(-1e9, { ctrlKey: true }), 657);
+  assert.ok(Number.isFinite(factor) && factor < 3, `one event stays bounded, got ${factor}`);
+});
+
+test("zoom direction follows the platform convention", () => {
+  assert.ok(zoomMath.wheelFactor(wheel(-100), 657) > 1, "wheel up and pinch out zoom in");
+  assert.ok(zoomMath.wheelFactor(wheel(100), 657) < 1, "wheel down and pinch in zoom out");
+});
+
+test("opposite gestures of equal size return to where they started", () => {
+  const inFactor = zoomMath.wheelFactor(wheel(-140, { ctrlKey: true }), 657);
+  const outFactor = zoomMath.wheelFactor(wheel(140, { ctrlKey: true }), 657);
+  assert.ok(Math.abs(inFactor * outFactor - 1) < 1e-12, "the curve must be symmetric");
+});
+
+test("malformed wheel events are inert rather than destructive", () => {
+  // A divide-by-zero in the old normalisation turned one notch into a jump to
+  // the zoom limit, so degenerate input must resolve to "no zoom", never NaN.
+  assert.equal(zoomMath.wheelPixels(wheel(Number.NaN), 657), 0);
+  assert.equal(zoomMath.wheelPixels(wheel(undefined), 657), 0);
+  assert.equal(zoomMath.wheelFactor(wheel(Number.NaN), 657), 1);
+  assert.equal(zoomMath.wheelPixels(wheel(-100), 0), -100);
+  assert.ok(Number.isFinite(zoomMath.wheelFactor(wheel(-100), Number.NaN)));
+});
+
+test("a trackpad's sub-percent steps survive as a continuous factor", () => {
+  // The wheel path multiplies a continuous goal distance rather than a rounded
+  // percent: a trackpad delivers dozens of sub-percent events a second, and
+  // rounding each one would quantise the glide into visible stairs.
+  const tiny = zoomMath.wheelFactor(wheel(-1, { ctrlKey: true }), 657);
+  assert.ok(tiny > 1 && tiny < 1.01, `a 1px event must still register, got ${tiny}`);
+  assert.notEqual(tiny, 1);
+});
+
+test("the button and keyboard zoom steps are unchanged", () => {
+  // stepZoom still snaps to the 25% grid; only wheel and pinch went continuous.
+  assert.equal(zoomMath.nextPercent(100, 1, 25, 50, 400), 125);
+  assert.equal(zoomMath.nextPercent(141, -1, 25, 50, 400), 125);
+  assert.equal(zoomMath.nextPercent(400, 1, 25, 50, 400), 400);
+  assert.equal(zoomMath.nextPercent(50, -1, 25, 50, 400), 50);
+});

--- a/tests/test_model_layout_asset.py
+++ b/tests/test_model_layout_asset.py
@@ -19,6 +19,7 @@ def test_model_viewer_node_suite() -> None:
             "tests/js/model_evidence.test.mjs",
             "tests/js/model_layout.test.mjs",
             "tests/js/model_share.test.mjs",
+            "tests/js/model_zoom.test.mjs",
         ],
         cwd=root,
         capture_output=True,

--- a/tests/test_model_layout_asset.py
+++ b/tests/test_model_layout_asset.py
@@ -17,6 +17,7 @@ def test_model_viewer_node_suite() -> None:
             node,
             "--test",
             "tests/js/model_evidence.test.mjs",
+            "tests/js/model_explore.test.mjs",
             "tests/js/model_layout.test.mjs",
             "tests/js/model_share.test.mjs",
             "tests/js/model_zoom.test.mjs",

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -413,6 +413,11 @@ class TestViewPage:
         assert 'id="layer-count-points"' in body
         assert "inferred placement · not evidence" in body
         assert 'id="clear-focus"' in body
+        assert 'id="mobile-guide"' in body
+        assert 'class="mobile-guide"' in body
+        assert '<details id="mobile-guide" class="mobile-guide"' in body
+        assert "<b>Guide</b><span>inferred placement · not evidence</span></summary>" in body
+        assert "Open Evidence on a model object for sourced support." in body
         assert 'role="combobox"' in body
         assert 'role="listbox"' in body
         # The drawer is one page, not a tabbed form: the claim is editable in
@@ -519,6 +524,27 @@ class TestViewPage:
         assert b"window.__persomeInteractionState" in viewer.body
         assert b"TOUCH_NODE_HIT_RADIUS_PX = 22" in viewer.body
         assert b"focusVisualsSuspended = true" in viewer.body
+        assert b"fittedOverviewPose" in viewer.body
+        assert b"CONSTELLATION_CARD_WIDTH" in viewer.body
+        assert b"renderer.setPixelRatio(1)" in viewer.body
+        assert b"renderer.getSize(new THREE.Vector2())" in viewer.body
+        assert b"renderer.setPixelRatio(viewState.pixelRatio)" in viewer.body
+        assert (
+            b"renderer.setSize(viewState.rendererSize.x, viewState.rendererSize.y, false)"
+            in viewer.body
+        )
+        assert b"cameraFlight = viewState.cameraFlight" in viewer.body
+        assert b"zoomGoalDistance = viewState.zoomGoalDistance" in viewer.body
+        assert b"camera.aspect = viewState.cameraAspect" in viewer.body
+        assert b"camera.quaternion.copy(viewState.cameraQuaternion)" in viewer.body
+        assert b"controls.target.copy(viewState.controlsTarget)" in viewer.body
+        assert b'if (slider.value !== "100")' in viewer.body
+        assert b"buildScene({ frame: false, preserveSelection: true })" in viewer.body
+        assert b"cutoff = viewState.cutoff" in viewer.body
+        assert b"layers: { ...layerVisible }" in viewer.body
+        assert b"layerVisible[layer] = true" in viewer.body
+        assert b"layerVisible[layer] = visible" in viewer.body
+        assert b"selectionReturnFocus = selected && viewState.returnFocusKey" in viewer.body
         assert b"new ResizeObserver(invalidatePanelBoxes)" in viewer.body
         assert b"flyToSelection" in viewer.body
         assert b"rebuildSearchEntries" in viewer.body
@@ -593,6 +619,9 @@ class TestViewPage:
         assert ".model-label.focus-muted" in css
         assert ".focus-note" in css
         assert ".focus-note button" in css
+        assert ".mobile-guide" in css
+        assert "bottom: 76px" in css
+        assert "min-height: 26px" in css
         assert "max-height: min(66dvh, 620px)" in css
         assert "env(safe-area-inset-bottom)" in css
 

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -404,7 +404,17 @@ class TestViewPage:
         assert 'id="zoom-out"' in body
         assert 'id="zoom-reset"' in body
         assert 'id="zoom-in"' in body
-        assert "Scroll or pinch to zoom" in body
+        assert "Select to focus" in body
+        assert "⌘K to find" in body
+        assert 'id="open-search"' in body
+        assert 'id="model-search-panel"' in body
+        assert 'id="model-search"' in body
+        assert 'class="legend"' in body
+        assert 'id="layer-count-points"' in body
+        assert "inferred placement · not evidence" in body
+        assert 'id="clear-focus"' in body
+        assert 'role="combobox"' in body
+        assert 'role="listbox"' in body
         # The drawer is one page, not a tabbed form: the claim is editable in
         # place and provenance folds away beneath it.
         assert 'role="tablist"' not in body
@@ -422,6 +432,7 @@ class TestViewPage:
     def test_bundled_viewer_assets_are_served(self, ac_root):
         three = routes.model_asset("three.module.js")
         layout = routes.model_asset("layout.mjs")
+        explore = routes.model_asset("explore.mjs")
         evidence = routes.model_asset("evidence.mjs")
         share = routes.model_asset("share.mjs")
         viewer = routes.model_asset("viewer.js")
@@ -430,12 +441,15 @@ class TestViewPage:
         assert len(three.body) > 1_000_000
         assert b"class WebGLRenderer" in three.body
         assert b"computeClusterLayout" in layout.body
+        assert b"rankSearchEntries" in explore.body
+        assert b"focusKeysForSelection" in explore.body
         assert b"nodeEvidenceCards" in evidence.body
         assert b"humanCard" in share.body
         assert b"buildXIntentUrl" in share.body
         assert b"drawHumanCard" in share.body
         assert b"drawConstellationCard" in share.body
         assert b'from "./layout.mjs"' in viewer.body
+        assert b'from "./explore.mjs"' in viewer.body
         assert b'from "./share.mjs"' in viewer.body
         assert b"model.points" in viewer.body
         assert b"model.lines" in viewer.body
@@ -502,6 +516,12 @@ class TestViewPage:
         assert b"private source content" in share.body
         assert b"Built locally with Persome \xc2\xb7 Build yours" in share.body
         assert b"window.__persomeZoomState" in viewer.body
+        assert b"window.__persomeInteractionState" in viewer.body
+        assert b"TOUCH_NODE_HIT_RADIUS_PX = 22" in viewer.body
+        assert b"focusVisualsSuspended = true" in viewer.body
+        assert b"new ResizeObserver(invalidatePanelBoxes)" in viewer.body
+        assert b"flyToSelection" in viewer.body
+        assert b"rebuildSearchEntries" in viewer.body
         assert b"if (!REDUCED_MOTION)" in viewer.body
         assert b'event.key === "+"' in viewer.body
         assert b'event.key === "-"' in viewer.body
@@ -513,10 +533,11 @@ class TestViewPage:
         assert b".evidence-breadcrumbs" in css.body
         assert b".error button" in css.body
         assert b"(min-width: 1181px) and (max-width: 1360px)" in css.body
-        assert b"top: 116px" in css.body
+        assert b"@media (max-width: 860px)" in css.body
         assert b"prefers-reduced-motion" in css.body
         assert viewer.media_type == "text/javascript"
         assert layout.media_type == "text/javascript"
+        assert explore.media_type == "text/javascript"
         assert share.media_type == "text/javascript"
         assert css.media_type == "text/css"
 
@@ -547,6 +568,33 @@ class TestViewPage:
         assert ".line-explorer:focus-within" in css
         assert '.model-label[aria-expanded="true"]' in css
         assert '.detail[data-kind="line"]' in css
+
+    def test_viewer_exploration_contract_is_local_and_non_mutating(self, ac_root):
+        page = render_memory_view()
+        viewer = routes.model_asset("viewer.js").body.decode()
+        css = routes.model_asset("viewer.css").body.decode()
+
+        assert "Local model explorer" in page
+        assert "Search queries stay on this Mac" in page
+        assert 'autocomplete="off"' in page
+        assert 'fetch("./search"' not in viewer
+        assert "rankSearchEntries(searchEntries, query, 9)" in viewer
+        assert "focusKeysForSelection(sceneModel, currentLayout, selected)" in viewer
+        assert "sceneModel = {" in viewer
+        assert "layerVisible[layer] = true" in viewer
+        assert "flyToSelection(entry.kind, entry.id)" in viewer
+        assert 'event.key.toLowerCase() === "f"' in viewer
+        assert "focusVisualsSuspended = false" in viewer
+        assert "selectionReturnFocus" in viewer
+        assert "renderStatus(currentCounts)" in viewer
+        assert '"hierarchy"' in viewer
+        assert "updateFocusLabels" in viewer
+        assert 'button.setAttribute("role", "option")' in viewer
+        assert ".model-label.focus-muted" in css
+        assert ".focus-note" in css
+        assert ".focus-note button" in css
+        assert "max-height: min(66dvh, 620px)" in css
+        assert "env(safe-area-inset-bottom)" in css
 
 
 class TestEvidenceResolverRoute:

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -279,9 +279,11 @@ class TestGraphJson:
                 )
             conn.commit()
 
-        projection = routes.model_share_card()["model"]
+        payload = routes.model_share_card()
+        projection = payload["model"]
         serialized = json.dumps(projection)
 
+        assert payload["generated_at"]
         assert set(projection) == {"root", "faces", "volumes", "stats"}
         assert set(projection["root"]) == {"signature", "observations", "confidence"}
         assert set(projection["faces"][0]) == {"signature", "observations", "confidence"}
@@ -311,6 +313,38 @@ class TestGraphJson:
             "receipt",
         ):
             assert private_value not in serialized
+
+    def test_share_card_matches_and_rescrubs_the_cached_graph_generation(
+        self, ac_root, monkeypatch
+    ):
+        calls = []
+        private_path = "/" + "Users" + "/synthetic-owner/private"
+        private_email = "synthetic-owner@example.com"
+        raw_signature = f"Coordinates {private_email} from {private_path}"
+        snapshot = {
+            "root": {"signature": raw_signature, "observations": 3, "confidence": 0.9},
+            "faces": [],
+            "volumes": [],
+            "stats": {"roots": 1},
+        }
+
+        def fake_live_snapshot(conn, *, redact=True):  # type: ignore[no-untyped-def]
+            calls.append(conn)
+            assert redact is False
+            return snapshot
+
+        monkeypatch.setattr(routes, "build_live_snapshot", fake_live_snapshot)
+
+        graph = routes.model_graph()
+        share = routes.model_share_card()
+
+        assert len(calls) == 1
+        assert share["generated_at"] == graph["generated_at"]
+        assert graph["model"]["root"]["signature"] == raw_signature
+        serialized_share = json.dumps(share["model"])
+        assert "[REDACTED]" in serialized_share
+        assert private_email not in serialized_share
+        assert private_path not in serialized_share
 
     def test_empty_store_returns_an_empty_snapshot(self, ac_root):
         graph = routes.model_graph()
@@ -516,6 +550,9 @@ class TestViewPage:
         assert b'shareButton.addEventListener("click", shareConstellationToX)' in viewer.body
         assert b"exportHumanCard({ toX: true })" not in viewer.body
         assert viewer.body.count(b"await loadShareProjection()") == 2
+        assert b"loadConstellationBundle" in viewer.body
+        assert b"graphPayload.generated_at === share.generatedAt" in viewer.body
+        assert b"fetchModelGraph()" in viewer.body
         assert b"drawConstellationCard(context, renderer.domElement, shareModel)" in viewer.body
         assert b"drawConstellationCard(context, renderer.domElement, model)" not in viewer.body
         assert b"private source content" in share.body
@@ -538,13 +575,16 @@ class TestViewPage:
         assert b"camera.aspect = viewState.cameraAspect" in viewer.body
         assert b"camera.quaternion.copy(viewState.cameraQuaternion)" in viewer.body
         assert b"controls.target.copy(viewState.controlsTarget)" in viewer.body
-        assert b'if (slider.value !== "100")' in viewer.body
+        assert b'if (!exportingDifferentModel && slider.value !== "100")' in viewer.body
         assert b"buildScene({ frame: false, preserveSelection: true })" in viewer.body
         assert b"cutoff = viewState.cutoff" in viewer.body
         assert b"layers: { ...layerVisible }" in viewer.body
         assert b"layerVisible[layer] = true" in viewer.body
         assert b"layerVisible[layer] = visible" in viewer.body
         assert b"selectionReturnFocus = selected && viewState.returnFocusKey" in viewer.body
+        assert b"autoRotate: controls.autoRotate" in viewer.body
+        assert b"controls.autoRotate = viewState.autoRotate" in viewer.body
+        assert b"model = viewState.model" in viewer.body
         assert b"new ResizeObserver(invalidatePanelBoxes)" in viewer.body
         assert b"flyToSelection" in viewer.body
         assert b"rebuildSearchEntries" in viewer.body
@@ -622,7 +662,8 @@ class TestViewPage:
         assert ".focus-note button" in css
         assert ".mobile-guide" in css
         assert "bottom: 76px" in css
-        assert "min-height: 26px" in css
+        assert "min-height: 44px" in css
+        assert "color: #aaa4b6" in css
         assert "max-height: min(66dvh, 620px)" in css
         assert "env(safe-area-inset-bottom)" in css
 

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -474,6 +474,20 @@ class TestViewPage:
         assert b"--build-color: var(--root)" in css.body
         assert b"--build-color: var(--point)" in css.body
         assert b"controls.zoomToCursor = true" in viewer.body
+        # The wheel is the viewer's, not OrbitControls'. Its wheel path lands
+        # the whole delta in one step while orbit and pan glide under damping,
+        # and normalises by devicePixelRatio, which halves the gain on a Retina
+        # display and divides by zero below 1. The viewer takes the wheel in the
+        # capture phase and drives its own damped, cursor-anchored goal — and
+        # taking only the wheel leaves OrbitControls' touch pinch and
+        # middle-button dolly working.
+        assert b"{ passive: false, capture: true }" in viewer.body
+        assert b"zoomAnchor" in viewer.body
+        assert b"zoomMath.wheelFactor" in viewer.body
+        assert b"controls.enableZoom = false" not in viewer.body
+        # Safari reports a trackpad pinch only as a gesture event, so a viewer
+        # that listens for ctrlKey wheel alone has no pinch there at all.
+        assert b'addEventListener("gesturechange"' in viewer.body
         assert b"downloadShareImage" in viewer.body
         assert b"shareReady = Boolean" in viewer.body
         assert b"window.open" in viewer.body

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -586,7 +586,8 @@ class TestViewPage:
         assert 'id="line-select"' in page
         assert 'lineSelectEl.addEventListener("change"' in viewer
         assert "placeholder.disabled = lines.length > 0" in viewer
-        assert "linePresentation(item, model)" in viewer
+        assert "indexLinePresentations(renderedLineItems, sceneModel, sceneNodeLabels)" in viewer
+        assert "linePresentations.get(line.id)?.option" in viewer
         assert 'appendMeta("Predicate", lineDetail?.predicate)' in viewer
         assert 'appendMeta("From", lineDetail?.source)' in viewer
         assert "item.source ? `Source ID: ${item.source}`" in viewer


### PR DESCRIPTION
## Summary

- turn the local `/model` viewer into an interactive galaxy with fast search, focused neighborhoods, timeline travel, layer controls, and responsive guidance
- harden drag, ordinary scroll, trackpad pinch, non-primary pointer release, inline editing, and selection invalidation across time and layer changes
- keep search indexed and explicit about current versus historical/shadow model state
- make constellation exports use one privacy-scrubbed graph generation, a stable 1200×675 frame, and exact restoration of the inspected camera, layers, timeline, focus, and rotation state
- keep the mobile Guide readable and explicit that inferred placement is navigation, not evidence

## Verification

- `PERSOME_LLM_MOCK=1 uv run pytest -m "not macos and not integration" -q` — 2301 passed, 17 deselected
- viewer JavaScript tests — 46 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- secret, PII, and language scans
- OpenAPI and DB schema drift tests — 4 passed
- synthetic local Chrome review at desktop and 390×844: search, focus, edit shortcut isolation, pointer cleanup, panel scroll, Ctrl-wheel pinch, time/layer invalidation, state restoration, and mobile overflow/spacing
- 50k-item common-query search benchmark: median 3.87 ms, p95 5.95 ms

All manual browser data was synthetic. No content was posted or shared to X.
