### PR TITLE
Refine the model galaxy palette

### DIFF
--- a/resources/model_assets/layout.mjs
+++ b/resources/model_assets/layout.mjs
@@ -325,7 +325,7 @@ function placePointClouds(points, pointClusterById, positions, sourceOrbitRadius
   return groups;
 }
 
-function placeContextNodes(lines, pointIds, positions) {
+function placeContextNodes(lines, pointIds, positions, hasRoot) {
   const ids = new Set();
   lines.filter((line) => line.kind === "relation").forEach((line) => {
     if (!pointIds.has(line.source)) ids.add(line.source);
@@ -333,7 +333,9 @@ function placeContextNodes(lines, pointIds, positions) {
   });
   const contextIds = [...ids].filter(Boolean).sort();
   contextIds.forEach((id) => {
-    const radius = 0.72 + stableHash(`context:${id}:radius`) * 0.68;
+    const radius = hasRoot
+      ? 1.1 + stableHash(`context:${id}:radius`) * 0.5
+      : 0.72 + stableHash(`context:${id}:radius`) * 0.68;
     positions.set(id, scale(unitVector(`context:${id}`), radius));
   });
   return contextIds;
@@ -379,7 +381,7 @@ export function computeClusterLayout(model) {
   if (root) positions.set(root.id, [0, 0, 0]);
   placeStableOrbit(volumes, positions, {
     phase: 0.2,
-    radius: 2,
+    radius: root ? 2.4 : 2,
     radialStep: 0.12,
     heightStep: 0.14,
   });
@@ -389,7 +391,7 @@ export function computeClusterLayout(model) {
   const sourceOrbitRadius = faces.length ? 7.2 : (volumes.length || root ? 4.2 : 1.2);
   const groups = placePointClouds(points, assignments.pointClusterById, positions, sourceOrbitRadius);
   const pointIds = new Set(points.map((point) => point.id));
-  const contextIds = placeContextNodes(lines, pointIds, positions);
+  const contextIds = placeContextNodes(lines, pointIds, positions, Boolean(root));
 
   const volumeIds = new Set(volumes.map((volume) => volume.id));
   const rootVolumeIds = root?.members?.filter((id) => volumeIds.has(id)) || [];

--- a/resources/model_assets/palette.mjs
+++ b/resources/model_assets/palette.mjs
@@ -1,31 +1,31 @@
 /**
  * Shared visual palette for the localhost model viewer and constellation card.
  *
- * The dense evidence field stays neutral. Chroma is reserved for promoted
- * structure and focus so the graph remains readable at real-model scale.
+ * The original semantic hues stay recognizable while their saturation and
+ * luminance are restrained for a dense, deep-space canvas.
  */
 export const MODEL_PALETTE = Object.freeze({
-  canvas: "#1c1c1c",
-  surface: "#232323",
-  surfaceRaised: "#282828",
-  text: "#dadada",
-  muted: "#a6a6ae",
-  dim: "#8a8a94",
-  point: "#b3b3b3",
-  line: "#666666",
-  lineUi: "#92929b",
-  face: "#53dfdd",
-  volume: "#a882ff",
-  root: "#fa99cd",
-  focus: "#a68af9",
-  entity: "#76767f",
-  guide: "#3f3f3f",
-  guideUi: "#8a8a94",
-  relation: "#44cf6e",
-  historical: "#666666",
-  success: "#44cf6e",
-  warning: "#e0de71",
-  error: "#fb7378",
+  canvas: "#090b16",
+  surface: "#111425",
+  surfaceRaised: "#181c33",
+  text: "#eceaf2",
+  muted: "#aaa6b8",
+  dim: "#878299",
+  point: "#72d8c0",
+  line: "#9f7a52",
+  lineUi: "#c5a16f",
+  face: "#e47bc9",
+  volume: "#8298ee",
+  root: "#ee809b",
+  focus: "#aa96ef",
+  entity: "#7f8196",
+  guide: "#34374d",
+  guideUi: "#898da4",
+  relation: "#68c69c",
+  historical: "#625f73",
+  success: "#59c995",
+  warning: "#d5b76a",
+  error: "#eb767f",
 });
 
 function colorNumber(value) {

--- a/resources/model_assets/palette.mjs
+++ b/resources/model_assets/palette.mjs
@@ -1,0 +1,57 @@
+/**
+ * Shared visual palette for the localhost model viewer and constellation card.
+ *
+ * The dense evidence field stays neutral. Chroma is reserved for promoted
+ * structure and focus so the graph remains readable at real-model scale.
+ */
+export const MODEL_PALETTE = Object.freeze({
+  canvas: "#1c1c1c",
+  surface: "#232323",
+  surfaceRaised: "#282828",
+  text: "#dadada",
+  muted: "#a6a6ae",
+  dim: "#8a8a94",
+  point: "#b3b3b3",
+  line: "#666666",
+  lineUi: "#92929b",
+  face: "#53dfdd",
+  volume: "#a882ff",
+  root: "#fa99cd",
+  focus: "#a68af9",
+  entity: "#76767f",
+  guide: "#3f3f3f",
+  guideUi: "#8a8a94",
+  relation: "#44cf6e",
+  historical: "#666666",
+  success: "#44cf6e",
+  warning: "#e0de71",
+  error: "#fb7378",
+});
+
+function colorNumber(value) {
+  return Number.parseInt(value.slice(1), 16);
+}
+
+export const MODEL_COLORS = Object.freeze({
+  points: colorNumber(MODEL_PALETTE.point),
+  lines: colorNumber(MODEL_PALETTE.line),
+  faces: colorNumber(MODEL_PALETTE.face),
+  volumes: colorNumber(MODEL_PALETTE.volume),
+  root: colorNumber(MODEL_PALETTE.root),
+  focus: colorNumber(MODEL_PALETTE.focus),
+  context: colorNumber(MODEL_PALETTE.entity),
+  hierarchy: colorNumber(MODEL_PALETTE.guide),
+  relation: colorNumber(MODEL_PALETTE.relation),
+  historical: colorNumber(MODEL_PALETTE.historical),
+  canvas: colorNumber(MODEL_PALETTE.canvas),
+  text: colorNumber(MODEL_PALETTE.text),
+});
+
+export function colorWithAlpha(value, alpha) {
+  const number = colorNumber(value);
+  const red = (number >> 16) & 255;
+  const green = (number >> 8) & 255;
+  const blue = number & 255;
+  const safeAlpha = Math.max(0, Math.min(1, Number(alpha) || 0));
+  return `rgba(${red}, ${green}, ${blue}, ${safeAlpha})`;
+}

--- a/resources/model_assets/palette.mjs
+++ b/resources/model_assets/palette.mjs
@@ -16,7 +16,7 @@ export const MODEL_PALETTE = Object.freeze({
   lineUi: "#c5a16f",
   face: "#e47bc9",
   volume: "#8298ee",
-  root: "#ee809b",
+  root: "#ff718f",
   focus: "#aa96ef",
   entity: "#7f8196",
   guide: "#34374d",

--- a/resources/model_assets/share.mjs
+++ b/resources/model_assets/share.mjs
@@ -1,3 +1,5 @@
+import { MODEL_PALETTE, colorWithAlpha } from "./palette.mjs";
+
 export const HUMAN_CARD_WIDTH = 1080;
 export const HUMAN_CARD_HEIGHT = 1350;
 export const HUMAN_CARD_FILE_NAME = "my-human-card.png";
@@ -223,18 +225,18 @@ function drawCover(context, source, width, height) {
 
 function drawBrandMark(context, x, y) {
   context.save();
-  context.strokeStyle = "rgba(255, 255, 255, 0.22)";
+  context.strokeStyle = colorWithAlpha(MODEL_PALETTE.text, 0.22);
   context.lineWidth = 1;
   context.beginPath();
   context.arc(x, y, 18, 0, Math.PI * 2);
   context.stroke();
 
   const nodes = [
-    [0, -6, "#ff6b8a"],
-    [-6, 5, "#ff64d6"],
-    [7, 5, "#7798ff"],
+    [0, -6, MODEL_PALETTE.root],
+    [-6, 5, MODEL_PALETTE.face],
+    [7, 5, MODEL_PALETTE.volume],
   ];
-  context.strokeStyle = "rgba(255, 255, 255, 0.19)";
+  context.strokeStyle = colorWithAlpha(MODEL_PALETTE.text, 0.19);
   context.beginPath();
   context.moveTo(x, y - 6);
   context.lineTo(x - 6, y + 5);
@@ -258,13 +260,13 @@ export function drawConstellationCard(context, source, model = {}) {
   const narrative = shareNarrative(model);
 
   context.save();
-  context.fillStyle = "#070610";
+  context.fillStyle = MODEL_PALETTE.canvas;
   context.fillRect(0, 0, width, height);
 
   const aura = context.createRadialGradient(760, 300, 20, 760, 300, 610);
-  aura.addColorStop(0, "rgba(105, 92, 210, 0.24)");
-  aura.addColorStop(0.46, "rgba(49, 35, 91, 0.13)");
-  aura.addColorStop(1, "rgba(7, 6, 16, 0)");
+  aura.addColorStop(0, colorWithAlpha(MODEL_PALETTE.focus, 0.14));
+  aura.addColorStop(0.46, colorWithAlpha(MODEL_PALETTE.volume, 0.06));
+  aura.addColorStop(1, colorWithAlpha(MODEL_PALETTE.canvas, 0));
   context.fillStyle = aura;
   context.fillRect(0, 0, width, height);
 
@@ -274,44 +276,44 @@ export function drawConstellationCard(context, source, model = {}) {
   context.restore();
 
   const textScrim = context.createLinearGradient(0, 0, 680, 0);
-  textScrim.addColorStop(0, "rgba(7, 6, 16, 0.96)");
-  textScrim.addColorStop(0.56, "rgba(7, 6, 16, 0.46)");
-  textScrim.addColorStop(1, "rgba(7, 6, 16, 0)");
+  textScrim.addColorStop(0, colorWithAlpha(MODEL_PALETTE.canvas, 0.96));
+  textScrim.addColorStop(0.56, colorWithAlpha(MODEL_PALETTE.canvas, 0.52));
+  textScrim.addColorStop(1, colorWithAlpha(MODEL_PALETTE.canvas, 0));
   context.fillStyle = textScrim;
   context.fillRect(0, 0, 760, height);
 
   const edge = context.createLinearGradient(0, height - 170, 0, height);
-  edge.addColorStop(0, "rgba(7, 6, 16, 0)");
-  edge.addColorStop(1, "rgba(7, 6, 16, 0.88)");
+  edge.addColorStop(0, colorWithAlpha(MODEL_PALETTE.canvas, 0));
+  edge.addColorStop(1, colorWithAlpha(MODEL_PALETTE.canvas, 0.88));
   context.fillStyle = edge;
   context.fillRect(0, height - 170, width, 170);
 
   drawBrandMark(context, 72, 66);
   context.shadowBlur = 0;
-  context.fillStyle = "rgba(248, 246, 255, 0.96)";
+  context.fillStyle = colorWithAlpha(MODEL_PALETTE.text, 0.96);
   context.font = "700 22px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
   context.fillText("Persome", 105, 62);
-  context.fillStyle = "rgba(164, 158, 181, 0.9)";
+  context.fillStyle = colorWithAlpha(MODEL_PALETTE.muted, 0.9);
   context.font = "700 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
   context.fillText("PERSONAL MODEL", 105, 80);
 
-  context.fillStyle = "rgba(195, 188, 210, 0.86)";
+  context.fillStyle = colorWithAlpha(MODEL_PALETTE.muted, 0.86);
   context.font = "700 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
   context.fillText("A LIVING MAP OF WHAT YOU NOTICE, REPEAT, AND BECOME", 54, 286);
 
   const headline = context.createLinearGradient(54, 310, 430, 430);
-  headline.addColorStop(0, "#fff8fc");
-  headline.addColorStop(0.52, "#ff85cf");
-  headline.addColorStop(1, "#8ea4ff");
+  headline.addColorStop(0, "#f0f0f2");
+  headline.addColorStop(0.52, MODEL_PALETTE.focus);
+  headline.addColorStop(1, MODEL_PALETTE.volume);
   context.fillStyle = headline;
   context.font = "650 52px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
   context.fillText("My personal", 52, 349);
   context.fillText("constellation.", 52, 403);
 
-  context.fillStyle = "rgba(255, 100, 214, 0.9)";
+  context.fillStyle = colorWithAlpha(MODEL_PALETTE.focus, 0.9);
   context.font = "750 9px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
   context.fillText("CURRENT MODEL", 55, 442);
-  context.fillStyle = "rgba(229, 224, 238, 0.88)";
+  context.fillStyle = colorWithAlpha(MODEL_PALETTE.text, 0.88);
   context.font = "500 14px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
   drawWrappedText(context, narrative.root, 54, 466, 430, 20, 3);
 
@@ -320,23 +322,25 @@ export function drawConstellationCard(context, source, model = {}) {
     const panelY = 468;
     const panelWidth = 404;
     const panelHeight = 132;
-    context.fillStyle = "rgba(9, 8, 18, 0.78)";
-    context.strokeStyle = "rgba(255, 255, 255, 0.12)";
+    context.fillStyle = colorWithAlpha(MODEL_PALETTE.surface, 0.86);
+    context.strokeStyle = colorWithAlpha(MODEL_PALETTE.text, 0.12);
     context.lineWidth = 1;
     context.beginPath();
     context.roundRect(panelX, panelY, panelWidth, panelHeight, 16);
     context.fill();
     context.stroke();
-    context.fillStyle = "rgba(162, 154, 181, 0.9)";
+    context.fillStyle = colorWithAlpha(MODEL_PALETTE.muted, 0.9);
     context.font = "750 9px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
     context.fillText("KEY PATTERNS", panelX + 18, panelY + 24);
     narrative.highlights.forEach((highlight, index) => {
       const rowY = panelY + 49 + index * 25;
-      context.fillStyle = highlight.kind === "VOLUME" ? "#7798ff" : "#ff64d6";
+      context.fillStyle = highlight.kind === "VOLUME"
+        ? MODEL_PALETTE.volume
+        : MODEL_PALETTE.face;
       context.beginPath();
       context.arc(panelX + 20, rowY - 4, 3, 0, Math.PI * 2);
       context.fill();
-      context.fillStyle = "rgba(226, 221, 237, 0.9)";
+      context.fillStyle = colorWithAlpha(MODEL_PALETTE.text, 0.9);
       context.font = "550 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
       const line = wrappedLines(context, highlight.text, panelWidth - 52, 1)[0] || "";
       context.fillText(line, panelX + 32, rowY);
@@ -345,16 +349,16 @@ export function drawConstellationCard(context, source, model = {}) {
 
   let statX = 56;
   shareStats(model).forEach(([label, value]) => {
-    context.fillStyle = "rgba(248, 246, 255, 0.94)";
+    context.fillStyle = colorWithAlpha(MODEL_PALETTE.text, 0.94);
     context.font = "650 18px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
     context.fillText(String(value), statX, 566);
-    context.fillStyle = "rgba(137, 130, 153, 0.92)";
+    context.fillStyle = colorWithAlpha(MODEL_PALETTE.dim, 0.92);
     context.font = "700 9px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
     context.fillText(label, statX, 583);
     statX += label === "VOLUMES" ? 92 : 78;
   });
 
-  context.fillStyle = "rgba(152, 145, 171, 0.9)";
+  context.fillStyle = colorWithAlpha(MODEL_PALETTE.dim, 0.9);
   context.font = "650 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
   context.fillText("GENERATED LOCALLY · SHARED BY YOU", 54, 628);
   context.textAlign = "right";

--- a/resources/model_assets/share.mjs
+++ b/resources/model_assets/share.mjs
@@ -302,7 +302,7 @@ export function drawConstellationCard(context, source, model = {}) {
   context.fillText("A LIVING MAP OF WHAT YOU NOTICE, REPEAT, AND BECOME", 54, 286);
 
   const headline = context.createLinearGradient(54, 310, 430, 430);
-  headline.addColorStop(0, "#f0f0f2");
+  headline.addColorStop(0, MODEL_PALETTE.text);
   headline.addColorStop(0.52, MODEL_PALETTE.focus);
   headline.addColorStop(1, MODEL_PALETTE.volume);
   context.fillStyle = headline;

--- a/resources/model_assets/viewer.css
+++ b/resources/model_assets/viewer.css
@@ -1,31 +1,31 @@
 :root {
   color-scheme: dark;
-  --bg: #1c1c1c;
-  --surface: rgba(35, 35, 35, 0.82);
-  --surface-strong: rgba(28, 28, 28, 0.96);
-  --surface-soft: rgba(40, 40, 40, 0.64);
-  --surface-modal: rgba(28, 28, 28, 0.98);
-  --overlay: rgba(14, 14, 16, 0.72);
-  --border: rgba(218, 218, 218, 0.12);
-  --border-bright: rgba(218, 218, 218, 0.22);
-  --text: #dadada;
-  --muted: #a6a6ae;
-  --dim: #8a8a94;
-  --point: #b3b3b3;
-  --line: #92929b;
-  --line-stroke: #666666;
-  --face: #53dfdd;
-  --volume: #a882ff;
-  --root: #fa99cd;
-  --focus: #a68af9;
-  --entity: #76767f;
-  --guide: #3f3f3f;
-  --guide-ui: #8a8a94;
-  --relation: #44cf6e;
-  --historical: #666666;
-  --success: #44cf6e;
-  --warning: #e0de71;
-  --danger: #fb7378;
+  --bg: #090b16;
+  --surface: rgba(17, 20, 37, 0.82);
+  --surface-strong: rgba(9, 11, 22, 0.96);
+  --surface-soft: rgba(24, 28, 51, 0.64);
+  --surface-modal: rgba(9, 11, 22, 0.98);
+  --overlay: rgba(3, 5, 13, 0.74);
+  --border: rgba(236, 234, 242, 0.12);
+  --border-bright: rgba(236, 234, 242, 0.22);
+  --text: #eceaf2;
+  --muted: #aaa6b8;
+  --dim: #878299;
+  --point: #72d8c0;
+  --line: #c5a16f;
+  --line-stroke: #9f7a52;
+  --face: #e47bc9;
+  --volume: #8298ee;
+  --root: #ee809b;
+  --focus: #aa96ef;
+  --entity: #7f8196;
+  --guide: #34374d;
+  --guide-ui: #898da4;
+  --relation: #68c69c;
+  --historical: #625f73;
+  --success: #59c995;
+  --warning: #d5b76a;
+  --danger: #eb767f;
   --radius: 18px;
 }
 
@@ -64,17 +64,17 @@ body::after {
 
 body::before {
   background:
-    radial-gradient(circle at 56% 48%, color-mix(in srgb, var(--focus) 10%, transparent), transparent 32%),
-    radial-gradient(circle at 78% 26%, color-mix(in srgb, var(--volume) 5%, transparent), transparent 26%),
-    radial-gradient(circle at 31% 78%, color-mix(in srgb, var(--face) 3%, transparent), transparent 30%),
-    linear-gradient(135deg, #1c1c1c 0%, #202024 48%, #1c1c1c 100%);
+    radial-gradient(circle at 56% 48%, color-mix(in srgb, var(--focus) 13%, transparent), transparent 32%),
+    radial-gradient(circle at 78% 26%, color-mix(in srgb, var(--root) 6%, transparent), transparent 26%),
+    radial-gradient(circle at 31% 78%, color-mix(in srgb, var(--point) 5%, transparent), transparent 30%),
+    linear-gradient(135deg, #080a16 0%, #10142a 48%, #090b16 100%);
 }
 
 body::after {
-  opacity: 0.16;
+  opacity: 0.18;
   background-image:
-    linear-gradient(rgba(218, 218, 218, 0.02) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(218, 218, 218, 0.014) 1px, transparent 1px);
+    linear-gradient(rgba(170, 185, 235, 0.024) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(170, 185, 235, 0.017) 1px, transparent 1px);
   background-size: 72px 72px;
   mask-image: radial-gradient(circle at center, black, transparent 82%);
 }
@@ -154,7 +154,7 @@ button {
   flex: none;
   border: 1px solid var(--border-bright);
   border-radius: 50%;
-  background: rgba(218, 218, 218, 0.035);
+  background: rgba(236, 234, 242, 0.035);
   box-shadow: inset 0 0 20px color-mix(in srgb, var(--root) 8%, transparent), 0 0 24px color-mix(in srgb, var(--focus) 8%, transparent);
 }
 
@@ -200,7 +200,7 @@ button {
   padding: 0 8px 0 10px;
   border: 1px solid var(--border);
   border-radius: 999px;
-  background: rgba(35, 35, 35, 0.68);
+  background: rgba(17, 20, 37, 0.68);
   color: var(--muted);
   cursor: pointer;
   transition: border-color 160ms ease, background 160ms ease, color 160ms ease;
@@ -265,7 +265,7 @@ button {
   padding: 4px;
   border: 1px solid var(--border);
   border-radius: 999px;
-  background: rgba(35, 35, 35, 0.74);
+  background: rgba(17, 20, 37, 0.74);
   box-shadow: 0 12px 42px rgba(0, 0, 0, 0.24);
   backdrop-filter: blur(20px);
 }
@@ -555,7 +555,7 @@ button {
 .model-flow i {
   width: 17px;
   height: 1px;
-  background: linear-gradient(90deg, rgba(218, 218, 218, 0.08), rgba(218, 218, 218, 0.36));
+  background: linear-gradient(90deg, rgba(236, 234, 242, 0.08), rgba(236, 234, 242, 0.36));
 }
 
 .status {
@@ -1582,7 +1582,7 @@ button {
   padding: 3px 8px;
   border: 1px solid rgba(255, 255, 255, 0.11);
   border-radius: 999px;
-  background: rgba(28, 28, 28, 0.84);
+  background: rgba(9, 11, 22, 0.84);
   box-shadow: 0 7px 20px rgba(0, 0, 0, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.04);
   color: var(--text);
   cursor: pointer;

--- a/resources/model_assets/viewer.css
+++ b/resources/model_assets/viewer.css
@@ -16,7 +16,7 @@
   --line-stroke: #9f7a52;
   --face: #e47bc9;
   --volume: #8298ee;
-  --root: #ee809b;
+  --root: #ff718f;
   --focus: #aa96ef;
   --entity: #7f8196;
   --guide: #34374d;

--- a/resources/model_assets/viewer.css
+++ b/resources/model_assets/viewer.css
@@ -1,19 +1,31 @@
 :root {
   color-scheme: dark;
-  --bg: #05040a;
-  --surface: rgba(13, 12, 24, 0.76);
-  --surface-strong: rgba(11, 10, 20, 0.94);
-  --surface-soft: rgba(14, 13, 27, 0.56);
-  --border: rgba(255, 255, 255, 0.11);
-  --border-bright: rgba(255, 255, 255, 0.2);
-  --text: #f8f6ff;
-  --muted: #a5a0b5;
-  --dim: #706a80;
-  --point: #4ef0c3;
-  --line: #ffc45e;
-  --face: #ff64d6;
-  --volume: #7798ff;
-  --root: #ff6b8a;
+  --bg: #1c1c1c;
+  --surface: rgba(35, 35, 35, 0.82);
+  --surface-strong: rgba(28, 28, 28, 0.96);
+  --surface-soft: rgba(40, 40, 40, 0.64);
+  --surface-modal: rgba(28, 28, 28, 0.98);
+  --overlay: rgba(14, 14, 16, 0.72);
+  --border: rgba(218, 218, 218, 0.12);
+  --border-bright: rgba(218, 218, 218, 0.22);
+  --text: #dadada;
+  --muted: #a6a6ae;
+  --dim: #8a8a94;
+  --point: #b3b3b3;
+  --line: #92929b;
+  --line-stroke: #666666;
+  --face: #53dfdd;
+  --volume: #a882ff;
+  --root: #fa99cd;
+  --focus: #a68af9;
+  --entity: #76767f;
+  --guide: #3f3f3f;
+  --guide-ui: #8a8a94;
+  --relation: #44cf6e;
+  --historical: #666666;
+  --success: #44cf6e;
+  --warning: #e0de71;
+  --danger: #fb7378;
   --radius: 18px;
 }
 
@@ -52,17 +64,17 @@ body::after {
 
 body::before {
   background:
-    radial-gradient(circle at 56% 48%, rgba(117, 74, 255, 0.21), transparent 30%),
-    radial-gradient(circle at 78% 26%, rgba(255, 75, 183, 0.11), transparent 24%),
-    radial-gradient(circle at 31% 78%, rgba(25, 216, 185, 0.08), transparent 28%),
-    linear-gradient(135deg, #05040a 0%, #090716 48%, #05040a 100%);
+    radial-gradient(circle at 56% 48%, color-mix(in srgb, var(--focus) 10%, transparent), transparent 32%),
+    radial-gradient(circle at 78% 26%, color-mix(in srgb, var(--volume) 5%, transparent), transparent 26%),
+    radial-gradient(circle at 31% 78%, color-mix(in srgb, var(--face) 3%, transparent), transparent 30%),
+    linear-gradient(135deg, #1c1c1c 0%, #202024 48%, #1c1c1c 100%);
 }
 
 body::after {
-  opacity: 0.2;
+  opacity: 0.16;
   background-image:
-    linear-gradient(rgba(255, 255, 255, 0.025) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255, 255, 255, 0.018) 1px, transparent 1px);
+    linear-gradient(rgba(218, 218, 218, 0.02) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(218, 218, 218, 0.014) 1px, transparent 1px);
   background-size: 72px 72px;
   mask-image: radial-gradient(circle at center, black, transparent 82%);
 }
@@ -140,24 +152,25 @@ button {
   width: 32px;
   height: 32px;
   flex: none;
-  border: 1px solid rgba(255, 255, 255, 0.16);
+  border: 1px solid var(--border-bright);
   border-radius: 50%;
-  background: rgba(255, 255, 255, 0.04);
-  box-shadow: inset 0 0 20px rgba(255, 107, 138, 0.08), 0 0 26px rgba(255, 107, 138, 0.09);
+  background: rgba(218, 218, 218, 0.035);
+  box-shadow: inset 0 0 20px color-mix(in srgb, var(--root) 8%, transparent), 0 0 24px color-mix(in srgb, var(--focus) 8%, transparent);
 }
 
 .brand-mark i {
+  --mark-color: var(--root);
   position: absolute;
   width: 5px;
   height: 5px;
   border-radius: 50%;
-  background: var(--root);
-  box-shadow: 0 0 10px rgba(255, 107, 138, 0.9);
+  background: var(--mark-color);
+  box-shadow: 0 0 9px var(--mark-color);
 }
 
 .brand-mark i:nth-child(1) { top: 8px; left: 13px; }
-.brand-mark i:nth-child(2) { top: 17px; left: 8px; background: var(--face); }
-.brand-mark i:nth-child(3) { top: 17px; left: 18px; background: var(--volume); }
+.brand-mark i:nth-child(2) { --mark-color: var(--face); top: 17px; left: 8px; }
+.brand-mark i:nth-child(3) { --mark-color: var(--volume); top: 17px; left: 18px; }
 
 .brand-lockup {
   display: grid;
@@ -185,16 +198,16 @@ button {
   min-width: 0;
   min-height: 36px;
   padding: 0 8px 0 10px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--border);
   border-radius: 999px;
-  background: rgba(13, 12, 24, 0.6);
+  background: rgba(35, 35, 35, 0.68);
   color: var(--muted);
   cursor: pointer;
   transition: border-color 160ms ease, background 160ms ease, color 160ms ease;
 }
 
 .search-trigger > span {
-  color: #d7d2e2;
+  color: var(--text);
   font-size: 17px;
   line-height: 1;
 }
@@ -222,9 +235,10 @@ button {
 
 .search-trigger:hover,
 .search-trigger:focus-visible {
-  border-color: rgba(119, 152, 255, 0.42);
-  outline: none;
-  background: rgba(119, 152, 255, 0.1);
+  border-color: var(--focus);
+  outline: 2px solid color-mix(in srgb, var(--focus) 72%, transparent);
+  outline-offset: 2px;
+  background: color-mix(in srgb, var(--focus) 9%, var(--surface));
   color: var(--text);
 }
 
@@ -251,7 +265,7 @@ button {
   padding: 4px;
   border: 1px solid var(--border);
   border-radius: 999px;
-  background: rgba(13, 12, 24, 0.7);
+  background: rgba(35, 35, 35, 0.74);
   box-shadow: 0 12px 42px rgba(0, 0, 0, 0.24);
   backdrop-filter: blur(20px);
 }
@@ -306,7 +320,7 @@ button {
 .layers button[data-layer="root"] { color: var(--root); }
 
 .layers button:not([aria-pressed="true"]) {
-  color: #666173;
+  color: var(--dim);
 }
 
 .layers button:hover,
@@ -358,7 +372,7 @@ button {
   min-height: 40px;
   padding: 0 5px;
   border-radius: 999px;
-  color: #d8d3e5;
+  color: var(--text);
   cursor: pointer;
   font-size: 10px;
   font-variant-numeric: tabular-nums;
@@ -373,7 +387,7 @@ button {
 }
 
 .zoom-controls button:focus-visible {
-  outline: 2px solid var(--volume);
+  outline: 2px solid var(--focus);
   outline-offset: 1px;
 }
 
@@ -393,8 +407,8 @@ button {
   width: 5px;
   height: 5px;
   border-radius: 50%;
-  background: var(--point);
-  box-shadow: 0 0 9px rgba(78, 240, 195, 0.75);
+  background: var(--success);
+  box-shadow: 0 0 9px color-mix(in srgb, var(--success) 72%, transparent);
 }
 
 .share-button {
@@ -403,10 +417,10 @@ button {
   gap: 7px;
   min-height: 40px;
   padding: 0 13px 0 10px;
-  border: 1px solid rgba(255, 100, 214, 0.26);
+  border: 1px solid color-mix(in srgb, var(--focus) 30%, transparent);
   border-radius: 999px;
-  background: linear-gradient(110deg, rgba(255, 100, 214, 0.15), rgba(119, 152, 255, 0.13));
-  color: #f5eefa;
+  background: linear-gradient(110deg, color-mix(in srgb, var(--focus) 13%, transparent), color-mix(in srgb, var(--volume) 9%, transparent));
+  color: var(--text);
   cursor: pointer;
   transition: color 160ms ease, background 160ms ease, border-color 160ms ease, transform 160ms ease;
 }
@@ -454,9 +468,9 @@ button {
 }
 
 .icon-button[aria-pressed="true"] {
-  border-color: rgba(119, 152, 255, 0.35);
-  background: rgba(119, 152, 255, 0.12);
-  color: #b5c5ff;
+  border-color: color-mix(in srgb, var(--focus) 48%, transparent);
+  background: color-mix(in srgb, var(--focus) 11%, transparent);
+  color: var(--focus);
 }
 
 .story {
@@ -473,7 +487,7 @@ button {
   align-items: center;
   gap: 9px;
   margin: 0 0 18px;
-  color: #bdb7cc;
+  color: var(--muted);
   font-size: 9px;
   font-weight: 750;
   letter-spacing: 0.19em;
@@ -485,7 +499,7 @@ button {
   height: 6px;
   border-radius: 50%;
   background: var(--root);
-  box-shadow: 0 0 0 5px rgba(255, 107, 138, 0.08), 0 0 17px rgba(255, 107, 138, 0.85);
+  box-shadow: 0 0 0 5px color-mix(in srgb, var(--root) 7%, transparent), 0 0 15px color-mix(in srgb, var(--root) 72%, transparent);
   animation: signal 2.4s ease-in-out infinite;
 }
 
@@ -496,7 +510,7 @@ button {
 
 .story h1 {
   margin: 0;
-  color: rgba(249, 247, 255, 0.97);
+  color: var(--text);
   font-size: clamp(36px, 4.2vw, 60px);
   font-weight: 660;
   letter-spacing: -0.065em;
@@ -508,7 +522,7 @@ button {
   color: transparent;
   font-style: normal;
   font-weight: 560;
-  background: linear-gradient(104deg, #ff8aa2 6%, #ff63d4 45%, #8b9cff 91%);
+  background: linear-gradient(104deg, #f0f0f2 6%, var(--focus) 48%, var(--volume) 91%);
   background-clip: text;
   -webkit-background-clip: text;
 }
@@ -518,7 +532,7 @@ button {
   max-width: 310px;
   margin: 26px 0 0;
   overflow: hidden;
-  color: rgba(218, 213, 229, 0.78);
+  color: var(--muted);
   font-size: 13px;
   line-height: 1.7;
   text-wrap: balance;
@@ -541,7 +555,7 @@ button {
 .model-flow i {
   width: 17px;
   height: 1px;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.42));
+  background: linear-gradient(90deg, rgba(218, 218, 218, 0.08), rgba(218, 218, 218, 0.36));
 }
 
 .status {
@@ -610,8 +624,8 @@ button {
 .stat[data-kind="root"] { --stat-color: var(--root); }
 
 .build-state {
-  --build-color: #8d8799;
-  --build-glow: rgba(141, 135, 153, 0.48);
+  --build-color: var(--dim);
+  --build-glow: color-mix(in srgb, var(--dim) 48%, transparent);
   display: flex;
   align-items: center;
   gap: 7px;
@@ -630,23 +644,23 @@ button {
 }
 
 .build-state--not-built {
-  --build-color: #8d8799;
-  --build-glow: rgba(141, 135, 153, 0.48);
+  --build-color: var(--dim);
+  --build-glow: color-mix(in srgb, var(--dim) 48%, transparent);
 }
 
 .build-state--building {
-  --build-color: var(--line);
-  --build-glow: rgba(255, 196, 94, 0.68);
+  --build-color: var(--warning);
+  --build-glow: color-mix(in srgb, var(--warning) 68%, transparent);
 }
 
 .build-state--degraded {
-  --build-color: var(--root);
-  --build-glow: rgba(255, 107, 138, 0.68);
+  --build-color: var(--danger);
+  --build-glow: color-mix(in srgb, var(--danger) 68%, transparent);
 }
 
 .build-state--complete {
-  --build-color: var(--point);
-  --build-glow: rgba(78, 240, 195, 0.72);
+  --build-color: var(--success);
+  --build-glow: color-mix(in srgb, var(--success) 72%, transparent);
 }
 
 .legend {
@@ -680,7 +694,7 @@ button {
 }
 
 .legend > summary::after {
-  color: #898397;
+  color: var(--dim);
   content: "−";
   font-size: 12px;
   font-weight: 400;
@@ -693,7 +707,7 @@ button {
 
 .legend > summary small {
   margin-left: auto;
-  color: #706a80;
+  color: var(--dim);
   font-size: 7px;
   font-weight: 650;
   letter-spacing: 0.08em;
@@ -711,19 +725,19 @@ button {
   align-items: center;
   gap: 7px;
   min-height: 22px;
-  color: #858092;
+  color: var(--dim);
   font-size: 9px;
 }
 
 .legend-body b {
-  color: #d8d4e1;
+  color: var(--text);
   font-size: 9px;
   font-weight: 650;
 }
 
 .legend > summary:focus-visible {
   border-radius: 5px;
-  outline: 2px solid var(--volume);
+  outline: 2px solid var(--focus);
   outline-offset: 5px;
 }
 
@@ -737,9 +751,9 @@ button {
 .swatch.point { color: var(--point); background: var(--point); }
 .swatch.line { color: var(--line); height: 1px; border-radius: 0; background: var(--line); }
 .swatch.guide {
-  color: var(--muted);
+  color: var(--guide-ui);
   height: 1px;
-  border-top: 1px dashed var(--muted);
+  border-top: 1px dashed var(--guide-ui);
   border-radius: 0;
   box-shadow: none;
 }
@@ -748,11 +762,10 @@ button {
 /* Entities render as small grey cubes, so the swatch is a square rather than a
    dot and carries no glow — they are context, not a claim about the owner. */
 .swatch.context {
-  color: var(--muted);
+  color: var(--entity);
   border-radius: 1px;
-  background: var(--muted);
+  background: var(--entity);
   box-shadow: none;
-  opacity: 0.8;
 }
 .swatch.root { color: var(--root); background: var(--root); transform: rotate(45deg); border-radius: 2px; }
 
@@ -777,7 +790,7 @@ button {
 
 .mobile-guide > summary::after {
   grid-column: 4;
-  color: #898397;
+  color: var(--dim);
   content: "+";
 }
 
@@ -786,14 +799,14 @@ button {
 }
 
 .mobile-guide > summary b {
-  color: #d8d4e1;
+  color: var(--text);
   font-size: 10px;
   font-weight: 650;
 }
 
 .mobile-guide > summary span:last-of-type {
   overflow: hidden;
-  color: #aaa4b6;
+  color: var(--muted);
   font-size: 10px;
   font-weight: 600;
   text-overflow: ellipsis;
@@ -802,7 +815,7 @@ button {
 
 .mobile-guide > summary:focus-visible {
   border-radius: 5px;
-  outline: 2px solid var(--volume);
+  outline: 2px solid var(--focus);
   outline-offset: 5px;
 }
 
@@ -810,7 +823,7 @@ button {
   margin: 9px 0 0;
   padding-top: 8px;
   border-top: 1px solid rgba(255, 255, 255, 0.07);
-  color: #858092;
+  color: var(--dim);
   font-size: 9px;
   line-height: 1.5;
 }
@@ -823,7 +836,7 @@ button {
   align-items: start;
   justify-items: center;
   padding: clamp(76px, 10vh, 118px) 20px 24px;
-  background: rgba(3, 2, 8, 0.7);
+  background: var(--overlay);
   backdrop-filter: blur(12px) saturate(115%);
   -webkit-backdrop-filter: blur(12px) saturate(115%);
 }
@@ -837,11 +850,11 @@ button {
   max-height: min(720px, calc(100dvh - 112px));
   overflow: hidden auto;
   padding: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  border: 1px solid var(--border-bright);
   border-radius: 22px;
   background:
-    radial-gradient(circle at 78% 0%, rgba(119, 152, 255, 0.12), transparent 35%),
-    rgba(10, 9, 19, 0.97);
+    radial-gradient(circle at 78% 0%, color-mix(in srgb, var(--focus) 7%, transparent), transparent 38%),
+    var(--surface-modal);
   box-shadow: 0 36px 120px rgba(0, 0, 0, 0.58), inset 0 1px 0 rgba(255, 255, 255, 0.055);
   color: var(--text);
   overscroll-behavior: contain;
@@ -857,7 +870,7 @@ button {
 
 .search-kicker {
   margin: 0 0 5px;
-  color: var(--volume);
+  color: var(--focus);
   font-size: 8px;
   font-weight: 750;
   letter-spacing: 0.16em;
@@ -878,18 +891,18 @@ button {
   gap: 7px;
   margin-top: 16px;
   padding: 5px 7px 5px 12px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border: 1px solid var(--border);
   border-radius: 14px;
   background: rgba(255, 255, 255, 0.045);
 }
 
 .search-field:focus-within {
-  border-color: rgba(119, 152, 255, 0.62);
-  box-shadow: 0 0 0 3px rgba(119, 152, 255, 0.09), 0 0 28px rgba(119, 152, 255, 0.08);
+  border-color: var(--focus);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--focus) 16%, transparent), 0 0 24px color-mix(in srgb, var(--focus) 9%, transparent);
 }
 
 .search-field > span {
-  color: #c4bfd0;
+  color: var(--text);
   font-size: 19px;
 }
 
@@ -906,7 +919,7 @@ button {
 }
 
 .search-field input::placeholder {
-  color: #726d7f;
+  color: var(--dim);
 }
 
 .search-field kbd {
@@ -991,9 +1004,13 @@ button {
 .search-result:hover,
 .search-result:focus-visible,
 .search-result[aria-selected="true"] {
-  border-color: color-mix(in srgb, var(--result-accent) 42%, transparent);
-  outline: none;
+  border-color: color-mix(in srgb, var(--result-accent) 56%, transparent);
   background: color-mix(in srgb, var(--result-accent) 9%, transparent);
+}
+
+.search-result:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
 }
 
 .search-dialog > footer {
@@ -1003,13 +1020,13 @@ button {
   margin-top: 12px;
   padding: 10px 2px 0;
   border-top: 1px solid rgba(255, 255, 255, 0.07);
-  color: #6e6979;
+  color: var(--dim);
   font-size: 8px;
 }
 
 .search-dialog > footer span:last-child {
   margin-left: auto;
-  color: #696475;
+  color: var(--dim);
 }
 
 .search-dialog > footer kbd {
@@ -1072,14 +1089,14 @@ button {
   padding: 7px 9px;
   border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 9px;
-  background: #12101d;
+  background: var(--surface);
   color: var(--text);
   font: 10px/1.4 -apple-system, BlinkMacSystemFont, "SF Pro Display", sans-serif;
 }
 
 .line-explorer select:focus-visible {
-  border-color: var(--line);
-  outline: 2px solid color-mix(in srgb, var(--line) 65%, transparent);
+  border-color: var(--focus);
+  outline: 2px solid color-mix(in srgb, var(--focus) 72%, transparent);
   outline-offset: 2px;
 }
 
@@ -1158,7 +1175,7 @@ button {
 }
 
 .focus-note b {
-  color: #dcd7e7;
+  color: var(--text);
   font-size: 9px;
   font-weight: 650;
 }
@@ -1175,7 +1192,7 @@ button {
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.045);
-  color: #c9c3d3;
+  color: var(--muted);
   cursor: pointer;
   font-size: 8px;
 }
@@ -1183,9 +1200,13 @@ button {
 .focus-note button:hover,
 .focus-note button:focus-visible {
   border-color: color-mix(in srgb, var(--detail-accent, var(--root)) 48%, transparent);
-  outline: none;
   background: color-mix(in srgb, var(--detail-accent, var(--root)) 10%, transparent);
   color: var(--text);
+}
+
+.focus-note button:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
 }
 
 /* The claim's box lives on `.detail-claim` alone, so the heading and the
@@ -1211,7 +1232,7 @@ button {
 
 .detail-receipts {
   margin-top: 10px;
-  color: #858091;
+  color: var(--dim);
   font: 9px/1.55 ui-monospace, "SFMono-Regular", Menlo, monospace;
   overflow-wrap: anywhere;
 }
@@ -1299,7 +1320,7 @@ button {
 
 .evidence-link b {
   overflow-wrap: anywhere;
-  color: #d8d4e1;
+  color: var(--text);
   font: 9px/1.45 ui-monospace, "SFMono-Regular", Menlo, monospace;
   font-weight: 500;
 }
@@ -1314,7 +1335,11 @@ button {
   border-color: var(--detail-accent, var(--root));
   background: rgba(255, 255, 255, 0.075);
   color: var(--text);
-  outline: none;
+}
+
+.evidence-link:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 1px;
 }
 
 .evidence-technical {
@@ -1333,7 +1358,7 @@ button {
 
 .evidence-technical div {
   padding: 0 9px 8px;
-  color: #777181;
+  color: var(--dim);
   font: 8px/1.5 ui-monospace, "SFMono-Regular", Menlo, monospace;
   overflow-wrap: anywhere;
   white-space: pre-wrap;
@@ -1342,7 +1367,7 @@ button {
 .evidence-summary,
 .evidence-note {
   margin: 7px 0 9px;
-  color: #b8b3c4;
+  color: var(--muted);
   font: 10px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Display", sans-serif;
   white-space: pre-wrap;
 }
@@ -1353,14 +1378,14 @@ button {
 }
 
 .evidence-missing {
-  color: #ff9cae;
+  color: var(--danger);
 }
 
 .evidence-fact,
 .evidence-preview,
 .evidence-loading {
   margin-top: 5px;
-  color: #858091;
+  color: var(--dim);
   font: 9px/1.55 ui-monospace, "SFMono-Regular", Menlo, monospace;
   overflow-wrap: anywhere;
 }
@@ -1368,7 +1393,7 @@ button {
 .evidence-preview {
   padding: 7px 0 0;
   border-top: 1px solid rgba(255, 255, 255, 0.055);
-  color: #a7a1b2;
+  color: var(--muted);
 }
 
 .timeline {
@@ -1392,7 +1417,7 @@ button {
 }
 
 .timeline-copy strong {
-  color: #d9d5e3;
+  color: var(--text);
   font-size: 9px;
   font-weight: 700;
 }
@@ -1419,7 +1444,7 @@ button {
 .timeline input {
   width: 100%;
   height: 2px;
-  accent-color: var(--face);
+  accent-color: var(--focus);
   cursor: ew-resize;
 }
 
@@ -1429,7 +1454,7 @@ button {
   right: 26px;
   bottom: 29px;
   margin: 0;
-  color: #625d70;
+  color: var(--dim);
   font-size: 8px;
   font-weight: 650;
   letter-spacing: 0.06em;
@@ -1439,7 +1464,7 @@ button {
 
 .gesture-hint span {
   margin-right: 5px;
-  color: #8d879c;
+  color: var(--muted);
 }
 
 .empty,
@@ -1467,7 +1492,7 @@ button {
 }
 
 .error {
-  color: #ff9cae;
+  color: var(--danger);
 }
 
 .error p {
@@ -1477,15 +1502,15 @@ button {
 .error button {
   margin-top: 14px;
   padding: 8px 15px;
-  border: 1px solid rgba(255, 156, 174, 0.34);
+  border: 1px solid color-mix(in srgb, var(--danger) 42%, transparent);
   border-radius: 999px;
-  background: rgba(255, 156, 174, 0.1);
-  color: #ffd4dc;
+  background: color-mix(in srgb, var(--danger) 10%, transparent);
+  color: var(--danger);
   cursor: pointer;
 }
 
 .error button:hover {
-  background: rgba(255, 156, 174, 0.18);
+  background: color-mix(in srgb, var(--danger) 18%, transparent);
 }
 
 .share-notice {
@@ -1498,9 +1523,9 @@ button {
   gap: 11px;
   width: min(330px, calc(100vw - 48px));
   padding: 13px 15px;
-  border: 1px solid rgba(78, 240, 195, 0.24);
+  border: 1px solid color-mix(in srgb, var(--success) 30%, transparent);
   border-radius: 15px;
-  background: rgba(10, 9, 19, 0.92);
+  background: var(--surface-strong);
   box-shadow: 0 18px 60px rgba(0, 0, 0, 0.34), inset 0 1px 0 rgba(255, 255, 255, 0.045);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
@@ -1517,8 +1542,8 @@ button {
   flex: none;
   place-items: center;
   border-radius: 50%;
-  background: rgba(78, 240, 195, 0.11);
-  color: var(--point);
+  background: color-mix(in srgb, var(--success) 11%, transparent);
+  color: var(--success);
   font-size: 16px;
 }
 
@@ -1539,12 +1564,12 @@ button {
 }
 
 .share-notice.failed {
-  border-color: rgba(255, 107, 138, 0.28);
+  border-color: color-mix(in srgb, var(--danger) 34%, transparent);
 }
 
 .share-notice.failed > span {
-  background: rgba(255, 107, 138, 0.11);
-  color: var(--root);
+  background: color-mix(in srgb, var(--danger) 11%, transparent);
+  color: var(--danger);
 }
 
 .model-label {
@@ -1557,9 +1582,9 @@ button {
   padding: 3px 8px;
   border: 1px solid rgba(255, 255, 255, 0.11);
   border-radius: 999px;
-  background: rgba(7, 6, 13, 0.78);
+  background: rgba(28, 28, 28, 0.84);
   box-shadow: 0 7px 20px rgba(0, 0, 0, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.04);
-  color: #dcd8e5;
+  color: var(--text);
   cursor: pointer;
   font-size: 9px;
   line-height: 14px;
@@ -1595,19 +1620,19 @@ button {
 .model-label[data-kind="face"] { --label-accent: var(--face); }
 .model-label[data-kind="volume"] { --label-accent: var(--volume); }
 .model-label[data-kind="root"] { --label-accent: var(--root); }
-.model-label[data-kind="context"] { --label-accent: var(--muted); }
+.model-label[data-kind="context"] { --label-accent: var(--entity); }
 
 /* No `transform` lift here: the renderer owns this element's transform and
    overwrites any rule with an inline one, so the lift never rendered. */
 .model-label:hover,
 .model-label:focus-visible {
   border-color: var(--label-accent);
-  background: rgba(20, 17, 34, 0.96);
+  background: var(--surface-strong);
 }
 
 .model-label[aria-expanded="true"] {
   border-color: var(--label-accent);
-  background: rgba(24, 20, 40, 0.98);
+  background: var(--surface-modal);
   box-shadow: 0 0 0 1px color-mix(in srgb, var(--label-accent) 65%, transparent), 0 8px 26px rgba(0, 0, 0, 0.42), 0 0 24px color-mix(in srgb, var(--label-accent) 18%, transparent);
 }
 
@@ -1634,7 +1659,7 @@ button {
 
 .model-label.focus-neighbor:not([aria-expanded="true"]) {
   border-color: color-mix(in srgb, var(--label-accent) 38%, transparent);
-  background: rgba(12, 10, 22, 0.9);
+  background: var(--surface-strong);
 }
 
 @media (min-width: 1361px) and (max-width: 1640px) {
@@ -2038,9 +2063,9 @@ button {
   max-width: min(720px, calc(100vw - 32px));
   padding: 8px 14px;
   border-radius: 8px;
-  border: 1px solid rgba(255, 176, 32, 0.55);
-  background: rgba(64, 44, 6, 0.92);
-  color: #ffd88a;
+  border: 1px solid color-mix(in srgb, var(--warning) 56%, transparent);
+  background: color-mix(in srgb, var(--warning) 14%, var(--surface-strong));
+  color: var(--warning);
   font-size: 13px;
   line-height: 1.4;
   text-align: center;
@@ -2136,9 +2161,9 @@ button {
   display: none;
 }
 
-.detail-status[data-tone="error"] { color: #ff9e94; }
-.detail-status[data-tone="warn"] { color: #ffd58a; }
-.detail-status[data-tone="ok"] { color: #96e2b2; }
+.detail-status[data-tone="error"] { color: var(--danger); }
+.detail-status[data-tone="warn"] { color: var(--warning); }
+.detail-status[data-tone="ok"] { color: var(--success); }
 
 /* Properties, not a table. One quiet line that wraps. */
 .detail-meta {
@@ -2159,7 +2184,7 @@ button {
 
 .detail-meta strong {
   margin-right: 4px;
-  color: #57525f;
+  color: var(--muted);
   font-weight: 600;
 }
 
@@ -2252,7 +2277,7 @@ button {
   border: 1px solid transparent;
   border-radius: 8px;
   background: transparent;
-  color: #8d8798;
+  color: var(--dim);
   cursor: pointer;
   font-size: 11px;
   font-weight: 600;
@@ -2260,9 +2285,9 @@ button {
 }
 
 .detail-reject:hover:not(:disabled) {
-  border-color: rgba(255, 138, 128, 0.3);
-  background: rgba(255, 106, 92, 0.1);
-  color: #ffb0a8;
+  border-color: color-mix(in srgb, var(--danger) 38%, transparent);
+  background: color-mix(in srgb, var(--danger) 10%, transparent);
+  color: var(--danger);
 }
 
 .detail-reject:disabled {
@@ -2271,7 +2296,7 @@ button {
 }
 
 .detail-authored {
-  color: #96e2b2;
+  color: var(--success);
 }
 
 /* Sits above the model-load banner so a save failure is never stacked

--- a/resources/model_assets/viewer.js
+++ b/resources/model_assets/viewer.js
@@ -785,14 +785,14 @@ function addRoot(root) {
   const position = positions.get(root.id);
   if (!position) return;
   const rootKey = selectionKey("root", root.id);
-  addGlow(position, COLORS.root, 4.2, 0.3, "root", 0.075, [rootKey]);
+  addGlow(position, COLORS.root, 4.2, 0.38, "root", 0.075, [rootKey]);
   const mesh = registerPickable(
     new THREE.Mesh(
       new THREE.DodecahedronGeometry(0.62, 0),
       new THREE.MeshPhysicalMaterial({
         color: COLORS.root,
         emissive: COLORS.root,
-        emissiveIntensity: 0.56,
+        emissiveIntensity: 0.68,
         roughness: 0.18,
         metalness: 0.08,
         clearcoat: 1,

--- a/resources/model_assets/viewer.js
+++ b/resources/model_assets/viewer.js
@@ -797,6 +797,7 @@ function addRoot(root) {
         metalness: 0.08,
         clearcoat: 1,
         clearcoatRoughness: 0.22,
+        depthTest: false,
       })
     ),
     "root",
@@ -804,6 +805,7 @@ function addRoot(root) {
     root
   );
   mesh.position.copy(position);
+  mesh.renderOrder = 2;
   addLabel(
     root.signature,
     position.clone().add(new THREE.Vector3(0, 0.66, 0)),

--- a/resources/model_assets/viewer.js
+++ b/resources/model_assets/viewer.js
@@ -136,9 +136,9 @@ scene.add(new THREE.HemisphereLight(COLORS.text, COLORS.canvas, 2.05));
 const keyLight = new THREE.DirectionalLight(COLORS.text, 2.35);
 keyLight.position.set(5, 11, 8);
 scene.add(keyLight);
-const faceLight = new THREE.PointLight(COLORS.faces, 7, 22, 2);
-faceLight.position.set(-5, -1, 3);
-scene.add(faceLight);
+const pointLight = new THREE.PointLight(COLORS.points, 7, 22, 2);
+pointLight.position.set(-5, -1, 3);
+scene.add(pointLight);
 const violetLight = new THREE.PointLight(COLORS.volumes, 8, 24, 2);
 violetLight.position.set(5, 4, -4);
 scene.add(violetLight);
@@ -839,7 +839,7 @@ function addModelLine(line) {
   const targetCluster = currentLayout?.pointClusterById.get(line.target);
   const sameCluster = sourceCluster && sourceCluster === targetCluster;
   // Transparent strokes keep a large model calm, but each semantic relation
-  // still needs to survive compositing against the charcoal canvas.
+  // still needs to survive compositing against the deep-space canvas.
   const opacity = evolution ? (sameCluster ? 0.5 : 0.2) : 0.36;
   const lineObject = addLine(
     start,

--- a/resources/model_assets/viewer.js
+++ b/resources/model_assets/viewer.js
@@ -1,6 +1,7 @@
 import * as THREE from "three";
 import { OrbitControls } from "three/addons/controls/OrbitControls.js";
 import { CSS2DObject, CSS2DRenderer } from "three/addons/renderers/CSS2DRenderer.js";
+import { MODEL_COLORS as COLORS, MODEL_PALETTE } from "./palette.mjs";
 import {
   computeClusterLayout,
   fittedOverviewPose,
@@ -38,16 +39,6 @@ import {
   drawConstellationCard,
   drawHumanCard,
 } from "./share.mjs";
-
-const COLORS = {
-  points: 0x4ef0c3,
-  lines: 0xffc45e,
-  faces: 0xff64d6,
-  volumes: 0x7798ff,
-  root: 0xff6b8a,
-  context: 0xa5a0b5,
-  hierarchy: 0x6e6688,
-};
 
 const canvasHost = document.getElementById("canvas");
 const viewerEl = document.getElementById("viewer");
@@ -98,7 +89,7 @@ const layerCountEls = Object.fromEntries(
 );
 
 const scene = new THREE.Scene();
-scene.fog = new THREE.FogExp2(0x070610, 0.026);
+scene.fog = new THREE.FogExp2(COLORS.canvas, 0.026);
 
 const camera = new THREE.PerspectiveCamera(50, 1, 0.1, 100);
 // No `preserveDrawingBuffer`: it makes the browser copy the whole framebuffer
@@ -116,7 +107,7 @@ renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
 renderer.setSize(window.innerWidth, window.innerHeight);
 renderer.outputColorSpace = THREE.SRGBColorSpace;
 renderer.toneMapping = THREE.ACESFilmicToneMapping;
-renderer.toneMappingExposure = 1.18;
+renderer.toneMappingExposure = 1.04;
 renderer.domElement.setAttribute("aria-hidden", "true");
 canvasHost.appendChild(renderer.domElement);
 
@@ -141,14 +132,14 @@ controls.dampingFactor = 0.07;
 controls.zoomToCursor = true;
 controls.target.set(0, 2.2, 0);
 
-scene.add(new THREE.HemisphereLight(0xdad6ff, 0x080710, 2.25));
-const keyLight = new THREE.DirectionalLight(0xffeafa, 2.65);
+scene.add(new THREE.HemisphereLight(COLORS.text, COLORS.canvas, 2.05));
+const keyLight = new THREE.DirectionalLight(COLORS.text, 2.35);
 keyLight.position.set(5, 11, 8);
 scene.add(keyLight);
-const cyanLight = new THREE.PointLight(COLORS.points, 12, 22, 2);
-cyanLight.position.set(-5, -1, 3);
-scene.add(cyanLight);
-const violetLight = new THREE.PointLight(COLORS.volumes, 13, 24, 2);
+const faceLight = new THREE.PointLight(COLORS.faces, 7, 22, 2);
+faceLight.position.set(-5, -1, 3);
+scene.add(faceLight);
+const violetLight = new THREE.PointLight(COLORS.volumes, 8, 24, 2);
 violetLight.position.set(5, 4, -4);
 scene.add(violetLight);
 
@@ -272,7 +263,7 @@ function addAtmosphere() {
   const stars = new THREE.Points(
     geometry,
     new THREE.PointsMaterial({
-      color: 0xc9c2ff,
+      color: COLORS.focus,
       size: 0.035,
       transparent: true,
       opacity: 0.38,
@@ -604,19 +595,19 @@ function addPoint(point, position, baseRadius, showLabel, promoted) {
   const material = new THREE.MeshStandardMaterial({
     color: COLORS.points,
     emissive: COLORS.points,
-    emissiveIntensity: active ? (promoted ? 0.72 : 0.34) : 0.12,
+    emissiveIntensity: active ? (promoted ? 0.44 : 0.2) : 0.06,
     transparent: true,
-    opacity: active ? (promoted ? 1 : 0.72) : (promoted ? 0.42 : 0.22),
+    opacity: active ? (promoted ? 0.9 : 0.58) : (promoted ? 0.3 : 0.16),
     roughness: 0.26,
   });
   const mesh = registerPickable(new THREE.Mesh(geometry, material), "points", "point", point);
   mesh.position.copy(position);
-  if (active && promoted && hash(`${point.id}:glow`) < 0.08) {
+  if (active && promoted && hash(`${point.id}:glow`) < 0.05) {
     addGlow(
       position,
       COLORS.points,
       radius * 5.4,
-      0.2,
+      0.1,
       "points",
       0.08,
       [selectionKey("point", point.id)],
@@ -690,14 +681,14 @@ function addFace(face, showLabel) {
   const memberIds = currentLayout?.facePointIds.get(face.id) || [];
   const memberPositions = memberIds.map((id) => positions.get(id)).filter(Boolean);
   addClusterHalo(memberPositions, position, [faceKey]);
-  addGlow(position, COLORS.faces, 1.55, 0.22, "faces", 0.07, [faceKey]);
+  addGlow(position, COLORS.faces, 1.55, 0.16, "faces", 0.07, [faceKey]);
   const node = registerPickable(
     new THREE.Mesh(
       new THREE.OctahedronGeometry(0.28, 0),
       new THREE.MeshStandardMaterial({
         color: COLORS.faces,
         emissive: COLORS.faces,
-        emissiveIntensity: 0.58,
+        emissiveIntensity: 0.42,
         roughness: 0.26,
       })
     ),
@@ -736,14 +727,14 @@ function addVolume(volume, showLabel) {
   const position = positions.get(volume.id);
   if (!position) return;
   const volumeKey = selectionKey("volume", volume.id);
-  addGlow(position, COLORS.volumes, 2.35, 0.25, "volumes", 0.06, [volumeKey]);
+  addGlow(position, COLORS.volumes, 2.35, 0.18, "volumes", 0.06, [volumeKey]);
   const mesh = registerPickable(
     new THREE.Mesh(
       new THREE.IcosahedronGeometry(0.48, 1),
       new THREE.MeshStandardMaterial({
         color: COLORS.volumes,
         emissive: COLORS.volumes,
-        emissiveIntensity: 0.42,
+        emissiveIntensity: 0.32,
         transparent: true,
         opacity: 0.72,
         wireframe: true,
@@ -794,14 +785,14 @@ function addRoot(root) {
   const position = positions.get(root.id);
   if (!position) return;
   const rootKey = selectionKey("root", root.id);
-  addGlow(position, COLORS.root, 4.2, 0.42, "root", 0.075, [rootKey]);
+  addGlow(position, COLORS.root, 4.2, 0.3, "root", 0.075, [rootKey]);
   const mesh = registerPickable(
     new THREE.Mesh(
       new THREE.DodecahedronGeometry(0.62, 0),
       new THREE.MeshPhysicalMaterial({
         color: COLORS.root,
         emissive: COLORS.root,
-        emissiveIntensity: 0.72,
+        emissiveIntensity: 0.56,
         roughness: 0.18,
         metalness: 0.08,
         clearcoat: 1,
@@ -847,11 +838,13 @@ function addModelLine(line) {
   const sourceCluster = currentLayout?.pointClusterById.get(line.source);
   const targetCluster = currentLayout?.pointClusterById.get(line.target);
   const sameCluster = sourceCluster && sourceCluster === targetCluster;
-  const opacity = evolution ? (sameCluster ? 0.5 : 0.16) : 0.46;
+  // Transparent strokes keep a large model calm, but each semantic relation
+  // still needs to survive compositing against the charcoal canvas.
+  const opacity = evolution ? (sameCluster ? 0.5 : 0.2) : 0.36;
   const lineObject = addLine(
     start,
     end,
-    evolution ? COLORS.lines : 0x6ebf8e,
+    evolution ? COLORS.lines : COLORS.relation,
     opacity,
     !evolution,
   );
@@ -878,13 +871,13 @@ function addGround() {
   [0.34, 0.58, 0.84, 1.08].forEach((factor, index) => {
     addOrbitRing(
       radius * factor,
-      index % 2 ? COLORS.volumes : COLORS.faces,
-      Math.max(0.025, 0.075 - index * 0.012),
+      COLORS.hierarchy,
+      Math.max(0.014, 0.038 - index * 0.007),
       [0.12 + index * 0.035, index * 0.18, 0.05 - index * 0.02],
       ringLayer
     );
   });
-  addOrbitRing(radius * 0.72, COLORS.root, 0.055, [Math.PI / 2.8, 0.42, 0.18], ringLayer);
+  addOrbitRing(radius * 0.72, COLORS.focus, 0.03, [Math.PI / 2.8, 0.42, 0.18], ringLayer);
 }
 
 function buildScene({
@@ -1460,11 +1453,11 @@ function paintConstellationHandoff(popup) {
   if (!popup) return;
   popup.document.title = "Preparing your Persome constellation";
   popup.document.body.innerHTML = `
-    <main style="min-height:100vh;display:grid;place-items:center;margin:0;background:#070610;color:#f7f4ff;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">
-      <section style="width:min(440px,calc(100vw - 48px));padding:38px;border:1px solid rgba(255,255,255,.12);border-radius:24px;background:linear-gradient(145deg,rgba(255,100,214,.11),rgba(119,152,255,.08));box-shadow:0 30px 100px rgba(0,0,0,.45)">
-        <p style="margin:0 0 18px;color:#ff83cf;font-size:11px;font-weight:750;letter-spacing:.16em">PERSOME · SHARE TO X</p>
+    <main style="min-height:100vh;display:grid;place-items:center;margin:0;background:${MODEL_PALETTE.canvas};color:${MODEL_PALETTE.text};font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">
+      <section style="width:min(440px,calc(100vw - 48px));padding:38px;border:1px solid rgba(218,218,218,.14);border-radius:24px;background:${MODEL_PALETTE.surface};box-shadow:0 30px 100px rgba(0,0,0,.45)">
+        <p style="margin:0 0 18px;color:${MODEL_PALETTE.focus};font-size:11px;font-weight:750;letter-spacing:.16em">PERSOME · SHARE TO X</p>
         <h1 style="margin:0;font-size:34px;line-height:1.05;letter-spacing:-.045em">Your constellation is downloading.</h1>
-        <p style="margin:18px 0 0;color:#b8b1c7;font-size:15px;line-height:1.65">In X, add <strong style="color:#fff">${CONSTELLATION_FILE_NAME}</strong> with the image button. Review the image before posting.</p>
+        <p style="margin:18px 0 0;color:${MODEL_PALETTE.muted};font-size:15px;line-height:1.65">In X, add <strong style="color:${MODEL_PALETTE.text}">${CONSTELLATION_FILE_NAME}</strong> with the image button. Review the image before posting.</p>
       </section>
     </main>`;
 }
@@ -1574,7 +1567,9 @@ function syncSelectionState() {
         target.element.setAttribute("aria-expanded", String(active));
       } else if (target.isLine && target.material) {
         const baseOpacity = Number(target.userData.baseOpacity || 0);
+        target.userData.baseColor ??= target.material.color.getHex();
         if (active) target.material.opacity = Math.min(1, baseOpacity * 2 + 0.24);
+        target.material.color.setHex(active ? COLORS.focus : target.userData.baseColor);
         target.renderOrder = active ? 5 : 0;
       } else if (target.isMesh) {
         target.userData.selectionBaseScale ||= target.scale.clone();

--- a/resources/model_assets/viewer.js
+++ b/resources/model_assets/viewer.js
@@ -797,7 +797,10 @@ function addRoot(root) {
         metalness: 0.08,
         clearcoat: 1,
         clearcoatRoughness: 0.22,
+        transparent: true,
+        opacity: 1,
         depthTest: false,
+        depthWrite: false,
       })
     ),
     "root",

--- a/src/persome/api/routes.py
+++ b/src/persome/api/routes.py
@@ -754,6 +754,7 @@ _MODEL_ASSETS = {
     "explore.mjs",
     "onboarding.css",
     "onboarding.js",
+    "palette.mjs",
     "three.module.js",
     "layout.mjs",
     "share.mjs",

--- a/tests/js/model_layout.test.mjs
+++ b/tests/js/model_layout.test.mjs
@@ -75,18 +75,25 @@ function fixture(extraPoints = []) {
 }
 
 test("lays the hierarchy out as centered, three-dimensional clusters", () => {
-  const layout = computeClusterLayout(fixture());
+  const model = fixture();
+  const layout = computeClusterLayout(model);
   const root = layout.positions.get("root");
 
   assert.deepEqual(root, [0, 0, 0]);
   assert.equal(layout.diagnostics.rootAtCenter, true);
-  assert.ok(layout.diagnostics.averageRadius.volumes > 1.5);
+  assert.ok(layout.diagnostics.averageRadius.volumes > 2.35);
   assert.ok(layout.diagnostics.averageRadius.faces > layout.diagnostics.averageRadius.volumes);
   assert.ok(layout.diagnostics.pointYSpread > 0.75);
   assert.equal(layout.diagnostics.directPoints, 18);
   assert.equal(layout.diagnostics.volumeMembershipEdges, 3);
   assert.ok(layout.diagnostics.sourceClusterPoints >= 6);
   assert.ok(layout.contextIds.includes("self"));
+  model.volumes.forEach((volume) => {
+    assert.ok(layoutMath.distance(layout.positions.get(volume.id), root) >= 2.4);
+  });
+  layout.contextIds.forEach((id) => {
+    assert.ok(layoutMath.distance(layout.positions.get(id), root) > 1.09);
+  });
   assert.ok(layoutMath.distance(layout.positions.get("face-focus"), root) > 3);
 });
 
@@ -122,6 +129,19 @@ test("keeps a point-only degraded model close to the center", () => {
   assert.equal(layout.diagnostics.sourceClusterPoints, 1);
   assert.ok(layout.diagnostics.averageRadius.points < 2);
   assert.ok(layout.diagnostics.bounds.radius < 3);
+});
+
+test("does not widen a rootless degraded hierarchy", () => {
+  const model = { ...fixture(), root: null };
+  const layout = computeClusterLayout(model);
+  const center = [0, 0, 0];
+
+  model.volumes.forEach((volume) => {
+    assert.ok(layoutMath.distance(layout.positions.get(volume.id), center) < 2.3);
+  });
+  layout.contextIds.forEach((id) => {
+    assert.ok(layoutMath.distance(layout.positions.get(id), center) < 1.41);
+  });
 });
 
 test("steps fitted zoom predictably through rapid actions and clamps its range", () => {

--- a/tests/js/model_palette.test.mjs
+++ b/tests/js/model_palette.test.mjs
@@ -47,8 +47,15 @@ function composite(foreground, background, alpha) {
   return `#${mixed.map((channel) => channel.toString(16).padStart(2, "0")).join("")}`;
 }
 
+function chroma(value) {
+  const values = channels(value);
+  return Math.max(...values) - Math.min(...values);
+}
+
 test("keeps CSS, WebGL, and export palette roles aligned", () => {
   assert.equal(cssToken("bg"), MODEL_PALETTE.canvas);
+  assert.equal(cssToken("surface"), colorWithAlpha(MODEL_PALETTE.surface, 0.82));
+  assert.equal(cssToken("surface-soft"), colorWithAlpha(MODEL_PALETTE.surfaceRaised, 0.64));
   assert.equal(cssToken("text"), MODEL_PALETTE.text);
   assert.equal(cssToken("muted"), MODEL_PALETTE.muted);
   assert.equal(cssToken("dim"), MODEL_PALETTE.dim);
@@ -64,6 +71,9 @@ test("keeps CSS, WebGL, and export palette roles aligned", () => {
   assert.equal(cssToken("guide-ui"), MODEL_PALETTE.guideUi);
   assert.equal(cssToken("relation"), MODEL_PALETTE.relation);
   assert.equal(cssToken("historical"), MODEL_PALETTE.historical);
+  assert.equal(cssToken("success"), MODEL_PALETTE.success);
+  assert.equal(cssToken("warning"), MODEL_PALETTE.warning);
+  assert.equal(cssToken("danger"), MODEL_PALETTE.error);
 
   assert.equal(MODEL_COLORS.points, Number.parseInt(MODEL_PALETTE.point.slice(1), 16));
   assert.equal(MODEL_COLORS.lines, Number.parseInt(MODEL_PALETTE.line.slice(1), 16));
@@ -72,13 +82,19 @@ test("keeps CSS, WebGL, and export palette roles aligned", () => {
   assert.equal(MODEL_COLORS.root, Number.parseInt(MODEL_PALETTE.root.slice(1), 16));
 });
 
-test("keeps dense evidence neutral and reserves chroma for promoted structure", () => {
-  assert.equal(MODEL_PALETTE.point, "#b3b3b3");
-  assert.equal(MODEL_PALETTE.line, "#666666");
+test("keeps the original semantic hues restrained on a deep-space canvas", () => {
+  assert.equal(MODEL_PALETTE.canvas, "#090b16");
+  assert.equal(MODEL_PALETTE.point, "#72d8c0");
+  assert.equal(MODEL_PALETTE.line, "#9f7a52");
+  assert.equal(MODEL_PALETTE.face, "#e47bc9");
+  assert.equal(MODEL_PALETTE.volume, "#8298ee");
+  assert.equal(MODEL_PALETTE.root, "#ee809b");
+  assert.ok(chroma(MODEL_PALETTE.canvas) >= 10, "canvas should remain blue-black, not charcoal");
+  assert.ok(chroma(MODEL_PALETTE.point) >= 60, "dense points should retain their mint hue");
+  assert.ok(chroma(MODEL_PALETTE.line) >= 50, "dense lines should retain their warm amber hue");
   assert.notEqual(MODEL_PALETTE.face, MODEL_PALETTE.volume);
   assert.notEqual(MODEL_PALETTE.volume, MODEL_PALETTE.root);
   assert.notEqual(MODEL_PALETTE.root, MODEL_PALETTE.face);
-  assert.ok(contrast(MODEL_PALETTE.line, MODEL_PALETTE.canvas) < 3);
   assert.ok(contrast(MODEL_PALETTE.focus, MODEL_PALETTE.canvas) >= 3);
 
   assert.ok(
@@ -86,16 +102,28 @@ test("keeps dense evidence neutral and reserves chroma for promoted structure", 
     "same-cluster evolution lines must remain visible after alpha compositing",
   );
   assert.ok(
+    contrast(composite(MODEL_PALETTE.line, MODEL_PALETTE.canvas, 0.5), MODEL_PALETTE.canvas) < 3,
+    "same-cluster evolution lines should not overpower dense points",
+  );
+  assert.ok(
     contrast(composite(MODEL_PALETTE.line, MODEL_PALETTE.canvas, 0.2), MODEL_PALETTE.canvas) >= 1.15,
     "cross-cluster evolution lines must remain subtly visible after alpha compositing",
+  );
+  assert.ok(
+    contrast(composite(MODEL_PALETTE.line, MODEL_PALETTE.canvas, 0.2), MODEL_PALETTE.canvas) < 1.5,
+    "cross-cluster evolution lines should remain atmospheric",
   );
   assert.ok(
     contrast(composite(MODEL_PALETTE.relation, MODEL_PALETTE.canvas, 0.36), MODEL_PALETTE.canvas) >= 2.1,
     "semantic relation lines must remain readable after alpha compositing",
   );
+  assert.ok(
+    contrast(composite(MODEL_PALETTE.relation, MODEL_PALETTE.canvas, 0.36), MODEL_PALETTE.canvas) < 3.2,
+    "semantic relation lines should not dominate the graph",
+  );
 });
 
-test("keeps essential small text and controls legible on charcoal surfaces", () => {
+test("keeps essential small text and controls legible on blue-black surfaces", () => {
   for (const role of ["text", "muted", "dim"]) {
     assert.ok(
       contrast(MODEL_PALETTE[role], MODEL_PALETTE.surface) >= 4.5,
@@ -108,6 +136,7 @@ test("keeps essential small text and controls legible on charcoal surfaces", () 
       `${role} must remain visible on the graph canvas`,
     );
   }
+  assert.ok(contrast(MODEL_PALETTE.focus, MODEL_PALETTE.surface) >= 3);
   for (const role of ["entity", "guideUi"]) {
     assert.ok(
       contrast(MODEL_PALETTE[role], MODEL_PALETTE.surface) >= 3,
@@ -117,7 +146,7 @@ test("keeps essential small text and controls legible on charcoal surfaces", () 
 });
 
 test("builds bounded rgba strings for canvas exports", () => {
-  assert.equal(colorWithAlpha(MODEL_PALETTE.focus, 0.14), "rgba(166, 138, 249, 0.14)");
-  assert.equal(colorWithAlpha(MODEL_PALETTE.root, 9), "rgba(250, 153, 205, 1)");
-  assert.equal(colorWithAlpha(MODEL_PALETTE.face, -1), "rgba(83, 223, 221, 0)");
+  assert.equal(colorWithAlpha("#123456", 0.14), "rgba(18, 52, 86, 0.14)");
+  assert.equal(colorWithAlpha("#123456", 9), "rgba(18, 52, 86, 1)");
+  assert.equal(colorWithAlpha("#123456", -1), "rgba(18, 52, 86, 0)");
 });

--- a/tests/js/model_palette.test.mjs
+++ b/tests/js/model_palette.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  MODEL_COLORS,
+  MODEL_PALETTE,
+  colorWithAlpha,
+} from "../../resources/model_assets/palette.mjs";
+
+const css = await readFile(
+  new URL("../../resources/model_assets/viewer.css", import.meta.url),
+  "utf8",
+);
+
+function cssToken(name) {
+  return css.match(new RegExp(`--${name}:\\s*([^;]+);`))?.[1]?.trim();
+}
+
+function channels(value) {
+  const number = Number.parseInt(value.slice(1), 16);
+  return [(number >> 16) & 255, (number >> 8) & 255, number & 255];
+}
+
+function luminance(value) {
+  const linear = channels(value).map((channel) => {
+    const normalized = channel / 255;
+    return normalized <= 0.04045
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2];
+}
+
+function contrast(left, right) {
+  const bright = Math.max(luminance(left), luminance(right));
+  const dark = Math.min(luminance(left), luminance(right));
+  return (bright + 0.05) / (dark + 0.05);
+}
+
+function composite(foreground, background, alpha) {
+  const front = channels(foreground);
+  const back = channels(background);
+  const mixed = front.map((channel, index) =>
+    Math.round(channel * alpha + back[index] * (1 - alpha)),
+  );
+  return `#${mixed.map((channel) => channel.toString(16).padStart(2, "0")).join("")}`;
+}
+
+test("keeps CSS, WebGL, and export palette roles aligned", () => {
+  assert.equal(cssToken("bg"), MODEL_PALETTE.canvas);
+  assert.equal(cssToken("text"), MODEL_PALETTE.text);
+  assert.equal(cssToken("muted"), MODEL_PALETTE.muted);
+  assert.equal(cssToken("dim"), MODEL_PALETTE.dim);
+  assert.equal(cssToken("point"), MODEL_PALETTE.point);
+  assert.equal(cssToken("line"), MODEL_PALETTE.lineUi);
+  assert.equal(cssToken("line-stroke"), MODEL_PALETTE.line);
+  assert.equal(cssToken("face"), MODEL_PALETTE.face);
+  assert.equal(cssToken("volume"), MODEL_PALETTE.volume);
+  assert.equal(cssToken("root"), MODEL_PALETTE.root);
+  assert.equal(cssToken("focus"), MODEL_PALETTE.focus);
+  assert.equal(cssToken("entity"), MODEL_PALETTE.entity);
+  assert.equal(cssToken("guide"), MODEL_PALETTE.guide);
+  assert.equal(cssToken("guide-ui"), MODEL_PALETTE.guideUi);
+  assert.equal(cssToken("relation"), MODEL_PALETTE.relation);
+  assert.equal(cssToken("historical"), MODEL_PALETTE.historical);
+
+  assert.equal(MODEL_COLORS.points, Number.parseInt(MODEL_PALETTE.point.slice(1), 16));
+  assert.equal(MODEL_COLORS.lines, Number.parseInt(MODEL_PALETTE.line.slice(1), 16));
+  assert.equal(MODEL_COLORS.faces, Number.parseInt(MODEL_PALETTE.face.slice(1), 16));
+  assert.equal(MODEL_COLORS.volumes, Number.parseInt(MODEL_PALETTE.volume.slice(1), 16));
+  assert.equal(MODEL_COLORS.root, Number.parseInt(MODEL_PALETTE.root.slice(1), 16));
+});
+
+test("keeps dense evidence neutral and reserves chroma for promoted structure", () => {
+  assert.equal(MODEL_PALETTE.point, "#b3b3b3");
+  assert.equal(MODEL_PALETTE.line, "#666666");
+  assert.notEqual(MODEL_PALETTE.face, MODEL_PALETTE.volume);
+  assert.notEqual(MODEL_PALETTE.volume, MODEL_PALETTE.root);
+  assert.notEqual(MODEL_PALETTE.root, MODEL_PALETTE.face);
+  assert.ok(contrast(MODEL_PALETTE.line, MODEL_PALETTE.canvas) < 3);
+  assert.ok(contrast(MODEL_PALETTE.focus, MODEL_PALETTE.canvas) >= 3);
+
+  assert.ok(
+    contrast(composite(MODEL_PALETTE.line, MODEL_PALETTE.canvas, 0.5), MODEL_PALETTE.canvas) >= 1.6,
+    "same-cluster evolution lines must remain visible after alpha compositing",
+  );
+  assert.ok(
+    contrast(composite(MODEL_PALETTE.line, MODEL_PALETTE.canvas, 0.2), MODEL_PALETTE.canvas) >= 1.15,
+    "cross-cluster evolution lines must remain subtly visible after alpha compositing",
+  );
+  assert.ok(
+    contrast(composite(MODEL_PALETTE.relation, MODEL_PALETTE.canvas, 0.36), MODEL_PALETTE.canvas) >= 2.1,
+    "semantic relation lines must remain readable after alpha compositing",
+  );
+});
+
+test("keeps essential small text and controls legible on charcoal surfaces", () => {
+  for (const role of ["text", "muted", "dim"]) {
+    assert.ok(
+      contrast(MODEL_PALETTE[role], MODEL_PALETTE.surface) >= 4.5,
+      `${role} must remain readable on the common panel surface`,
+    );
+  }
+  for (const role of ["point", "lineUi", "face", "volume", "root", "focus"]) {
+    assert.ok(
+      contrast(MODEL_PALETTE[role], MODEL_PALETTE.canvas) >= 3,
+      `${role} must remain visible on the graph canvas`,
+    );
+  }
+  for (const role of ["entity", "guideUi"]) {
+    assert.ok(
+      contrast(MODEL_PALETTE[role], MODEL_PALETTE.surface) >= 3,
+      `${role} legend cues must remain visible on the common panel surface`,
+    );
+  }
+});
+
+test("builds bounded rgba strings for canvas exports", () => {
+  assert.equal(colorWithAlpha(MODEL_PALETTE.focus, 0.14), "rgba(166, 138, 249, 0.14)");
+  assert.equal(colorWithAlpha(MODEL_PALETTE.root, 9), "rgba(250, 153, 205, 1)");
+  assert.equal(colorWithAlpha(MODEL_PALETTE.face, -1), "rgba(83, 223, 221, 0)");
+});

--- a/tests/js/model_palette.test.mjs
+++ b/tests/js/model_palette.test.mjs
@@ -88,10 +88,11 @@ test("keeps the original semantic hues restrained on a deep-space canvas", () =>
   assert.equal(MODEL_PALETTE.line, "#9f7a52");
   assert.equal(MODEL_PALETTE.face, "#e47bc9");
   assert.equal(MODEL_PALETTE.volume, "#8298ee");
-  assert.equal(MODEL_PALETTE.root, "#ee809b");
+  assert.equal(MODEL_PALETTE.root, "#ff718f");
   assert.ok(chroma(MODEL_PALETTE.canvas) >= 10, "canvas should remain blue-black, not charcoal");
   assert.ok(chroma(MODEL_PALETTE.point) >= 60, "dense points should retain their mint hue");
   assert.ok(chroma(MODEL_PALETTE.line) >= 50, "dense lines should retain their warm amber hue");
+  assert.ok(chroma(MODEL_PALETTE.root) >= 120, "the Root should stay clearly coral, not dusty pink");
   assert.notEqual(MODEL_PALETTE.face, MODEL_PALETTE.volume);
   assert.notEqual(MODEL_PALETTE.volume, MODEL_PALETTE.root);
   assert.notEqual(MODEL_PALETTE.root, MODEL_PALETTE.face);

--- a/tests/test_model_layout_asset.py
+++ b/tests/test_model_layout_asset.py
@@ -19,6 +19,7 @@ def test_model_viewer_node_suite() -> None:
             "tests/js/model_evidence.test.mjs",
             "tests/js/model_explore.test.mjs",
             "tests/js/model_layout.test.mjs",
+            "tests/js/model_palette.test.mjs",
             "tests/js/model_share.test.mjs",
             "tests/js/model_zoom.test.mjs",
         ],

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -473,6 +473,7 @@ class TestViewPage:
         layout = routes.model_asset("layout.mjs")
         explore = routes.model_asset("explore.mjs")
         evidence = routes.model_asset("evidence.mjs")
+        palette = routes.model_asset("palette.mjs")
         share = routes.model_asset("share.mjs")
         viewer = routes.model_asset("viewer.js")
         css = routes.model_asset("viewer.css")
@@ -483,13 +484,17 @@ class TestViewPage:
         assert b"rankSearchEntries" in explore.body
         assert b"focusKeysForSelection" in explore.body
         assert b"nodeEvidenceCards" in evidence.body
+        assert b"MODEL_PALETTE" in palette.body
+        assert b"MODEL_COLORS" in palette.body
         assert b"humanCard" in share.body
         assert b"buildXIntentUrl" in share.body
         assert b"drawHumanCard" in share.body
         assert b"drawConstellationCard" in share.body
         assert b'from "./layout.mjs"' in viewer.body
         assert b'from "./explore.mjs"' in viewer.body
+        assert b'from "./palette.mjs"' in viewer.body
         assert b'from "./share.mjs"' in viewer.body
+        assert b'from "./palette.mjs"' in share.body
         assert b"model.points" in viewer.body
         assert b"model.lines" in viewer.body
         assert b"model.faces" in viewer.body
@@ -522,10 +527,10 @@ class TestViewPage:
         assert b".build-state--building" in css.body
         assert b".build-state--degraded" in css.body
         assert b".build-state--complete" in css.body
-        assert b"--build-color: #8d8799" in css.body
-        assert b"--build-color: var(--line)" in css.body
-        assert b"--build-color: var(--root)" in css.body
-        assert b"--build-color: var(--point)" in css.body
+        assert b"--build-color: var(--dim)" in css.body
+        assert b"--build-color: var(--warning)" in css.body
+        assert b"--build-color: var(--danger)" in css.body
+        assert b"--build-color: var(--success)" in css.body
         assert b"controls.zoomToCursor = true" in viewer.body
         # The wheel is the viewer's, not OrbitControls'. Its wheel path lands
         # the whole delta in one step while orbit and pan glide under damping,
@@ -604,6 +609,7 @@ class TestViewPage:
         assert viewer.media_type == "text/javascript"
         assert layout.media_type == "text/javascript"
         assert explore.media_type == "text/javascript"
+        assert palette.media_type == "text/javascript"
         assert share.media_type == "text/javascript"
         assert css.media_type == "text/css"
 
@@ -663,7 +669,7 @@ class TestViewPage:
         assert ".mobile-guide" in css
         assert "bottom: 76px" in css
         assert "min-height: 44px" in css
-        assert "color: #aaa4b6" in css
+        assert "color: var(--muted)" in css
         assert "max-height: min(66dvh, 620px)" in css
         assert "env(safe-area-inset-bottom)" in css
 


### PR DESCRIPTION
## What changed

- Keeps the original mint, amber, magenta, indigo, and coral semantic roles while moving the canvas and panels toward a restrained blue-black deep-space palette.
- Centralizes CSS, WebGL, and constellation-export colors in `palette.mjs`.
- Improves small-text, focus-ring, relationship-line, guide, status, warning, and legend contrast.
- Brightens Root to a clearer coral and restores restrained glow/emissive emphasis.
- Adds Root-only breathing room: Context nodes sit at 1.10–1.60 and Volumes at 2.40–2.64 from the center; rootless/degraded layouts retain their previous compact radii.
- Renders Root as the final scene anchor so dense transparent Volume geometry cannot cover it.
- Leaves model data, interaction semantics, evidence/provenance behavior, and the separate HUMAN.md card design unchanged.

## Why

The gray-first iteration reduced the galaxy semantic character, while the real local model showed that dense Volume geometry could visually swallow the central Root. This version keeps the original Persome hues, adds a subtle star-field atmosphere, and makes the hierarchy readable without turning the graph into a neon visualization.

## Verification

- Node model suite: 51 passed.
- Focused viewer/sample Python suite: 32 passed.
- Ruff check and format check passed.
- Secret, PII, and language scans passed.
- Synthetic showcase and authenticated real-local-data browser smoke completed with WebGL rendering and no console errors.
- GitHub CI: Ubuntu, macOS latest, macOS Intel, and package smoke all passed.

No Share/X action was triggered.