### PR TITLE
fix: bound associative identity matches

### DIFF
--- a/MCP.md
+++ b/MCP.md
@@ -52,7 +52,7 @@ Example client configuration:
 |---|---|
 | `list_memories` | List durable Markdown memory files. |
 | `read_memory` | Read a memory file with time, tag, and tail filters. |
-| `search` | Search durable memory with lexical and optional dense retrieval. |
+| `search` | Search durable memory with lexical and optional dense retrieval; latency-sensitive ranked-hit consumers may pass `include_chains=false` to skip relation-chain narration. |
 | `read_receipt` | Resolve an entry ID to local provenance. |
 | `related_events` | Retrieve time-adjacent context around one memory entry: overlapping timeline blocks plus nearest captures, anchored on parseable `occurred_at` else write time. Context is observed data, not evidence for the entry. |
 | `resolve_evidence` | Resolve any model ID or receipt one layer down with human labels; separates direct sources, nearby context, and Point history. |

--- a/src/persome/evomem/identity.py
+++ b/src/persome/evomem/identity.py
@@ -155,22 +155,40 @@ def resolve_identity(mention: str, roster: Roster) -> Resolution:
 def scan_mentions(text: str, roster: Roster) -> list[str]:
     """§3.2 associative-Q entity slot — ZERO-LLM distillation of the present.
 
-    Scan the (normalized) text for every roster canonical/alias as a substring
-    and return the matched CANONICAL identities, deduped, ordered by first
-    occurrence. This is the "weights arm perception" loop made literal: the
-    bigger the graph's roster, the more the runtime can see. Substring matching
-    is deliberate — Chinese runs tokenize as one FTS token, so word-boundary
-    matching would go blind exactly where the entity head matters most.
+    Scan the (normalized) text for every roster canonical/alias and return the
+    matched CANONICAL identities, deduped, ordered by first occurrence. Chinese
+    names keep substring matching because Chinese runs tokenize as one FTS token.
+    ASCII word edges must be bounded, however: a one-letter identity such as
+    ``D`` must not arm the relation head merely because a query says
+    ``evidence``. This is the "weights arm perception" loop made literal without
+    turning ordinary English substrings into people.
     """
     hay = norm(text)
     if not hay:
         return []
     found: list[tuple[int, str]] = []
     seen: set[str] = set()
+
+    def ascii_word(char: str) -> bool:
+        return char.isascii() and (char.isalnum() or char == "_")
+
+    def mention_position(key: str) -> int:
+        start = 0
+        while True:
+            pos = hay.find(key, start)
+            if pos < 0:
+                return -1
+            end = pos + len(key)
+            left_ok = not (ascii_word(key[0]) and pos > 0 and ascii_word(hay[pos - 1]))
+            right_ok = not (ascii_word(key[-1]) and end < len(hay) and ascii_word(hay[end]))
+            if left_ok and right_ok:
+                return pos
+            start = pos + 1
+
     for key, canonical in roster._by_norm.items():
         if canonical in seen:
             continue
-        pos = hay.find(key)
+        pos = mention_position(key)
         if pos >= 0:
             found.append((pos, canonical))
             seen.add(canonical)

--- a/src/persome/mcp/server.py
+++ b/src/persome/mcp/server.py
@@ -243,6 +243,7 @@ def _search(  # type: ignore[no-untyped-def]
     until: str | None = None,
     top_k: int = 5,
     include_superseded: bool = False,
+    include_chains: bool = True,
     breadth: float = 0.0,
     entities: list[str] | None = None,
     include_bodies: bool = False,
@@ -266,17 +267,21 @@ def _search(  # type: ignore[no-untyped-def]
         # (kill-switch [search] associative_read_enabled)
         from ..retrieval import associative as assoc_mod
 
-        hits, chains_text = assoc_mod.associative_read(
+        read_result = assoc_mod.associative_read(
             conn,
             query=query,
             path_patterns=paths,
             since=since,
             until=until,
             top_k=top_k,
-            with_chains=True,
+            with_chains=include_chains,
             entities=entities,
             mmr_diversity=breadth,
         )
+        if include_chains:
+            hits, chains_text = read_result
+        else:
+            hits = read_result
     metas = fts.entry_metadata_map(conn, [h.id for h in hits])
     face_index = (
         _face_membership_index(conn, include_bodies=include_bodies)
@@ -904,7 +909,7 @@ top-down — who they are (resident), what happened (recall), what was on screen
 
 ### Compressed memory (recall)
 
-- `search(query, paths?, since?, until?, top_k?, breadth?, entities?, include_bodies?)`
+- `search(query, paths?, since?, until?, top_k?, breadth?, entities?, include_bodies?, include_chains?)`
   — semantic + keyword recall over distilled facts. Natural language works; you do
   not need the user's original phrasing. Knobs:
   - `entities=["Alex"]` when you KNOW who the question is about (aliases resolve;
@@ -912,6 +917,8 @@ top-down — who they are (resident), what happened (recall), what was on screen
   - `breadth=0.3–0.7` for survey/research questions (diverse angles over
     near-duplicate top hits); leave 0 when grounding a specific fact.
   - `include_bodies=true` to also attach higher-level cross-domain patterns.
+  - `include_chains=false` when a latency-sensitive consumer only needs ranked
+    hits and their IDs, not relation-chain narration.
 - `verify_fact(claim, top_k?, fresh_within_days?)` — freshness check for ONE claim.
   Call before stating time-sensitive facts (versions, task status, who-does-what,
   schedules) as current. It judges TIME only, but explains any existing open
@@ -964,7 +971,7 @@ Each hit carries more than text — use all of it:
   instance of a verified pattern, so the pattern likely holds in new situations.
 - `confidence` / `conflicted` — reliability metadata; `conflicted: true` means an
   unresolved contradiction exists — do not present that fact as settled.
-- `chains` (top-level) — how the hits connect back to the user, with receipt
+- `chains` (top-level, when requested and available) — how the hits connect back to the user, with receipt
   pointers `⟨entry_id:path⟩`. Anchors listed as orphans have no proven link yet.
 
 ## Combining tools
@@ -1204,6 +1211,7 @@ def build_server(
         until: str | None = None,
         top_k: int = default_top_k,
         include_superseded: bool = False,
+        include_chains: bool = True,
         breadth: float = 0.0,
         entities: list[str] | None = None,
         include_bodies: bool = False,
@@ -1249,6 +1257,10 @@ def build_server(
         directly when you KNOW who the question is about (e.g.
         `entities=["Alex"]` while the query text paraphrases) — unknown names
         are ignored, never an error.
+
+        `include_chains=false` skips relation-chain narration for latency-sensitive
+        consumers that only need ranked hits. Result IDs still remain available as
+        evidence handles. The default stays true for backwards compatibility.
         """
         query = bounded_text("query", query, maximum=20_000)
         paths = bounded_text_list(
@@ -1277,6 +1289,7 @@ def build_server(
                     until=until,
                     top_k=top_k,
                     include_superseded=include_superseded,
+                    include_chains=include_chains,
                     breadth=breadth,
                     entities=entities,
                     include_bodies=include_bodies,

--- a/tests/test_associative_read_cutover.py
+++ b/tests/test_associative_read_cutover.py
@@ -139,6 +139,14 @@ class TestMcpSearchCutover:
             out = mcp_server._search(conn, query="\u5f20\u4f1f \u5728\u5fd9\u4ec0\u4e48", top_k=5)
             assert zw in {r["id"] for r in out["results"]}
             assert "chains" in out and "\u5f20\u4f1f" in out["chains"]
+            hits_only = mcp_server._search(
+                conn,
+                query="\u5f20\u4f1f \u5728\u5fd9\u4ec0\u4e48",
+                top_k=5,
+                include_chains=False,
+            )
+            assert zw in {r["id"] for r in hits_only["results"]}
+            assert "chains" not in hits_only
             # archaeology mode: include_superseded is not an associative question
             out2 = mcp_server._search(
                 conn,

--- a/tests/test_identity_mentions.py
+++ b/tests/test_identity_mentions.py
@@ -1,0 +1,22 @@
+from persome.evomem import identity
+
+
+def test_ascii_identity_does_not_match_inside_an_ordinary_word() -> None:
+    roster = identity.Roster.build([("D", []), ("Ann", [])])
+
+    assert identity.scan_mentions("closure evidence timeout", roster) == []
+    assert identity.scan_mentions("planning the release", roster) == []
+
+
+def test_ascii_identity_still_matches_as_a_complete_token() -> None:
+    roster = identity.Roster.build([("D", []), ("Ann", [])])
+
+    assert identity.scan_mentions("Ask D, then Ann.", roster) == ["D", "Ann"]
+
+
+def test_chinese_identity_keeps_substring_matching() -> None:
+    roster = identity.Roster.build([("\u5f20\u4f1f", [])])
+
+    assert identity.scan_mentions("\u5f20\u4f1f\u4eca\u5929\u5728\u5fd9\u4ec0\u4e48", roster) == [
+        "\u5f20\u4f1f"
+    ]


### PR DESCRIPTION
## What changed

- require ASCII identity names and aliases to match at word boundaries while preserving Chinese substring matching
- add regression coverage for one-letter and ordinary Latin names
- let latency-sensitive MCP consumers opt out of relation-chain narration with `include_chains=false` while keeping the default compatible

## Root cause

A roster identity such as `D` matched the `d` inside ordinary query words such as `evidence`. That false-positive entity slot activated two-hop relation expansion and many unindexed `LIKE` scans over the memory corpus.

## Impact

On the real owner-local model, the same five-hit query improved from 60.9s to 0.82s with default chain delivery, and to 0.60s with `include_chains=false`. The result count stayed at five.

## Validation

- `PERSOME_LLM_MOCK=1 uv run pytest -m "not macos and not integration"` — 2304 passed, 17 deselected
- Ruff lint and format checks
- secret, PII, and English-language scans
- real stdio MCP A/B against the owner-local model
