### PR TITLE
fix: isolate updated Runtime imports

### DIFF
--- a/docs/runtime-internals.md
+++ b/docs/runtime-internals.md
@@ -65,8 +65,11 @@ refuses to replace an unmarked file at that path.
 `start` holds `<PERSOME_ROOT>/.daemon.lock` from preflight through the entire
 foreground or background daemon lifetime. Background start transfers that held
 lock into a fresh `posix_spawn`/exec process instead of running Runtime code in a
-fork-cloned Python/SQLite process. This prevents two concurrent starters from
-both passing the PID check. The daemon writes a numeric `.pid` for
+fork-cloned Python/SQLite process. The child also uses Python's safe-path mode
+and ignores caller-provided Python package/home/virtualenv overrides, so a
+checkout in the caller's working directory cannot shadow the installed Runtime
+while it operates on the configured data root. This prevents two concurrent
+starters from both passing the PID check. The daemon writes a numeric `.pid` for
 one-release compatibility plus an owner-only `.runtime-state.json` containing
 its random generation, start/update times, readiness phase, effective capture
 and OCR policy, native permission probes, and the last capture/privacy receipt.

--- a/docs/runtime-internals.md
+++ b/docs/runtime-internals.md
@@ -66,8 +66,9 @@ refuses to replace an unmarked file at that path.
 foreground or background daemon lifetime. Background start transfers that held
 lock into a fresh `posix_spawn`/exec process instead of running Runtime code in a
 fork-cloned Python/SQLite process. The child also uses Python's safe-path mode
-and ignores caller-provided Python package/home/virtualenv overrides, so a
-checkout in the caller's working directory cannot shadow the installed Runtime
+and ignores caller-provided import-path, interpreter-prefix, and
+active-environment overrides, so a checkout in the caller's working directory
+cannot shadow the installed Runtime
 while it operates on the configured data root. This prevents two concurrent
 starters from both passing the PID check. The daemon writes a numeric `.pid` for
 one-release compatibility plus an owner-only `.runtime-state.json` containing

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -135,6 +135,19 @@ def _spawn_background_runtime(daemon_lock, *, capture_only: bool) -> int:  # typ
     child_lock_fd = 4 if parent_lock_fd == 3 else 3
     command = _background_daemon_command(capture_only=capture_only)
     env = dict(os.environ)
+    # ``python -m`` normally prepends the caller's working directory to
+    # ``sys.path``. An update started from another checkout could therefore
+    # restart into that checkout's package while still using the real data
+    # root. Keep the fresh interpreter bound to its installed Runtime.
+    env["PYTHONSAFEPATH"] = "1"
+    env["PYTHONNOUSERSITE"] = "1"
+    for variable in (
+        "PYTHONHOME",
+        "PYTHONPATH",
+        "VIRTUAL_ENV",
+        "__PYVENV_LAUNCHER__",
+    ):
+        env.pop(variable, None)
     # Unlike ``start --foreground`` owned by the Desktop app, plain background
     # start has always outlived its launching shell/app. Do not let the fresh
     # exec accidentally opt into the foreground parent-death watcher.
@@ -1390,6 +1403,11 @@ def update(
         "[yellow]Restart every editor/client connected to Persome before resuming writes.[/yellow] "
         "A stdio MCP process loaded from the previous release cannot join the new SQLite "
         "maintenance gate until it reconnects."
+    )
+    console.print(
+        "[yellow]Reopen any /model tab from before the update with "
+        "[bold]persome model open[/bold].[/yellow] The open page still belongs to the "
+        "previous Runtime."
     )
 
 

--- a/src/persome/cli.py
+++ b/src/persome/cli.py
@@ -140,10 +140,11 @@ def _spawn_background_runtime(daemon_lock, *, capture_only: bool) -> int:  # typ
     # restart into that checkout's package while still using the real data
     # root. Keep the fresh interpreter bound to its installed Runtime.
     env["PYTHONSAFEPATH"] = "1"
-    env["PYTHONNOUSERSITE"] = "1"
     for variable in (
+        "PYTHONEXECUTABLE",
         "PYTHONHOME",
         "PYTHONPATH",
+        "PYTHONPLATLIBDIR",
         "VIRTUAL_ENV",
         "__PYVENV_LAUNCHER__",
     ):
@@ -1406,8 +1407,8 @@ def update(
     )
     console.print(
         "[yellow]Reopen any /model tab from before the update with "
-        "[bold]persome model open[/bold].[/yellow] The open page still belongs to the "
-        "previous Runtime."
+        "[bold]persome model open[/bold].[/yellow] The open tab keeps assets loaded from "
+        "the previous release."
     )
 
 

--- a/src/persome/updater.py
+++ b/src/persome/updater.py
@@ -465,8 +465,10 @@ def _child_environment(*, include_source: Path | None = None) -> dict[str, str]:
     env["PYTHONNOUSERSITE"] = "1"
     for variable in (
         "SSL_CERT_FILE",
+        "PYTHONEXECUTABLE",
         "PYTHONHOME",
         "PYTHONPATH",
+        "PYTHONPLATLIBDIR",
         "VIRTUAL_ENV",
         "__PYVENV_LAUNCHER__",
     ):

--- a/tests/test_cli_lifecycle.py
+++ b/tests/test_cli_lifecycle.py
@@ -177,9 +177,12 @@ def test_background_spawn_execs_fresh_interpreter_and_transfers_lock(
         return 4242
 
     monkeypatch.delattr(cli.sys, "frozen", raising=False)
+    monkeypatch.delenv("PYTHONNOUSERSITE", raising=False)
     monkeypatch.setenv("PERSOME_PARENT_PID", "1234")
+    monkeypatch.setenv("PYTHONEXECUTABLE", "/tmp/foreign-python")
     monkeypatch.setenv("PYTHONHOME", "/tmp/foreign-python")
     monkeypatch.setenv("PYTHONPATH", "/tmp/foreign-package")
+    monkeypatch.setenv("PYTHONPLATLIBDIR", "/tmp/foreign-lib")
     monkeypatch.setenv("VIRTUAL_ENV", "/tmp/foreign-venv")
     monkeypatch.setenv("__PYVENV_LAUNCHER__", "/tmp/foreign-python")
     monkeypatch.setattr(cli.os, "posix_spawn", fake_posix_spawn)
@@ -199,9 +202,11 @@ def test_background_spawn_execs_fresh_interpreter_and_transfers_lock(
     assert seen["env"][cli._BACKGROUND_DAEMON_LOCK_FD_ENV] == "3"
     assert "PERSOME_PARENT_PID" not in seen["env"]
     assert seen["env"]["PYTHONSAFEPATH"] == "1"
-    assert seen["env"]["PYTHONNOUSERSITE"] == "1"
+    assert "PYTHONNOUSERSITE" not in seen["env"]
+    assert "PYTHONEXECUTABLE" not in seen["env"]
     assert "PYTHONHOME" not in seen["env"]
     assert "PYTHONPATH" not in seen["env"]
+    assert "PYTHONPLATLIBDIR" not in seen["env"]
     assert "VIRTUAL_ENV" not in seen["env"]
     assert "__PYVENV_LAUNCHER__" not in seen["env"]
     assert seen["file_actions"] == [

--- a/tests/test_cli_lifecycle.py
+++ b/tests/test_cli_lifecycle.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import json
 import shlex
+import subprocess
 import time
 from types import SimpleNamespace
 
@@ -177,6 +178,10 @@ def test_background_spawn_execs_fresh_interpreter_and_transfers_lock(
 
     monkeypatch.delattr(cli.sys, "frozen", raising=False)
     monkeypatch.setenv("PERSOME_PARENT_PID", "1234")
+    monkeypatch.setenv("PYTHONHOME", "/tmp/foreign-python")
+    monkeypatch.setenv("PYTHONPATH", "/tmp/foreign-package")
+    monkeypatch.setenv("VIRTUAL_ENV", "/tmp/foreign-venv")
+    monkeypatch.setenv("__PYVENV_LAUNCHER__", "/tmp/foreign-python")
     monkeypatch.setattr(cli.os, "posix_spawn", fake_posix_spawn)
 
     assert cli._spawn_background_runtime(lock, capture_only=True) == 4242
@@ -193,6 +198,12 @@ def test_background_spawn_execs_fresh_interpreter_and_transfers_lock(
     assert seen["setsid"] is True
     assert seen["env"][cli._BACKGROUND_DAEMON_LOCK_FD_ENV] == "3"
     assert "PERSOME_PARENT_PID" not in seen["env"]
+    assert seen["env"]["PYTHONSAFEPATH"] == "1"
+    assert seen["env"]["PYTHONNOUSERSITE"] == "1"
+    assert "PYTHONHOME" not in seen["env"]
+    assert "PYTHONPATH" not in seen["env"]
+    assert "VIRTUAL_ENV" not in seen["env"]
+    assert "__PYVENV_LAUNCHER__" not in seen["env"]
     assert seen["file_actions"] == [
         (cli.os.POSIX_SPAWN_DUP2, 91, 3),
         (cli.os.POSIX_SPAWN_CLOSE, 91),
@@ -200,6 +211,50 @@ def test_background_spawn_execs_fresh_interpreter_and_transfers_lock(
         (cli.os.POSIX_SPAWN_DUP2, 0, 1),
         (cli.os.POSIX_SPAWN_DUP2, 0, 2),
     ]
+
+
+def test_background_spawn_cannot_import_persome_from_caller_working_directory(
+    ac_root, tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    caller_directory = tmp_path / "foreign-cwd"
+    caller_directory.mkdir()
+    fake_package = caller_directory / "persome"
+    fake_package.mkdir()
+    (fake_package / "__init__.py").write_text("", encoding="utf-8")
+    marker = caller_directory / "cwd-package-imported"
+    (fake_package / "cli.py").write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).touch()\n",
+        encoding="utf-8",
+    )
+    seen: dict[str, object] = {}
+
+    def fake_posix_spawn(
+        _executable: str,
+        command: list[str],
+        env: dict[str, str],
+        **_kwargs: object,
+    ) -> int:
+        seen.update(command=command, env=env)
+        return 4242
+
+    monkeypatch.delattr(cli.sys, "frozen", raising=False)
+    monkeypatch.chdir(caller_directory)
+    monkeypatch.setenv("PYTHONPATH", str(caller_directory))
+    monkeypatch.setattr(cli.os, "posix_spawn", fake_posix_spawn)
+
+    assert cli._spawn_background_runtime(_FakeLock(), capture_only=False) == 4242
+    command = seen["command"]
+    result = subprocess.run(
+        [*command[:3], "--help"],
+        cwd=caller_directory,
+        env=seen["env"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not marker.exists()
 
 
 def test_background_spawn_uses_fd_four_when_parent_lock_is_fd_three(

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -455,6 +455,8 @@ def test_cli_update_runs_download_stop_install_and_restore(
     assert "preserved" in result.output
     assert "Restart every editor/client connected to Persome" in result.output
     assert "previous release" in result.output
+    assert "Reopen any /model tab from before the update" in result.output
+    assert "persome model open" in result.output
     assert "Checking for an interrupted update" in result.output
     assert "Downloading the latest official main revision" in result.output
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -178,6 +178,8 @@ def test_installer_uses_update_mode_without_shell_interpolation(
     source = updater.UpdateSource(_source_tree(tmp_path / "source"), "c" * 40, False)
     seen: dict[str, object] = {}
     monkeypatch.setenv("SSL_CERT_FILE", str(paths.root() / "venv" / "cert.pem"))
+    monkeypatch.setenv("PYTHONEXECUTABLE", "/tmp/foreign-python")
+    monkeypatch.setenv("PYTHONPLATLIBDIR", "/tmp/foreign-lib")
 
     class Process:
         def __init__(self, command: list[str], **kwargs: object) -> None:
@@ -201,7 +203,9 @@ def test_installer_uses_update_mode_without_shell_interpolation(
     assert env["PERSOME_ROOT"] == str(paths.root())
     assert env["PERSOME_INSTALL_HOME"] == str(paths.root())
     assert "SSL_CERT_FILE" not in env
+    assert "PYTHONEXECUTABLE" not in env
     assert "PYTHONPATH" not in env
+    assert "PYTHONPLATLIBDIR" not in env
     assert env["PERSOME_UPDATE_DEFER_COMMIT"] == "1"
     assert env["PERSOME_UPDATE_REPLACEMENT"] == str(paths.root() / "venv.replacement.update")
     assert env["PERSOME_UPDATE_TRANSACTION_ID"] == transaction_id


### PR DESCRIPTION
## Summary

- start the background Runtime with Python safe-path mode and ignore caller-controlled import-path, interpreter-prefix, and active-environment overrides
- apply the same macOS `PYTHONEXECUTABLE` and `PYTHONPLATLIBDIR` isolation to updater-managed child processes while preserving supported user-site installs
- prevent a stale checkout in the update callers working directory from shadowing the newly installed Runtime
- tell users to reopen a pre-update `/model` tab with `persome model open`
- add a real fake-working-directory import regression and document the boundary

## Root cause

The updater fresh-clones main, builds a fresh wheel, atomically swaps only the virtualenv, and the packaged/live Galaxy asset bytes match the source revision. Two paths can still look stale:

1. The background restart used `python -m persome.cli` with the callers working directory and Python environment. A stale `persome` package or redirected interpreter prefix could win import resolution, serve its viewer assets, and run mismatched storage code against the pinned real `PERSOME_ROOT`. This change closes that updater background-restart path.
2. A browser document opened before the update retains its already-loaded CSS and ES-module graph. A fresh `persome model open` uses the new Runtime; the completion message now makes that required navigation explicit.

For the local-data complaint, the update path does not delete or replace personal data. The previously verified update-restart SIGBUS from post-initialization forking is already fixed by the current `posix_spawn` path, and the SQLite descriptor/maintenance-owner fixes are also on main. Pre-update stdio MCP processes can still perform row DML until editors reconnect, which is why the update warning remains. The cwd/interpreter shadow fixed here was the remaining direct stale-code route in the updater background-daemon restart, not proof of one root cause for every reported crash. Database migration rollback remains a broader transaction-design concern, but it is not established as the cause of the reported incidents.

## Review fixes

- removed a documentation phrase that the PII scanner interpreted as a literal home path
- scrubbed macOS `PYTHONEXECUTABLE` and Python `PYTHONPLATLIBDIR` after reproducing foreign-venv and stdlib redirection
- kept normal user-site imports enabled so plain `pip install --user` remains supported
- completed independent code, updater, data-safety, portability, and test reviews with no remaining merge blocker

## Validation

- locked, hash-constrained wheel build and wheel-installed focused updater/viewer/lifecycle suite: 91 passed
- full offline mocked suite: 2302 passed, 17 intentionally deselected
- store safety: 39 passed
- OpenAPI and database schema drift: 4 passed
- Swift package: 19 passed; generic iOS build succeeded
- dependency audit: no known vulnerabilities
- synthetic MCP: 21 tools, search receipt and model projection verified
- isolated wheel package smoke: CLI and 15 required bundled assets verified
- Ruff lint/format, shell syntax, PII, secret, language, documentation-link, and diff checks passed

Real-provider integration and live Accessibility capture tests remain intentionally deselected by the repository CI gate because they require credentials or TCC access.